### PR TITLE
VIV-57: Implement separate directories for models and audio files

### DIFF
--- a/VivaDicta/Extensions/FileManager+Directories.swift
+++ b/VivaDicta/Extensions/FileManager+Directories.swift
@@ -1,0 +1,50 @@
+//
+//  FileManager+Directories.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2025.09.28
+//
+
+import Foundation
+
+extension FileManager {
+    enum DirectoryType {
+        case models
+        case audio
+        case parakeetModels
+
+        var folderName: String {
+            switch self {
+            case .models:
+                return "Models"
+            case .audio:
+                return "Audio"
+            case .parakeetModels:
+                return "Models/Parakeet"
+            }
+        }
+    }
+
+    static func appDirectory(for type: DirectoryType) -> URL {
+        let documentsDirectory = URL.documentsDirectory
+        let directory = documentsDirectory.appendingPathComponent(type.folderName)
+
+        // Create directory if it doesn't exist
+        if !FileManager.default.fileExists(atPath: directory.path) {
+            try? FileManager.default.createDirectory(
+                at: directory,
+                withIntermediateDirectories: true,
+                attributes: nil
+            )
+        }
+
+        return directory
+    }
+
+    static func createAppDirectories() {
+        // Create all necessary directories on app launch
+        _ = appDirectory(for: .models)
+        _ = appDirectory(for: .audio)
+        _ = appDirectory(for: .parakeetModels)
+    }
+}

