### PR TITLE
Add Parakeet V2 and V3 model support with proper version handling

### DIFF
--- a/VivaDicta/Models/ParakeetModel.swift
+++ b/VivaDicta/Models/ParakeetModel.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-//import FluidAudio
+import FluidAudio
 
 struct ParakeetModel: @MainActor TranscriptionModel, Equatable {
     static func == (lhs: ParakeetModel, rhs: ParakeetModel) -> Bool {
@@ -22,17 +22,29 @@ struct ParakeetModel: @MainActor TranscriptionModel, Equatable {
     let accuracy: Double
     let ramUsage: Double
 
-    let supportManyLanguages = true
+    var supportManyLanguages: Bool {
+        supportedLanguages.count > 1
+    }
 
     let supportedLanguages: [String: String]
 }
 
 // MARK: - Download & File Management
 extension ParakeetModel {
-    var modelsDirectory: URL {
-        FileManager.appDirectory(for: .parakeetModels).appendingPathComponent("parakeet-tdt-0.6b-v3-coreml")
+    var version: AsrModelVersion {
+        name.lowercased().contains("v2") ? .v2 : .v3
     }
-
+    
+    var modelsDirectory: URL {
+        switch version {
+        case .v2:
+            FileManager.appDirectory(for: .parakeetModels).appendingPathComponent("parakeet-tdt-0.6b-v2-coreml")
+        case .v3:
+            FileManager.appDirectory(for: .parakeetModels).appendingPathComponent("parakeet-tdt-0.6b-v3-coreml")
+        }
+        
+    }
+    
     var isDownloaded: Bool {
         FileManager.default.fileExists(atPath: modelsDirectory.path)
     }

--- a/VivaDicta/Models/TranscriptionModelProvider.swift
+++ b/VivaDicta/Models/TranscriptionModelProvider.swift
@@ -139,15 +139,25 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
     static var allParakeetModels: [ParakeetModel] {
         [
             ParakeetModel(
-                name: "parakeet-tdt-0.6b",
-                displayName: "Parakeet",
-                description: "NVIDIA's ASR model for lightning-fast transcription with multi-lingual support.",
-                size: "630 MB",
+                name: "parakeet-tdt-0.6b-v3",
+                displayName: "Parakeet V3",
+                description: "NVIDIA's Parakeet V3 model with multilingual support across English and 25 European languages.",
+                size: "494 MB",
                 speed: 0.99,
                 accuracy: 0.94,
                 ramUsage: 0.8,
                 supportedLanguages: allLanguages
-            )
+            ),
+            ParakeetModel(
+                name: "parakeet-tdt-0.6b-v2",
+                displayName: "Parakeet V2",
+                description: "NVIDIA's Parakeet V2 model optimized for lightning-fast English-only transcription.",
+                size: "474 MB",
+                speed: 0.99,
+                accuracy: 0.94,
+                ramUsage: 0.8,
+                supportedLanguages: getLanguageDictionary(supportManyLanguages: false)
+            ),
         ]
     }
 

--- a/VivaDicta/Services/ModelDownloadManager.swift
+++ b/VivaDicta/Services/ModelDownloadManager.swift
@@ -65,6 +65,10 @@ class ModelDownloadManager: @unchecked Sendable {
 
 
     // MARK: - Parakeet Model Download
+//    
+//    private func parakeetVersion(for modelName: String) -> AsrModelVersion {
+//        modelName.lowercased().contains("v2") ? .v2 : .v3
+//    }
 
     private func downloadParakeetModel(_ model: ParakeetModel) async throws {
         await MainActor.run {
@@ -90,7 +94,7 @@ class ModelDownloadManager: @unchecked Sendable {
         }
 
         do {
-            async let asrDownload = AsrModels.downloadAndLoad(to: model.modelsDirectory, version: .v3)
+            async let asrDownload = AsrModels.downloadAndLoad(to: model.modelsDirectory, version: model.version)
             async let vadDownload = DownloadUtils.loadModels(
                 .vad,
                 modelNames: Array(ModelNames.VAD.requiredModels),

--- a/VivaDicta/Services/Transcription/ParakeetTranscriptionService.swift
+++ b/VivaDicta/Services/Transcription/ParakeetTranscriptionService.swift
@@ -16,16 +16,16 @@ class ParakeetTranscriptionService: TranscriptionService {
 
     init() {}
 
-    func loadModel(modelsDirectory: URL) async throws {
+    func loadModel(model: ParakeetModel) async throws {
         guard asrManager == nil else {
             return
         }
-        
+
         do {
             let manager = AsrManager(config: .default)
-            let models = try await AsrModels.load(from: modelsDirectory)
+            let models = try await AsrModels.load(from: model.modelsDirectory, version: model.version)
             try await manager.initialize(models: models)
-            
+
             self.asrManager = manager
             logger.logNotice("✅ Parakeet ASR model loaded successfully")
         } catch {
@@ -39,7 +39,7 @@ class ParakeetTranscriptionService: TranscriptionService {
             throw TranscriptionError.unsupportedModel
         }
         
-        try await loadModel(modelsDirectory: parakeetModel.modelsDirectory)
+        try await loadModel(model: parakeetModel)
         
         guard let asrManager = asrManager else {
             logger.logNotice("🦜 ASR manager not initialized, cannot transcribe")


### PR DESCRIPTION
## Summary
- Added support for both Parakeet V2 (English-only, optimized) and V3 (multilingual) models
- Fixed model version loading to ensure correct version is loaded based on configuration
- Improved model management with explicit version passing to FluidAudio SDK

## Changes Made
- **ParakeetModel.swift**: Added version property to distinguish between V2 and V3 models
- **TranscriptionModelProvider.swift**: Added both Parakeet V2 and V3 models to available models list
- **ParakeetTranscriptionService.swift**: Updated to pass explicit version when loading models via `AsrModels.load(from:version:)`
- **ModelDownloadManager.swift**: Enhanced download logic to handle version-specific model downloads

## Key Improvements
- Parakeet V2: Optimized for English-only transcription with better performance
- Parakeet V3: Supports 25+ European languages including English
- Proper version handling ensures the correct model variant is loaded
- Fixed issue where V3 was being loaded even when V2 was configured

## Testing
- [x] Built successfully with no compilation errors
- [x] Model loading works with explicit version parameter
- [x] V2 model loads correctly for English-only mode
- [x] V3 model loads correctly for multilingual mode
- [x] Transcription works with both model versions

## Breaking Changes
None - existing Parakeet functionality is preserved

## Notes
- The fix ensures that `AsrModels.load()` receives the explicit version parameter, preventing version mismatch issues
- Both models share the same VAD (Voice Activity Detection) components
- Models are cleaned up from memory after transcription to minimize RAM usage