### PR TITLE
Add dynamic OpenRouter models fetching

### DIFF
--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -33,6 +33,13 @@ class AIService {
         self.selectedMode = getMode(name: selectedModeName)
         refreshConnectedProviders()
         loadSavedOpenRouterModels()
+        
+        // Fetch OpenRouter models on startup if API key exists
+        Task {
+            if connectedProviders.contains(.openRouter) {
+                await fetchOpenRouterModels()
+            }
+        }
     }
     
     public func getMode(name: String) -> AIEnhanceMode {

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -13,6 +13,7 @@ class AIService {
     private let logger = Logger(subsystem: "com.antonnovoselov.VivaDicta", category: "AIService")
     
     public var connectedProviders: [AIProvider] = []
+    public var openRouterModels: [String] = []
     
     public var selectedModeName: String {
         didSet {
@@ -31,6 +32,7 @@ class AIService {
         self.selectedModeName = UserDefaults.standard.string(forKey: Constants.kSelectedAIMode) ?? DefaultPrompts.regular.aiEnhanceMode.name
         self.selectedMode = getMode(name: selectedModeName)
         refreshConnectedProviders()
+        loadSavedOpenRouterModels()
     }
     
     public func getMode(name: String) -> AIEnhanceMode {
@@ -58,6 +60,16 @@ class AIService {
     private func saveSelectedModeName(_ modeName: String) {
         userDefaults.setValue(modeName, forKey: Constants.kSelectedAIMode)
         logger.info("Saved AI enhance mode: \(modeName)")
+    }
+    
+    private func loadSavedOpenRouterModels() {
+        if let savedModels = userDefaults.array(forKey: "openRouterModels") as? [String] {
+            openRouterModels = savedModels
+        }
+    }
+    
+    private func saveOpenRouterModels() {
+        userDefaults.set(openRouterModels, forKey: "openRouterModels")
     }
     
     // MARK: - Enhance methods
@@ -231,6 +243,11 @@ class AIService {
                 self.refreshConnectedProviders()
                 
             }
+        }
+        
+        // Fetch OpenRouter models if this is an OpenRouter key
+        if isValid && provider == .openRouter {
+            await fetchOpenRouterModels()
         }
         
         return isValid
@@ -419,6 +436,58 @@ class AIService {
         } catch {
             logger.notice("🔑 Grok API key verification failed: \(error.localizedDescription, privacy: .public)")
             return false
+        }
+    }
+    
+    // MARK: - OpenRouter Models methods
+    public func getAvailableModels(for provider: AIProvider) -> [String] {
+        if provider == .openRouter {
+            return openRouterModels
+        }
+        return provider.availableModels
+    }
+    
+    public func fetchOpenRouterModels() async {
+        let url = URL(string: "https://openrouter.ai/api/v1/models")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            
+            guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+                logger.error("Failed to fetch OpenRouter models: Invalid HTTP response")
+                await MainActor.run { 
+                    self.openRouterModels = []
+                    self.saveOpenRouterModels()
+                }
+                return
+            }
+            
+            guard let jsonResponse = try? JSONSerialization.jsonObject(with: data) as? [String: Any], 
+                  let dataArray = jsonResponse["data"] as? [[String: Any]] else {
+                logger.error("Failed to parse OpenRouter models JSON")
+                await MainActor.run { 
+                    self.openRouterModels = []
+                    self.saveOpenRouterModels()
+                }
+                return
+            }
+            
+            let models = dataArray.compactMap { $0["id"] as? String }
+            await MainActor.run { 
+                self.openRouterModels = models.sorted()
+                self.saveOpenRouterModels()
+            }
+            logger.info("Successfully fetched \(models.count) OpenRouter models.")
+            
+        } catch {
+            logger.error("Error fetching OpenRouter models: \(error.localizedDescription)")
+            await MainActor.run { 
+                self.openRouterModels = []
+                self.saveOpenRouterModels()
+            }
         }
     }
 }

--- a/VivaDicta/Views/SettingsScreen/AIModeConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/AIModeConfigurationView.swift
@@ -54,7 +54,7 @@ struct AIModeConfigurationView: View {
                     if hasKey {
                         
                         Picker(selection: $viewModel.aiModel) {
-                            ForEach(provider.availableModels, id: \.self) { model in
+                            ForEach(aiService.getAvailableModels(for: provider), id: \.self) { model in
                                 Text(model).tag(model as String?)
                             }
                             


### PR DESCRIPTION
## Summary
- Implement dynamic fetching of OpenRouter models from API instead of using empty static array
- Add persistent storage of fetched models in UserDefaults
- Automatically fetch models on app startup if OpenRouter API key exists
- Fetch models when new OpenRouter API key is added

## Changes
- Add `openRouterModels` array property to `AIService`
- Implement `fetchOpenRouterModels()` method to call OpenRouter API
- Add save/load methods for model persistence
- Update UI to use dynamic models via `getAvailableModels(for:)` method
- Add startup fetching when OpenRouter API key already exists

## Test plan
- [x] Verify OpenRouter models are fetched when adding new API key
- [x] Confirm models persist across app restarts
- [x] Check that models are automatically refreshed on startup
- [x] Ensure UI shows fetched models in picker instead of empty list