### PR TITLE
VIV-33: Break direct link between AIService and TranscriptionManager

### DIFF
--- a/VivaDicta/AppState.swift
+++ b/VivaDicta/AppState.swift
@@ -12,14 +12,36 @@ import SwiftUI
 class AppState {
     var transcriptionManager: TranscriptionManager!
     var aiService: AIService!
-    
+
     var selectedTab: TabTag = .record
 
     init() {
         transcriptionManager = TranscriptionManager()
-        aiService = AIService(transcriptionManager: transcriptionManager)
-        transcriptionManager.aiService = aiService
-        transcriptionManager.handleModeChange(aiService.selectedMode)
+        aiService = AIService()
+
+        // Set up callbacks to coordinate between services
+        aiService.onModeChange = { [weak self] newMode in
+            self?.handleModeChange(newMode)
+        }
+
+        transcriptionManager.onCloudModelsUpdate = { [weak self] in
+            self?.handleCloudModelsUpdate()
+        }
+
+        // Initialize TranscriptionManager with the current mode
+        transcriptionManager.setCurrentMode(aiService.selectedMode)
+    }
+
+    // This method is called when AIService changes its mode
+    public func handleModeChange(_ newMode: FlowMode) {
+        // Update TranscriptionManager's current mode
+        transcriptionManager.setCurrentMode(newMode)
+    }
+
+    // This method is called when TranscriptionManager updates cloud models
+    public func handleCloudModelsUpdate() {
+        // Notify AIService to refresh its connected providers
+        aiService.refreshConnectedProviders()
     }
     
     func transcribe(audioURL: URL) async throws -> String {

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -16,8 +16,9 @@ class AIService {
     public var openRouterModels: [String] = []
     public var modes: [FlowMode] = []
 
-    private let transcriptionManager: TranscriptionManager
-    
+    // Callback for mode changes
+    public var onModeChange: ((FlowMode) -> Void)?
+
     public var selectedModeName: String {
         didSet {
             self.saveSelectedModeName(selectedModeName)
@@ -27,7 +28,7 @@ class AIService {
     
     public var selectedMode: FlowMode = FlowMode.defaultMode {
         didSet {
-            transcriptionManager.handleModeChange(selectedMode)
+            onModeChange?(selectedMode)
         }
     }
     
@@ -35,14 +36,13 @@ class AIService {
     private let baseTimeout: TimeInterval = 30
 
     
-    init(transcriptionManager: TranscriptionManager) {
-        self.transcriptionManager = transcriptionManager
+    init() {
         self.selectedModeName = UserDefaults.standard.string(forKey: Constants.kSelectedAIMode) ?? FlowMode.defaultMode.name
         loadModes()
         self.selectedMode = getMode(name: selectedModeName)
         refreshConnectedProviders()
         loadSavedOpenRouterModels()
-        
+
         Task {
             if connectedProviders.contains(.openRouter) {
                 await fetchOpenRouterModels()

--- a/VivaDicta/Services/Transcription/TranscriptionManager.swift
+++ b/VivaDicta/Services/Transcription/TranscriptionManager.swift
@@ -14,7 +14,10 @@ class TranscriptionManager {
     private let whisperPrompt: WhisperPrompt
     private var localTranscriptionService: LocalTranscriptionService!
     private let cloudTranscriptionService = CloudTranscriptionService()
-    weak var aiService: AIService?
+    private(set) var currentMode: FlowMode = FlowMode.defaultMode
+
+    // Callback for when cloud models are updated
+    public var onCloudModelsUpdate: (() -> Void)?
 
     var allAvailableModels: [any TranscriptionModel] = TranscriptionModelProvider.allLocalModels + TranscriptionModelProvider.allCloudModels
 
@@ -36,9 +39,10 @@ class TranscriptionManager {
         self.localTranscriptionService = LocalTranscriptionService(transcriptionManager: self)
     }
     
-    public func handleModeChange(_ mode: FlowMode) {
+    public func setCurrentMode(_ mode: FlowMode) {
+        currentMode = mode
         applyModeLanguage(mode)
-        
+
         // Preheat Local Whisper Model if needed
         if mode.transcriptionProvider == .local {
             if let localModel = TranscriptionModelProvider.allLocalModels.first(where: { $0.name == mode.transcriptionModel }) {
@@ -70,18 +74,16 @@ class TranscriptionManager {
 
     public func updateCloudModels() {
         allAvailableModels = TranscriptionModelProvider.allLocalModels + TranscriptionModelProvider.allCloudModels
-        aiService?.refreshConnectedProviders()
+        onCloudModelsUpdate?()
     }
     
     
     public func getCurrentTranscriptionModel() -> (any TranscriptionModel)? {
-        guard let aiService = aiService else { return nil }
-        let mode = aiService.selectedMode
-        let provider = mode.transcriptionProvider
-        let modelName = mode.transcriptionModel
-        
+        let provider = currentMode.transcriptionProvider
+        let modelName = currentMode.transcriptionModel
+
         let allModels: [any TranscriptionModel] = TranscriptionModelProvider.allLocalModels + TranscriptionModelProvider.allCloudModels
-        
+
         return allModels.first { model in
             model.provider == provider && model.name == modelName
         }

--- a/VivaDicta/Views/ModelsScreen/CloudModelConfigurationView.swift
+++ b/VivaDicta/Views/ModelsScreen/CloudModelConfigurationView.swift
@@ -15,7 +15,7 @@ struct CloudModelConfigurationView: View {
     @State var apiKey: String = ""
     @State private var isVerifying: Bool = false
     @State private var verificationError: String? = nil
-    @State private var aiService = AIService(transcriptionManager: TranscriptionManager())
+    @State private var aiService = AIService()
     
     var body: some View {
         

--- a/VivaDicta/Views/SettingsScreen/AddAPIKeyView.swift
+++ b/VivaDicta/Views/SettingsScreen/AddAPIKeyView.swift
@@ -99,7 +99,7 @@ struct AddAPIKeyView: View {
     NavigationStack {
         AddAPIKeyView(
             provider: .openAI,
-            aiService: AIService(transcriptionManager: TranscriptionManager()),
+            aiService: AIService(),
             onSave: {_ in })
     }
 }

--- a/VivaDicta/Views/SettingsScreen/ModeEditView.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditView.swift
@@ -212,7 +212,7 @@ struct ModeEditView: View {
 }
 
 #Preview {
-    @Previewable @State var aiService = AIService(transcriptionManager: TranscriptionManager())
+    @Previewable @State var aiService = AIService()
     @Previewable @State var promptsManager = PromptsManager()
     @Previewable @State var appState = AppState()
     @Previewable @State var transcriptionManager = TranscriptionManager()


### PR DESCRIPTION
## Summary
Refactored the architecture to completely decouple AIService and TranscriptionManager, eliminating circular dependencies and improving code maintainability.

## Changes
- **Removed direct dependencies** between AIService and TranscriptionManager
- **Made AppState the central coordinator** using callback-based communication
- **Simplified responsibilities**:
  - TranscriptionManager: Focuses only on transcription tasks
  - AIService: Manages AI enhancement and modes
  - AppState: Coordinates communication between services
- **Implemented closure-based callbacks** instead of protocol dependencies

## Architecture Improvements
### Before
```
AIService ←→ TranscriptionManager (circular dependency)
```

### After  
```
AIService → AppState → TranscriptionManager
         ↙️          ↘️
    (callbacks)   (direct calls)
```

## Data Flow
- **Mode changes**: `AIService.onModeChange` → `AppState.handleModeChange()` → `TranscriptionManager.setCurrentMode()`
- **Cloud model updates**: `TranscriptionManager.onCloudModelsUpdate` → `AppState.handleCloudModelsUpdate()` → `AIService.refreshConnectedProviders()`

## Benefits
✅ No circular dependencies
✅ Single responsibility for each service
✅ Clear, unidirectional data flow
✅ Better testability - services can be tested in isolation
✅ More flexible and maintainable architecture
✅ Services don't know about each other

## Testing
- [x] Build succeeds without compilation errors
- [x] All existing functionality preserved
- [x] Preview code updated to use new initializers

## Linear Issue
Closes [VIV-33](https://linear.app/antonnovoselov/issue/VIV-33/break-direct-link-between-aiservice-and-transcriptionmanager)

🤖 Generated with [Claude Code](https://claude.ai/code)