### PR TITLE
Add bottom sheet for keyboard flow activation

### DIFF
--- a/VivaDicta/AppState.swift
+++ b/VivaDicta/AppState.swift
@@ -29,6 +29,7 @@ class AppState {
     var shouldNavigateToModels: Bool = false
     var shouldStartRecording: Bool = false
     var selectedTranscriptionID: UUID? = nil  // For Spotlight navigation
+    var showKeyboardFlowSheet: Bool = false  // For showing keyboard flow activation sheet
 
     init() {
         transcriptionManager = TranscriptionManager()

--- a/VivaDicta/AppState.swift
+++ b/VivaDicta/AppState.swift
@@ -153,6 +153,7 @@ class AppState {
     /// Check if the Live Activity is stale and end it if necessary
     /// Called when the app returns to foreground
     public func checkAndEndStaleLiveActivity() {
+        
         guard liveActivity != nil,
               let startTime = liveActivityStartTime else { return }
 

--- a/VivaDicta/Views/KeyboardFlowSheet.swift
+++ b/VivaDicta/Views/KeyboardFlowSheet.swift
@@ -73,17 +73,11 @@ struct KeyboardFlowSheet: View {
 //            .debugBorder()
 //            .padding(.bottom, 20)
         }
-        .debugBorder()
-//        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .ignoresSafeArea()
-//        .debugBorder()
-//        .background(Color(.systemGroupedBackground))
-        .onAppear {
-            // Auto-dismiss after a delay if needed
-            DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
-//                appState.showKeyboardFlowSheet = false
-            }
+        .contentShape(.rect)
+        .onTapGesture {
+            appState.showKeyboardFlowSheet = false
         }
+        .ignoresSafeArea()
     }
     
 }

--- a/VivaDicta/Views/KeyboardFlowSheet.swift
+++ b/VivaDicta/Views/KeyboardFlowSheet.swift
@@ -24,40 +24,42 @@ struct KeyboardFlowSheet: View {
             Text("Keyboard Flow Activated")
                 .font(.title)
                 .fontWeight(.bold)
-                .padding(.horizontal)
-                .padding(.top, 40)
+//                .padding(.horizontal)
+                .padding(.top, 20)
+//                .debugBorder()
 
             Spacer()
 
             // Swipe back instruction with arrow icon
             VStack(spacing: 20) {
                 Image(systemName: "arrow.uturn.backward.circle.fill")
-                    .font(.system(size: 60))
-                    .foregroundStyle(.blue)
+                    .font(.system(size: 40))
+                    .foregroundStyle(.orange)
 
                 Text("Swipe back to start using\nVivaDicta dictation")
                     .font(.title3)
                     .fontWeight(.medium)
                     .multilineTextAlignment(.center)
-                    .padding(.horizontal)
+//                    .padding(.horizontal)
             }
+//            .debugBorder()
 
             Spacer()
 
             // Bottom swipe indicator
-            VStack(spacing: 8) {
+            VStack(spacing: 0) {
                 Text("Swipe right from here")
                     .font(.footnote)
                     .foregroundStyle(.secondary)
-                
+
 //                Spacer()
-                
+
                 Capsule()
                     .fill(Color.blue.opacity(0.5))
                     .frame(width: 134, height: 5)
                     .padding(.top, 8)
 //                    .padding(.bottom, 20)
-                
+
                 //                Capsule()
                 //                    .background(.blue)
 //                    .frame(height: 6)
@@ -68,10 +70,14 @@ struct KeyboardFlowSheet: View {
 //                    .scaleEffect(y: 1.5)
 //                    .frame(maxWidth: 200)
             }
-//            .padding(.bottom, 40)
+//            .debugBorder()
+//            .padding(.bottom, 20)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color(.systemGroupedBackground))
+        .debugBorder()
+//        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .ignoresSafeArea()
+//        .debugBorder()
+//        .background(Color(.systemGroupedBackground))
         .onAppear {
             // Auto-dismiss after a delay if needed
             DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
@@ -79,10 +85,28 @@ struct KeyboardFlowSheet: View {
             }
         }
     }
+    
 }
 
-#Preview {
+
+
+#Preview(traits: .transcriptionsMockData) {
     @State @Previewable var appState = AppState()
-
-    KeyboardFlowSheet(appState: appState)
+    MainView(appState: appState)
+        .sheet(isPresented: .constant(true)) {
+            KeyboardFlowSheet(appState: appState)
+                .presentationDetents([.fraction(0.3)])
+                .presentationDragIndicator(.hidden)
+//                .interactiveDismissDisabled(false)
+        }
 }
+
+
+
+//#Preview {
+//    @State @Previewable var appState = AppState()
+//    
+//    
+//
+//    KeyboardFlowSheet(appState: appState)
+//}

--- a/VivaDicta/Views/KeyboardFlowSheet.swift
+++ b/VivaDicta/Views/KeyboardFlowSheet.swift
@@ -10,26 +10,17 @@ import SwiftUI
 struct KeyboardFlowSheet: View {
     @Bindable var appState: AppState
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.scenePhase) private var scenePhase
 
     var body: some View {
         VStack(spacing: 0) {
-            // Handle bar
-//            Capsule()
-//                .fill(Color.secondary.opacity(0.5))
-//                .frame(width: 40, height: 5)
-//                .padding(.top, 8)
-//                .padding(.bottom, 20)
-
-            // Title
             Text("Keyboard Flow Activated")
                 .font(.title)
                 .fontWeight(.bold)
-//                .padding(.horizontal)
                 .padding(.top, 20)
-//                .debugBorder()
-
+            
             Spacer()
-
+            
             // Swipe back instruction with arrow icon
             VStack(spacing: 20) {
                 Image(systemName: "arrow.uturn.backward.circle.fill")
@@ -40,38 +31,20 @@ struct KeyboardFlowSheet: View {
                     .font(.title3)
                     .fontWeight(.medium)
                     .multilineTextAlignment(.center)
-//                    .padding(.horizontal)
             }
-//            .debugBorder()
-
+            
             Spacer()
-
-            // Bottom swipe indicator
+            
             VStack(spacing: 0) {
                 Text("Swipe right from here")
                     .font(.footnote)
                     .foregroundStyle(.secondary)
 
-//                Spacer()
-
                 Capsule()
                     .fill(Color.blue.opacity(0.5))
                     .frame(width: 134, height: 5)
                     .padding(.top, 8)
-//                    .padding(.bottom, 20)
-
-                //                Capsule()
-                //                    .background(.blue)
-//                    .frame(height: 6)
-//                    .frame(maxWidth: 100)
-
-//                ProgressView(value: 0.3)
-//                    .tint(.blue)
-//                    .scaleEffect(y: 1.5)
-//                    .frame(maxWidth: 200)
             }
-//            .debugBorder()
-//            .padding(.bottom, 20)
         }
         .contentShape(.rect)
         .onTapGesture {
@@ -79,10 +52,7 @@ struct KeyboardFlowSheet: View {
         }
         .ignoresSafeArea()
     }
-    
 }
-
-
 
 #Preview(traits: .transcriptionsMockData) {
     @State @Previewable var appState = AppState()
@@ -91,16 +61,6 @@ struct KeyboardFlowSheet: View {
             KeyboardFlowSheet(appState: appState)
                 .presentationDetents([.fraction(0.3)])
                 .presentationDragIndicator(.hidden)
-//                .interactiveDismissDisabled(false)
         }
 }
 
-
-
-//#Preview {
-//    @State @Previewable var appState = AppState()
-//    
-//    
-//
-//    KeyboardFlowSheet(appState: appState)
-//}

--- a/VivaDicta/Views/KeyboardFlowSheet.swift
+++ b/VivaDicta/Views/KeyboardFlowSheet.swift
@@ -1,0 +1,88 @@
+//
+//  KeyboardFlowSheet.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2025.11.21
+//
+
+import SwiftUI
+
+struct KeyboardFlowSheet: View {
+    @Bindable var appState: AppState
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Handle bar
+//            Capsule()
+//                .fill(Color.secondary.opacity(0.5))
+//                .frame(width: 40, height: 5)
+//                .padding(.top, 8)
+//                .padding(.bottom, 20)
+
+            // Title
+            Text("Keyboard Flow Activated")
+                .font(.title)
+                .fontWeight(.bold)
+                .padding(.horizontal)
+                .padding(.top, 40)
+
+            Spacer()
+
+            // Swipe back instruction with arrow icon
+            VStack(spacing: 20) {
+                Image(systemName: "arrow.uturn.backward.circle.fill")
+                    .font(.system(size: 60))
+                    .foregroundStyle(.blue)
+
+                Text("Swipe back to start using\nVivaDicta dictation")
+                    .font(.title3)
+                    .fontWeight(.medium)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal)
+            }
+
+            Spacer()
+
+            // Bottom swipe indicator
+            VStack(spacing: 8) {
+                Text("Swipe right from here")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                
+//                Spacer()
+                
+                Capsule()
+                    .fill(Color.blue.opacity(0.5))
+                    .frame(width: 134, height: 5)
+                    .padding(.top, 8)
+//                    .padding(.bottom, 20)
+                
+                //                Capsule()
+                //                    .background(.blue)
+//                    .frame(height: 6)
+//                    .frame(maxWidth: 100)
+
+//                ProgressView(value: 0.3)
+//                    .tint(.blue)
+//                    .scaleEffect(y: 1.5)
+//                    .frame(maxWidth: 200)
+            }
+//            .padding(.bottom, 40)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(.systemGroupedBackground))
+        .onAppear {
+            // Auto-dismiss after a delay if needed
+            DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
+//                appState.showKeyboardFlowSheet = false
+            }
+        }
+    }
+}
+
+#Preview {
+    @State @Previewable var appState = AppState()
+
+    KeyboardFlowSheet(appState: appState)
+}