--- a/VivaDicta/Models/ParakeetModel.swift
+++ b/VivaDicta/Models/ParakeetModel.swift
@@ -30,7 +30,7 @@ struct ParakeetModel: @MainActor TranscriptionModel, Equatable {
 // MARK: - Download & File Management
 extension ParakeetModel {
     var modelsDirectory: URL {
-        URL.documentsDirectory.appendingPathComponent("parakeet-tdt-0.6b-v3-coreml")
+        FileManager.appDirectory(for: .parakeetModels).appendingPathComponent("parakeet-tdt-0.6b-v3-coreml")
     }
 
     var isDownloaded: Bool {

--- a/VivaDicta/Models/WhisperLocalModel.swift
+++ b/VivaDicta/Models/WhisperLocalModel.swift
@@ -53,7 +53,7 @@ extension WhisperLocalModel {
     }
     
     var fileURL: URL {
-        URL.documentsDirectory.appendingPathComponent(filename)
+        FileManager.appDirectory(for: .models).appendingPathComponent(filename)
     }
     
     var fileExists: Bool {

--- a/VivaDicta/Services/ModelDownloadManager.swift
+++ b/VivaDicta/Services/ModelDownloadManager.swift
@@ -105,17 +105,17 @@ class ModelDownloadManager: @unchecked Sendable {
         let progressKeyCoreML = model.name + "_coreml"
         let coreMLData = try await downloadFileWithProgress(from: url, progressKey: progressKeyCoreML)
 
-        let coreMLZipPath = URL.documentsDirectory.appendingPathComponent("ggml-\(model.name)-encoder.mlmodelc.zip")
+        let coreMLZipPath = FileManager.appDirectory(for: .models).appendingPathComponent("ggml-\(model.name)-encoder.mlmodelc.zip")
         try coreMLData.write(to: coreMLZipPath)
 
         try await unzipAndSetupCoreMLModel(for: model, zipPath: coreMLZipPath, progressKey: progressKeyCoreML)
     }
 
     private func unzipAndSetupCoreMLModel(for model: WhisperLocalModel, zipPath: URL, progressKey: String) async throws {
-        let coreMLDestination = URL.documentsDirectory.appendingPathComponent("ggml-\(model.name)-encoder.mlmodelc")
+        let coreMLDestination = FileManager.appDirectory(for: .models).appendingPathComponent("ggml-\(model.name)-encoder.mlmodelc")
 
         try? FileManager.default.removeItem(at: coreMLDestination)
-        try Zip.unzipFile(zipPath, destination: URL.documentsDirectory, overwrite: true, password: nil)
+        try Zip.unzipFile(zipPath, destination: FileManager.appDirectory(for: .models), overwrite: true, password: nil)
         try verifyAndCleanupCoreMLFiles(model, coreMLDestination, zipPath, progressKey)
     }
 
@@ -174,7 +174,7 @@ class ModelDownloadManager: @unchecked Sendable {
             async let vadDownload = DownloadUtils.loadModels(
                 .vad,
                 modelNames: Array(ModelNames.VAD.requiredModels),
-                directory: URL.documentsDirectory
+                directory: FileManager.appDirectory(for: .parakeetModels)
             )
 
             _ = try await (asrDownload, vadDownload)
@@ -206,7 +206,7 @@ class ModelDownloadManager: @unchecked Sendable {
     // MARK: - Common Download Utilities
 
     private func downloadFileWithProgress(from url: URL, progressKey: String) async throws -> Data {
-        let destinationURL = URL.documentsDirectory.appendingPathComponent(UUID().uuidString)
+        let destinationURL = FileManager.appDirectory(for: .models).appendingPathComponent(UUID().uuidString)
 
         return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Data, Error>) in
             let task = URLSession.shared.downloadTask(with: url) { tempURL, response, error in

--- a/VivaDicta/Services/Transcription/ParakeetTranscriptionService.swift
+++ b/VivaDicta/Services/Transcription/ParakeetTranscriptionService.swift
@@ -93,10 +93,10 @@ class ParakeetTranscriptionService: TranscriptionService {
 
         // Initialize VAD manager if needed
         if vadManager == nil {
-            // VAD models are stored in documents directory
+            // VAD models are stored in parakeet models directory
             vadManager = try await VadManager(
                 config: vadConfig,
-                modelDirectory: URL.documentsDirectory
+                modelDirectory: FileManager.appDirectory(for: .parakeetModels)
             )
         }
 

--- a/VivaDicta/Views/AudioPlayerView.swift
+++ b/VivaDicta/Views/AudioPlayerView.swift
@@ -192,7 +192,7 @@ struct AudioPlayerView: View {
     @State private var playerManager = AudioPlayerManager()
     
     private var audioURL: URL? {
-        URL.documentsDirectory.appendingPathComponent(audioFileName)
+        FileManager.appDirectory(for: .audio).appendingPathComponent(audioFileName)
     }
     
     var body: some View {

--- a/VivaDicta/Views/RecordViewModel.swift
+++ b/VivaDicta/Views/RecordViewModel.swift
@@ -94,7 +94,7 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
     var transcribingSpeechTask: Task<Void, Never>?
     
     var captureURL: URL {
-        URL.documentsDirectory.appendingPathComponent("recording.m4a")
+        FileManager.appDirectory(for: .audio).appendingPathComponent("recording.m4a")
     }
     
     var recordingState: RecordingState = .idle {
@@ -203,7 +203,7 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
     
     func stopCaptureAudio(modelContext: ModelContext) {
         resetValues()
-        let finalURL = URL.documentsDirectory.appendingPathComponent("\(UUID().uuidString).m4a")
+        let finalURL = FileManager.appDirectory(for: .audio).appendingPathComponent("\(UUID().uuidString).m4a")
         do {
             try FileManager.default.moveItem(at: captureURL, to: finalURL)
             transcribingSpeechTask = transcribeSpeechTask(recordURL: finalURL, modelContext: modelContext)

--- a/VivaDicta/Views/TranscriptionsView.swift
+++ b/VivaDicta/Views/TranscriptionsView.swift
@@ -107,7 +107,7 @@ struct TranscriptionsView: View {
             let transcription = displayedTranscriptions[index]
             
             if let audioFileName = transcription.audioFileName {
-                let audioURL = URL.documentsDirectory.appendingPathComponent(audioFileName)
+                let audioURL = FileManager.appDirectory(for: .audio).appendingPathComponent(audioFileName)
                 try? FileManager.default.removeItem(at: audioURL)
             }
             

--- a/VivaDicta/VivaDictaApp.swift
+++ b/VivaDicta/VivaDictaApp.swift
@@ -10,6 +10,11 @@ import SwiftData
 
 @main
 struct VivaDictaApp: App {
+    init() {
+        // Initialize app directories
+        FileManager.createAppDirectories()
+    }
+
     var body: some Scene {
         WindowGroup {
             TabBarView()


### PR DESCRIPTION
## Summary
This PR implements dedicated directories for different types of files in the app to improve organization and maintainability.

## Changes
- **Created FileManager extension** with directory management utilities
- **Implemented separate directories**:
  - `Documents/Models/` - Whisper models and Core ML files
  - `Documents/Models/Parakeet/` - Parakeet-specific models  
  - `Documents/Audio/` - Recorded audio files
- **Updated all file operations** to use the new directory structure:
  - WhisperLocalModel now saves to Models directory
  - ParakeetModel now saves to Models/Parakeet directory
  - Audio recordings save to Audio directory
  - Model downloads go to appropriate directories
- **App initialization** creates directories on launch

## Technical Details
- Added `FileManager.appDirectory(for:)` method to centralize directory management
- Directories are created automatically if they don't exist
- No migration logic included as app hasn't been released yet

## Testing
- ✅ App builds successfully
- ✅ Directories are created on app launch
- ✅ Models download to correct locations
- ✅ Audio files save to Audio directory

## Breaking Changes
None - this is a pre-release change

## Related Issue
Closes VIV-57