### PR TITLE
Fix AI Enhance Prompts navigation

### DIFF
--- a/VivaDicta/Services/AIEnhance/UserPrompt.swift
+++ b/VivaDicta/Services/AIEnhance/UserPrompt.swift
@@ -10,20 +10,17 @@ import Foundation
 struct UserPrompt: Identifiable, Codable, Equatable, Hashable {
     let id: UUID
     let title: String
-    let description: String
     let promptInstructions: String
     let createdAt: Date
     
     init(
         id: UUID = UUID(),
         title: String,
-        description: String,
         promptInstructions: String,
         createdAt: Date = Date()
     ) {
         self.id = id
         self.title = title
-        self.description = description
         self.promptInstructions = promptInstructions
         self.createdAt = createdAt
     }

--- a/VivaDicta/Views/MainView.swift
+++ b/VivaDicta/Views/MainView.swift
@@ -115,30 +115,9 @@ struct MainView: View {
                     }
                 }
                 .fullScreenCover(isPresented: $showingSettings) {
-                    NavigationStack {
-                        SettingsView(appState: appState)
-                            .navigationTitle("Settings")
-                            .navigationBarTitleDisplayMode(.inline)
-                            .toolbar {
-
-                                if #available(iOS 26.0, *) {
-                                    ToolbarItem(placement: .topBarLeading) {
-                                        Button("Close", systemImage: "xmark") {
-                                            showingSettings = false
-                                        }
-                                    }
-                                } else {
-                                    ToolbarItem(placement: .topBarLeading) {
-                                        Button("Close") {
-                                            showingSettings = false
-                                        }
-                                    }
-                                }
-                            }
-                    }
-
-                    .interactiveDismissDisabled(true)
-                    .navigationTransition(.zoom(sourceID: "SettingsSheetTransition", in: sheetTransitions))
+                    SettingsView(appState: appState)
+                        .interactiveDismissDisabled(true)
+                        .navigationTransition(.zoom(sourceID: "SettingsSheetTransition", in: sheetTransitions))
                 }
                 .navigationDestination(for: Transcription.self) { transcription in
                     TranscriptionDetailView(transcription: transcription, appState: appState)

--- a/VivaDicta/Views/SettingsScreen/Prompts/PromptAddView.swift
+++ b/VivaDicta/Views/SettingsScreen/Prompts/PromptAddView.swift
@@ -46,7 +46,7 @@ struct PromptAddView: View {
     var body: some View {
         NavigationStack {
             Form {
-                Section(header: Text("Prompt Details")) {
+                Section(header: Text("Prompt Name")) {
                     TextField("Title", text: $title)
                 }
 

--- a/VivaDicta/Views/SettingsScreen/Prompts/PromptAddView.swift
+++ b/VivaDicta/Views/SettingsScreen/Prompts/PromptAddView.swift
@@ -51,8 +51,13 @@ struct PromptAddView: View {
                 }
 
                 Section(header: Text("Prompt Instructions")) {
-                    TextEditor(text: $promptInstructions)
-                        .frame(minHeight: 200)
+                    NavigationLink {
+                        PromptInstructionsEditorView(instructions: $promptInstructions)
+                    } label: {
+                        Text(promptInstructions.isEmpty ? "Tap to add instructions" : promptInstructions)
+                            .lineLimit(3)
+                            .foregroundStyle(promptInstructions.isEmpty ? .secondary : .primary)
+                    }
                 }
             }
             .navigationTitle("New \(currentTemplate.displayName) Prompt")

--- a/VivaDicta/Views/SettingsScreen/Prompts/PromptAddView.swift
+++ b/VivaDicta/Views/SettingsScreen/Prompts/PromptAddView.swift
@@ -15,6 +15,7 @@ struct PromptAddView: View {
 
     @State private var title: String = ""
     @State private var promptInstructions: String = ""
+    @State private var showInstructionsEditor = false
 
     private var currentTemplate: PromptsTemplates {
         return templateToCreateNewPrompt ?? .regular
@@ -51,13 +52,15 @@ struct PromptAddView: View {
                 }
 
                 Section(header: Text("Prompt Instructions")) {
-                    NavigationLink {
-                        PromptInstructionsEditorView(instructions: $promptInstructions)
+                    Button {
+                        showInstructionsEditor = true
                     } label: {
                         Text(promptInstructions.isEmpty ? "Tap to add instructions" : promptInstructions)
                             .lineLimit(3)
                             .foregroundStyle(promptInstructions.isEmpty ? .secondary : .primary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
                     }
+                    .buttonStyle(.plain)
                 }
             }
             .navigationTitle("New \(currentTemplate.displayName) Prompt")
@@ -98,6 +101,11 @@ struct PromptAddView: View {
             } else {
                 title = currentTemplate.defaultTitle
                 promptInstructions = currentTemplate.prompt
+            }
+        }
+        .sheet(isPresented: $showInstructionsEditor) {
+            NavigationStack {
+                PromptInstructionsEditorView(instructions: $promptInstructions)
             }
         }
     }

--- a/VivaDicta/Views/SettingsScreen/Prompts/PromptAddView.swift
+++ b/VivaDicta/Views/SettingsScreen/Prompts/PromptAddView.swift
@@ -19,6 +19,16 @@ struct PromptAddView: View {
     private var currentTemplate: PromptsTemplates {
         return templateToCreateNewPrompt ?? .regular
     }
+
+    private func savePrompt() {
+        let prompt = UserPrompt(
+            title: title,
+            description: description,
+            promptInstructions: promptInstructions)
+
+        promptsManager.addPrompt(prompt)
+        dismiss()
+    }
     
     init(template: PromptsTemplates? = nil,
          editingPrompt: UserPrompt? = nil,
@@ -32,11 +42,11 @@ struct PromptAddView: View {
             Form {
                 Section(header: Text("Prompt Details")) {
                     TextField("Title", text: $title)
-                    
+
                     TextField("Description", text: $description, axis: .vertical)
                         .lineLimit(3...6)
                 }
-                
+
                 Section(header: Text("Prompt Instructions")) {
                     TextEditor(text: $promptInstructions)
                         .frame(minHeight: 200)
@@ -56,29 +66,17 @@ struct PromptAddView: View {
                         }
                     }
                 }
-                
+
                 ToolbarItem(placement: .topBarTrailing) {
-                    if #available(iOS 26, *){
+                    if #available(iOS 26, *) {
                         Button(role: .confirm) {
-                            let prompt = UserPrompt(
-                                title: title,
-                                description: description,
-                                promptInstructions: promptInstructions)
-                            
-                            promptsManager.addPrompt(prompt)
-                            dismiss()
+                            savePrompt()
                         }
                         .disabled(title.isEmpty)
                         .tint(.blue)
                     } else {
                         Button("Save") {
-                            let prompt = UserPrompt(
-                                title: title,
-                                description: description,
-                                promptInstructions: promptInstructions)
-                            
-                            promptsManager.addPrompt(prompt)
-                            dismiss()
+                            savePrompt()
                         }
                         .disabled(title.isEmpty)
                     }

--- a/VivaDicta/Views/SettingsScreen/Prompts/PromptAddView.swift
+++ b/VivaDicta/Views/SettingsScreen/Prompts/PromptAddView.swift
@@ -11,11 +11,12 @@ struct PromptAddView: View {
     @Environment(\.dismiss) var dismiss
     let templateToCreateNewPrompt: PromptsTemplates?
     let promptsManager: PromptsManager
-    
+    var onComplete: (() -> Void)?
+
     @State private var title: String = ""
     @State private var description: String = ""
     @State private var promptInstructions: String = ""
-    
+
     private var currentTemplate: PromptsTemplates {
         return templateToCreateNewPrompt ?? .regular
     }
@@ -27,14 +28,21 @@ struct PromptAddView: View {
             promptInstructions: promptInstructions)
 
         promptsManager.addPrompt(prompt)
-        dismiss()
+        dismissAndComplete()
     }
-    
+
+    private func dismissAndComplete() {
+        dismiss()
+        onComplete?()
+    }
+
     init(template: PromptsTemplates? = nil,
          editingPrompt: UserPrompt? = nil,
-         promptsManager: PromptsManager) {
+         promptsManager: PromptsManager,
+         onComplete: (() -> Void)? = nil) {
         self.templateToCreateNewPrompt = template
         self.promptsManager = promptsManager
+        self.onComplete = onComplete
     }
     
     var body: some View {
@@ -58,11 +66,11 @@ struct PromptAddView: View {
                 ToolbarItem(placement: .topBarLeading) {
                     if #available(iOS 26, *) {
                         Button(role: .close) {
-                            dismiss()
+                            dismissAndComplete()
                         }
                     } else {
                         Button("Cancel") {
-                            dismiss()
+                            dismissAndComplete()
                         }
                     }
                 }

--- a/VivaDicta/Views/SettingsScreen/Prompts/PromptAddView.swift
+++ b/VivaDicta/Views/SettingsScreen/Prompts/PromptAddView.swift
@@ -14,7 +14,6 @@ struct PromptAddView: View {
     var onComplete: (() -> Void)?
 
     @State private var title: String = ""
-    @State private var description: String = ""
     @State private var promptInstructions: String = ""
 
     private var currentTemplate: PromptsTemplates {
@@ -24,7 +23,6 @@ struct PromptAddView: View {
     private func savePrompt() {
         let prompt = UserPrompt(
             title: title,
-            description: description,
             promptInstructions: promptInstructions)
 
         promptsManager.addPrompt(prompt)
@@ -50,9 +48,6 @@ struct PromptAddView: View {
             Form {
                 Section(header: Text("Prompt Details")) {
                     TextField("Title", text: $title)
-
-                    TextField("Description", text: $description, axis: .vertical)
-                        .lineLimit(3...6)
                 }
 
                 Section(header: Text("Prompt Instructions")) {
@@ -94,11 +89,9 @@ struct PromptAddView: View {
         .onAppear {
             if currentTemplate == .custom {
                 title = ""
-                description = ""
                 promptInstructions = ""
             } else {
                 title = currentTemplate.defaultTitle
-                description = currentTemplate.description
                 promptInstructions = currentTemplate.prompt
             }
         }

--- a/VivaDicta/Views/SettingsScreen/Prompts/PromptEditingView.swift
+++ b/VivaDicta/Views/SettingsScreen/Prompts/PromptEditingView.swift
@@ -13,7 +13,6 @@ struct PromptEditView: View {
     let promptsManager: PromptsManager
     
     @State private var title: String = ""
-    @State private var description: String = ""
     @State private var promptInstructions: String = ""
     
     init(editingPrompt: UserPrompt? = nil,
@@ -26,9 +25,6 @@ struct PromptEditView: View {
             Form {
                 Section(header: Text("Prompt Details")) {
                     TextField("Title", text: $title)
-                    
-                    TextField("Description", text: $description, axis: .vertical)
-                        .lineLimit(3...6)
                 }
                 
                 Section(header: Text("Prompt Instructions")) {
@@ -41,18 +37,6 @@ struct PromptEditView: View {
             
             
             .toolbar {
-//                ToolbarItem(placement: .topBarLeading) {
-//                    if #available(iOS 26, *) {
-//                        Button(role: .close) {
-//                            dismiss()
-//                        }
-//                    } else {
-//                        Button("Cancel") {
-//                            dismiss()
-//                        }
-//                    }
-//                }
-                
                 ToolbarItem(placement: .topBarTrailing) {
                     if #available(iOS 26, *){
                         Button(role: .confirm) {
@@ -61,7 +45,6 @@ struct PromptEditView: View {
                                 let updatedPrompt = UserPrompt(
                                     id: existingPrompt.id,
                                     title: title,
-                                    description: description,
                                     promptInstructions: promptInstructions,
                                     createdAt: existingPrompt.createdAt
                                 )
@@ -78,7 +61,6 @@ struct PromptEditView: View {
                                 let updatedPrompt = UserPrompt(
                                     id: existingPrompt.id,
                                     title: title,
-                                    description: description,
                                     promptInstructions: promptInstructions,
                                     createdAt: existingPrompt.createdAt
                                 )
@@ -95,7 +77,6 @@ struct PromptEditView: View {
             if let existingPrompt = editingPrompt {
                 // Pre-fill with existing prompt data
                 title = existingPrompt.title
-                description = existingPrompt.description
                 promptInstructions = existingPrompt.promptInstructions
             }
         }

--- a/VivaDicta/Views/SettingsScreen/Prompts/PromptEditingView.swift
+++ b/VivaDicta/Views/SettingsScreen/Prompts/PromptEditingView.swift
@@ -23,7 +23,7 @@ struct PromptEditView: View {
     }
     
     var body: some View {
-        NavigationStack {
+//        NavigationStack {
             Form {
                 Section(header: Text("Prompt Details")) {
                     TextField("Title", text: $title)
@@ -42,17 +42,17 @@ struct PromptEditView: View {
             
             
             .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
-                    if #available(iOS 26, *) {
-                        Button(role: .close) {
-                            dismiss()
-                        }
-                    } else {
-                        Button("Cancel") {
-                            dismiss()
-                        }
-                    }
-                }
+//                ToolbarItem(placement: .topBarLeading) {
+//                    if #available(iOS 26, *) {
+//                        Button(role: .close) {
+//                            dismiss()
+//                        }
+//                    } else {
+//                        Button("Cancel") {
+//                            dismiss()
+//                        }
+//                    }
+//                }
                 
                 ToolbarItem(placement: .topBarTrailing) {
                     if #available(iOS 26, *){
@@ -92,7 +92,7 @@ struct PromptEditView: View {
                 }
             }
             
-        }
+//        }
         
         .onAppear {
             if let existingPrompt = editingPrompt {

--- a/VivaDicta/Views/SettingsScreen/Prompts/PromptEditingView.swift
+++ b/VivaDicta/Views/SettingsScreen/Prompts/PromptEditingView.swift
@@ -14,6 +14,7 @@ struct PromptEditView: View {
     
     @State private var title: String = ""
     @State private var promptInstructions: String = ""
+    @State private var showInstructionsEditor = false
     
     init(editingPrompt: UserPrompt? = nil,
          promptsManager: PromptsManager) {
@@ -28,13 +29,15 @@ struct PromptEditView: View {
             }
             
             Section(header: Text("Prompt Instructions")) {
-                NavigationLink {
-                    PromptInstructionsEditorView(instructions: $promptInstructions)
+                Button {
+                    showInstructionsEditor = true
                 } label: {
                     Text(promptInstructions.isEmpty ? "Tap to add instructions" : promptInstructions)
                         .lineLimit(3)
                         .foregroundStyle(promptInstructions.isEmpty ? .secondary : .primary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
                 }
+                .buttonStyle(.plain)
             }
         }
         .navigationTitle("Edit Prompt")
@@ -83,6 +86,11 @@ struct PromptEditView: View {
                 // Pre-fill with existing prompt data
                 title = existingPrompt.title
                 promptInstructions = existingPrompt.promptInstructions
+            }
+        }
+        .sheet(isPresented: $showInstructionsEditor) {
+            NavigationStack {
+                PromptInstructionsEditorView(instructions: $promptInstructions)
             }
         }
     }

--- a/VivaDicta/Views/SettingsScreen/Prompts/PromptEditingView.swift
+++ b/VivaDicta/Views/SettingsScreen/Prompts/PromptEditingView.swift
@@ -23,7 +23,6 @@ struct PromptEditView: View {
     }
     
     var body: some View {
-//        NavigationStack {
             Form {
                 Section(header: Text("Prompt Details")) {
                     TextField("Title", text: $title)
@@ -91,8 +90,6 @@ struct PromptEditView: View {
                     }
                 }
             }
-            
-//        }
         
         .onAppear {
             if let existingPrompt = editingPrompt {

--- a/VivaDicta/Views/SettingsScreen/Prompts/PromptEditingView.swift
+++ b/VivaDicta/Views/SettingsScreen/Prompts/PromptEditingView.swift
@@ -22,56 +22,56 @@ struct PromptEditView: View {
     }
     
     var body: some View {
-            Form {
-                Section(header: Text("Prompt Details")) {
-                    TextField("Title", text: $title)
-                }
-                
-                Section(header: Text("Prompt Instructions")) {
-                    TextEditor(text: $promptInstructions)
-                        .frame(minHeight: 200)
-                }
+        Form {
+            Section(header: Text("Prompt Name")) {
+                TextField("Title", text: $title)
             }
-            .navigationTitle("Edit Prompt")
-            .toolbarTitleDisplayMode(.inline)
             
-            
-            .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
-                    if #available(iOS 26, *){
-                        Button(role: .confirm) {
-                            if let existingPrompt = editingPrompt {
-                                // Update existing prompt
-                                let updatedPrompt = UserPrompt(
-                                    id: existingPrompt.id,
-                                    title: title,
-                                    promptInstructions: promptInstructions,
-                                    createdAt: existingPrompt.createdAt
-                                )
-                                promptsManager.updatePrompt(updatedPrompt)
-                            }
-                            dismiss()
+            Section(header: Text("Prompt Instructions")) {
+                TextEditor(text: $promptInstructions)
+                    .frame(minHeight: 200)
+            }
+        }
+        .navigationTitle("Edit Prompt")
+        .toolbarTitleDisplayMode(.inline)
+        
+        
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                if #available(iOS 26, *){
+                    Button(role: .confirm) {
+                        if let existingPrompt = editingPrompt {
+                            // Update existing prompt
+                            let updatedPrompt = UserPrompt(
+                                id: existingPrompt.id,
+                                title: title,
+                                promptInstructions: promptInstructions,
+                                createdAt: existingPrompt.createdAt
+                            )
+                            promptsManager.updatePrompt(updatedPrompt)
                         }
-                        .disabled(title.isEmpty)
-                        .tint(.blue)
-                    } else {
-                        Button("Save") {
-                            if let existingPrompt = editingPrompt {
-                                // Update existing prompt
-                                let updatedPrompt = UserPrompt(
-                                    id: existingPrompt.id,
-                                    title: title,
-                                    promptInstructions: promptInstructions,
-                                    createdAt: existingPrompt.createdAt
-                                )
-                                promptsManager.updatePrompt(updatedPrompt)
-                            }
-                            dismiss()
-                        }
-                        .disabled(title.isEmpty)
+                        dismiss()
                     }
+                    .disabled(title.isEmpty)
+                    .tint(.blue)
+                } else {
+                    Button("Save") {
+                        if let existingPrompt = editingPrompt {
+                            // Update existing prompt
+                            let updatedPrompt = UserPrompt(
+                                id: existingPrompt.id,
+                                title: title,
+                                promptInstructions: promptInstructions,
+                                createdAt: existingPrompt.createdAt
+                            )
+                            promptsManager.updatePrompt(updatedPrompt)
+                        }
+                        dismiss()
+                    }
+                    .disabled(title.isEmpty)
                 }
             }
+        }
         
         .onAppear {
             if let existingPrompt = editingPrompt {

--- a/VivaDicta/Views/SettingsScreen/Prompts/PromptEditingView.swift
+++ b/VivaDicta/Views/SettingsScreen/Prompts/PromptEditingView.swift
@@ -28,8 +28,13 @@ struct PromptEditView: View {
             }
             
             Section(header: Text("Prompt Instructions")) {
-                TextEditor(text: $promptInstructions)
-                    .frame(minHeight: 200)
+                NavigationLink {
+                    PromptInstructionsEditorView(instructions: $promptInstructions)
+                } label: {
+                    Text(promptInstructions.isEmpty ? "Tap to add instructions" : promptInstructions)
+                        .lineLimit(3)
+                        .foregroundStyle(promptInstructions.isEmpty ? .secondary : .primary)
+                }
             }
         }
         .navigationTitle("Edit Prompt")

--- a/VivaDicta/Views/SettingsScreen/Prompts/PromptInstructionsEditorView.swift
+++ b/VivaDicta/Views/SettingsScreen/Prompts/PromptInstructionsEditorView.swift
@@ -1,0 +1,34 @@
+//
+//  PromptInstructionsEditorView.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2025.11.27
+//
+
+import SwiftUI
+
+struct PromptInstructionsEditorView: View {
+    @Environment(\.dismiss) var dismiss
+    @Binding var instructions: String
+
+    var body: some View {
+        TextEditor(text: $instructions)
+            .padding()
+            .navigationTitle("Prompt Instructions")
+            .toolbarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    if #available(iOS 26, *) {
+                        Button(role: .confirm) {
+                            dismiss()
+                        }
+                        .tint(.blue)
+                    } else {
+                        Button("Done") {
+                            dismiss()
+                        }
+                    }
+                }
+            }
+    }
+}

--- a/VivaDicta/Views/SettingsScreen/Prompts/PromptsSettings.swift
+++ b/VivaDicta/Views/SettingsScreen/Prompts/PromptsSettings.swift
@@ -23,6 +23,12 @@ struct PromptsSettings: View {
                 promptsList
             }
         }
+        .navigationDestination(item: $editingPrompt, destination: { prompt in
+            PromptEditView(
+                editingPrompt: prompt,
+                promptsManager: promptsManager
+            )
+        })
         .sheet(isPresented: $showingTemplateSelection) {
             NavigationStack {
                 TemplateSelectionView(
@@ -45,12 +51,12 @@ struct PromptsSettings: View {
                 promptsManager: promptsManager
             )
         }
-        .sheet(item: $editingPrompt) { prompt in
-            PromptEditView(
-                editingPrompt: prompt,
-                promptsManager: promptsManager
-            )
-        }
+//        .sheet(item: $editingPrompt) { prompt in
+//            PromptEditView(
+//                editingPrompt: prompt,
+//                promptsManager: promptsManager
+//            )
+//        }
         .toolbar {
             if #available(iOS 26, *) {
                 ToolbarItem {
@@ -98,9 +104,9 @@ struct PromptsSettings: View {
     private var promptsList: some View {
         List {
             ForEach(promptsManager.userPrompts) { prompt in
-                Button(action: {
+                Button {
                     editingPrompt = prompt
-                }) {
+                } label: {
                     PromptRowView(prompt: prompt)
                 }
                 .buttonStyle(.plain)

--- a/VivaDicta/Views/SettingsScreen/Prompts/PromptsSettings.swift
+++ b/VivaDicta/Views/SettingsScreen/Prompts/PromptsSettings.swift
@@ -8,12 +8,8 @@
 import SwiftUI
 
 struct PromptsSettings: View {
-    @Namespace private var transition
-    
     var promptsManager: PromptsManager
-    @State private var showingTemplateSelection = false
-    @State private var selectedTemplate: PromptsTemplates?
-    @State private var editingPrompt: UserPrompt?
+    var transition: Namespace.ID
     
     var body: some View {
         VStack(spacing: 0) {
@@ -23,53 +19,24 @@ struct PromptsSettings: View {
                 promptsList
             }
         }
-        .sheet(isPresented: $showingTemplateSelection) {
-            NavigationStack {
-                TemplateSelectionView(
-                    selectedTemplate: $selectedTemplate,
-                    isPresented: $showingTemplateSelection
-                )
-                .navigationTitle("Select Template")
-                .navigationBarTitleDisplayMode(.inline)
-
-                .scrollContentBackground(.visible)
-            }
-            .navigationTransition(
-                .zoom(sourceID: "info", in: transition)
-            )
-            .presentationDetents([.medium])
-        }
-        .sheet(item: $selectedTemplate) { template in
-            PromptAddView(
-                template: template,
-                promptsManager: promptsManager
-            )
-        }
-//        .sheet(item: $editingPrompt) { prompt in
-//            PromptEditView(
-//                editingPrompt: prompt,
-//                promptsManager: promptsManager
-//            )
-//        }
         .toolbar {
             if #available(iOS 26, *) {
                 ToolbarItem {
-                    Button("Add Data", systemImage: "plus") {
-                        showingTemplateSelection = true
+                    NavigationLink(value: SettingsDestination.promptsTemplates) {
+                        Label("Add Data", systemImage: "plus")
                     }
                     .buttonStyle(.glassProminent)
                     .tint(.blue)
                 }
-                .matchedTransitionSource(id: "info", in: transition)
+                .matchedTransitionSource(id: "addPrompt", in: transition)
             } else {
                 ToolbarItem {
-                    Button("Add Data", systemImage: "plus") {
-                        showingTemplateSelection = true
+                    NavigationLink(value: SettingsDestination.promptsTemplates) {
+                        Label("Add Data", systemImage: "plus")
                     }
                 }
             }
         }
-        .sensoryFeedback(.selection, trigger: showingTemplateSelection)
         .toolbarTitleDisplayMode(.inlineLarge)
         .navigationTitle("Prompts")
     }
@@ -159,5 +126,6 @@ struct PromptRowView: View {
 
 #Preview {
     @Previewable @State var promptsManager = PromptsManager()
-    PromptsSettings(promptsManager: promptsManager)
+    @Previewable @Namespace var transition
+    PromptsSettings(promptsManager: promptsManager, transition: transition)
 }

--- a/VivaDicta/Views/SettingsScreen/Prompts/PromptsSettings.swift
+++ b/VivaDicta/Views/SettingsScreen/Prompts/PromptsSettings.swift
@@ -105,19 +105,9 @@ struct PromptRowView: View {
     
     var body: some View {
         HStack {
-            VStack(alignment: .leading, spacing: 4) {
-                Text(prompt.title)
-                    .font(.headline)
-                    .foregroundStyle(.primary)
-                
-                if !prompt.description.isEmpty {
-                    Text(prompt.description)
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(2)
-                }
-            }
-            Spacer()
+            Text(prompt.title)
+                .font(.headline)
+                .foregroundStyle(.primary)
         }
         .padding(.vertical, 8)
         .contentShape(.rect)

--- a/VivaDicta/Views/SettingsScreen/Prompts/PromptsSettings.swift
+++ b/VivaDicta/Views/SettingsScreen/Prompts/PromptsSettings.swift
@@ -23,12 +23,6 @@ struct PromptsSettings: View {
                 promptsList
             }
         }
-        .navigationDestination(item: $editingPrompt, destination: { prompt in
-            PromptEditView(
-                editingPrompt: prompt,
-                promptsManager: promptsManager
-            )
-        })
         .sheet(isPresented: $showingTemplateSelection) {
             NavigationStack {
                 TemplateSelectionView(
@@ -104,12 +98,9 @@ struct PromptsSettings: View {
     private var promptsList: some View {
         List {
             ForEach(promptsManager.userPrompts) { prompt in
-                Button {
-                    editingPrompt = prompt
-                } label: {
+                NavigationLink(value: prompt) {
                     PromptRowView(prompt: prompt)
                 }
-                .buttonStyle(.plain)
                 .swipeActions(edge: .trailing, allowsFullSwipe: false) {
                     Button("Delete", role: .destructive) {
                         promptsManager.deletePrompt(prompt)

--- a/VivaDicta/Views/SettingsScreen/Prompts/TemplateSectionView.swift
+++ b/VivaDicta/Views/SettingsScreen/Prompts/TemplateSectionView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct TemplateSelectionView: View {
     var promptsManager: PromptsManager
+    @Environment(\.dismiss) private var dismiss
     @State private var selectedTemplate: PromptsTemplates?
 
     var body: some View {
@@ -35,7 +36,10 @@ struct TemplateSelectionView: View {
         .fullScreenCover(item: $selectedTemplate) { template in
             PromptAddView(
                 template: template,
-                promptsManager: promptsManager
+                promptsManager: promptsManager,
+                onComplete: {
+                    dismiss()
+                }
             )
         }
     }

--- a/VivaDicta/Views/SettingsScreen/Prompts/TemplateSectionView.swift
+++ b/VivaDicta/Views/SettingsScreen/Prompts/TemplateSectionView.swift
@@ -8,19 +8,18 @@
 import SwiftUI
 
 struct TemplateSelectionView: View {
-    @Binding var selectedTemplate: PromptsTemplates?
-    @Binding var isPresented: Bool
-    
+    var promptsManager: PromptsManager
+    @State private var selectedTemplate: PromptsTemplates?
+
     var body: some View {
         List(PromptsTemplates.allCases) { template in
-            Button(action: {
+            Button {
                 selectedTemplate = template
-                isPresented = false
-            }) {
+            } label: {
                 VStack(alignment: .leading, spacing: 8) {
                     Text(template.displayName)
                         .font(.headline)
-                    
+
                     Text(template.description)
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
@@ -28,8 +27,16 @@ struct TemplateSelectionView: View {
                 }
                 .padding(.vertical, 4)
             }
-            .buttonStyle(PlainButtonStyle())
+            .buttonStyle(.plain)
         }
+        .navigationTitle("Select Template")
+        .navigationBarTitleDisplayMode(.inline)
         .scrollContentBackground(.visible)
+        .fullScreenCover(item: $selectedTemplate) { template in
+            PromptAddView(
+                template: template,
+                promptsManager: promptsManager
+            )
+        }
     }
 }

--- a/VivaDicta/Views/SettingsScreen/SettingsDestination.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsDestination.swift
@@ -9,5 +9,6 @@ import Foundation
 
 enum SettingsDestination: Hashable {
     case promptsSettings
+    case promptsTemplates
     case transcriptionModels
 }

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -15,6 +15,7 @@ struct SettingsView: View {
 
     @Environment(\.dismiss) private var dismiss
     @State var navigationPath = NavigationPath()
+    @Namespace private var promptsTransition
     @AppStorage("IsVADEnabled") private var isVADEnabled = true
     @AppStorage("audioSessionTimeout") private var audioSessionTimeout = 180
     private let prewarmManager = AudioPrewarmManager.shared
@@ -168,9 +169,12 @@ struct SettingsView: View {
             .navigationDestination(for: SettingsDestination.self) { destination in
                 switch destination {
                 case .promptsSettings:
-                    PromptsSettings(promptsManager: promptsManager)
+                    PromptsSettings(promptsManager: promptsManager, transition: promptsTransition)
                 case .transcriptionModels:
                     ModelsView(appState: appState)
+                case .promptsTemplates:
+                    TemplateSelectionView(promptsManager: promptsManager)
+                        .navigationTransition(.zoom(sourceID: "addPrompt", in: promptsTransition))
                 }
             }
             .navigationDestination(for: UserPrompt.self) { prompt in

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -13,6 +13,7 @@ struct SettingsView: View {
     var appState: AppState
     @State var promptsManager = PromptsManager()
 
+    @Environment(\.dismiss) private var dismiss
     @State var navigationPath = NavigationPath()
     @AppStorage("IsVADEnabled") private var isVADEnabled = true
     @AppStorage("audioSessionTimeout") private var audioSessionTimeout = 180
@@ -170,6 +171,29 @@ struct SettingsView: View {
                     PromptsSettings(promptsManager: promptsManager)
                 case .transcriptionModels:
                     ModelsView(appState: appState)
+                }
+            }
+//            .navigationDestination(for: UserPrompt.self) { prompt in
+//                PromptEditView(
+//                    editingPrompt: prompt,
+//                    promptsManager: promptsManager
+//                )
+//            }
+            .navigationTitle("Settings")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                if #available(iOS 26.0, *) {
+                    ToolbarItem(placement: .topBarLeading) {
+                        Button("Close", systemImage: "xmark") {
+                            dismiss()
+                        }
+                    }
+                } else {
+                    ToolbarItem(placement: .topBarLeading) {
+                        Button("Close") {
+                            dismiss()
+                        }
+                    }
                 }
             }
 

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -173,12 +173,12 @@ struct SettingsView: View {
                     ModelsView(appState: appState)
                 }
             }
-//            .navigationDestination(for: UserPrompt.self) { prompt in
-//                PromptEditView(
-//                    editingPrompt: prompt,
-//                    promptsManager: promptsManager
-//                )
-//            }
+            .navigationDestination(for: UserPrompt.self) { prompt in
+                PromptEditView(
+                    editingPrompt: prompt,
+                    promptsManager: promptsManager
+                )
+            }
             .navigationTitle("Settings")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {


### PR DESCRIPTION
## Summary

- Fixed navigation issues in Prompts settings screen
- Migrated to `.navigationDestination(for:)` approach for type-safe navigation
- Fixed bug where editing prompt instructions in `PromptEditView` would not persist changes
- Changed `PromptInstructionsEditorView` to present as modal sheet instead of NavigationLink push to prevent state loss during navigation
- Removed unused `description` field from `UserPrompt` model
- Cleaned up navigation logic in `MainView`, `PromptsSettings`, and related views

## Key Changes

- **PromptEditView**: Fixed state persistence issue by presenting `PromptInstructionsEditorView` as a sheet instead of pushing onto navigation stack
- **PromptAddView**: Updated to use sheet presentation for consistency
- **SettingsView**: Added `.navigationDestination(for: UserPrompt.self)` for editing prompts
- **PromptsSettings**: Simplified navigation using new destination-based approach

## Test Plan

- [ ] Create a new prompt from template - verify instructions can be edited
- [ ] Create a new custom prompt - verify instructions save correctly
- [ ] Edit an existing prompt's instructions - verify changes persist after saving
- [ ] Navigate through prompts settings - verify no crashes or unexpected behavior