### PR TITLE
VIV-56: Add mode picker to Record screen

### DIFF
--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -135,21 +135,21 @@ class AIService {
             modes = [FlowMode.defaultMode]
         }
         
-        logger.info("Loaded \(self.modes.count) AI enhance modes")
+        logger.info("Loaded \(self.modes.count) Flow Modes")
     }
     
     private func saveModes() {
         guard let encoded = try? JSONEncoder().encode(modes) else {
-            logger.error("Failed to encode AI enhance modes")
+            logger.error("Failed to encode Flow Modes")
             return
         }
         userDefaults.set(encoded, forKey: "AIEnhanceModes")
-        logger.info("Saved \(self.modes.count) AI enhance modes")
+        logger.info("Saved \(self.modes.count) Flow Modes")
     }
     
     private func saveSelectedModeName(_ modeName: String) {
         userDefaults.setValue(modeName, forKey: Constants.kSelectedAIMode)
-        logger.info("Saved AI enhance mode: \(modeName)")
+        logger.info("Saved Flow Mode: \(modeName)")
     }
     
     private func loadSavedOpenRouterModels() {

--- a/VivaDicta/Views/RecordView.swift
+++ b/VivaDicta/Views/RecordView.swift
@@ -12,8 +12,7 @@ struct RecordView: View {
     @Environment(\.modelContext) var modelContext
     @State var vm: RecordViewModel
     @State var isSymbolAnimating = false
-
-    var appState: AppState
+    @Bindable var appState: AppState
 
     var body: some View {
         if appState.transcriptionManager.getCurrentTranscriptionModel() != nil {
@@ -39,6 +38,7 @@ struct RecordView: View {
     
     var modelSelectedView: some View {
         VStack(spacing: 16) {
+            modePicker
             Spacer()
             SiriWaveView(power: $vm.audioPower)
                 .opacity(vm.siriWaveFormOpacity)
@@ -128,6 +128,23 @@ struct RecordView: View {
                 .font(.system(size: 44))
         }
         .buttonStyle(.borderless)
+    }
+
+    var modePicker: some View {
+        HStack {
+            Spacer()
+
+            Picker("Mode", selection: $appState.aiService.selectedModeName) {
+                ForEach(appState.aiService.modes, id: \.name) { mode in
+                    Text(mode.name)
+                        .tag(mode.name)
+                }
+            }
+            .pickerStyle(.menu)
+            .tint(.primary)
+        }
+        .padding(.horizontal)
+        .padding(.top)
     }
 }
 

--- a/VivaDicta/Views/RecordView.swift
+++ b/VivaDicta/Views/RecordView.swift
@@ -12,16 +12,15 @@ struct RecordView: View {
     @Environment(\.modelContext) var modelContext
     @State var vm: RecordViewModel
     @State var isSymbolAnimating = false
-    @Bindable var appState: AppState
 
     var body: some View {
-        if appState.transcriptionManager.getCurrentTranscriptionModel() != nil {
+        if vm.transcriptionManager.getCurrentTranscriptionModel() != nil {
             modelSelectedView
 
         } else {
             Button {
-                appState.shouldNavigateToModels = true
-                appState.selectedTab = .settings
+                vm.appState?.shouldNavigateToModels = true
+                vm.appState?.selectedTab = .settings
             } label: {
                 Text("Select transcription model")
             }
@@ -29,11 +28,7 @@ struct RecordView: View {
     }
 
     init(appState: AppState) {
-        self.appState = appState
-        self._vm = State(wrappedValue: RecordViewModel(
-            transcriptionManager: appState.transcriptionManager,
-            aiService: appState.aiService
-        ))
+        self._vm = State(wrappedValue: RecordViewModel(appState: appState))
     }
     
     var modelSelectedView: some View {
@@ -134,8 +129,8 @@ struct RecordView: View {
         HStack {
             Spacer()
 
-            Picker("Mode", selection: $appState.aiService.selectedModeName) {
-                ForEach(appState.aiService.modes, id: \.name) { mode in
+            Picker("Mode", selection: $vm.selectedModeName) {
+                ForEach(vm.availableModes, id: \.name) { mode in
                     Text(mode.name)
                         .tag(mode.name)
                 }

--- a/VivaDicta/Views/RecordViewModel.swift
+++ b/VivaDicta/Views/RecordViewModel.swift
@@ -62,20 +62,32 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
     #if !os(macOS)
     var recordingSession = AVAudioSession.sharedInstance()
     #endif
-    
+
     var animationTimer: Timer?
-    
-//    var transcriptionService: TranscriptionService?
-    private let transcriptionManager: TranscriptionManager
-    private let aiService: AIService?
+
+    weak var appState: AppState?
+    public var transcriptionManager: TranscriptionManager {
+        appState?.transcriptionManager ?? TranscriptionManager()
+    }
+    public var aiService: AIService {
+        appState?.aiService ?? AIService()
+    }
+
+    var selectedModeName: String {
+        get { appState?.aiService.selectedModeName ?? "" }
+        set { appState?.aiService.selectedModeName = newValue }
+    }
+
+    var availableModes: [FlowMode] {
+        appState?.aiService.modes ?? []
+    }
 
     // TODO: Add auto stop feature later
 //    var recordingTimer: Timer?
 //    var prevAudioPower: Double?
 
-    init(transcriptionManager: TranscriptionManager, aiService: AIService? = nil) {
-        self.transcriptionManager = transcriptionManager
-        self.aiService = aiService
+    init(appState: AppState) {
+        self.appState = appState
         super.init()
     }
     
@@ -213,7 +225,7 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
                 let audioDuration = (try? CMTimeGetSeconds(await audioAsset.load(.duration))) ?? 0.0
 
                 // Check if AI Enhancement is properly configured
-                if let aiService = aiService, aiService.isProperlyConfigured() {
+                if aiService.isProperlyConfigured() {
                     
                     do {
                         let (enhancedText, enhancementDuration, promptName) = try await aiService.enhance(transcribedText)

--- a/VivaDicta/Views/RecordViewModel.swift
+++ b/VivaDicta/Views/RecordViewModel.swift
@@ -10,14 +10,14 @@ import Foundation
 import AVFoundation
 import SwiftData
 
-enum RecordingState {
+enum RecordingState: Equatable {
     case idle
     case recording
     case transcribing
     case error(RecordError)
 }
 
-enum RecordError: LocalizedError {
+enum RecordError: LocalizedError, Equatable {
     case avInitError
     case userDenied
     case recordError

--- a/VivaDicta/Views/SettingsScreen/ModeEditView.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditView.swift
@@ -49,8 +49,8 @@ struct ModeEditView: View {
                         Text(provider.rawValue.capitalized).tag(provider)
                     }
                 }
-                .tint(.primary)
-                .pickerStyle(.menu)
+//                .tint(.primary)
+//                .pickerStyle(.menu)
                 .onChange(of: viewModel.transcriptionProvider) { _, newProvider in
                     viewModel.updateTranscriptionProvider(newProvider)
                 }

--- a/VivaDicta/Views/SettingsScreen/ModeEditView.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditView.swift
@@ -41,13 +41,16 @@ struct ModeEditView: View {
                 TextField("Mode Name", text: $viewModel.modeName)
             }
             
-            Section("Transcription") {
+            Section(header: Text("Transcription"),
+                    footer: Text(viewModel.transcriptionFooterText)) {
+                
                 Picker("Provider", selection: $viewModel.transcriptionProvider) {
                     ForEach(TranscriptionModelProvider.allCases) { provider in
                         Text(provider.rawValue.capitalized).tag(provider)
                     }
                 }
-                .pickerStyle(.navigationLink)
+                .tint(.primary)
+                .pickerStyle(.menu)
                 .onChange(of: viewModel.transcriptionProvider) { _, newProvider in
                     viewModel.updateTranscriptionProvider(newProvider)
                 }
@@ -83,7 +86,7 @@ struct ModeEditView: View {
                         } label: {
                             HStack {
                                 Image(systemName: "arrow.down.circle")
-                                Text("Download Local Model")
+                                Text("Download Local Transcription Model")
                                 Spacer()
                                 Image(systemName: "chevron.right")
                                     .foregroundColor(.secondary)

--- a/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
@@ -29,6 +29,22 @@ class ModeEditViewModel {
     
     private let originalMode: FlowMode?
     
+    private var hasAvailableTranscriptionModels: Bool {
+        // Check if any local models are downloaded
+        let hasLocalModels = transcriptionManager.availableWhisperLocalModels.count > 0
+        
+        // Check if any cloud models are configured (have API keys)
+        let hasConfiguredCloudModels = TranscriptionModelProvider.allCloudModels.contains { model in
+            model.apiKey != nil
+        }
+        
+        return hasLocalModels || hasConfiguredCloudModels
+    }
+    
+    public var transcriptionFooterText: String {
+        hasAvailableTranscriptionModels ? "" : "No transcription models available. Download a local model or add an API key for a cloud model."
+    }
+    
     var isEditing: Bool {
         originalMode != nil
     }

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -15,7 +15,7 @@ struct SettingsView: View {
     @State var navigationPath = NavigationPath()
     @AppStorage("IsVADEnabled") private var isVADEnabled = true
     
-    private var hasAvailableModels: Bool {
+    private var hasAvailableTranscriptionModels: Bool {
         // Check if any local models are downloaded
         let hasLocalModels = appState.transcriptionManager.availableWhisperLocalModels.count > 0
         
@@ -50,7 +50,7 @@ struct SettingsView: View {
                     }
                     
                     // Add New Mode button - only show if models are available
-                    if hasAvailableModels {
+                    if hasAvailableTranscriptionModels {
                         NavigationLink(
                             destination: ModeEditView(
                                 mode: nil,


### PR DESCRIPTION
## Summary
- Added a mode picker to the Record screen for quick transcription mode switching
- Users can now change transcription modes on-the-fly, even during recording
- Improved UX with cleaner, more accessible mode selection

## Changes
- **RecordView.swift**: Added mode picker UI with menu-style selection
- **RecordViewModel.swift**: Made RecordingState and RecordError Equatable for proper state comparisons
- **ModeEditView.swift**: Enhanced UI with better picker styling and helpful footer text
- **ModeEditViewModel.swift**: Added logic to show informative footer when no models are available

## Features
- Mode picker positioned at the top of the Record screen for easy access
- Can switch modes during recording - the selected mode at stop time will be used for transcription
- Clean, primary-colored UI that matches the app's design language
- Helpful feedback when no transcription models are available

## Testing
- Built successfully with Xcode
- Mode picker properly displays all available modes
- Mode changes persist and affect transcription behavior
- UI remains responsive during recording state changes

## Notes
- The mode change takes effect when recording stops, not when it starts
- This allows users to decide on the best transcription mode after hearing their recording