### PR TITLE
Load whisper model on demand to reduce RAM usage (VIV-60)

### DIFF
--- a/VivaDicta/Services/Transcription/LocalWhisperTranscriptionService.swift
+++ b/VivaDicta/Services/Transcription/LocalWhisperTranscriptionService.swift
@@ -6,92 +6,74 @@
 //
 
 import Foundation
-import whisper
 import os
-
+import whisper
 
 class LocalTranscriptionService: TranscriptionService {
-
-    private var whisperContext: WhisperContext?
     private let logger = Logger(subsystem: "com.antonnovoselov.VivaDicta", category: "LocalTranscriptionService")
-    private weak var transcriptionManager: TranscriptionManager?
 
-    init(transcriptionManager: TranscriptionManager? = nil) {
-        self.transcriptionManager = transcriptionManager
-    }
-    
+    init() {}
+
     func transcribe(audioURL: URL, model: any TranscriptionModel) async throws -> String {
         guard model.provider == .local else {
             throw WhisperStateError.modelLoadFailed
         }
-        
-        logger.notice("Initiating local transcription for model: \(model.displayName)")
-        
-        // Check if the required model is already loaded in TranscriptionManager
-        if let transcriptionManager = transcriptionManager,
-           let loadedContext = await transcriptionManager.whisperContext,
-           let currentModel = await transcriptionManager.getCurrentTranscriptionModel(),
-            currentModel.provider == .local,
-            currentModel.name == model.name {
 
-            logger.notice("✅ Using already loaded model: \(model.name)")
-            whisperContext = loadedContext
-        } else {
-            // TODO: Important - remove this branch of logic, make it reliable instead
-            // Model not loaded or wrong model loaded, proceed with loading
-            // Resolve the on-disk URL using TranscriptionManager.availableModels (covers imports)
-            let resolvedURL: URL? = await transcriptionManager?.availableWhisperLocalModels.first { $0.name == model.name }?.fileURL
-            guard let modelURL = resolvedURL, FileManager.default.fileExists(atPath: modelURL.path) else {
-                logger.error("Model file not found for: \(model.name)")
-                throw WhisperStateError.modelLoadFailed
-            }
-            
-            logger.notice("Loading model: \(model.name)")
-            do {
-                whisperContext = try await WhisperContext.createContext(path: modelURL.path)
-            } catch {
-                logger.error("Failed to load model: \(model.name) - \(error.localizedDescription)")
-                throw WhisperStateError.modelLoadFailed
-            }
-        }
-        
-        guard let whisperContext = whisperContext else {
-            logger.error("Cannot transcribe: Model could not be loaded")
+        logger.notice("Initiating local transcription for model: \(model.displayName)")
+
+        // Always create a new context for each transcription to minimize RAM usage
+        // Find the model file on disk
+        let availableModels = TranscriptionModelProvider.allLocalModels.filter { $0.fileExists }
+        guard let localModel = availableModels.first(where: { $0.name == model.name }) else {
+            logger.error("Model file not found for: \(model.name)")
             throw WhisperStateError.modelLoadFailed
         }
-        
+
+        let modelURL = localModel.fileURL
+        guard FileManager.default.fileExists(atPath: modelURL.path) else {
+            logger.error("Model file does not exist at path: \(modelURL.path)")
+            throw WhisperStateError.modelLoadFailed
+        }
+
+        logger.notice("Loading model: \(model.name) from \(modelURL.path)")
+        let whisperContext: WhisperContext
+        do {
+            whisperContext = try await WhisperContext.createContext(path: modelURL.path)
+        } catch {
+            logger.error("Failed to load model: \(model.name) - \(error.localizedDescription)")
+            throw WhisperStateError.modelLoadFailed
+        }
+
         // Read audio data
         let data = try readAudioSamples(audioURL)
-        
+
         // Set prompt
         let currentPrompt = UserDefaults.standard.string(forKey: Constants.kTranscriptionPrompt) ?? ""
         await whisperContext.setPrompt(currentPrompt)
-        
+
         // Transcribe
         let success = await whisperContext.fullTranscribe(samples: data)
-        
+
         guard success else {
             logger.error("Core transcription engine failed (whisper_full).")
             throw WhisperStateError.whisperCoreFailed
         }
-        
-        var text = await whisperContext.getTranscription()
-        
+
+        let text = await whisperContext.getTranscription()
+
         logger.notice("✅ Local transcription completed successfully.")
-        
-        // Only release resources if we created a new context (not using the shared one)
-        if await transcriptionManager?.whisperContext !== whisperContext {
-            await whisperContext.releaseResources()
-            self.whisperContext = nil
-        }
-        
+
+        // Always release resources after transcription to minimize RAM usage
+        await whisperContext.releaseResources()
+        logger.notice("✅ Whisper context resources released.")
+
         return text
     }
-    
+
     private func readAudioSamples(_ url: URL) throws -> [Float] {
         let data = try Data(contentsOf: url)
         let floats = stride(from: 44, to: data.count, by: 2).map {
-            return data[$0..<$0 + 2].withUnsafeBytes {
+            data[$0 ..< $0 + 2].withUnsafeBytes {
                 let short = Int16(littleEndian: $0.load(as: Int16.self))
                 return max(-1.0, min(Float(short) / 32767.0, 1.0))
             }
@@ -99,7 +81,3 @@ class LocalTranscriptionService: TranscriptionService {
         return floats
     }
 }
-
-
-
-

--- a/VivaDicta/Services/Transcription/TranscriptionManager.swift
+++ b/VivaDicta/Services/Transcription/TranscriptionManager.swift
@@ -5,16 +5,15 @@
 //  Created by Anton Novoselov on 2025.09.17
 //
 
-import SwiftUI
 import Foundation
+import SwiftUI
 
 @Observable
 class TranscriptionManager {
-    var whisperContext: WhisperContext?
     private let whisperPrompt: WhisperPrompt
     private var localTranscriptionService: LocalTranscriptionService!
     private let cloudTranscriptionService = CloudTranscriptionService()
-    private(set) var currentMode: FlowMode = FlowMode.defaultMode
+    private(set) var currentMode: FlowMode = .defaultMode
 
     // Callback for when cloud models are updated
     public var onCloudModelsUpdate: (() -> Void)?
@@ -35,49 +34,30 @@ class TranscriptionManager {
     }
 
     init() {
-        self.whisperPrompt = WhisperPrompt()
-        self.localTranscriptionService = LocalTranscriptionService(transcriptionManager: self)
+        whisperPrompt = WhisperPrompt()
+        localTranscriptionService = LocalTranscriptionService()
     }
-    
+
     public func setCurrentMode(_ mode: FlowMode) {
         currentMode = mode
         applyModeLanguage(mode)
+    }
 
-        // Preheat Local Whisper Model if needed
-        if mode.transcriptionProvider == .local {
-            if let localModel = TranscriptionModelProvider.allLocalModels.first(where: { $0.name == mode.transcriptionModel }) {
-                Task {
-                    try? await preheatLocalModel(localModel)
-                }
-            }
-        }
-    }
-    
-    func preheatLocalModel(_ model: WhisperLocalModel) async throws {
-        do {
-            whisperContext = try await WhisperContext.createContext(path: model.fileURL.path)
-        } catch {
-            throw WhisperStateError.modelLoadFailed
-        }
-    }
-    
     private func updateLanguage(_ language: String) {
         selectedLanguage = language
         whisperPrompt.updateTranscriptionPrompt()
     }
-    
+
     private func applyModeLanguage(_ mode: FlowMode) {
         let language = mode.transcriptionLanguage ?? "auto"
         updateLanguage(language)
     }
-    
 
     public func updateCloudModels() {
         allAvailableModels = TranscriptionModelProvider.allLocalModels + TranscriptionModelProvider.allCloudModels
         onCloudModelsUpdate?()
     }
-    
-    
+
     public func getCurrentTranscriptionModel() -> (any TranscriptionModel)? {
         let provider = currentMode.transcriptionProvider
         let modelName = currentMode.transcriptionModel
@@ -88,12 +68,12 @@ class TranscriptionManager {
             model.provider == provider && model.name == modelName
         }
     }
-    
+
     public func transcribe(audioURL: URL) async throws -> String {
         guard let model = getCurrentTranscriptionModel() else {
             throw WhisperStateError.transcriptionFailed
         }
-        
+
         let transcriptionService: any TranscriptionService
         switch model.provider {
         case .local:
@@ -101,7 +81,7 @@ class TranscriptionManager {
         default:
             transcriptionService = cloudTranscriptionService
         }
-        
+
         return try await transcriptionService.transcribe(audioURL: audioURL, model: model)
     }
 }

--- a/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
@@ -116,31 +116,12 @@ class ModeEditViewModel {
         let availableModels = getAvailableTranscriptionModels(for: newProvider)
         transcriptionModel = availableModels.first ?? ""
         logger.info("Updated transcription provider to: \(newProvider.rawValue), model: \(self.transcriptionModel)")
-
-        // Preheat local whisper model if switching to a Local transcription
-        preheatLocalTranscriptionModelIfNeeded()
     }
 
     func updateTranscriptionModel(_ newModel: String) {
         transcriptionModel = newModel
         logger.info("Updated transcription model to: \(newModel)")
 
-        // Preheat local whisper model if it's Local transcription provider
-        preheatLocalTranscriptionModelIfNeeded()
-    }
-    
-    private func preheatLocalTranscriptionModelIfNeeded() {
-        guard transcriptionProvider == .local,
-              !transcriptionModel.isEmpty else {
-            return
-        }
-
-        if let localModel = TranscriptionModelProvider.allLocalModels.first(where: { $0.name == transcriptionModel }) {
-            Task {
-                try? await transcriptionManager.preheatLocalModel(localModel)
-                logger.info("Preheated local model: \(localModel.name)")
-            }
-        }
     }
     
     // MARK: - Language Settings

--- a/VivaDicta/Whisper/LibWhisper.swift
+++ b/VivaDicta/Whisper/LibWhisper.swift
@@ -25,11 +25,6 @@ actor WhisperContext {
 
     deinit {
         whisper_free(context)
-//        if let context = context {
-//            whisper_free(context)
-//        }
-        
-        
     }
 
     func fullTranscribe(samples: [Float]) -> Bool {
@@ -120,10 +115,7 @@ actor WhisperContext {
         let whisperContext = WhisperContext()
         try await whisperContext.initializeModel(path: path)
         
-        // Load VAD model from bundle resources
-        // TODO: Add Vad
-//        let vadModelPath = await VADModelManager.shared.getModelPath()
-//        await whisperContext.setVADModelPath(vadModelPath)
+        // VAD model loading can be added here if needed in the future
         
         return whisperContext
     }


### PR DESCRIPTION
## Summary
- Implemented on-demand whisper model loading to prevent iOS from killing the app due to memory pressure
- Model now loads only when transcription starts, not when selected
- This approach is similar to VoiceInk's implementation and significantly reduces idle RAM usage

## Changes
- ✅ Removed `whisperContext` property from TranscriptionManager
- ✅ Removed `preheatLocalModel()` method and all preheating logic  
- ✅ Modified LocalTranscriptionService to create/release WhisperContext on each use
- ✅ Cleaned up dead code and TODO comments in LibWhisper.swift
- ✅ Updated ModeEditViewModel to remove preheating calls

## Testing
- Built successfully with no compilation errors
- Model loading occurs only when transcription starts
- Resources are properly released after each transcription

## Impact
This change introduces a small loading delay when starting transcription but prevents iOS from terminating the app due to excessive memory usage when idle.

## Linear Issue
Fixes [VIV-60](https://linear.app/antonnovoselov/issue/VIV-60/load-whisper-model-when-transcribe-starts-not-preheat)