### PR TITLE
Limit CoreML usage to Medium and smaller models only (VIV-68)

### DIFF
--- a/VivaDicta/Models/WhisperLocalModel.swift
+++ b/VivaDicta/Models/WhisperLocalModel.swift
@@ -41,7 +41,15 @@ extension WhisperLocalModel {
     var coreMLDownloadURL: URL? {
         // Only non-quantized models have Core ML versions
         guard !name.contains("q5") && !name.contains("q8") else { return nil }
+
+        // Skip CoreML for Large and Large-Turbo models (too big for Apple Neural Engine)
+        guard !isLargeModel else { return nil }
+
         return URL(string: "\(Self.defaultURL)ggml-\(name)-encoder.mlmodelc.zip")
+    }
+
+    var isLargeModel: Bool {
+        name.contains("large")
     }
     
     var fileURL: URL {

--- a/VivaDictaTests/VivaDictaTests.swift
+++ b/VivaDictaTests/VivaDictaTests.swift
@@ -6,15 +6,79 @@
 //
 
 import Testing
+@testable import VivaDicta
 
 struct VivaDictaTests {
 
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions
-        #expect(true)
-        
-        
-        
+    @Test func testCoreMLRestrictedToMediumAndSmaller() async throws {
+        // Get all local models from TranscriptionModelProvider
+        let allLocalModels = TranscriptionModelProvider.allLocalModels
+
+        for model in allLocalModels {
+            if model.name.contains("large") {
+                // Large models should not have CoreML URL
+                #expect(model.coreMLDownloadURL == nil, "Large model '\(model.name)' should not have CoreML URL")
+            } else if model.name.contains("q5") || model.name.contains("q8") {
+                // Quantized models should not have CoreML URL
+                #expect(model.coreMLDownloadURL == nil, "Quantized model '\(model.name)' should not have CoreML URL")
+            } else if model.name.contains("tiny") || model.name.contains("base") ||
+                      model.name.contains("small") || model.name.contains("medium") {
+                // Small/Medium models should have CoreML URL
+                #expect(model.coreMLDownloadURL != nil, "Model '\(model.name)' should have CoreML URL")
+            }
+        }
+    }
+
+    @Test func testIsLargeModelProperty() async throws {
+        // Test the isLargeModel property directly
+        let largeModel = WhisperLocalModel(
+            name: "large-v3",
+            displayName: "Large v3",
+            description: "Test",
+            size: "3GB",
+            speed: 1.0,
+            accuracy: 1.0,
+            ramUsage: 3.0,
+            supportedLanguages: [:]
+        )
+
+        let largeTurboModel = WhisperLocalModel(
+            name: "large-v3-turbo",
+            displayName: "Large v3 Turbo",
+            description: "Test",
+            size: "1.5GB",
+            speed: 2.0,
+            accuracy: 0.95,
+            ramUsage: 1.5,
+            supportedLanguages: [:]
+        )
+
+        let mediumModel = WhisperLocalModel(
+            name: "medium",
+            displayName: "Medium",
+            description: "Test",
+            size: "1.5GB",
+            speed: 2.0,
+            accuracy: 0.9,
+            ramUsage: 1.5,
+            supportedLanguages: [:]
+        )
+
+        let tinyModel = WhisperLocalModel(
+            name: "tiny",
+            displayName: "Tiny",
+            description: "Test",
+            size: "39MB",
+            speed: 10.0,
+            accuracy: 0.7,
+            ramUsage: 0.1,
+            supportedLanguages: [:]
+        )
+
+        #expect(largeModel.isLargeModel == true, "large-v3 should be identified as large model")
+        #expect(largeTurboModel.isLargeModel == true, "large-v3-turbo should be identified as large model")
+        #expect(mediumModel.isLargeModel == false, "medium should not be identified as large model")
+        #expect(tinyModel.isLargeModel == false, "tiny should not be identified as large model")
     }
 
 }


### PR DESCRIPTION
## Summary

This PR restricts CoreML model usage to Medium and smaller Whisper models, preventing Large and Large-Turbo models from attempting to load into Apple Neural Engine where they fail due to size constraints.

### Problem
- Large and Large-Turbo models are too big for Apple Neural Engine
- When these models try to load CoreML, they fail and fall back to slow CPU execution
- This creates unnecessary download overhead and runtime issues

### Solution
- Added `isLargeModel` property to identify Large models
- Modified `coreMLDownloadURL` to return nil for Large models
- CoreML now only downloads for: Tiny, Base, Small, and Medium models

## Changes

- **WhisperLocalModel.swift**: Added logic to skip CoreML for Large models
- **VivaDictaTests.swift**: Added comprehensive unit tests to verify the restriction

## Testing

✅ Unit tests added and passing:
- `testCoreMLRestrictedToMediumAndSmaller`: Verifies all models have correct CoreML availability
- `testIsLargeModelProperty`: Tests the model size detection logic

✅ Build successful with no warnings for the main changes

## Performance Impact

This change improves performance for Large model users by:
- Reducing download size (no unnecessary CoreML download)  
- Preventing failed ANE loading attempts
- Using optimized Metal/CPU paths directly

## Linear Issue

Closes [VIV-68](https://linear.app/antonnovoselov/issue/VIV-68/limit-coreml-usage-to-medium-and-smaller-models-only)

🤖 Generated with [Claude Code](https://claude.ai/code)