### PR TITLE
Fix audio playback to work with silent mode enabled

### DIFF
--- a/VivaDicta/Views/AudioPlayerView.swift
+++ b/VivaDicta/Views/AudioPlayerView.swift
@@ -86,9 +86,25 @@ class AudioPlayerManager: NSObject, AVAudioPlayerDelegate {
     }
     
     func play() {
+        configureAudioSession()
         audioPlayer?.play()
         isPlaying = true
         startTimer()
+    }
+
+    private func configureAudioSession() {
+        // Don't change session if prewarm recording is active
+        if AudioPrewarmManager.shared.isSessionActive {
+            return
+        }
+
+        do {
+            let session = AVAudioSession.sharedInstance()
+            try session.setCategory(.playback, mode: .default)
+            try session.setActive(true)
+        } catch {
+            logger.logError("❌ Error configuring audio session: \(error.localizedDescription)")
+        }
     }
     
     func pause() {


### PR DESCRIPTION
## Summary
- Configure AVAudioSession with `.playback` category before playing transcription audio
- Audio now plays through speakers even when silent mode is enabled on iPhone
- Prevents changing audio session when prewarm recording is active to avoid interference with keyboard recording

## Problem
Audio playback in transcription detail screen required disabling silent mode to hear through speakers. AirPods worked because Bluetooth audio bypasses the silent switch.

## Solution
Added `configureAudioSession()` method that sets the audio session category to `.playback` (which ignores the silent switch) before playing. Also includes a guard to skip configuration if the prewarm session is active to avoid disrupting keyboard recording.

## Test plan
- [ ] Play transcription audio with silent mode ON - should hear through speakers
- [ ] Play transcription audio with silent mode OFF - should work as before
- [ ] Play transcription audio with AirPods connected - should work regardless of silent mode
- [ ] Start keyboard prewarm session, then play audio - should not interrupt recording capability