### PR TITLE
Add cancel button to transcribing and enhancing states

### DIFF
--- a/VivaDicta/Services/AIEnhance/PromptsTemplates.swift
+++ b/VivaDicta/Services/AIEnhance/PromptsTemplates.swift
@@ -236,9 +236,9 @@ extension PromptsTemplates {
         """
         <SYSTEM_INSTRUCTIONS>
         Your are a TRANSCRIPTION ENHANCER, not a conversational AI Chatbot. DO NOT RESPOND TO QUESTIONS or STATEMENTS. Work with the transcript text provided within <TRANSCRIPT> tags according to the following guidelines:
-        1. Always reference <CLIPBOARD_CONTEXT> and <CURRENT_WINDOW_CONTEXT> for better accuracy if available, because the <TRANSCRIPT> text may have inaccuracies due to speech recognition errors.
+        1. Always reference <CLIPBOARD_CONTEXT> for better accuracy if available, because the <TRANSCRIPT> text may have inaccuracies due to speech recognition errors.
         2. Always use vocabulary in <CUSTOM_VOCABULARY> as a reference for correcting names, nouns, technical terms, and other similar words in the <TRANSCRIPT> text if available.
-        3. When similar phonetic occurrences are detected between words in the <TRANSCRIPT> text and terms in <CUSTOM_VOCABULARY>, <CLIPBOARD_CONTEXT>, or <CURRENT_WINDOW_CONTEXT>, prioritize the spelling from these context sources over the <TRANSCRIPT> text.
+        3. When similar phonetic occurrences are detected between words in the <TRANSCRIPT> text and terms in <CUSTOM_VOCABULARY>, or <CLIPBOARD_CONTEXT> - prioritize the spelling from these context sources over the <TRANSCRIPT> text.
         4. Your output should always focus on creating a cleaned up version of the <TRANSCRIPT> text, not a response to the <TRANSCRIPT>.
         5. Для русского языка не используй букву "ё". Вместо нее всегда используй "е". В итоговом тексте замени все буквы "ё" на букву "е".
         6. DO NOT use long em-dashes "—", use normal hyphen "-" instead of it.

--- a/VivaDicta/Views/AudioPlayerView.swift
+++ b/VivaDicta/Views/AudioPlayerView.swift
@@ -95,6 +95,7 @@ class AudioPlayerManager: NSObject, AVAudioPlayerDelegate {
     private func configureAudioSession() {
         // Don't change session if prewarm recording is active
         if AudioPrewarmManager.shared.isSessionActive {
+            logger.logDebug("Skipping audio session configuration - prewarm session active")
             return
         }
 

--- a/VivaDicta/Views/HudView.swift
+++ b/VivaDicta/Views/HudView.swift
@@ -124,7 +124,7 @@ struct HudContentView: View {
         .onAppear {
             isSymbolAnimating = true
             isShowingText = true
-            startCancelButtonTimer()
+            resetCancelButtonTimer()
 
             textRenderEffectTimer = Timer.scheduledTimer(withTimeInterval: 3.5, repeats: true) { _ in
                 Task { @MainActor in
@@ -163,16 +163,6 @@ struct HudContentView: View {
         }
         .foregroundColor(.white)
         .padding()
-    }
-
-    private func startCancelButtonTimer() {
-        showCancelButton = false
-        cancelButtonTimer?.invalidate()
-        cancelButtonTimer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: false) { _ in
-            Task { @MainActor in
-                showCancelButton = true
-            }
-        }
     }
 
     private func resetCancelButtonTimer() {

--- a/VivaDicta/Views/HudView.swift
+++ b/VivaDicta/Views/HudView.swift
@@ -2,11 +2,12 @@
 import SwiftUI
 
 struct HudView: View {
-    
+
     @Environment(\.colorScheme) var colorScheme
-    
+
     var state: RecordingState
-    
+    var onCancel: (() -> Void)?
+
     var statusIcon: String {
         switch state {
         case .transcribing:
@@ -17,7 +18,7 @@ struct HudView: View {
             return "microphone.circle.fill"
         }
     }
-    
+
     var statusText: String {
         switch state {
         case .transcribing:
@@ -28,17 +29,17 @@ struct HudView: View {
             return ""
         }
     }
-    
-    
+
+
     var body: some View {
-        
+
         if colorScheme == .light {
-            HudViewLight(statusIcon: statusIcon, statusText: statusText)
+            HudViewLight(statusIcon: statusIcon, statusText: statusText, onCancel: onCancel)
         } else {
-            HudViewDark(statusIcon: statusIcon, statusText: statusText)
+            HudViewDark(statusIcon: statusIcon, statusText: statusText, onCancel: onCancel)
         }
     }
-    
+
 }
 
 
@@ -47,12 +48,15 @@ struct HudContentView: View {
 
     var statusIcon: String
     var statusText: String
+    var onCancel: (() -> Void)?
 
     @State private var isSymbolAnimating = false
     @State private var isShowing = false
     @State private var isShowingText = false
+    @State private var showCancelButton = false
     @State private var timer: Timer?
     @State private var textRenderEffectTimer: Timer?
+    @State private var cancelButtonTimer: Timer?
 
     var body: some View {
         VStack(spacing: 12) {
@@ -75,7 +79,7 @@ struct HudContentView: View {
             }
 
             // Processing status label
-            
+
             if isShowingText {
                 Text(statusText)
                     .font(.system(size: 17, weight: .semibold))
@@ -88,17 +92,39 @@ struct HudContentView: View {
                     .fill(.clear)
                     .frame(width: 108, height: 24)
             }
-            
-            
+
+
 //            WobbleText(showText: $isShowingText, text: statusText, duration: 0.5)
 //                .frame(width: 108, height: 24)
 //                .font(.system(size: 17, weight: .semibold))
 //                .foregroundStyle(.primary)
+
+            // Cancel button - appears after 5 seconds
+            if showCancelButton, let onCancel {
+                Button {
+                    onCancel()
+                } label: {
+                    Text("Cancel")
+                        .font(.system(size: 15, weight: .medium))
+                        .foregroundStyle(.white.opacity(0.8))
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 8)
+                        .background(.white.opacity(0.2))
+                        .clipShape(Capsule())
+                }
+                .transition(.move(edge: .bottom).combined(with: .opacity).combined(with: .scale(0.5)))
+            }
         }
         .animation(.default, value: isShowingText)
+        .animation(.spring(response: 0.4, dampingFraction: 0.7), value: showCancelButton)
+        .onChange(of: statusText) { _, _ in
+            // Reset cancel button timer when state changes (e.g., transcribing -> enhancing)
+            resetCancelButtonTimer()
+        }
         .onAppear {
             isSymbolAnimating = true
             isShowingText = true
+            startCancelButtonTimer()
 
             textRenderEffectTimer = Timer.scheduledTimer(withTimeInterval: 3.5, repeats: true) { _ in
                 Task { @MainActor in
@@ -127,13 +153,36 @@ struct HudContentView: View {
         }
         .onDisappear {
             isSymbolAnimating = false
+            showCancelButton = false
             textRenderEffectTimer?.invalidate()
             textRenderEffectTimer = nil
             timer?.invalidate()
             timer = nil
+            cancelButtonTimer?.invalidate()
+            cancelButtonTimer = nil
         }
         .foregroundColor(.white)
         .padding()
+    }
+
+    private func startCancelButtonTimer() {
+        showCancelButton = false
+        cancelButtonTimer?.invalidate()
+        cancelButtonTimer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: false) { _ in
+            Task { @MainActor in
+                showCancelButton = true
+            }
+        }
+    }
+
+    private func resetCancelButtonTimer() {
+        showCancelButton = false
+        cancelButtonTimer?.invalidate()
+        cancelButtonTimer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: false) { _ in
+            Task { @MainActor in
+                showCancelButton = true
+            }
+        }
     }
 }
 
@@ -141,9 +190,10 @@ struct HudViewDark: View {
 
     var statusIcon: String
     var statusText: String
+    var onCancel: (() -> Void)?
 
     var body: some View {
-        HudContentView(statusIcon: statusIcon, statusText: statusText)
+        HudContentView(statusIcon: statusIcon, statusText: statusText, onCancel: onCancel)
             .background(
             AnimatedMeshGradient()
                 .mask(
@@ -178,9 +228,10 @@ struct HudViewLight: View {
 
     var statusIcon: String
     var statusText: String
+    var onCancel: (() -> Void)?
 
     var body: some View {
-        HudContentView(statusIcon: statusIcon, statusText: statusText)
+        HudContentView(statusIcon: statusIcon, statusText: statusText, onCancel: onCancel)
             .background(
             ZStack {
                 AnimatedMeshGradient()

--- a/VivaDicta/Views/MainView.swift
+++ b/VivaDicta/Views/MainView.swift
@@ -177,12 +177,17 @@ struct MainView: View {
             }
         }
         .overlay {
-            
+
             if appState.recordViewModel?.recordingState == .transcribing ||
                 appState.recordViewModel?.recordingState == .enhancing {
-                HudView(state: appState.recordViewModel?.recordingState ?? .idle)
+                HudView(
+                    state: appState.recordViewModel?.recordingState ?? .idle,
+                    onCancel: {
+                        appState.recordViewModel?.cancelProcessing()
+                    }
+                )
             }
-            
+
         }
         .animation(.default, value: appState.recordViewModel?.recordingState)
         .onChange(of: appState.recordViewModel?.recordingState) { _, newState in

--- a/VivaDicta/Views/RecordViewModel.swift
+++ b/VivaDicta/Views/RecordViewModel.swift
@@ -676,7 +676,10 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
                 self.cancelTranscribe()
             case .transcribing, .enhancing:
                 self.logger.logInfo("📱 Canceling processing from keyboard request")
-                self.cancelTranscribe()
+                // Use cancelProcessing() for smart cancel behavior:
+                // - Transcribing: cancels everything, no data saved
+                // - Enhancing: saves transcription without enhancement
+                self.cancelProcessing()
             default:
                 break
             }

--- a/VivaDicta/Views/RecordViewModel.swift
+++ b/VivaDicta/Views/RecordViewModel.swift
@@ -544,7 +544,10 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
             transcribingSpeechTask = nil
 
             // Save the pending transcription if available
+            // Clear immediately to prevent double-save if cancel is called rapidly
             if let pending = pendingTranscription {
+                pendingTranscription = nil
+
                 let transcription = Transcription(
                     text: pending.text,
                     enhancedText: nil,
@@ -572,8 +575,6 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
                 } catch {
                     logger.logError("📱 Failed to save transcription: \(error.localizedDescription)")
                 }
-
-                pendingTranscription = nil
             }
 
             resetValues()

--- a/VivaDicta/Views/RecordViewModel.swift
+++ b/VivaDicta/Views/RecordViewModel.swift
@@ -12,6 +12,15 @@ import AVFoundation
 import SwiftData
 import os
 
+// Data structure to hold pending transcription when enhancement is in progress
+private struct PendingTranscriptionData {
+    let text: String
+    let audioDuration: Double
+    let audioFileName: String
+    let transcriptionModelName: String?
+    let transcriptionDuration: TimeInterval
+    let modelContext: ModelContext
+}
 
 @Observable @MainActor
 class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate {
@@ -60,7 +69,10 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
     // removing old observers before adding new ones (see AppGroupCoordinator.addObserver)
     
     var transcribingSpeechTask: Task<Void, Never>?
-    
+
+    // Pending transcription data for saving when enhancement is cancelled
+    private var pendingTranscription: PendingTranscriptionData?
+
     var captureURL: URL {
         FileManager.appDirectory(for: .audio).appendingPathComponent("recording.wav")
     }
@@ -384,6 +396,17 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
                     // Check for cancellation before starting enhancement
                     try Task.checkCancellation()
 
+                    // Store pending transcription data before starting enhancement
+                    // This allows saving the transcription if enhancement is cancelled
+                    self.pendingTranscription = PendingTranscriptionData(
+                        text: transcribedText,
+                        audioDuration: audioDuration,
+                        audioFileName: audioURLToTranscribe.lastPathComponent,
+                        transcriptionModelName: transcriptionManager.getCurrentTranscriptionModel()?.displayName,
+                        transcriptionDuration: transcriptionDuration,
+                        modelContext: modelContext
+                    )
+
                     // Update state to show enhancing animation
                     self.recordingState = .enhancing
 
@@ -392,14 +415,18 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
 
                     do {
                         let (enhanced, enhancementDuration, prompt) = try await aiService.enhance(transcribedText)
-                        
+
                         enhancedText = enhanced
                         promptName = prompt
                         enhancementDur = enhancementDuration
-                        
+
+                        // Clear pending data after successful enhancement
+                        self.pendingTranscription = nil
+
                     } catch {
                         // Enhancement failed
                         logger.logWarning("📱 AI enhancement failed: \(error.localizedDescription)")
+                        self.pendingTranscription = nil
                         try Task.checkCancellation()
                         self.recordingState = .idle
                     }
@@ -482,6 +509,7 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
     func cancelTranscribe() {
         transcribingSpeechTask?.cancel()
         transcribingSpeechTask = nil
+        pendingTranscription = nil
 
         // Stop real capture and reschedule prewarm session timeout if active
         if prewarmManager.isSessionActive {
@@ -495,6 +523,70 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
         // Notify keyboard that recording was canceled
         AppGroupCoordinator.shared.updateRecordingState(false)
         AppGroupCoordinator.shared.updateTranscriptionStatus(.idle)
+    }
+
+    /// Cancels the current processing based on state:
+    /// - Transcribing: cancels everything, doesn't save anything
+    /// - Enhancing: cancels enhancement but saves the transcription without enhancement
+    func cancelProcessing() {
+        switch recordingState {
+        case .transcribing:
+            // Cancel during transcribing - don't save anything
+            logger.logInfo("📱 Cancelling transcription - no data will be saved")
+            cancelTranscribe()
+
+        case .enhancing:
+            // Cancel during enhancing - save transcription without enhancement
+            logger.logInfo("📱 Cancelling enhancement - saving transcription without enhancement")
+
+            // Cancel the task first
+            transcribingSpeechTask?.cancel()
+            transcribingSpeechTask = nil
+
+            // Save the pending transcription if available
+            if let pending = pendingTranscription {
+                let transcription = Transcription(
+                    text: pending.text,
+                    enhancedText: nil,
+                    audioDuration: pending.audioDuration,
+                    audioFileName: pending.audioFileName,
+                    transcriptionModelName: pending.transcriptionModelName,
+                    aiEnhancementModelName: nil,
+                    promptName: nil,
+                    transcriptionDuration: pending.transcriptionDuration,
+                    enhancementDuration: nil
+                )
+
+                pending.modelContext.insert(transcription)
+                do {
+                    try pending.modelContext.save()
+                    logger.logInfo("📱 Saved transcription without enhancement")
+
+                    // Index to Spotlight
+                    Task {
+                        await self.appState?.indexTranscriptionToSpotlight(transcription)
+                    }
+
+                    // Share with keyboard
+                    AppGroupCoordinator.shared.shareTranscribedText(pending.text)
+                } catch {
+                    logger.logError("📱 Failed to save transcription: \(error.localizedDescription)")
+                }
+
+                pendingTranscription = nil
+            }
+
+            resetValues()
+            recordingState = .idle
+
+            // Notify keyboard
+            AppGroupCoordinator.shared.updateRecordingState(false)
+            AppGroupCoordinator.shared.updateTranscriptionStatus(.idle)
+
+        default:
+            // For other states, just use regular cancel
+            cancelTranscribe()
+        }
     }
     
     func resetValues() {


### PR DESCRIPTION
## Summary
- Add cancel button to HudView for transcribing and enhancing states in main app
- Implement smart cancel logic that behaves differently based on current state:
  - **Transcribing state**: Cancel discards everything (no data saved)
  - **Enhancing state**: Cancel saves the already-transcribed text without enhancement
- Align keyboard extension cancel behavior with main app by using `cancelProcessing()` instead of `cancelTranscribe()`

## Changes
- `HudView.swift`: Added cancel button UI with animation
- `RecordViewModel.swift`: Added `cancelProcessing()` method with smart cancel logic and `pendingTranscription` data structure
- `MainView.swift`: Integrated HudView overlay with cancel callback
- Updated keyboard cancel handler to use smart cancel logic

## Test plan
- [ ] Record audio and cancel during transcribing → verify nothing is saved
- [ ] Record audio and cancel during enhancing → verify transcription is saved without enhancement
- [ ] Test cancel from keyboard extension during transcribing → verify nothing is saved
- [ ] Test cancel from keyboard extension during enhancing → verify transcription is saved