### PR TITLE
Add widget deeplink support for instant recording

### DIFF
--- a/VivaDicta.xcodeproj/project.pbxproj
+++ b/VivaDicta.xcodeproj/project.pbxproj
@@ -110,6 +110,7 @@
 		18E1C8192E8E79D100BE8A11 /* Exceptions for "VivaDicta" folder in "VivaDictaWidgetExtension" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
+				Intents/ToggleRecordIntent.swift,
 				Models/VivaDictaLiveActivityAttributes.swift,
 				Utilities/LoggerExtension.swift,
 			);

--- a/VivaDicta.xcodeproj/project.pbxproj
+++ b/VivaDicta.xcodeproj/project.pbxproj
@@ -110,6 +110,7 @@
 		18E1C8192E8E79D100BE8A11 /* Exceptions for "VivaDicta" folder in "VivaDictaWidgetExtension" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
+				AppGroupCoordinator.swift,
 				Intents/ToggleRecordIntent.swift,
 				Models/VivaDictaLiveActivityAttributes.swift,
 				Utilities/LoggerExtension.swift,

--- a/VivaDicta/AppGroupCoordinator.swift
+++ b/VivaDicta/AppGroupCoordinator.swift
@@ -55,6 +55,7 @@ public final class AppGroupCoordinator {
         static let transcriptionError = "com.antonnovoselov.VivaDicta.transcriptionError"
         static let audioLevelUpdated = "com.antonnovoselov.VivaDicta.audioLevelUpdated"
         static let stopHotMicFromWidget = "com.antonnovoselov.VivaDicta.stopHotMicFromWidget"
+        static let startRecordingFromControl = "com.antonnovoselov.VivaDicta.startRecordingFromControl"
     }
 
     public enum TranscriptionStatus: String {
@@ -85,6 +86,7 @@ public final class AppGroupCoordinator {
     @MainActor var onAudioLevelUpdated: ((CGFloat) -> Void)?
     @MainActor var onRecordingStateChanged: ((Bool) -> Void)?
     @MainActor var onStopHotMicFromWidget: (() -> Void)?
+    @MainActor var onStartRecordingFromControl: (() -> Void)?
 
     // MARK: - Initialization
     private init() {
@@ -120,6 +122,10 @@ public final class AppGroupCoordinator {
         let timestamp = Date().timeIntervalSince1970
         sharedDefaults?.set(timestamp, forKey: UserDefaultsKeys.lastRecordingTimestamp)
         postDarwinNotification(NotificationNames.startRecording)
+    }
+
+    public func requestStartRecordingFromControl() {
+        postDarwinNotification(NotificationNames.startRecordingFromControl)
     }
 
     public func requestStopRecording() {
@@ -487,6 +493,19 @@ public final class AppGroupCoordinator {
             nil,
             .deliverImmediately
         )
+
+        CFNotificationCenterAddObserver(
+            center,
+            Unmanaged.passUnretained(self).toOpaque(),
+            { (center, observer, name, object, userInfo) in
+                guard let observer = observer else { return }
+                let coordinator = Unmanaged<AppGroupCoordinator>.fromOpaque(observer).takeUnretainedValue()
+                coordinator.handleStartRecordingFromControlNotification()
+            },
+            NotificationNames.startRecordingFromControl as CFString,
+            nil,
+            .deliverImmediately
+        )
     }
 
     nonisolated private func removeNotificationObservers() {
@@ -596,6 +615,12 @@ public final class AppGroupCoordinator {
         // Trust the notification and stop immediately
         Task { @MainActor in
             await onStopHotMicFromWidget?()
+        }
+    }
+
+    nonisolated private func handleStartRecordingFromControlNotification() {
+        Task { @MainActor in
+            await onStartRecordingFromControl?()
         }
     }
 }

--- a/VivaDicta/Intents/ToggleRecordIntent.swift
+++ b/VivaDicta/Intents/ToggleRecordIntent.swift
@@ -9,25 +9,33 @@ import AppIntents
 import SwiftUI
 
 struct ToggleRecordIntent: AppIntent {
-    
-    static let title: LocalizedStringResource = "Start Recording"
-    static let description = IntentDescription("Start recording in VivaDicta")
+
+    static let title: LocalizedStringResource = "Toggle Recording"
+    static let description = IntentDescription("Toggle recording in VivaDicta")
 
     static let openAppWhenRun: Bool = true
-    
+
     @available(iOS 26.0, *)
     static let supportedModes: IntentModes = .foreground(.immediate)
 
 
     func perform() async throws -> some IntentResult {
-        // Use Darwin notification to communicate with the main app
-        // This is consistent with how keyboard extension communicates
-        Task { @MainActor in
-            AppGroupCoordinator.shared.requestStartRecordingFromControl()
+        // Check current recording state and toggle accordingly
+        await MainActor.run {
+            let coordinator = AppGroupCoordinator.shared
+            let isCurrentlyRecording = coordinator.isRecording
+
+            if isCurrentlyRecording {
+                // If recording, stop it
+                coordinator.requestStopRecording()
+            } else {
+                // If not recording, start it from Control Center
+                coordinator.requestStartRecordingFromControl()
+            }
         }
 
         // The app will open due to openAppWhenRun = true
-        // and will receive the notification to start recording
+        // and will receive the appropriate notification
 
         return .result()
     }

--- a/VivaDicta/Intents/ToggleRecordIntent.swift
+++ b/VivaDicta/Intents/ToggleRecordIntent.swift
@@ -14,6 +14,9 @@ struct ToggleRecordIntent: AppIntent {
     static let description = IntentDescription("Start recording in VivaDicta")
 
     static let openAppWhenRun: Bool = true
+    
+    @available(iOS 26.0, *)
+    static let supportedModes: IntentModes = .foreground(.immediate)
 
 
     func perform() async throws -> some IntentResult {

--- a/VivaDicta/Intents/ToggleRecordIntent.swift
+++ b/VivaDicta/Intents/ToggleRecordIntent.swift
@@ -6,19 +6,26 @@
 //
 
 import AppIntents
+import SwiftUI
 
 struct ToggleRecordIntent: AppIntent {
-    static let title: LocalizedStringResource = "Toggle Record"
-    static let description = IntentDescription("Toggles Record in VivaDicta")
     
+    static let title: LocalizedStringResource = "Start Recording"
+    static let description = IntentDescription("Start recording in VivaDicta")
+
     static let openAppWhenRun: Bool = true
-    
-    
+
+
     func perform() async throws -> some IntentResult {
-        
-        
-        
-        
+        // Use Darwin notification to communicate with the main app
+        // This is consistent with how keyboard extension communicates
+        Task { @MainActor in
+            AppGroupCoordinator.shared.requestStartRecordingFromControl()
+        }
+
+        // The app will open due to openAppWhenRun = true
+        // and will receive the notification to start recording
+
         return .result()
     }
 

--- a/VivaDicta/Intents/ToggleRecordIntent.swift
+++ b/VivaDicta/Intents/ToggleRecordIntent.swift
@@ -1,0 +1,25 @@
+//
+//  ToggleRecordIntent.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2025.11.13
+//
+
+import AppIntents
+
+struct ToggleRecordIntent: AppIntent {
+    static let title: LocalizedStringResource = "Toggle Record"
+    static let description = IntentDescription("Toggles Record in VivaDicta")
+    
+    static let openAppWhenRun: Bool = true
+    
+    
+    func perform() async throws -> some IntentResult {
+        
+        
+        
+        
+        return .result()
+    }
+
+}

--- a/VivaDicta/Views/RecordViewModel.swift
+++ b/VivaDicta/Views/RecordViewModel.swift
@@ -619,6 +619,27 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
                 // TODO: Implement resume functionality if needed
             }
         }
+
+        // Handle start recording request from Control Center
+        AppGroupCoordinator.shared.onStartRecordingFromControl = { [weak self] in
+            guard let self = self else { return }
+
+            self.logger.logInfo("📱 Starting recording from Control Center request")
+
+            // Navigate to the Record tab
+            self.appState?.selectedTab = .record
+
+            // Start recording after a small delay to ensure UI is ready
+            Task { @MainActor in
+                try? await Task.sleep(nanoseconds: 100_000_000) // 100ms delay
+
+                // Only start if not already recording
+                if self.recordingState != .recording {
+                    self.startCaptureAudio()
+                    self.logger.logInfo("🎙️ Started recording from Control Center")
+                }
+            }
+        }
     }
 
 }

--- a/VivaDicta/Views/SettingsScreen/ModelsView.swift
+++ b/VivaDicta/Views/SettingsScreen/ModelsView.swift
@@ -56,6 +56,7 @@ struct ModelsView: View {
                     }
                 }
             }
+            .scrollContentBackground(.visible)
         }
         .navigationDestination(item: $cloudModelToConfigure, destination: { model in
             CloudModelConfigurationView(

--- a/VivaDicta/Views/SettingsScreen/Prompts/PromptsSettings.swift
+++ b/VivaDicta/Views/SettingsScreen/Prompts/PromptsSettings.swift
@@ -32,7 +32,7 @@ struct PromptsSettings: View {
                 .navigationTitle("Select Template")
                 .navigationBarTitleDisplayMode(.inline)
 
-                .scrollContentBackground(.hidden)
+                .scrollContentBackground(.visible)
             }
             .navigationTransition(
                 .zoom(sourceID: "info", in: transition)

--- a/VivaDicta/Views/SettingsScreen/Prompts/TemplateSectionView.swift
+++ b/VivaDicta/Views/SettingsScreen/Prompts/TemplateSectionView.swift
@@ -30,5 +30,6 @@ struct TemplateSelectionView: View {
             }
             .buttonStyle(PlainButtonStyle())
         }
+        .scrollContentBackground(.visible)
     }
 }

--- a/VivaDicta/VivaDictaApp.swift
+++ b/VivaDicta/VivaDictaApp.swift
@@ -55,25 +55,27 @@ struct VivaDictaApp: App {
         if url.absoluteString == "vivadicta://record-for-keyboard" {
             logger.logInfo("📱 Recognized as keyboard recording request")
             
-//            appState.startLiveActivity()
+            //            appState.startLiveActivity()
             
-
+            
             // Start audio prewarm session to keep app alive in background
             do {
-//                try AudioSessionManager.shared.startHotMicSession(timeoutSeconds: 180)
+                //                try AudioSessionManager.shared.startHotMicSession(timeoutSeconds: 180)
                 try AudioPrewarmManager.shared.startPrewarmSession()
-
+                
                 // Activate keyboard session to notify keyboard that hot mic is ready
                 AppGroupCoordinator.shared.activateKeyboardSession(
                     timeoutSeconds: AudioPrewarmManager.shared.audioSessionTimeout
                 )
-
+                
                 logger.logInfo("🎙️ Hot Mic and keyboard session activated from deeplink")
-
+                
             } catch {
                 logger.logError("⚠️ Failed to start prewarm session: \(error.localizedDescription)")
             }
-
+        } else if url.absoluteString == "startRecordFromWidget" {
+            logger.logInfo("🎙️ Hot Mic and keyboard session activated from deeplink")
+            
         } else {
             logger.logWarning("📱 Unknown deep link URL: \(url.absoluteString)")
         }

--- a/VivaDicta/VivaDictaApp.swift
+++ b/VivaDicta/VivaDictaApp.swift
@@ -74,8 +74,17 @@ struct VivaDictaApp: App {
                 logger.logError("⚠️ Failed to start prewarm session: \(error.localizedDescription)")
             }
         } else if url.absoluteString == "startRecordFromWidget" {
-            logger.logInfo("🎙️ Hot Mic and keyboard session activated from deeplink")
-            
+            logger.logInfo("📱 Recognized as widget recording request")
+
+            // Navigate to the Record tab
+            appState.selectedTab = .record
+
+            // Start recording automatically after a small delay to ensure UI is ready
+            Task { @MainActor in
+                try? await Task.sleep(nanoseconds: 100_000_000) // 100ms delay
+                appState.recordViewModel.startCaptureAudio()
+                logger.logInfo("🎙️ Started recording from widget deeplink")
+            }
         } else {
             logger.logWarning("📱 Unknown deep link URL: \(url.absoluteString)")
         }

--- a/VivaDictaWidget/AppIntent.swift
+++ b/VivaDictaWidget/AppIntent.swift
@@ -13,17 +13,29 @@ struct ConfigurationAppIntent: WidgetConfigurationIntent {
     static let title: LocalizedStringResource = "Configuration"
     static let description: IntentDescription = "Select color"
 
-    // An example configurable parameter.
-    @Parameter(title: "Color", default: "WidgetColorOrange")
-    var widgetColorString: String
+//    // An example configurable parameter.
+//    @Parameter(title: "Color", default: "WidgetColorOrange")
+//    var widgetColorString: String
+    
+    @Parameter(title: "Color", optionsProvider: ColorOptionsProvider())
+    var widgetColorString: String?
     
     var widgetColor: Color {
-        return Color(widgetColorString)
+        return Color("WidgetColor\(widgetColorString ?? WidgetColor.def.rawValue)")
     }
 }
 
-enum WidgetColor: String {
-    case def = "WidgetColorOrange"
-    case red = "WidgetColorRed"
-    case blue = "WidgetColorBlue"
+struct ColorOptionsProvider: DynamicOptionsProvider {
+    func results() async throws -> [String] {
+        return WidgetColor.allCases.map {$0.rawValue}
+    }
+
+    func defaultResult() async -> String? { WidgetColor.def.rawValue }
+}
+
+enum WidgetColor: String, CaseIterable {
+    case def = "Orange"
+    case red = "Red"
+    case blue = "Blue"
+    case green = "Green"
 }

--- a/VivaDictaWidget/AppIntent.swift
+++ b/VivaDictaWidget/AppIntent.swift
@@ -12,10 +12,6 @@ import AppIntents
 struct ConfigurationAppIntent: WidgetConfigurationIntent {
     static let title: LocalizedStringResource = "Configuration"
     static let description: IntentDescription = "Select color"
-
-//    // An example configurable parameter.
-//    @Parameter(title: "Color", default: "WidgetColorOrange")
-//    var widgetColorString: String
     
     @Parameter(title: "Color", optionsProvider: ColorOptionsProvider())
     var widgetColorString: String?
@@ -27,7 +23,7 @@ struct ConfigurationAppIntent: WidgetConfigurationIntent {
 
 struct ColorOptionsProvider: DynamicOptionsProvider {
     func results() async throws -> [String] {
-        return WidgetColor.allCases.map {$0.rawValue}
+        return WidgetColor.allCases.map { $0.rawValue }
     }
 
     func defaultResult() async -> String? { WidgetColor.def.rawValue }

--- a/VivaDictaWidget/AppIntent.swift
+++ b/VivaDictaWidget/AppIntent.swift
@@ -6,13 +6,24 @@
 //
 
 import WidgetKit
+import SwiftUI
 import AppIntents
 
 struct ConfigurationAppIntent: WidgetConfigurationIntent {
-    static var title: LocalizedStringResource { "Configuration" }
-    static var description: IntentDescription { "This is an example widget." }
+    static let title: LocalizedStringResource = "Configuration"
+    static let description: IntentDescription = "Select color"
 
     // An example configurable parameter.
-    @Parameter(title: "Favorite Emoji", default: "😃")
-    var favoriteEmoji: String
+    @Parameter(title: "Color", default: "WidgetColorOrange")
+    var widgetColorString: String
+    
+    var widgetColor: Color {
+        return Color(widgetColorString)
+    }
+}
+
+enum WidgetColor: String {
+    case def = "WidgetColorOrange"
+    case red = "WidgetColorRed"
+    case blue = "WidgetColorBlue"
 }

--- a/VivaDictaWidget/Assets.xcassets/WidgetColorBlue.colorset/Contents.json
+++ b/VivaDictaWidget/Assets.xcassets/WidgetColorBlue.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "0.563",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "0.746",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/VivaDictaWidget/Assets.xcassets/WidgetColorGreen.colorset/Contents.json
+++ b/VivaDictaWidget/Assets.xcassets/WidgetColorGreen.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.170",
+          "green" : "0.811",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.243",
+          "green" : "0.942",
+          "red" : "0.192"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/VivaDictaWidget/Assets.xcassets/WidgetColorOrange.colorset/Contents.json
+++ b/VivaDictaWidget/Assets.xcassets/WidgetColorOrange.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.723",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.682",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/VivaDictaWidget/Assets.xcassets/WidgetColorRed.colorset/Contents.json
+++ b/VivaDictaWidget/Assets.xcassets/WidgetColorRed.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.029",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.164",
+          "green" : "0.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/VivaDictaWidget/VivaDictaLiveActivity.swift
+++ b/VivaDictaWidget/VivaDictaLiveActivity.swift
@@ -50,7 +50,7 @@ struct VivaDictaLiveActivity: Widget {
                 Image(systemName: "microphone.square.fill")
                     .foregroundStyle(.green)
             }
-            .widgetURL(URL(string: "http://www.apple.com"))
+//            .widgetURL(URL(string: "http://www.apple.com"))
             .keylineTint(Color.red)
         }
     }

--- a/VivaDictaWidget/VivaDictaWidget.swift
+++ b/VivaDictaWidget/VivaDictaWidget.swift
@@ -19,17 +19,9 @@ struct Provider: AppIntentTimelineProvider {
     }
     
     func timeline(for configuration: ConfigurationAppIntent, in context: Context) async -> Timeline<SimpleEntry> {
-        var entries: [SimpleEntry] = []
-
-        // Generate a timeline consisting of five entries an hour apart, starting from the current date.
-        let currentDate = Date()
-        for hourOffset in 0 ..< 5 {
-            let entryDate = Calendar.current.date(byAdding: .hour, value: hourOffset, to: currentDate)!
-            let entry = SimpleEntry(date: entryDate, configuration: configuration)
-            entries.append(entry)
-        }
-
-        return Timeline(entries: entries, policy: .atEnd)
+        let entry = SimpleEntry(date: .now, configuration: configuration)
+        
+        return Timeline(entries: [entry], policy: .never)
     }
 
 //    func relevances() async -> WidgetRelevances<ConfigurationAppIntent> {
@@ -49,8 +41,12 @@ struct VivaDictaWidgetEntryView : View {
         VStack {
             Image(systemName: "mic.circle")
                 .symbolRenderingMode(.hierarchical)
-                .foregroundStyle(entry.configuration.widgetColor)
+                .foregroundStyle(entry.configuration.widgetColor.gradient)
                 .font(.system(size: 80))
+        }
+        .containerBackground(for: .widget) {
+            ContainerRelativeShape()
+                .fill(entry.configuration.widgetColor.opacity(0.1).gradient)
         }
     }
 }
@@ -61,7 +57,6 @@ struct VivaDictaWidget: Widget {
     var body: some WidgetConfiguration {
         AppIntentConfiguration(kind: kind, intent: ConfigurationAppIntent.self, provider: Provider()) { entry in
             VivaDictaWidgetEntryView(entry: entry)
-                .containerBackground(.fill.tertiary, for: .widget)
         }
         .supportedFamilies([.systemSmall])
     }

--- a/VivaDictaWidget/VivaDictaWidget.swift
+++ b/VivaDictaWidget/VivaDictaWidget.swift
@@ -48,7 +48,8 @@ struct VivaDictaWidgetEntryView : View {
     var body: some View {
         VStack {
             Image(systemName: "mic.circle")
-                .symbolRenderingMode(.multicolor)
+                .symbolRenderingMode(.hierarchical)
+                .foregroundStyle(entry.configuration.widgetColor)
                 .font(.system(size: 80))
         }
     }
@@ -67,15 +68,15 @@ struct VivaDictaWidget: Widget {
 }
 
 extension ConfigurationAppIntent {
-    fileprivate static var smiley: ConfigurationAppIntent {
+    fileprivate static var def: ConfigurationAppIntent {
         let intent = ConfigurationAppIntent()
-        intent.favoriteEmoji = "😀"
+        intent.widgetColorString = WidgetColor.def.rawValue
         return intent
     }
     
-    fileprivate static var starEyes: ConfigurationAppIntent {
+    fileprivate static var red: ConfigurationAppIntent {
         let intent = ConfigurationAppIntent()
-        intent.favoriteEmoji = "🤩"
+        intent.widgetColorString = WidgetColor.red.rawValue
         return intent
     }
 }
@@ -83,6 +84,6 @@ extension ConfigurationAppIntent {
 #Preview(as: .systemSmall) {
     VivaDictaWidget()
 } timeline: {
-    SimpleEntry(date: .now, configuration: .smiley)
-    SimpleEntry(date: .now, configuration: .starEyes)
+    SimpleEntry(date: .now, configuration: .def)
+    SimpleEntry(date: .now, configuration: .red)
 }

--- a/VivaDictaWidget/VivaDictaWidget.swift
+++ b/VivaDictaWidget/VivaDictaWidget.swift
@@ -2,11 +2,12 @@
 //  VivaDictaWidget.swift
 //  VivaDictaWidget
 //
-//  Created by Anton Novoselov on 02.10.2025.
+//  Created by Anton Novoselov on 2025.10.02
 //
 
 import WidgetKit
 import SwiftUI
+
 
 struct Provider: AppIntentTimelineProvider {
     func placeholder(in context: Context) -> SimpleEntry {
@@ -46,11 +47,9 @@ struct VivaDictaWidgetEntryView : View {
 
     var body: some View {
         VStack {
-            Text("Time:")
-            Text(entry.date, style: .time)
-
-            Text("Favorite Emoji:")
-            Text(entry.configuration.favoriteEmoji)
+            Image(systemName: "mic.circle")
+                .symbolRenderingMode(.multicolor)
+                .font(.system(size: 80))
         }
     }
 }
@@ -63,6 +62,7 @@ struct VivaDictaWidget: Widget {
             VivaDictaWidgetEntryView(entry: entry)
                 .containerBackground(.fill.tertiary, for: .widget)
         }
+        .supportedFamilies([.systemSmall])
     }
 }
 

--- a/VivaDictaWidget/VivaDictaWidget.swift
+++ b/VivaDictaWidget/VivaDictaWidget.swift
@@ -46,8 +46,11 @@ struct VivaDictaWidgetEntryView : View {
         }
         .containerBackground(for: .widget) {
             ContainerRelativeShape()
-                .fill(entry.configuration.widgetColor.opacity(0.1).gradient)
+                .fill(entry.configuration.widgetColor.gradient.opacity(0.9))
+                .colorInvert()
+                .saturation(0.2)
         }
+        
     }
 }
 

--- a/VivaDictaWidget/VivaDictaWidget.swift
+++ b/VivaDictaWidget/VivaDictaWidget.swift
@@ -35,8 +35,32 @@ struct SimpleEntry: TimelineEntry {
 }
 
 struct VivaDictaWidgetEntryView : View {
+    @Environment(\.widgetFamily) var family
+    
     var entry: Provider.Entry
 
+    var body: some View {
+        
+        switch family {
+        case .systemSmall:
+            WidgetViewSmall(entry: entry)
+        case .accessoryCircular:
+            LockScreenCircularView()
+        case .accessoryRectangular:
+            LockScreenRectangularView()
+        case .accessoryInline:
+            Label("Start record", systemImage: "microphone.circle.fill")
+                .widgetURL(URL(string: "startRecordFromWidget"))
+        case .systemMedium, .systemLarge, .systemExtraLarge:
+            EmptyView()
+        @unknown default:
+            EmptyView()
+        }
+    }
+}
+
+private struct WidgetViewSmall: View {
+    var entry: SimpleEntry
     var body: some View {
         VStack {
             Image(systemName: "mic.circle")
@@ -50,9 +74,46 @@ struct VivaDictaWidgetEntryView : View {
                 .colorInvert()
                 .saturation(0.2)
         }
-        
     }
 }
+
+private struct LockScreenCircularView: View {
+    var body: some View {
+        
+        VStack {
+            Image(systemName: "mic.circle")
+                .symbolRenderingMode(.hierarchical)
+                .foregroundStyle(.orange.gradient)
+                .font(.system(size: 40))
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+        .background {
+            ContainerRelativeShape()
+                .fill(LinearGradient(colors: [.white.opacity(0.5), .clear],
+                                     startPoint: .bottom, endPoint: .top))
+        }
+        .containerBackground(for: .widget) { }
+    }
+}
+
+private struct LockScreenRectangularView: View {
+    var body: some View {
+        
+        VStack {
+            HStack(alignment: .center, spacing: 12) {
+                Image(systemName: "mic.circle")
+                    .symbolRenderingMode(.hierarchical)
+                    .foregroundStyle(.orange.gradient)
+                    .font(.system(size: 40))
+                
+                Text("VivaDicta")
+            }
+        }
+        
+        .containerBackground(for: .widget) { }
+    }
+}
+
 
 struct VivaDictaWidget: Widget {
     let kind: String = "VivaDictaWidget"
@@ -61,7 +122,12 @@ struct VivaDictaWidget: Widget {
         AppIntentConfiguration(kind: kind, intent: ConfigurationAppIntent.self, provider: Provider()) { entry in
             VivaDictaWidgetEntryView(entry: entry)
         }
-        .supportedFamilies([.systemSmall])
+        .configurationDisplayName("VivaDicta")
+        .description("Record Note in VivaDicta")
+        .supportedFamilies([.systemSmall,
+                            .accessoryRectangular,
+                            .accessoryCircular,
+                            .accessoryInline])
     }
 }
 
@@ -79,7 +145,7 @@ extension ConfigurationAppIntent {
     }
 }
 
-#Preview(as: .systemSmall) {
+#Preview(as: .accessoryCircular) {
     VivaDictaWidget()
 } timeline: {
     SimpleEntry(date: .now, configuration: .def)

--- a/VivaDictaWidget/VivaDictaWidget.swift
+++ b/VivaDictaWidget/VivaDictaWidget.swift
@@ -44,10 +44,13 @@ struct VivaDictaWidgetEntryView : View {
         switch family {
         case .systemSmall:
             WidgetViewSmall(entry: entry)
+                .widgetURL(URL(string: "startRecordFromWidget"))
         case .accessoryCircular:
             LockScreenCircularView()
+                .widgetURL(URL(string: "startRecordFromWidget"))
         case .accessoryRectangular:
             LockScreenRectangularView()
+                .widgetURL(URL(string: "startRecordFromWidget"))
         case .accessoryInline:
             Label("Start record", systemImage: "microphone.circle.fill")
                 .widgetURL(URL(string: "startRecordFromWidget"))

--- a/VivaDictaWidget/VivaDictaWidgetBundle.swift
+++ b/VivaDictaWidget/VivaDictaWidgetBundle.swift
@@ -2,7 +2,7 @@
 //  VivaDictaWidgetBundle.swift
 //  VivaDictaWidget
 //
-//  Created by Anton Novoselov on 02.10.2025.
+//  Created by Anton Novoselov on 2025.10.02
 //
 
 import WidgetKit

--- a/VivaDictaWidget/VivaDictaWidgetControl.swift
+++ b/VivaDictaWidget/VivaDictaWidgetControl.swift
@@ -10,50 +10,64 @@ import SwiftUI
 import WidgetKit
 
 struct VivaDictaWidgetControl: ControlWidget {
-    static let kind: String = "com.antonnovoselov.VivaDicta.VivaDictaWidget"
-
     var body: some ControlWidgetConfiguration {
-        AppIntentControlConfiguration(
-            kind: Self.kind,
-            provider: Provider()
-        ) { value in
-            ControlWidgetToggle(
-                "Start Timer",
-                isOn: value.isRunning,
-                action: StartTimerIntent(value.name)
-            ) { isRunning in
-                Label(isRunning ? "On" : "Off", systemImage: "timer")
+        
+        StaticControlConfiguration(kind: "VivaDictaControlWidget") {
+            
+            ControlWidgetButton(action: ToggleRecordIntent()) {
+                Image(systemName: "microphone.circle")
             }
         }
-        .displayName("Timer")
-        .description("A an example control that runs a timer.")
+        
+        
+        .displayName("Toggle Record")
+        .description("Toggle Record in VivaDicta")
     }
 }
 
-extension VivaDictaWidgetControl {
-    struct Value {
-        var isRunning: Bool
-        var name: String
-    }
 
-    struct Provider: AppIntentControlValueProvider {
-        func previewValue(configuration: TimerConfiguration) -> Value {
-            VivaDictaWidgetControl.Value(isRunning: false, name: configuration.timerName)
-        }
 
-        func currentValue(configuration: TimerConfiguration) async throws -> Value {
-            let isRunning = true // Check if the timer is running
-            return VivaDictaWidgetControl.Value(isRunning: isRunning, name: configuration.timerName)
-        }
-    }
-}
 
-struct TimerConfiguration: ControlConfigurationIntent {
-    static let title: LocalizedStringResource = "Timer Name Configuration"
 
-    @Parameter(title: "Timer Name", default: "Timer")
-    var timerName: String
-}
+/// An App Intent that generates a developer horoscope based on a GitHub username.
+///
+/// This intent is used to trigger horoscope generation through system integrations
+/// such as Siri, Shortcuts, or Spotlight. It calls `HoroscopeService` to fetch
+/// the result and returns a `HoroscopeView` to display it.
+///
+/// - Parameters:
+///   - username: The GitHub username used to generate a personalized horoscope.
+/// - Returns: A rendered `HoroscopeView` inside a system snippet UI.
+//struct HoroscopeIntent: AppIntent {
+//    static var parameterSummary: some ParameterSummary {
+//        Summary("Generate a horoscope for \(\.$username)")
+//    }
+//
+//    static var title: LocalizedStringResource = "Horoscope"
+//    static var description = IntentDescription("Generates a horoscope")
+//
+//    @Parameter(title: "Github username")
+//    var username: String
+//
+//    @Dependency
+//    private var horoscopeService: HoroscopeService
+//
+//    func perform() async throws -> some IntentResult & ShowsSnippetView {
+//        let horoscope = try await horoscopeService.horoscope(username: username)
+//        return .result(view: HoroscopeView(horoscope: horoscope))
+//    }
+//}
+
+
+
+
+
+
+
+
+
+
+
 
 struct StartTimerIntent: SetValueIntent {
     static let title: LocalizedStringResource = "Start a timer"

--- a/VivaDictaWidget/VivaDictaWidgetControl.swift
+++ b/VivaDictaWidget/VivaDictaWidgetControl.swift
@@ -2,7 +2,7 @@
 //  VivaDictaWidgetControl.swift
 //  VivaDictaWidget
 //
-//  Created by Anton Novoselov on 02.10.2025.
+//  Created by Anton Novoselov on 2025.10.02
 //
 
 import AppIntents


### PR DESCRIPTION
## Summary
This PR adds support for starting audio recording directly when the app is opened from a widget deeplink. This enables a seamless experience where users can tap a widget and immediately begin recording without additional interaction.

## Changes
- ✨ Added deeplink handler for `startRecordFromWidget` URL in `VivaDictaApp.swift`
- 🎯 Auto-navigation to Record tab when widget deeplink is triggered
- 🎙️ Automatic recording start with a small delay to ensure UI readiness
- 📝 Added logging for debugging widget-triggered recording flow

## Implementation Details
When the app receives the `startRecordFromWidget` deeplink:
1. Immediately switches to the Record tab
2. Waits 100ms for UI to be ready
3. Automatically starts audio recording
4. User sees the recording interface with active recording

## Testing
- ✅ Successfully built and compiled the project
- ✅ Deeplink handler properly integrated with existing navigation
- ✅ Recording starts automatically when triggered via deeplink

## Related Changes
Recent commits in this branch:
- Add widgetURL deeplink support
- Add LockScreen widgets
- UI updates and cleanup

## Breaking Changes
None - this is a non-breaking feature addition.