### PR TITLE
Add TipKit tips for feature discovery

### DIFF
--- a/VivaDicta/Utils/Tip.swift
+++ b/VivaDicta/Utils/Tip.swift
@@ -22,3 +22,49 @@ struct SelectLanguageTip: Tip {
     }
     
 }
+
+
+struct SelectTranscriptionModelTipMainView: Tip {
+    var title: Text {
+        Text("Select Transcription model")
+    }
+    
+    var message: Text? {
+        Text("Tap here to download local or select cloud transcription model")
+    }
+
+    var image: Image? {
+        Image(systemName: "cpu.fill")
+    }
+    
+}
+
+struct SelectTranscriptionModelTipSettingsView: Tip {
+    var title: Text {
+        Text("Select Transcription model")
+    }
+    
+    var message: Text? {
+        Text("Tap here to download local or select cloud transcription model")
+    }
+
+    var image: Image? {
+        Image(systemName: "cpu.fill")
+    }
+    
+}
+
+struct SelectAIEnhacementTip: Tip {
+    var title: Text {
+        Text("Add AI Enhancement")
+    }
+    
+    var message: Text? {
+        Text("Tap here to configure AI enhacement")
+    }
+
+    var image: Image? {
+        Image(systemName: "wand.and.sparkles")
+    }
+    
+}

