### PR TITLE
Add iOS 18 zoom transitions to navigation

### DIFF
--- a/VivaDicta/Views/SettingsScreen/ModelsView.swift
+++ b/VivaDicta/Views/SettingsScreen/ModelsView.swift
@@ -12,6 +12,8 @@ struct ModelsView: View {
     @State var modelType: TranscriptionModelType = .local
     @State var cloudModelToConfigure: CloudModel?
     @State private var downloadManager: ModelDownloadManager
+    
+    @Namespace var zoomNamespace
 
     init(appState: AppState) {
         self.appState = appState
@@ -48,6 +50,7 @@ struct ModelsView: View {
                                     model: model,
                                     downloadManager: downloadManager
                                 )
+                                
                             } else if let cloudModel = model as? CloudModel {
                                 CloudModelCard(
                                     model: cloudModel,
@@ -58,6 +61,7 @@ struct ModelsView: View {
                                         handleAPIKeyDeletion(for: cloudModel)
                                     }
                                 )
+                                .matchedTransitionSource(id: cloudModel.id, in: zoomNamespace)
                             }
                         }
                         .padding(.horizontal)
@@ -73,6 +77,7 @@ struct ModelsView: View {
                 onSave: { cloudModel in
                     cloudModelConfigured(cloudModel)
                 })
+            .navigationTransition(.zoom(sourceID: model.id, in: zoomNamespace))
         })
         .navigationTitle("Transcription Models")
         .navigationBarTitleDisplayMode(.large)

--- a/VivaDicta/Views/TranscriptionsContentView.swift
+++ b/VivaDicta/Views/TranscriptionsContentView.swift
@@ -51,28 +51,18 @@ struct TranscriptionsContentView: View {
                                 TranscriptionDetailView(transcription: transcription, appState: appState)
                                     .navigationTransition(.zoom(sourceID: transcription.id, in: zoomNamespace))
                                 
+                                // TODO: - Decide - wether we need to keep drag to dismiss
+//                                    .interactiveDismissDisabled(true)
+                                
                                 
                             } label: {
                                 TranscriptionRowView(
                                     transcription: transcription,
                                     isNewlyInserted: newlyInsertedIDs.contains(transcription.id)
                                 )
-                                
-                                
-                                
                             }
                             .matchedTransitionSource(id: transcription.id, in: zoomNamespace)
 
-//                            
-//                            NavigationLink(destination: TranscriptionDetailView(transcription: transcription, appState: appState)) {
-//                                TranscriptionRowView(
-//                                    transcription: transcription,
-//                                    isNewlyInserted: newlyInsertedIDs.contains(transcription.id)
-//                                )
-//                                
-//                                
-//                                
-//                            }
                         }
                         .onDelete(perform: deleteTranscription)
                     }

--- a/VivaDicta/Views/TranscriptionsContentView.swift
+++ b/VivaDicta/Views/TranscriptionsContentView.swift
@@ -13,6 +13,8 @@ struct TranscriptionsContentView: View {
     @Environment(\.modelContext) private var modelContext
     @Query(sort: \Transcription.timestamp, order: .reverse) private var allTranscriptions: [Transcription]
 
+    @Namespace var zoomNamespace
+    
     @Binding var searchText: String
     @State private var filteredTranscriptions: [Transcription] = []
     @State private var searchTask: Task<Void, Never>?
@@ -48,6 +50,9 @@ struct TranscriptionsContentView: View {
                             
                             NavigationLink {
                                 TranscriptionDetailView(transcription: transcription, appState: appState)
+                                    .navigationTransition(.zoom(sourceID: transcription.id, in: zoomNamespace))
+                                
+                                
                             } label: {
                                 TranscriptionRowView(
                                     transcription: transcription,
@@ -55,7 +60,9 @@ struct TranscriptionsContentView: View {
                                 )
                                 
                                 
+                                
                             }
+                            .matchedTransitionSource(id: transcription.id, in: zoomNamespace)
 
 //                            
 //                            NavigationLink(destination: TranscriptionDetailView(transcription: transcription, appState: appState)) {

--- a/VivaDicta/Views/TranscriptionsContentView.swift
+++ b/VivaDicta/Views/TranscriptionsContentView.swift
@@ -18,7 +18,6 @@ struct TranscriptionsContentView: View {
     @Binding var searchText: String
     @State private var filteredTranscriptions: [Transcription] = []
     @State private var searchTask: Task<Void, Never>?
-    @State private var navigationPath = NavigationPath()
     @State private var newlyInsertedIDs: Set<UUID> = []
     @State private var previousTranscriptionCount = 0
     @State private var showGoToTopButton = false


### PR DESCRIPTION
## Summary
- Add zoom navigation transition to TranscriptionDetailView when navigating from transcription list
- Add zoom navigation transition to Cloud model detail cards in ModelsView
- Remove unused `navigationPath` state variable from TranscriptionsContentView
- Clean up deprecated NavigationLink patterns

## Changes
- **TranscriptionsContentView.swift**: Use `NavigationLink { destination }` with `.navigationTransition(.zoom(...))` and `.matchedTransitionSource()` for smooth zoom animations
- **ModelsView.swift**: Add zoom transition source matching for cloud model cards

## Test plan
- [ ] Verify zoom transition when tapping transcription row
- [ ] Verify zoom transition when tapping cloud model cards
- [ ] Test on iOS 18+ devices/simulators
- [ ] Confirm Spotlight deep linking still works (uses separate programmatic navigation path)