### PR TITLE
Add VAD toggle support to WhisperKit transcription

### DIFF
--- a/VivaDicta/Services/Transcription/WhisperKitTranscriptionService.swift
+++ b/VivaDicta/Services/Transcription/WhisperKitTranscriptionService.swift
@@ -131,8 +131,12 @@ class WhisperKitTranscriptionService: TranscriptionService {
         do {
             // Get selected language if not auto-detect (shared with keyboard)
             let language = UserDefaultsStorage.shared.string(forKey: AppGroupCoordinator.kSelectedLanguageKey) ?? "auto"
-            let decodingOptions = DecodingOptions(language: language == "auto" ? nil : language, detectLanguage: language == "auto")
-
+            let decodingOptions = DecodingOptions(
+                language: (language == "auto" ? nil : language),
+                detectLanguage: (language == "auto" ? true : nil),
+                chunkingStrategy: .vad
+            )
+            
             // Perform transcription
             let result = try await whisperKit.transcribe(audioPath: audioURL.path, decodeOptions: decodingOptions)
 

--- a/VivaDicta/Services/Transcription/WhisperKitTranscriptionService.swift
+++ b/VivaDicta/Services/Transcription/WhisperKitTranscriptionService.swift
@@ -131,10 +131,12 @@ class WhisperKitTranscriptionService: TranscriptionService {
         do {
             // Get selected language if not auto-detect (shared with keyboard)
             let language = UserDefaultsStorage.shared.string(forKey: AppGroupCoordinator.kSelectedLanguageKey) ?? "auto"
+            // VAD setting should be shared with keyboard extension
+            let isVADEnabled = UserDefaultsStorage.shared.object(forKey: AppGroupCoordinator.kIsVADEnabled) as? Bool ?? true
             let decodingOptions = DecodingOptions(
                 language: (language == "auto" ? nil : language),
                 detectLanguage: (language == "auto" ? true : nil),
-                chunkingStrategy: .vad
+                chunkingStrategy: isVADEnabled ? .vad : nil
             )
             
             // Perform transcription


### PR DESCRIPTION
## Summary
- Enables VAD (Voice Activity Detection) setting for WhisperKit transcription service
- WhisperKit now respects the VAD toggle from Settings, consistent with Parakeet behavior
- When VAD is enabled (default): uses `chunkingStrategy: .vad`
- When VAD is disabled: uses `chunkingStrategy: nil`

## Changes
- Updated `WhisperKitTranscriptionService.swift` to read VAD setting from `AppGroupCoordinator.kIsVADEnabled`
- Applied conditional chunking strategy based on user preference

## Test plan
- [ ] Toggle VAD setting OFF in Settings, transcribe audio with WhisperKit - verify no VAD chunking
- [ ] Toggle VAD setting ON in Settings, transcribe audio with WhisperKit - verify VAD chunking is applied
- [ ] Verify setting is shared with keyboard extension