### PR TITLE
VIV-78: Add instant keyboard recording toggle to Settings

### DIFF
--- a/VivaDicta/Services/AudioPrewarmManager.swift
+++ b/VivaDicta/Services/AudioPrewarmManager.swift
@@ -37,6 +37,9 @@ final class AudioPrewarmManager {
     // Audio level for visualization (0.0 to 1.0)
     private(set) var currentAudioLevel: Float = 0.0
 
+    // Observable property for session state
+    private(set) var isSessionActiveObservable: Bool = false
+
     private let logger = Logger(subsystem: "com.antonnovoselov.VivaDicta", category: "AudioPrewarmManager")
 
     /// Returns true if the prewarm session is active
@@ -96,6 +99,9 @@ final class AudioPrewarmManager {
         // Setup session timeout
         scheduleSessionTimeout()
 
+        // Update observable state
+        isSessionActiveObservable = true
+
         logger.logInfo("🎙️ Prewarm session started successfully")
     }
 
@@ -132,6 +138,9 @@ final class AudioPrewarmManager {
         expiryTimer = nil
 
         sessionStartTime = nil
+
+        // Update observable state
+        isSessionActiveObservable = false
 
         #if !os(macOS)
         do {

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -18,8 +18,6 @@ struct SettingsView: View {
     @State private var prewarmManager = AudioPrewarmManager.shared
     @State private var showPrewarmError = false
     @State private var prewarmErrorMessage = ""
-    @State private var isSessionActive = false
-    @State private var sessionCheckTimer: Timer?
     
     var body: some View {
         NavigationStack(path: $navigationPath) {
@@ -110,7 +108,7 @@ struct SettingsView: View {
                                     .foregroundStyle(.blue)
                                     .font(.body)
 
-                                if isSessionActive {
+                                if prewarmManager.isSessionActiveObservable {
                                     HStack {
                                         Circle()
                                             .fill(.green)
@@ -127,7 +125,7 @@ struct SettingsView: View {
                             Spacer()
                         }
                     }
-                    .disabled(isSessionActive)
+                    .disabled(prewarmManager.isSessionActiveObservable)
                     .buttonStyle(.plain)
 
                     VStack(alignment: .leading, spacing: 8) {
@@ -176,12 +174,6 @@ struct SettingsView: View {
                 appState.shouldNavigateToModels = false
                 navigationPath.append(SettingsDestination.transcriptionModels)
             }
-            // Check initial session state
-            isSessionActive = prewarmManager.isSessionActive
-            startSessionMonitoring()
-        }
-        .onDisappear {
-            stopSessionMonitoring()
         }
         .alert("Prewarm Session Error", isPresented: $showPrewarmError) {
             Button("OK") {
@@ -211,31 +203,10 @@ struct SettingsView: View {
                 timeoutSeconds: prewarmManager.audioSessionTimeout
             )
 
-            // Update local state to trigger UI update
-            isSessionActive = true
-
         } catch {
             prewarmErrorMessage = "Failed to activate session: \(error.localizedDescription)"
             showPrewarmError = true
         }
-    }
-
-    private func startSessionMonitoring() {
-        stopSessionMonitoring()
-        // Check session status every second
-        sessionCheckTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
-            Task { @MainActor in
-                let currentStatus = AudioPrewarmManager.shared.isSessionActive
-                if isSessionActive != currentStatus {
-                    isSessionActive = currentStatus
-                }
-            }
-        }
-    }
-
-    private func stopSessionMonitoring() {
-        sessionCheckTimer?.invalidate()
-        sessionCheckTimer = nil
     }
 }
 

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -11,10 +11,14 @@ struct SettingsView: View {
 
     var appState: AppState
     @State var promptsManager = PromptsManager()
-    
+
     @State var navigationPath = NavigationPath()
     @AppStorage("IsVADEnabled") private var isVADEnabled = true
     @AppStorage("audioSessionTimeout") private var audioSessionTimeout = 180
+    @State private var prewarmManager = AudioPrewarmManager.shared
+    @State private var currentTime = Date()
+    @State private var showPrewarmError = false
+    @State private var prewarmErrorMessage = ""
     
     var body: some View {
         NavigationStack(path: $navigationPath) {
@@ -93,26 +97,59 @@ struct SettingsView: View {
                     }
                 }
 
-                Section("Audio") {
-                    Picker("Session Timeout", selection: $audioSessionTimeout) {
-                        Text("Immediate").tag(0)
-                        Text("15 seconds").tag(15)
-                        Text("30 seconds").tag(30)
-                        Text("60 seconds").tag(60)
-                        Text("90 seconds").tag(90)
-                        Text("2 minutes").tag(120)
-                        Text("3 minutes").tag(180)
-                        Text("5 minutes").tag(300)
-                        Text("15 minutes").tag(900)
-                        Text("30 minutes").tag(1800)
-                        Text("1 hour").tag(3600)
-                    }
-                    .pickerStyle(.menu)
-                    .tint(.primary)
+                Section("Keyboard") {
+                    Button(action: activateKeyboardRecordingSession) {
+                        HStack {
+                            Image(systemName: "keyboard")
+                                .foregroundStyle(.blue)
+                                .font(.body)
+                            
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("Enable Keyboard Recording Session")
+                                    .foregroundStyle(.blue)
+                                    .font(.body)
 
-                    Text("Keep microphone session active after recording stops to prevent activation errors during consecutive recordings.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                                if prewarmManager.isSessionActive {
+                                    HStack {
+                                        Circle()
+                                            .fill(.green)
+                                            .frame(width: 6)
+                                            
+                                        Text("Session active")
+                                            .font(.caption)
+                                            .foregroundStyle(.green)
+                                    }
+                                    
+                                }
+                            }
+
+                            Spacer()
+                        }
+                    }
+                    .disabled(prewarmManager.isSessionActive)
+                    .buttonStyle(.plain)
+
+                    VStack(alignment: .leading, spacing: 8) {
+                        Picker("Session Timeout", selection: $audioSessionTimeout) {
+                            Text("Immediate").tag(0)
+                            Text("15 seconds").tag(15)
+                            Text("30 seconds").tag(30)
+                            Text("60 seconds").tag(60)
+                            Text("90 seconds").tag(90)
+                            Text("2 minutes").tag(120)
+                            Text("3 minutes").tag(180)
+                            Text("5 minutes").tag(300)
+                            Text("15 minutes").tag(900)
+                            Text("30 minutes").tag(1800)
+                            Text("1 hour").tag(3600)
+                        }
+                        .pickerStyle(.menu)
+                        .tint(.primary)
+
+                        Text("Keep microphone session active to allow recording from keyboard")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
                 }
             }
             .navigationDestination(for: FlowMode.self) { mode in
@@ -138,14 +175,78 @@ struct SettingsView: View {
                 appState.shouldNavigateToModels = false
                 navigationPath.append(SettingsDestination.transcriptionModels)
             }
+            startSessionUpdateTimer()
+        }
+        .onDisappear {
+            stopSessionUpdateTimer()
+        }
+        .alert("Prewarm Session Error", isPresented: $showPrewarmError) {
+            Button("OK") {
+                showPrewarmError = false
+            }
+        } message: {
+            Text(prewarmErrorMessage)
         }
     }
     
     private func deleteMode(_ mode: FlowMode) {
         // Prevent deletion if there's only one mode
         guard appState.aiService.modes.count > 1 else { return }
-        
+
         appState.aiService.deleteMode(mode)
+    }
+
+    // MARK: - Keyboard Recording Session Actions
+
+    private func activateKeyboardRecordingSession() {
+        do {
+            // Start the pre-warm session (same as when receiving deep link)
+            try prewarmManager.startPrewarmSession()
+
+            // Activate keyboard session to notify keyboard that hot mic is ready
+            AppGroupCoordinator.shared.activateKeyboardSession(
+                timeoutSeconds: prewarmManager.audioSessionTimeout
+            )
+
+            // Start timer to update UI
+            startSessionUpdateTimer()
+
+        } catch {
+            prewarmErrorMessage = "Failed to activate session: \(error.localizedDescription)"
+            showPrewarmError = true
+        }
+    }
+
+    private func endKeyboardRecordingSession() {
+        prewarmManager.endSession()
+        stopSessionUpdateTimer()
+    }
+
+    private func startSessionUpdateTimer() {
+        Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
+            Task { @MainActor in
+                // Update time to trigger view refresh
+                currentTime = Date()
+            }
+        }
+    }
+
+    private func stopSessionUpdateTimer() {
+        // Timer will be automatically invalidated when view disappears
+    }
+
+    private func formatTimeout(_ seconds: Int) -> String {
+        if seconds == 0 {
+            return "immediate"
+        } else if seconds < 60 {
+            return "\(seconds) seconds"
+        } else if seconds < 3600 {
+            let minutes = seconds / 60
+            return minutes == 1 ? "1 minute" : "\(minutes) minutes"
+        } else {
+            let hours = seconds / 3600
+            return hours == 1 ? "1 hour" : "\(hours) hours"
+        }
     }
 }
 

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -15,7 +15,7 @@ struct SettingsView: View {
     @State var navigationPath = NavigationPath()
     @AppStorage("IsVADEnabled") private var isVADEnabled = true
     @AppStorage("audioSessionTimeout") private var audioSessionTimeout = 180
-    @State private var prewarmManager = AudioPrewarmManager.shared
+    private let prewarmManager = AudioPrewarmManager.shared
     @State private var showPrewarmError = false
     @State private var prewarmErrorMessage = ""
     

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -18,6 +18,8 @@ struct SettingsView: View {
     @State private var prewarmManager = AudioPrewarmManager.shared
     @State private var showPrewarmError = false
     @State private var prewarmErrorMessage = ""
+    @State private var isSessionActive = false
+    @State private var sessionCheckTimer: Timer?
     
     var body: some View {
         NavigationStack(path: $navigationPath) {
@@ -108,24 +110,24 @@ struct SettingsView: View {
                                     .foregroundStyle(.blue)
                                     .font(.body)
 
-                                if prewarmManager.isSessionActive {
+                                if isSessionActive {
                                     HStack {
                                         Circle()
                                             .fill(.green)
                                             .frame(width: 6)
-                                            
+
                                         Text("Session active")
                                             .font(.caption)
                                             .foregroundStyle(.green)
                                     }
-                                    
+
                                 }
                             }
 
                             Spacer()
                         }
                     }
-                    .disabled(prewarmManager.isSessionActive)
+                    .disabled(isSessionActive)
                     .buttonStyle(.plain)
 
                     VStack(alignment: .leading, spacing: 8) {
@@ -174,6 +176,12 @@ struct SettingsView: View {
                 appState.shouldNavigateToModels = false
                 navigationPath.append(SettingsDestination.transcriptionModels)
             }
+            // Check initial session state
+            isSessionActive = prewarmManager.isSessionActive
+            startSessionMonitoring()
+        }
+        .onDisappear {
+            stopSessionMonitoring()
         }
         .alert("Prewarm Session Error", isPresented: $showPrewarmError) {
             Button("OK") {
@@ -203,10 +211,31 @@ struct SettingsView: View {
                 timeoutSeconds: prewarmManager.audioSessionTimeout
             )
 
+            // Update local state to trigger UI update
+            isSessionActive = true
+
         } catch {
             prewarmErrorMessage = "Failed to activate session: \(error.localizedDescription)"
             showPrewarmError = true
         }
+    }
+
+    private func startSessionMonitoring() {
+        stopSessionMonitoring()
+        // Check session status every second
+        sessionCheckTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
+            Task { @MainActor in
+                let currentStatus = AudioPrewarmManager.shared.isSessionActive
+                if isSessionActive != currentStatus {
+                    isSessionActive = currentStatus
+                }
+            }
+        }
+    }
+
+    private func stopSessionMonitoring() {
+        sessionCheckTimer?.invalidate()
+        sessionCheckTimer = nil
     }
 }
 

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -16,7 +16,6 @@ struct SettingsView: View {
     @AppStorage("IsVADEnabled") private var isVADEnabled = true
     @AppStorage("audioSessionTimeout") private var audioSessionTimeout = 180
     @State private var prewarmManager = AudioPrewarmManager.shared
-    @State private var currentTime = Date()
     @State private var showPrewarmError = false
     @State private var prewarmErrorMessage = ""
     
@@ -175,10 +174,6 @@ struct SettingsView: View {
                 appState.shouldNavigateToModels = false
                 navigationPath.append(SettingsDestination.transcriptionModels)
             }
-            startSessionUpdateTimer()
-        }
-        .onDisappear {
-            stopSessionUpdateTimer()
         }
         .alert("Prewarm Session Error", isPresented: $showPrewarmError) {
             Button("OK") {
@@ -208,44 +203,9 @@ struct SettingsView: View {
                 timeoutSeconds: prewarmManager.audioSessionTimeout
             )
 
-            // Start timer to update UI
-            startSessionUpdateTimer()
-
         } catch {
             prewarmErrorMessage = "Failed to activate session: \(error.localizedDescription)"
             showPrewarmError = true
-        }
-    }
-
-    private func endKeyboardRecordingSession() {
-        prewarmManager.endSession()
-        stopSessionUpdateTimer()
-    }
-
-    private func startSessionUpdateTimer() {
-        Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
-            Task { @MainActor in
-                // Update time to trigger view refresh
-                currentTime = Date()
-            }
-        }
-    }
-
-    private func stopSessionUpdateTimer() {
-        // Timer will be automatically invalidated when view disappears
-    }
-
-    private func formatTimeout(_ seconds: Int) -> String {
-        if seconds == 0 {
-            return "immediate"
-        } else if seconds < 60 {
-            return "\(seconds) seconds"
-        } else if seconds < 3600 {
-            let minutes = seconds / 60
-            return minutes == 1 ? "1 minute" : "\(minutes) minutes"
-        } else {
-            let hours = seconds / 3600
-            return hours == 1 ? "1 hour" : "\(hours) hours"
         }
     }
 }


### PR DESCRIPTION
## Summary
Adds a button in Settings to manually activate the pre-warm session for instant keyboard recording, providing the same functionality as the Deep Link from keyboard extension.

## Changes
- ✅ Added "Enable Keyboard Recording Session" button in new Keyboard section in Settings
- ✅ Moved session timeout picker to Keyboard section for better UX organization  
- ✅ Real-time session status indicator with green dot when active
- ✅ Button automatically disables when session is already active
- ✅ Implemented proper Observable pattern for reactive UI updates without timers

## Technical Implementation
- Added `isSessionActiveObservable` stored property to `AudioPrewarmManager` for proper SwiftUI observation
- Settings screen directly observes this property for instant UI updates
- Session activation uses the same `startPrewarmSession()` and `AppGroupCoordinator.activateKeyboardSession()` flow as Deep Link
- Removed initial timer-based polling approach in favor of cleaner Observable pattern

## Testing Performed
- ✅ Verified button activates pre-warm session successfully
- ✅ Confirmed green "Session active" indicator appears immediately on activation
- ✅ Tested session expiration - indicator disappears automatically when session times out
- ✅ Verified button becomes disabled while session is active
- ✅ Confirmed keyboard extension can still record when session is pre-warmed from Settings

## Screenshots
Button shows in Settings > Keyboard section with clear status indication

## Breaking Changes
None - This is an additive feature that doesn't affect existing functionality

## Notes
- Session timeout is configurable via the picker (15s to 1 hour options)
- Uses the same pre-warm infrastructure as the keyboard extension Deep Link
- Provides users manual control over keyboard recording readiness