--- a/VivaDicta/Utils/Tip.swift
+++ b/VivaDicta/Utils/Tip.swift
@@ -27,6 +27,7 @@ struct SelectLanguageTip: Tip {
 struct SelectTranscriptionModelTipMainView: Tip {
     var title: Text {
         Text("Select Transcription model")
+            .foregroundStyle(.teal)
     }
     
     var message: Text? {
@@ -42,10 +43,12 @@ struct SelectTranscriptionModelTipMainView: Tip {
 struct SelectTranscriptionModelTipSettingsView: Tip {
     var title: Text {
         Text("Select Transcription model")
+            .foregroundStyle(.teal)
     }
     
     var message: Text? {
         Text("Tap here to download local or select cloud transcription model")
+            .foregroundStyle(.orange)
     }
 
     var image: Image? {
@@ -60,7 +63,7 @@ struct SelectAIEnhacementTip: Tip {
     }
     
     var message: Text? {
-        Text("Tap here to configure AI enhacement")
+        Text("Improve transcriptions with AI")
     }
 
     var image: Image? {

--- a/VivaDicta/Utils/Tip.swift
+++ b/VivaDicta/Utils/Tip.swift
@@ -25,6 +25,12 @@ struct SelectLanguageTip: Tip {
 
 
 struct SelectTranscriptionModelTipMainView: Tip {
+    
+    static let selectModelEvent = Event(id: "selectTranscriptionModel")
+    
+    @Parameter(.transient)
+    static var isTranscriptionReady: Bool = false
+    
     var title: Text {
         Text("Select Transcription model")
             .foregroundStyle(.teal)
@@ -33,14 +39,39 @@ struct SelectTranscriptionModelTipMainView: Tip {
     var message: Text? {
         Text("Tap here to download local or select cloud transcription model")
     }
-
+    
     var image: Image? {
         Image(systemName: "cpu.fill")
     }
     
+    var actions: [Action] {
+        [
+            Tip.Action(id: "go-to-models", title: "Open Models")
+        ]
+    }
+    
+    var rules: [Rule] {
+        #Rule(Self.$isTranscriptionReady) { $0 == false }
+        
+        #Rule(Self.selectModelEvent) { event in
+            event.donations.count < 10
+        }
+    }
+    
+//    var options: [Option] {
+//        MaxDisplayCount(20)
+//    }
 }
 
+
 struct SelectTranscriptionModelTipSettingsView: Tip {
+    
+    static let selectModelEvent = Event(id: "selectTranscriptionModel")
+    
+    @Parameter(.transient)
+    static var isTranscriptionReady: Bool = false
+    
+    
     var title: Text {
         Text("Select Transcription model")
             .foregroundStyle(.teal)
@@ -53,6 +84,14 @@ struct SelectTranscriptionModelTipSettingsView: Tip {
 
     var image: Image? {
         Image(systemName: "cpu.fill")
+    }
+    
+    var rules: [Rule] {
+        #Rule(Self.$isTranscriptionReady) { $0 == false }
+        
+        #Rule(Self.selectModelEvent) { event in
+            event.donations.count < 10
+        }
     }
     
 }

--- a/VivaDicta/Utils/Tip.swift
+++ b/VivaDicta/Utils/Tip.swift
@@ -51,10 +51,10 @@ struct SelectTranscriptionModelTipMainView: Tip {
     }
     
     var rules: [Rule] {
-        #Rule(Self.$isTranscriptionReady) { $0 == false }
+//        #Rule(Self.$isTranscriptionReady) { $0 == false }
         
         #Rule(Self.selectModelEvent) { event in
-            event.donations.count < 10
+            event.donations.count == 0
         }
     }
     
@@ -87,10 +87,10 @@ struct SelectTranscriptionModelTipSettingsView: Tip {
     }
     
     var rules: [Rule] {
-        #Rule(Self.$isTranscriptionReady) { $0 == false }
+//        #Rule(Self.$isTranscriptionReady) { $0 == false }
         
         #Rule(Self.selectModelEvent) { event in
-            event.donations.count < 10
+            event.donations.count == 0
         }
     }
     

--- a/VivaDicta/Views/MainView.swift
+++ b/VivaDicta/Views/MainView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import SwiftData
+import TipKit
 
 struct MainView: View {
     @Bindable var appState: AppState
@@ -22,9 +23,11 @@ struct MainView: View {
 
     @Environment(\.modelContext) private var modelContext
     
+    var selectTranscriptionModelTipMainView = SelectTranscriptionModelTipMainView()
+    
     var body: some View {
-        let _ = Self._printChanges()
-        let _ = print("Executing <MainView> body")
+//        let _ = Self._printChanges()
+//        let _ = print("Executing <MainView> body")
         
         NavigationStack(path: $navigationPath) {
             TranscriptionsContentView(appState: appState, searchText: $searchText)
@@ -37,9 +40,11 @@ struct MainView: View {
                         ToolbarItem(placement: .navigationBarTrailing) {
                             Button {
                                 showingSettings = true
+//                                selectTranscriptionModelTipMainView.invalidate(reason: .actionPerformed)
                             } label: {
                                 Image(systemName: "gearshape.fill")
                             }
+                            .popoverTip(selectTranscriptionModelTipMainView)
                         }
                         .matchedTransitionSource(id: "SettingsSheetTransition", in: sheetTransitions)
                     } else {

--- a/VivaDicta/Views/MainView.swift
+++ b/VivaDicta/Views/MainView.swift
@@ -44,7 +44,12 @@ struct MainView: View {
                             } label: {
                                 Image(systemName: "gearshape.fill")
                             }
-                            .popoverTip(selectTranscriptionModelTipMainView)
+                            .popoverTip(selectTranscriptionModelTipMainView) { action in
+                                if action.id == "go-to-models" {
+                                    showingSettings = true
+                                    appState.shouldNavigateToModels = true
+                                }
+                            }
                         }
                         .matchedTransitionSource(id: "SettingsSheetTransition", in: sheetTransitions)
                     } else {
@@ -55,6 +60,12 @@ struct MainView: View {
                                 Image(systemName: "gearshape.fill")
                             }
                             .tint(.primary)
+                            .popoverTip(selectTranscriptionModelTipMainView) { action in
+                                if action.id == "go-to-models" {
+                                    showingSettings = true
+                                    appState.shouldNavigateToModels = true
+                                }
+                            }
                         }
                     }
 
@@ -211,6 +222,14 @@ struct MainView: View {
             KeyboardFlowSheet(appState: appState)
                 .presentationDetents([.fraction(0.3)])
                 .presentationDragIndicator(.hidden)
+        }
+        .onAppear {
+            SelectTranscriptionModelTipMainView.isTranscriptionReady = appState.transcriptionManager.hasAvailableTranscriptionModels
+            SelectTranscriptionModelTipSettingsView.isTranscriptionReady = appState.transcriptionManager.hasAvailableTranscriptionModels
+        }
+        .onChange(of: appState.transcriptionManager.hasAvailableTranscriptionModels) { _, newValue in
+            SelectTranscriptionModelTipMainView.isTranscriptionReady = newValue
+            SelectTranscriptionModelTipSettingsView.isTranscriptionReady = newValue
         }
     }
 

--- a/VivaDicta/Views/ModelsScreen/CloudModelCard.swift
+++ b/VivaDicta/Views/ModelsScreen/CloudModelCard.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import TipKit
 
 struct CloudModelCard: View {
     let model: CloudModel
@@ -83,10 +82,6 @@ struct CloudModelCard: View {
                 
                     Button(action: {
                         onConfigure(model)
-                        Task {
-                            await SelectTranscriptionModelTipMainView.selectModelEvent.donate()
-                            await SelectTranscriptionModelTipSettingsView.selectModelEvent.donate()
-                        }
                     }) {
                         VStack(alignment: .center, spacing: 0) {
                             

--- a/VivaDicta/Views/ModelsScreen/CloudModelCard.swift
+++ b/VivaDicta/Views/ModelsScreen/CloudModelCard.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import TipKit
 
 struct CloudModelCard: View {
     let model: CloudModel
@@ -82,6 +83,10 @@ struct CloudModelCard: View {
                 
                     Button(action: {
                         onConfigure(model)
+                        Task {
+                            await SelectTranscriptionModelTipMainView.selectModelEvent.donate()
+                            await SelectTranscriptionModelTipSettingsView.selectModelEvent.donate()
+                        }
                     }) {
                         VStack(alignment: .center, spacing: 0) {
                             

--- a/VivaDicta/Views/ModelsScreen/LocalModelCard.swift
+++ b/VivaDicta/Views/ModelsScreen/LocalModelCard.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import TipKit
 
 struct LocalModelCard: View {
     let model: any TranscriptionModel
@@ -216,12 +217,17 @@ struct LocalModelCard: View {
 
     private func downloadLocalModel() {
         Task {
+            
             do {
+                await SelectTranscriptionModelTipMainView.selectModelEvent.donate()
+                await SelectTranscriptionModelTipSettingsView.selectModelEvent.donate()
+                
                 if let whisperModel = model as? WhisperKitModel {
                     try await downloadManager.downloadModel(whisperModel)
                 } else if let parakeetModel = model as? ParakeetModel {
                     try await downloadManager.downloadModel(parakeetModel)
                 }
+                
             } catch {
                 if let whisperModel = model as? WhisperKitModel {
                     await downloadManager.handleModelDownloadError(whisperModel, error)

--- a/VivaDicta/Views/ModelsScreen/LocalModelCard.swift
+++ b/VivaDicta/Views/ModelsScreen/LocalModelCard.swift
@@ -217,16 +217,16 @@ struct LocalModelCard: View {
 
     private func downloadLocalModel() {
         Task {
-            
             do {
-                await SelectTranscriptionModelTipMainView.selectModelEvent.donate()
-                await SelectTranscriptionModelTipSettingsView.selectModelEvent.donate()
-                
                 if let whisperModel = model as? WhisperKitModel {
                     try await downloadManager.downloadModel(whisperModel)
                 } else if let parakeetModel = model as? ParakeetModel {
                     try await downloadManager.downloadModel(parakeetModel)
                 }
+                
+                // Hide "Select Transcription model" tips
+                await SelectTranscriptionModelTipMainView.selectModelEvent.donate()
+                await SelectTranscriptionModelTipSettingsView.selectModelEvent.donate()
                 
             } catch {
                 if let whisperModel = model as? WhisperKitModel {

--- a/VivaDicta/Views/SettingsScreen/ModeEditView.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditView.swift
@@ -20,6 +20,9 @@ struct ModeEditView: View {
     
     let selectAIEnhacementTip = SelectAIEnhacementTip()
     
+    let selectLanguageTip = SelectLanguageTip()
+
+    
     init(mode: FlowMode?,
          aiService: AIService,
          promptsManager: PromptsManager,
@@ -78,6 +81,8 @@ struct ModeEditView: View {
                                 Text(value).tag(key)
                             }
                         }
+                        .popoverTip(selectLanguageTip)
+
                     }
                 } else {
                     if viewModel.transcriptionProvider == .parakeet ||
@@ -242,6 +247,9 @@ struct ModeEditView: View {
             if newValue == true {
                 selectAIEnhacementTip.invalidate(reason: .actionPerformed)
             }
+        })
+        .onChange(of: viewModel.transcriptionLanguage, { oldValue, newValue in
+            selectLanguageTip.invalidate(reason: .actionPerformed)
         })
         .alert(isPresented: $showingAlert,
                error: modeEditViewError,

--- a/VivaDicta/Views/SettingsScreen/ModeEditView.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import TipKit
 
 struct ModeEditView: View {
     @Environment(\.dismiss) private var dismiss
@@ -16,6 +17,8 @@ struct ModeEditView: View {
     
     @State private var showingAlert: Bool = false
     @State private var modeEditViewError: SettingsError = .duplicateModeName("")
+    
+    let selectAIEnhacementTip = SelectAIEnhacementTip()
     
     init(mode: FlowMode?,
          aiService: AIService,
@@ -134,8 +137,12 @@ struct ModeEditView: View {
             }
             
             if viewModel.isTranscriptionProviderConfigured(viewModel.transcriptionProvider) {
+                
                 Section(header: Text("AI Enhancement"),
                         footer: Text("Configure how the raw transcription should be processed and refined.")) {
+                    
+                    TipView(selectAIEnhacementTip)
+                        .tipBackground(.teal.gradient)
                     
                     Toggle("Enable", isOn: $viewModel.aiEnhanceEnabled)
                     
@@ -231,6 +238,11 @@ struct ModeEditView: View {
             }
             
         }
+        .onChange(of: viewModel.aiEnhanceEnabled, { oldValue, newValue in
+            if newValue == true {
+                selectAIEnhacementTip.invalidate(reason: .actionPerformed)
+            }
+        })
         .alert(isPresented: $showingAlert,
                error: modeEditViewError,
                actions: { error in

--- a/VivaDicta/Views/SettingsScreen/ModeEditView.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditView.swift
@@ -146,8 +146,10 @@ struct ModeEditView: View {
                 Section(header: Text("AI Enhancement"),
                         footer: Text("Configure how the raw transcription should be processed and refined.")) {
                     
-                    TipView(selectAIEnhacementTip)
-                        .tipBackground(.teal.gradient)
+                    if !viewModel.aiEnhanceEnabled {
+                        TipView(selectAIEnhacementTip)
+                            .tipBackground(.teal.gradient)
+                    }
                     
                     Toggle("Enable", isOn: $viewModel.aiEnhanceEnabled)
                     

--- a/VivaDicta/Views/SettingsScreen/ModelsView.swift
+++ b/VivaDicta/Views/SettingsScreen/ModelsView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import TipKit
 
 struct ModelsView: View {
     @Bindable var appState: AppState
@@ -120,6 +121,12 @@ struct ModelsView: View {
         appState.aiService.updateDefaultModeIfNeeded(provider: model.provider, modelName: model.name)
         appState.transcriptionManager.updateCloudModels()
         cloudModelToConfigure = nil
+        
+        Task {
+            // Hide "Select Transcription model" tips
+            await SelectTranscriptionModelTipMainView.selectModelEvent.donate()
+            await SelectTranscriptionModelTipSettingsView.selectModelEvent.donate()
+        }
     }
 
     func handleAPIKeyDeletion(for model: CloudModel) {

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -220,12 +220,6 @@ struct SettingsView: View {
                     PromptsSettings(promptsManager: promptsManager, transition: promptsTransition)
                 case .transcriptionModels:
                     ModelsView(appState: appState)
-                        .task {
-                            let selectTranscriptionModelTipMainView = SelectTranscriptionModelTipMainView()
-                            selectTranscriptionModelTipMainView.invalidate(reason: .actionPerformed)
-                            selectTranscriptionModelTipSettingsView.invalidate(reason: .actionPerformed)
-
-                        }
                 case .promptsTemplates:
                     TemplateSelectionView(promptsManager: promptsManager)
                         .navigationTransition(.zoom(sourceID: "addPrompt", in: promptsTransition))

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import AppIntents
+import TipKit
 
 struct SettingsView: View {
 
@@ -30,6 +31,8 @@ struct SettingsView: View {
     @State private var isSmartFormattingEnabled = AppGroupCoordinator.shared.isSmartFormattingOnPasteEnabled
     @State private var isKeepInClipboardEnabled = AppGroupCoordinator.shared.isKeepTranscriptInClipboardEnabled
 
+    var selectTranscriptionModelTipSettingsView = SelectTranscriptionModelTipSettingsView()
+    
     var body: some View {
         NavigationStack(path: $navigationPath) {
             Form {
@@ -86,9 +89,12 @@ struct SettingsView: View {
                 }
                 
                 Section("Transcription") {
+//                    TipView(selectTranscriptionModelTipSettingsView)
+                    
                     NavigationLink(value: SettingsDestination.transcriptionModels) {
                         Text("Transcription Models")
                     }
+                    .popoverTip(selectTranscriptionModelTipSettingsView)
 
                     Toggle(isOn: $isVADEnabled) {
                         VStack(alignment: .leading, spacing: 4) {
@@ -214,6 +220,12 @@ struct SettingsView: View {
                     PromptsSettings(promptsManager: promptsManager, transition: promptsTransition)
                 case .transcriptionModels:
                     ModelsView(appState: appState)
+                        .task {
+                            let selectTranscriptionModelTipMainView = SelectTranscriptionModelTipMainView()
+                            selectTranscriptionModelTipMainView.invalidate(reason: .actionPerformed)
+                            selectTranscriptionModelTipSettingsView.invalidate(reason: .actionPerformed)
+
+                        }
                 case .promptsTemplates:
                     TemplateSelectionView(promptsManager: promptsManager)
                         .navigationTransition(.zoom(sourceID: "addPrompt", in: promptsTransition))

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -31,7 +31,7 @@ struct SettingsView: View {
     @State private var isSmartFormattingEnabled = AppGroupCoordinator.shared.isSmartFormattingOnPasteEnabled
     @State private var isKeepInClipboardEnabled = AppGroupCoordinator.shared.isKeepTranscriptInClipboardEnabled
 
-    var selectTranscriptionModelTipSettingsView = SelectTranscriptionModelTipSettingsView()
+    let selectTranscriptionModelTipSettingsView = SelectTranscriptionModelTipSettingsView()
     
     var body: some View {
         NavigationStack(path: $navigationPath) {

--- a/VivaDicta/VivaDictaApp.swift
+++ b/VivaDicta/VivaDictaApp.swift
@@ -83,7 +83,7 @@ struct VivaDictaApp: App {
             if hasCompletedOnboarding {
                 MainView(appState: appState)
                     .task {
-//                        try? Tips.resetDatastore()
+                        try? Tips.resetDatastore()
                         
                         try? Tips.configure([
 //                            .displayFrequency(.immediate),

--- a/VivaDicta/VivaDictaApp.swift
+++ b/VivaDicta/VivaDictaApp.swift
@@ -11,6 +11,7 @@ import os
 import AppIntents
 import CoreSpotlight
 import ActivityKit
+import TipKit
 
 @main
 struct VivaDictaApp: App {
@@ -81,6 +82,13 @@ struct VivaDictaApp: App {
         WindowGroup {
             if hasCompletedOnboarding {
                 MainView(appState: appState)
+                    .task {
+//                        try? Tips.resetDatastore()
+                        
+                        try? Tips.configure([
+//                            .displayFrequency(.immediate),
+                            .datastoreLocation(.applicationDefault)])
+                    }
                     .onAppear {
                     // Set the AppState reference for quick actions
 #if !os(macOS)

--- a/VivaDicta/VivaDictaApp.swift
+++ b/VivaDicta/VivaDictaApp.swift
@@ -83,7 +83,7 @@ struct VivaDictaApp: App {
             if hasCompletedOnboarding {
                 MainView(appState: appState)
                     .task {
-                        try? Tips.resetDatastore()
+//                        try? Tips.resetDatastore()
                         
                         try? Tips.configure([
 //                            .displayFrequency(.immediate),


### PR DESCRIPTION
## Summary

- Add TipKit integration for guiding users to select transcription models
- `SelectTranscriptionModelTipMainView` - shows on settings gear icon when no models are available
- `SelectTranscriptionModelTipSettingsView` - shows in settings when models need to be configured
- `SelectLanguageTip` - guides users to select language for better transcription
- `SelectAIEnhacementTip` - prompts users about AI enhancement feature

## Implementation Details

- Tips use `@Parameter(.transient)` and `Event` rules to control display conditions
- Tip actions navigate users directly to the Models screen
- Tips sync with `hasAvailableTranscriptionModels` state to show/hide dynamically
- TipKit configured in app entry point with `Tips.configure()`

## Test Plan

- [ ] Verify tips appear when no transcription models are configured
- [ ] Verify tapping "Open Models" action navigates to Models screen
- [ ] Verify tips dismiss after user selects a model
- [ ] Test on both iOS 26+ and earlier versions