### PR TITLE
[VIV-55] Add flow mode deletion with swipe gestures in Settings

### DIFF
--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -20,14 +20,16 @@ struct SettingsView: View {
             Form {
                 // Modes section
                 Section("Modes") {
-                    
+
                     ForEach(appState.aiService.modes) { mode in
                         NavigationLink(value: mode) {
                             Text(mode.name)
                                 .font(.body.weight(.medium))
                         }
                     }
-                    
+                    .onDelete(perform: deleteMode)
+                    .deleteDisabled(appState.aiService.modes.count <= 1)
+
                     // Add New Mode button
                     NavigationLink(
                         destination: ModeEditView(
@@ -41,13 +43,13 @@ struct SettingsView: View {
                                     Image(systemName: "plus.circle.fill")
                                         .foregroundColor(.blue)
                                         .font(.title2)
-                                    
+
                                     Text("Add New Mode")
                                         .foregroundColor(.blue)
                                         .font(.body)
-                                    
+
                                     Spacer()
-                                    
+
                                 }
                             }
                 }
@@ -85,7 +87,17 @@ struct SettingsView: View {
                     PromptsSettings(promptsManager: promptsManager)
                 }
             }
-            
+
+        }
+    }
+
+    private func deleteMode(at offsets: IndexSet) {
+        // Prevent deletion if there's only one mode
+        guard appState.aiService.modes.count > 1 else { return }
+
+        for index in offsets {
+            let mode = appState.aiService.modes[index]
+            appState.aiService.deleteMode(mode)
         }
     }
 }

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -26,9 +26,16 @@ struct SettingsView: View {
                             Text(mode.name)
                                 .font(.body.weight(.medium))
                         }
+                        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                            if appState.aiService.modes.count > 1 {
+                                Button(role: .destructive) {
+                                    deleteMode(mode)
+                                } label: {
+                                    Label("Delete", systemImage: "trash")
+                                }
+                            }
+                        }
                     }
-                    .onDelete(perform: deleteMode)
-                    .deleteDisabled(appState.aiService.modes.count <= 1)
 
                     // Add New Mode button
                     NavigationLink(
@@ -91,14 +98,11 @@ struct SettingsView: View {
         }
     }
 
-    private func deleteMode(at offsets: IndexSet) {
+    private func deleteMode(_ mode: FlowMode) {
         // Prevent deletion if there's only one mode
         guard appState.aiService.modes.count > 1 else { return }
 
-        for index in offsets {
-            let mode = appState.aiService.modes[index]
-            appState.aiService.deleteMode(mode)
-        }
+        appState.aiService.deleteMode(mode)
     }
 }
 


### PR DESCRIPTION
## Summary
- Implemented swipe-to-delete functionality for flow modes in the Settings screen
- Added protection to prevent deletion of the last remaining mode
- Disabled automatic deletion on full swipe - users must explicitly tap the Delete button

## Changes
- Added `.swipeActions` modifier to flow mode cells with a Delete button
- Implemented `deleteMode` function that checks mode count before deletion
- Set `allowsFullSwipe: false` to require explicit confirmation
- Delete button only appears when there's more than one mode

## Testing
- ✅ Swipe gesture shows Delete button on flow mode cells
- ✅ Cannot delete the last remaining mode (button doesn't appear)
- ✅ Full swipe to the left doesn't trigger automatic deletion
- ✅ Explicit tap on Delete button is required to confirm deletion
- ✅ Build succeeds without warnings

## Notes
- Uses existing `AIService.deleteMode()` method which already has safety checks
- Improves UX by preventing accidental deletions