### PR TITLE
Add medium Whisper models for improved transcription options

### DIFF
--- a/VivaDicta/Models/TranscriptionModelProvider.swift
+++ b/VivaDicta/Models/TranscriptionModelProvider.swift
@@ -110,6 +110,29 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
                 supportedLanguages: getLanguageDictionary(supportManyLanguages: false)
             ),
             WhisperLocalModel(
+                name: "medium",
+                displayName: "Medium",
+                description: "Medium model, high accuracy with decent speed, supports multiple languages",
+                provider: .local,
+                size: "1.5 GB",
+                speed: 0.6,
+                accuracy: 0.90,
+                ramUsage: 2.5,
+                supportedLanguages: getLanguageDictionary(supportManyLanguages: true)
+            ),
+            WhisperLocalModel(
+                name: "medium.en",
+                displayName: "Medium (English)",
+                description: "Medium model optimized for English, high accuracy with decent speed",
+                provider: .local,
+                size: "1.5 GB",
+                speed: 0.6,
+                accuracy: 0.92,
+                ramUsage: 2.5,
+                supportedLanguages: getLanguageDictionary(supportManyLanguages: false)
+            ),
+
+            WhisperLocalModel(
                 name: "large-v2",
                 displayName: "Large v2",
                 description: "Large model v2, slower than Medium but more accurate",


### PR DESCRIPTION
## Summary

This PR adds two new Whisper model configurations to expand transcription options:
- **Medium model**: Multi-language support, 1.5 GB size
- **Medium.en model**: English-optimized variant, 1.5 GB size

## Changes

- Added  and  models to the TranscriptionModelProvider
- Both models configured with appropriate performance characteristics:
  - High accuracy (90-92%)
  - Decent speed (0.6 relative performance)
  - 2.5 GB RAM usage
  - 1.5 GB download size

## Benefits

These medium models provide a valuable middle ground between the smaller models (tiny/base/small) and larger models (large-v2/large-v3), offering:
- Better accuracy than small models
- Lower resource requirements than large models
- Good balance for most transcription use cases

## Testing

- [ ] Verify model configurations appear correctly in the Models tab
- [ ] Test downloading medium models
- [ ] Verify transcription accuracy with medium models
- [ ] Check RAM usage during transcription
- [ ] Test both multi-language and English-only variants

## Related

Addresses #46 - Add medium Whisper model options