--- a/VivaDicta/Views/MainView.swift
+++ b/VivaDicta/Views/MainView.swift
@@ -147,6 +147,12 @@ struct MainView: View {
                 }
             }
         }
+        .sheet(isPresented: $appState.showKeyboardFlowSheet) {
+            KeyboardFlowSheet(appState: appState)
+                .presentationDetents([.medium])
+                .presentationDragIndicator(.hidden)
+//                .interactiveDismissDisabled(false)
+        }
     }
 
     private func startRecording() {

--- a/VivaDicta/Views/MainView.swift
+++ b/VivaDicta/Views/MainView.swift
@@ -149,9 +149,8 @@ struct MainView: View {
         }
         .sheet(isPresented: $appState.showKeyboardFlowSheet) {
             KeyboardFlowSheet(appState: appState)
-                .presentationDetents([.medium])
+                .presentationDetents([.fraction(0.3)])
                 .presentationDragIndicator(.hidden)
-//                .interactiveDismissDisabled(false)
         }
     }
 

--- a/VivaDicta/VivaDictaApp.swift
+++ b/VivaDicta/VivaDictaApp.swift
@@ -144,6 +144,10 @@ struct VivaDictaApp: App {
                     handleTranscriptionActivity(userActivity)
                 }
                 .onChange(of: scenePhase) { oldPhase, newPhase in
+                    if oldPhase == .active && newPhase == .inactive {
+                        appState.showKeyboardFlowSheet = false
+                    }
+
                     switch newPhase {
                     case .active:
                         logger.logInfo("🎬 App became active - checking for stale Live Activity")

--- a/VivaDicta/VivaDictaApp.swift
+++ b/VivaDicta/VivaDictaApp.swift
@@ -168,22 +168,24 @@ struct VivaDictaApp: App {
         // Handle deep links from keyboard extension
         if url.absoluteString == "vivadicta://record-for-keyboard" {
             logger.logInfo("📱 Recognized as keyboard recording request")
-            
+
             appState.startLiveActivity()
-            
-            
+
+            // Show the keyboard flow sheet
+            appState.showKeyboardFlowSheet = true
+
             // Start audio prewarm session to keep app alive in background
             do {
                 //                try AudioSessionManager.shared.startHotMicSession(timeoutSeconds: 180)
                 try AudioPrewarmManager.shared.startPrewarmSession()
-                
+
                 // Activate keyboard session to notify keyboard that hot mic is ready
                 AppGroupCoordinator.shared.activateKeyboardSession(
                     timeoutSeconds: AudioPrewarmManager.shared.audioSessionTimeout
                 )
-                
+
                 logger.logInfo("🎙️ Hot Mic and keyboard session activated from deeplink")
-                
+
             } catch {
                 logger.logError("⚠️ Failed to start prewarm session: \(error.localizedDescription)")
             }


### PR DESCRIPTION
## Summary
Implemented a bottom sheet that appears when the keyboard flow is activated via deep link, providing clear instructions to users on how to return to the host app where they invoked the custom keyboard.

## Changes
- Created `KeyboardFlowSheet` view with:
  - "Keyboard Flow Activated" title
  - Arrow icon and swipe back instruction
  - Bottom swipe indicator
- Added `showKeyboardFlowSheet` property to `AppState` to control sheet visibility
- Updated deep link handler in `VivaDictaApp` to show the sheet when keyboard flow is activated
- Added sheet presentation to `MainView`
- Implemented automatic dismissal when app becomes inactive (user swipes back)

## UI/UX Features
- Clean, minimal design with centered instructions
- Orange arrow icon indicating swipe back gesture
- Bottom indicator showing where to swipe from
- Auto-dismisses when user leaves the app (becomes inactive)
- Can also be dismissed by tapping anywhere on the sheet
- Compact presentation detent for a non-intrusive experience

## Test Plan
- [x] Built successfully on iOS 26.0 simulator
- [x] Sheet appears when keyboard flow is activated via deep link
- [x] Sheet auto-dismisses when app becomes inactive
- [x] Sheet can be manually dismissed by tapping
- [x] UI matches design requirements

## Technical Notes
- Uses SwiftUI sheet presentation with `.fraction(0.3)` detent
- Monitors `scenePhase` to detect app lifecycle changes
- Dismissal is handled both at the sheet level and app level for reliability