### PR TITLE
VIV-76: Add animated sparkles for AI enhancement state

### DIFF
--- a/VivaDicta/Views/RecordView.swift
+++ b/VivaDicta/Views/RecordView.swift
@@ -95,6 +95,17 @@ struct RecordView: View {
 
                 Text("Transcribing...")
             }
+        case .enhancing:
+            VStack(spacing: 12) {
+                Image(systemName: "sparkles")
+                    .symbolEffect(.bounce.up.byLayer, options: .repeat(.periodic(delay: 0.3)), value: isSymbolAnimating)
+                    .font(.system(size: 80))
+                    .foregroundStyle(.blue)
+                    .onAppear { isSymbolAnimating = true }
+                    .onDisappear { isSymbolAnimating = false }
+
+                Text("Enhancing with AI...")
+            }
         default: EmptyView()
         }
     }

--- a/VivaDicta/Views/RecordViewModel.swift
+++ b/VivaDicta/Views/RecordViewModel.swift
@@ -16,6 +16,7 @@ enum RecordingState: Equatable {
     case idle
     case recording
     case transcribing
+    case enhancing
     case error(RecordError)
 }
 
@@ -424,6 +425,9 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
                 
                 // Check if AI Enhancement is properly configured
                 if aiService.isProperlyConfigured() {
+                    // Update state to show enhancing animation
+                    self.recordingState = .enhancing
+
                     // Notify keyboard that AI enhancement has started
                     AppGroupCoordinator.shared.updateTranscriptionStatus(.enhancing)
 


### PR DESCRIPTION
## Summary
Adds animated sparkles SF Symbol to visually indicate when AI is enhancing transcribed text in the RecordView, providing clear user feedback during the enhancement phase.

## Changes
- ✅ Added new `enhancing` state to `RecordingState` enum
- ✅ Modified transcription flow to set enhancement state when AI processing begins
- ✅ Added sparkles SF Symbol with bounce animation for AI enhancement
- ✅ Display "Enhancing with AI..." text during enhancement

## Visual Implementation
- **Symbol**: `sparkles` SF Symbol
- **Animation**: Bounce by layer with 0.3s periodic delay
- **Color**: Blue for visual distinction
- **Text**: "Enhancing with AI..." for clarity

## Testing Performed
- ✅ Verified build succeeds without errors
- ✅ Confirmed animation triggers when AI enhancement starts
- ✅ Tested state transitions: Recording → Transcribing → Enhancing → Idle
- ✅ Verified animation matches keyboard extension pattern

## User Flow
1. User starts recording (microphone button visible)
2. Recording stops → Shows animated pencil "Transcribing..."
3. Transcription completes → Shows animated sparkles "Enhancing with AI..."
4. Enhancement completes → Returns to idle state (microphone button)

## Notes
- Animation pattern matches the keyboard extension for consistency
- Only shows enhancement state when AI service is properly configured
- Gracefully handles enhancement failures by returning to idle state

## Related
- Follows similar pattern to keyboard extension processing animations
- Part of improved user feedback during transcription workflow