### PR TITLE
VIV-69: Hide 'Add new mode' button when no models available

### DIFF
--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -14,7 +14,19 @@ struct SettingsView: View {
 
     @State var navigationPath = NavigationPath()
     @AppStorage("IsVADEnabled") private var isVADEnabled = true
-    
+
+    private var hasAvailableModels: Bool {
+        // Check if any local models are downloaded
+        let hasLocalModels = appState.transcriptionManager.availableWhisperLocalModels.count > 0
+
+        // Check if any cloud models are configured (have API keys)
+        let hasConfiguredCloudModels = TranscriptionModelProvider.allCloudModels.contains { model in
+            model.apiKey != nil
+        }
+
+        return hasLocalModels || hasConfiguredCloudModels
+    }
+
     var body: some View {
         NavigationStack(path: $navigationPath) {
             Form {
@@ -37,28 +49,30 @@ struct SettingsView: View {
                         }
                     }
 
-                    // Add New Mode button
-                    NavigationLink(
-                        destination: ModeEditView(
-                            mode: nil,
-                            aiService: appState.aiService,
-                            promptsManager: promptsManager,
-                            transcriptionManager: appState.transcriptionManager,
-                            selectedTab: $appState.selectedTab,
-                            navigationPath: $navigationPath)) {
-                                HStack {
-                                    Image(systemName: "plus.circle.fill")
-                                        .foregroundColor(.blue)
-                                        .font(.title2)
+                    // Add New Mode button - only show if models are available
+                    if hasAvailableModels {
+                        NavigationLink(
+                            destination: ModeEditView(
+                                mode: nil,
+                                aiService: appState.aiService,
+                                promptsManager: promptsManager,
+                                transcriptionManager: appState.transcriptionManager,
+                                selectedTab: $appState.selectedTab,
+                                navigationPath: $navigationPath)) {
+                                    HStack {
+                                        Image(systemName: "plus.circle.fill")
+                                            .foregroundColor(.blue)
+                                            .font(.title2)
 
-                                    Text("Add New Mode")
-                                        .foregroundColor(.blue)
-                                        .font(.body)
+                                        Text("Add New Mode")
+                                            .foregroundColor(.blue)
+                                            .font(.body)
 
-                                    Spacer()
+                                        Spacer()
 
+                                    }
                                 }
-                            }
+                    }
                 }
                 
                 Section("Transcription") {

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -8,31 +8,31 @@
 import SwiftUI
 
 struct SettingsView: View {
-
+    
     @Bindable var appState: AppState
     @State var promptsManager = PromptsManager()
-
+    
     @State var navigationPath = NavigationPath()
     @AppStorage("IsVADEnabled") private var isVADEnabled = true
-
+    
     private var hasAvailableModels: Bool {
         // Check if any local models are downloaded
         let hasLocalModels = appState.transcriptionManager.availableWhisperLocalModels.count > 0
-
+        
         // Check if any cloud models are configured (have API keys)
         let hasConfiguredCloudModels = TranscriptionModelProvider.allCloudModels.contains { model in
             model.apiKey != nil
         }
-
+        
         return hasLocalModels || hasConfiguredCloudModels
     }
-
+    
     var body: some View {
         NavigationStack(path: $navigationPath) {
             Form {
                 // Modes section
                 Section("Modes") {
-
+                    
                     ForEach(appState.aiService.modes) { mode in
                         NavigationLink(value: mode) {
                             Text(mode.name)
@@ -48,7 +48,7 @@ struct SettingsView: View {
                             }
                         }
                     }
-
+                    
                     // Add New Mode button - only show if models are available
                     if hasAvailableModels {
                         NavigationLink(
@@ -63,15 +63,23 @@ struct SettingsView: View {
                                         Image(systemName: "plus.circle.fill")
                                             .foregroundColor(.blue)
                                             .font(.title2)
-
+                                        
                                         Text("Add New Mode")
                                             .foregroundColor(.blue)
                                             .font(.body)
-
+                                        
                                         Spacer()
-
+                                        
                                     }
                                 }
+                    } else {
+                        HStack {
+                            Image(systemName: "info.circle")
+                                .foregroundStyle(.secondary)
+                            Text("Download models or configure API keys to add new modes")
+                                .foregroundStyle(.secondary)
+                                .font(.footnote)
+                        }
                     }
                 }
                 
@@ -86,7 +94,7 @@ struct SettingsView: View {
                         }
                     }
                 }
-
+                
                 Section("AI Enhancement") {
                     NavigationLink(value: SettingsDestination.promptsSettings) {
                         Text("LLM Prompts")
@@ -108,14 +116,14 @@ struct SettingsView: View {
                     PromptsSettings(promptsManager: promptsManager)
                 }
             }
-
+            
         }
     }
-
+    
     private func deleteMode(_ mode: FlowMode) {
         // Prevent deletion if there's only one mode
         guard appState.aiService.modes.count > 1 else { return }
-
+        
         appState.aiService.deleteMode(mode)
     }
 }
@@ -130,7 +138,7 @@ struct SettingsView: View {
 enum SettingsError: LocalizedError {
     case duplicateModeName(String)
     case unexpectedError(String)
-
+    
     var errorDescription: String? {
         switch self {
         case .duplicateModeName(_):
@@ -139,7 +147,7 @@ enum SettingsError: LocalizedError {
             "Unexpected Error"
         }
     }
-
+    
     var failureReason: String {
         switch self {
         case .duplicateModeName(let name):


### PR DESCRIPTION
## Summary
This PR addresses VIV-69 by hiding the "Add new mode" button in the Settings view when there are no transcription models available for use.

## Changes
- Added `hasAvailableModels` computed property in `SettingsView` that checks:
  - Whether any local Whisper models are downloaded
  - Whether any cloud models have API keys configured
- Wrapped the "Add new mode" button in a conditional statement to only display when models are available

## Problem Solved
Previously, users could click "Add new mode" even when they had no transcription models configured or downloaded, which would lead to a confusing experience where they couldn't actually use the mode they created. Now the button is only shown when there's at least one working model available.

## Test Plan
- [x] Build succeeds without errors
- [ ] Verify button is hidden when no local models are downloaded AND no cloud APIs are configured  
- [ ] Verify button appears when at least one local model is downloaded
- [ ] Verify button appears when at least one cloud API key is configured
- [ ] Verify existing modes continue to work as expected