### PR TITLE
Add text replacement feature for transcriptions

### DIFF
--- a/VivaDicta/Services/ReplacementsService.swift
+++ b/VivaDicta/Services/ReplacementsService.swift
@@ -12,35 +12,36 @@ import os
 @Observable
 class ReplacementsService {
     private let logger = Logger(category: .customVocabulary)
-    private let userDefaults: UserDefaults
-    private let storageKey: String
+    private static let userDefaults: UserDefaults = UserDefaultsStorage.appPrivate
+    private static let storageKey: String = UserDefaultsStorage.Keys.textReplacements
 
     /// Maximum character length for original or replacement text
     static let maxTextLength = 100
 
     /// Ordered array of replacements (newest first)
     private(set) var replacements: [Replacement] = []
+    
+    static func loadAllReplacements() -> [Replacement]? {
+        guard let data = userDefaults.data(forKey: storageKey),
+              let decoded = try? JSONDecoder().decode([Replacement].self, from: data) else {
+            return nil
+        }
+        
+        return decoded
+    }
 
-    init(userDefaults: UserDefaults = UserDefaultsStorage.appPrivate,
-         storageKey: String = UserDefaultsStorage.Keys.textReplacements) {
-        self.userDefaults = userDefaults
-        self.storageKey = storageKey
+    init() {
         loadReplacements()
     }
 
     private func loadReplacements() {
-        guard let data = userDefaults.data(forKey: storageKey),
-              let decoded = try? JSONDecoder().decode([Replacement].self, from: data) else {
-            replacements = []
-            return
-        }
-        replacements = decoded
+        replacements = Self.loadAllReplacements() ?? []
         logger.logInfo("Loaded \(self.replacements.count) text replacements")
     }
 
     private func saveReplacements() {
         guard let data = try? JSONEncoder().encode(replacements) else { return }
-        userDefaults.set(data, forKey: storageKey)
+        Self.userDefaults.set(data, forKey: Self.storageKey)
     }
 
     func addReplacement(original: String, replacement: String) {
@@ -116,6 +117,62 @@ class ReplacementsService {
         replacements.remove(atOffsets: offsets)
         saveReplacements()
         logger.logInfo("Deleted \(offsets.count) replacements")
+    }
+
+    // MARK: - Apply Replacements
+
+    /// Applies all stored replacements to the given text (case-insensitive with word boundaries)
+    /// - Parameter text: The text to apply replacements to
+    /// - Returns: The text with all replacements applied
+    static func applyReplacements(to text: String) -> String {
+        guard let replacements = loadAllReplacements(), !replacements.isEmpty else {
+            return text
+        }
+
+        var modifiedText = text
+
+        for replacement in replacements {
+            let original = replacement.original
+            let replacementText = replacement.replacement
+
+            let usesBoundaries = usesWordBoundaries(for: original)
+
+            if usesBoundaries {
+                // Word-boundary regex using Swift native Regex (case-insensitive)
+                let escapedOriginal = NSRegularExpression.escapedPattern(for: original)
+                if let regex = try? Regex("\\b\(escapedOriginal)\\b").ignoresCase() {
+                    modifiedText = modifiedText.replacing(regex, with: replacementText)
+                }
+            } else {
+                // For non-spaced scripts (CJK, Thai, etc.), use simple case-insensitive replacement
+                if let regex = try? Regex(NSRegularExpression.escapedPattern(for: original)).ignoresCase() {
+                    modifiedText = modifiedText.replacing(regex, with: replacementText)
+                }
+            }
+        }
+
+        return modifiedText
+    }
+
+    /// Returns false for languages without spaces (CJK, Thai), true for spaced languages
+    private static func usesWordBoundaries(for text: String) -> Bool {
+        let nonSpacedScripts: [ClosedRange<UInt32>] = [
+            0x3040...0x309F, // Hiragana
+            0x30A0...0x30FF, // Katakana
+            0x4E00...0x9FFF, // CJK Unified Ideographs
+            0xAC00...0xD7AF, // Hangul Syllables
+            0x0E00...0x0E7F  // Thai
+        ]
+
+        for scalar in text.unicodeScalars {
+            for range in nonSpacedScripts {
+                if range.contains(scalar.value) {
+                    return false
+                }
+            }
+        }
+
+        return true
     }
 }
 

--- a/VivaDicta/Services/ReplacementsService.swift
+++ b/VivaDicta/Services/ReplacementsService.swift
@@ -178,7 +178,7 @@ class ReplacementsService {
 
 // MARK: - Replacement Model
 
-struct Replacement: Identifiable, Codable, Equatable, Hashable {
+struct Replacement: Identifiable, Codable, Equatable, Hashable, Sendable {
     var id: UUID
     let original: String
     let replacement: String

--- a/VivaDicta/Services/ReplacementsService.swift
+++ b/VivaDicta/Services/ReplacementsService.swift
@@ -11,37 +11,31 @@ import os
 
 @Observable
 class ReplacementsService {
-    private let logger = Logger(category: .customVocabulary)
-    private static let userDefaults: UserDefaults = UserDefaultsStorage.appPrivate
-    private static let storageKey: String = UserDefaultsStorage.Keys.textReplacements
+    private let logger = Logger(category: .replacementsService)
+    private let userDefaults: UserDefaults
+    private let storageKey: String
 
     /// Maximum character length for original or replacement text
     static let maxTextLength = 100
 
     /// Ordered array of replacements (newest first)
     private(set) var replacements: [Replacement] = []
-    
-    static func loadAllReplacements() -> [Replacement]? {
-        guard let data = userDefaults.data(forKey: storageKey),
-              let decoded = try? JSONDecoder().decode([Replacement].self, from: data) else {
-            return nil
-        }
-        
-        return decoded
-    }
 
-    init() {
+    init(userDefaults: UserDefaults = UserDefaultsStorage.appPrivate,
+         storageKey: String = UserDefaultsStorage.Keys.textReplacements) {
+        self.userDefaults = userDefaults
+        self.storageKey = storageKey
         loadReplacements()
     }
 
     private func loadReplacements() {
-        replacements = Self.loadAllReplacements() ?? []
+        replacements = Self.loadReplacements(from: userDefaults, storageKey: storageKey) ?? []
         logger.logInfo("Loaded \(self.replacements.count) text replacements")
     }
 
     private func saveReplacements() {
         guard let data = try? JSONEncoder().encode(replacements) else { return }
-        Self.userDefaults.set(data, forKey: Self.storageKey)
+        userDefaults.set(data, forKey: storageKey)
     }
 
     func addReplacement(original: String, replacement: String) {
@@ -119,16 +113,34 @@ class ReplacementsService {
         logger.logInfo("Deleted \(offsets.count) replacements")
     }
 
+    // MARK: - Static Methods for Loading
+
+    /// Loads replacements from the specified UserDefaults
+    static func loadReplacements(
+        from userDefaults: UserDefaults = UserDefaultsStorage.appPrivate,
+        storageKey: String = UserDefaultsStorage.Keys.textReplacements
+    ) -> [Replacement]? {
+        guard let data = userDefaults.data(forKey: storageKey),
+              let decoded = try? JSONDecoder().decode([Replacement].self, from: data) else {
+            return nil
+        }
+        return decoded
+    }
+
     // MARK: - Apply Replacements
 
     /// Applies all stored replacements to the given text (case-insensitive with word boundaries)
     /// - Parameter text: The text to apply replacements to
     /// - Returns: The text with all replacements applied
     static func applyReplacements(to text: String) -> String {
-        guard let replacements = loadAllReplacements(), !replacements.isEmpty else {
+        guard let replacements = loadReplacements(), !replacements.isEmpty else {
             return text
         }
+        return applyReplacements(replacements, to: text)
+    }
 
+    /// Applies the given replacements to the text (for testing)
+    static func applyReplacements(_ replacements: [Replacement], to text: String) -> String {
         var modifiedText = text
 
         for replacement in replacements {
@@ -155,7 +167,8 @@ class ReplacementsService {
     }
 
     /// Returns false for languages without spaces (CJK, Thai), true for spaced languages
-    private static func usesWordBoundaries(for text: String) -> Bool {
+    /// Made internal for testing
+    static func usesWordBoundaries(for text: String) -> Bool {
         let nonSpacedScripts: [ClosedRange<UInt32>] = [
             0x3040...0x309F, // Hiragana
             0x30A0...0x30FF, // Katakana

--- a/VivaDicta/Services/ReplacementsService.swift
+++ b/VivaDicta/Services/ReplacementsService.swift
@@ -1,0 +1,134 @@
+//
+//  ReplacementsService.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2025.12.10
+//
+
+import Foundation
+import SwiftUI
+import os
+
+@Observable
+class ReplacementsService {
+    private let logger = Logger(category: .customVocabulary)
+    private let userDefaults: UserDefaults
+    private let storageKey: String
+
+    /// Maximum character length for original or replacement text
+    static let maxTextLength = 100
+
+    /// Ordered array of replacements (newest first)
+    private(set) var replacements: [Replacement] = []
+
+    init(userDefaults: UserDefaults = UserDefaultsStorage.appPrivate,
+         storageKey: String = UserDefaultsStorage.Keys.textReplacements) {
+        self.userDefaults = userDefaults
+        self.storageKey = storageKey
+        loadReplacements()
+    }
+
+    private func loadReplacements() {
+        guard let data = userDefaults.data(forKey: storageKey),
+              let decoded = try? JSONDecoder().decode([Replacement].self, from: data) else {
+            replacements = []
+            return
+        }
+        replacements = decoded
+        logger.logInfo("Loaded \(self.replacements.count) text replacements")
+    }
+
+    private func saveReplacements() {
+        guard let data = try? JSONEncoder().encode(replacements) else { return }
+        userDefaults.set(data, forKey: storageKey)
+    }
+
+    func addReplacement(original: String, replacement: String) {
+        var trimmedOriginal = original.trimmingCharacters(in: .whitespacesAndNewlines)
+        var trimmedReplacement = replacement.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !trimmedOriginal.isEmpty, !trimmedReplacement.isEmpty else { return }
+
+        // Truncate if too long
+        if trimmedOriginal.count > Self.maxTextLength {
+            trimmedOriginal = String(trimmedOriginal.prefix(Self.maxTextLength))
+        }
+        if trimmedReplacement.count > Self.maxTextLength {
+            trimmedReplacement = String(trimmedReplacement.prefix(Self.maxTextLength))
+        }
+
+        // Check for duplicate original (case-insensitive)
+        let isDuplicate = replacements.contains {
+            $0.original.lowercased() == trimmedOriginal.lowercased()
+        }
+        guard !isDuplicate else {
+            logger.logWarning("Replacement already exists for: \(trimmedOriginal)")
+            return
+        }
+
+        let newReplacement = Replacement(original: trimmedOriginal, replacement: trimmedReplacement)
+        replacements.insert(newReplacement, at: 0)
+        saveReplacements()
+        logger.logInfo("Added replacement: \(trimmedOriginal) -> \(trimmedReplacement)")
+    }
+
+    func updateReplacement(_ oldReplacement: Replacement, original: String, replacement: String) {
+        var trimmedOriginal = original.trimmingCharacters(in: .whitespacesAndNewlines)
+        var trimmedReplacement = replacement.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !trimmedOriginal.isEmpty, !trimmedReplacement.isEmpty else { return }
+
+        // Truncate if too long
+        if trimmedOriginal.count > Self.maxTextLength {
+            trimmedOriginal = String(trimmedOriginal.prefix(Self.maxTextLength))
+        }
+        if trimmedReplacement.count > Self.maxTextLength {
+            trimmedReplacement = String(trimmedReplacement.prefix(Self.maxTextLength))
+        }
+
+        // Check for duplicate original (case-insensitive), excluding the one being edited
+        let isDuplicate = replacements.contains {
+            $0.original.lowercased() == trimmedOriginal.lowercased() && $0.id != oldReplacement.id
+        }
+        guard !isDuplicate else {
+            logger.logWarning("Replacement already exists for: \(trimmedOriginal)")
+            return
+        }
+
+        if let index = replacements.firstIndex(where: { $0.id == oldReplacement.id }) {
+            replacements[index] = Replacement(
+                id: oldReplacement.id,
+                original: trimmedOriginal,
+                replacement: trimmedReplacement
+            )
+            saveReplacements()
+            logger.logInfo("Updated replacement: \(trimmedOriginal) -> \(trimmedReplacement)")
+        }
+    }
+
+    func deleteReplacement(_ replacement: Replacement) {
+        replacements.removeAll { $0.id == replacement.id }
+        saveReplacements()
+        logger.logInfo("Deleted replacement: \(replacement.original)")
+    }
+
+    func deleteReplacements(at offsets: IndexSet) {
+        replacements.remove(atOffsets: offsets)
+        saveReplacements()
+        logger.logInfo("Deleted \(offsets.count) replacements")
+    }
+}
+
+// MARK: - Replacement Model
+
+struct Replacement: Identifiable, Codable, Equatable, Hashable {
+    var id: UUID
+    let original: String
+    let replacement: String
+
+    init(id: UUID = UUID(), original: String, replacement: String) {
+        self.id = id
+        self.original = original
+        self.replacement = replacement
+    }
+}

--- a/VivaDicta/Services/Transcription/TranscriptionManager.swift
+++ b/VivaDicta/Services/Transcription/TranscriptionManager.swift
@@ -120,6 +120,8 @@ class TranscriptionManager {
             result = TextFormatter.format(result)
         }
         
+        // Let's add replacements here
+        
         return result
     }
 

--- a/VivaDicta/Services/Transcription/TranscriptionManager.swift
+++ b/VivaDicta/Services/Transcription/TranscriptionManager.swift
@@ -115,13 +115,14 @@ class TranscriptionManager {
         let text = try await transcriptionService.transcribe(audioURL: audioURL, model: model)
         
         var result = TranscriptionOutputFilter.filter(text)
-        
+
         if UserDefaults.standard.object(forKey: UserDefaultsStorage.Keys.isTextFormattingEnabled) as? Bool ?? true {
             result = TextFormatter.format(result)
         }
-        
-        // Let's add replacements here
-        
+
+        // Apply text replacements
+        result = ReplacementsService.applyReplacements(to: result)
+
         return result
     }
 

--- a/VivaDicta/Services/Transcription/TranscriptionManager.swift
+++ b/VivaDicta/Services/Transcription/TranscriptionManager.swift
@@ -120,8 +120,10 @@ class TranscriptionManager {
             result = TextFormatter.format(result)
         }
 
-        // Apply text replacements
-        result = ReplacementsService.applyReplacements(to: result)
+        // Apply text replacements if enabled
+        if UserDefaults.standard.object(forKey: UserDefaultsStorage.Keys.isReplacementsEnabled) as? Bool ?? true {
+            result = ReplacementsService.applyReplacements(to: result)
+        }
 
         return result
     }

--- a/VivaDicta/Utilities/LoggerExtension.swift
+++ b/VivaDicta/Utilities/LoggerExtension.swift
@@ -42,6 +42,7 @@ public enum LogCategory: String {
     case appGroupCoordinator = "AppGroupCoordinator"
     case promptsManager = "PromptsManager"
     case customVocabulary = "CustomVocabulary"
+    case replacementsService = "ReplacementsService"
 
     // MARK: - Keyboard Extension
     case keyboardExtension = "KeyboardExtension"

--- a/VivaDicta/Utils/UserDefaultsStorage.swift
+++ b/VivaDicta/Utils/UserDefaultsStorage.swift
@@ -31,5 +31,6 @@ enum UserDefaultsStorage {
         static let displaySiriTip = "displaySiriTip"
         static let customVocabularyWords = "customVocabularyWords"
         static let textReplacements = "textReplacements"
+        static let isReplacementsEnabled = "isReplacementsEnabled"
     }
 }

--- a/VivaDicta/Utils/UserDefaultsStorage.swift
+++ b/VivaDicta/Utils/UserDefaultsStorage.swift
@@ -30,6 +30,6 @@ enum UserDefaultsStorage {
         static let isTextFormattingEnabled = "IsTextFormattingEnabled"
         static let displaySiriTip = "displaySiriTip"
         static let customVocabularyWords = "customVocabularyWords"
-
+        static let textReplacements = "textReplacements"
     }
 }

--- a/VivaDicta/Views/SettingsScreen/DictionaryView.swift
+++ b/VivaDicta/Views/SettingsScreen/DictionaryView.swift
@@ -1,5 +1,5 @@
 //
-//  DictionaryView.swift
+//  WordsDictionaryView.swift
 //  VivaDicta
 //
 //  Created by Anton Novoselov on 2025.12.10
@@ -7,66 +7,47 @@
 
 import SwiftUI
 
-struct DictionaryView: View {
-
-    enum DictionaryType: String, CaseIterable, Identifiable {
-        var id: Self { self }
-        case dictionary = "Dictionary"
-        case replacements = "Replacements"
-    }
-
-    @State var dictionaryType: DictionaryType = .dictionary
+struct WordsDictionaryView: View {
     @State private var newWord: String = ""
     @State private var customVocabularyService = CustomVocabularyService()
     @State private var wordToEdit: EditableWord?
-    
+
     @State private var editMode = false
     @State private var selectedWords: [String] = []
 
     var body: some View {
         VStack(spacing: 0) {
-            Picker("Dictionary Type", selection: $dictionaryType) {
-                ForEach(DictionaryType.allCases) {
-                    Text($0.rawValue)
-                }
-            }
-            .pickerStyle(.segmented)
-            .padding(.horizontal)
-            .padding(.vertical, 12)
-
-            if dictionaryType == .dictionary {
-                dictionaryContent
+            if customVocabularyService.words.isEmpty {
+                emptyStateView
             } else {
-                ReplacementsView()
+                if editMode {
+                    editModeToolbar
+                }
+                wordsList
+            }
+
+            if !editMode {
+                addWordBar
             }
         }
         .toolbar {
-            if dictionaryType == .dictionary {
-                if editMode {
-                    ToolbarItem(placement: .confirmationAction) {
-                        Button("Done") {
-                            selectedWords.removeAll()
-                            editMode = false
-                        }
+            if editMode {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") {
+                        selectedWords.removeAll()
+                        editMode = false
                     }
-                } else {
-                    ToolbarItem(placement: .primaryAction) {
-                        Button("Edit") {
-                            editMode = true
-                        }
-                        .disabled(customVocabularyService.words.isEmpty)
+                }
+            } else {
+                ToolbarItem(placement: .primaryAction) {
+                    Button("Edit") {
+                        editMode = true
                     }
+                    .disabled(customVocabularyService.words.isEmpty)
                 }
             }
         }
-        .navigationTitle("Dictionary")
-        .onChange(of: dictionaryType) { _, _ in
-            // Exit edit mode when switching tabs
-            if editMode {
-                selectedWords.removeAll()
-                editMode = false
-            }
-        }
+        .navigationTitle("Spelling Corrections")
         .navigationBarTitleDisplayMode(.inline)
         .sheet(item: $wordToEdit) { item in
             EditVocabularySheet(wordToEdit: item) { editedWord in
@@ -77,89 +58,82 @@ struct DictionaryView: View {
         }
     }
 
-    private var dictionaryContent: some View {
-        VStack(spacing: 0) {
-            if customVocabularyService.words.isEmpty {
-                ContentUnavailableView {
-                    Label("No Words", systemImage: "text.book.closed")
-                } description: {
-                    Text("Add words that should be recognized correctly during transcription")
+    private var emptyStateView: some View {
+        ContentUnavailableView {
+            Label("No Words", systemImage: "text.book.closed")
+        } description: {
+            Text("Add words that should be recognized correctly during transcription")
+        }
+        .frame(maxHeight: .infinity)
+    }
+
+    private var editModeToolbar: some View {
+        HStack {
+            Button(allWordsSelected ? "Deselect All" : "Select All") {
+                if allWordsSelected {
+                    selectedWords.removeAll()
+                } else {
+                    selectedWords = customVocabularyService.words
                 }
-                .frame(maxHeight: .infinity)
-            } else {
-                if editMode {
-                    HStack {
-                        Button(allWordsSelected ? "Deselect All" : "Select All") {
-                            if allWordsSelected {
-                                selectedWords.removeAll()
-                            } else {
-                                selectedWords = customVocabularyService.words
-                            }
-                        }
-
-                        Spacer()
-
-                        if !selectedWords.isEmpty {
-                            Button("Delete", role: .destructive) {
-                                deleteSelectedWords()
-                            }
-                        }
-                    }
-                    .padding(.horizontal)
-                    .padding(.vertical, 8)
-                }
-
-                List {
-                    ForEach(customVocabularyService.words, id: \.self) { word in
-                        
-                        Button {
-                            if editMode {
-                                toggleSelection(word)
-                            } else {
-                                wordToEdit = EditableWord(word: word)
-                            }
-                        } label: {
-                            HStack {
-                                if editMode {
-                                    Image(systemName: selectedWords.contains(word) ? "checkmark.circle.fill" : "circle")
-                                        .foregroundStyle(selectedWords.contains(word) ? .blue : .secondary)
-                                        .font(.title2)
-                                }
-
-                                Text(word)
-                                Spacer()
-                            }
-                            .contentShape(.rect)
-                        }
-                        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                            if !editMode {
-                                Button(role: .destructive) {
-                                    customVocabularyService.deleteWord(word)
-                                } label: {
-                                    Label("Delete", systemImage: "trash")
-                                }
-
-                                Button {
-                                    wordToEdit = EditableWord(word: word)
-                                } label: {
-                                    Label("Edit", systemImage: "pencil")
-                                }
-                                .tint(.blue)
-                            }
-                        }
-                    }
-                }
-                .listStyle(.plain)
             }
 
-            if !editMode {
-                addWordBar
+            Spacer()
+
+            if !selectedWords.isEmpty {
+                Button("Delete", role: .destructive) {
+                    deleteSelectedWords()
+                }
             }
         }
+        .padding(.horizontal)
+        .padding(.vertical, 8)
     }
 
     private var allWordsSelected: Bool {
         !customVocabularyService.words.isEmpty && selectedWords.count == customVocabularyService.words.count
+    }
+
+    private var wordsList: some View {
+        List {
+            ForEach(customVocabularyService.words, id: \.self) { word in
+                Button {
+                    if editMode {
+                        toggleSelection(word)
+                    } else {
+                        wordToEdit = EditableWord(word: word)
+                    }
+                } label: {
+                    HStack {
+                        if editMode {
+                            Image(systemName: selectedWords.contains(word) ? "checkmark.circle.fill" : "circle")
+                                .foregroundStyle(selectedWords.contains(word) ? .blue : .secondary)
+                                .font(.title2)
+                        }
+
+                        Text(word)
+                        Spacer()
+                    }
+                    .contentShape(.rect)
+                }
+                .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                    if !editMode {
+                        Button(role: .destructive) {
+                            customVocabularyService.deleteWord(word)
+                        } label: {
+                            Label("Delete", systemImage: "trash")
+                        }
+
+                        Button {
+                            wordToEdit = EditableWord(word: word)
+                        } label: {
+                            Label("Edit", systemImage: "pencil")
+                        }
+                        .tint(.blue)
+                    }
+                }
+            }
+        }
+        .listStyle(.plain)
     }
 
     private func toggleSelection(_ word: String) {
@@ -181,7 +155,6 @@ struct DictionaryView: View {
             editMode = false
         }
     }
-    
 
     private var addWordBar: some View {
         VStack(spacing: 4) {
@@ -299,6 +272,6 @@ private struct EditVocabularySheet: View {
 
 #Preview {
     NavigationStack {
-        DictionaryView(dictionaryType: .dictionary)
+        WordsDictionaryView()
     }
 }

--- a/VivaDicta/Views/SettingsScreen/DictionaryView.swift
+++ b/VivaDicta/Views/SettingsScreen/DictionaryView.swift
@@ -37,27 +37,36 @@ struct DictionaryView: View {
             if dictionaryType == .dictionary {
                 dictionaryContent
             } else {
-                replacementsContent
+                ReplacementsView()
             }
         }
         .toolbar {
-            if editMode {
-                ToolbarItem(placement: .confirmationAction) {
-                    Button("Done") {
-                        selectedWords.removeAll()
-                        editMode = false
+            if dictionaryType == .dictionary {
+                if editMode {
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("Done") {
+                            selectedWords.removeAll()
+                            editMode = false
+                        }
                     }
-                }
-            } else {
-                ToolbarItem(placement: .primaryAction) {
-                    Button("Edit") {
-                        editMode = true
+                } else {
+                    ToolbarItem(placement: .primaryAction) {
+                        Button("Edit") {
+                            editMode = true
+                        }
+                        .disabled(customVocabularyService.words.isEmpty)
                     }
-                    .disabled(customVocabularyService.words.isEmpty)
                 }
             }
         }
         .navigationTitle("Dictionary")
+        .onChange(of: dictionaryType) { _, _ in
+            // Exit edit mode when switching tabs
+            if editMode {
+                selectedWords.removeAll()
+                editMode = false
+            }
+        }
         .navigationBarTitleDisplayMode(.inline)
         .sheet(item: $wordToEdit) { item in
             EditVocabularySheet(wordToEdit: item) { editedWord in
@@ -172,67 +181,7 @@ struct DictionaryView: View {
             editMode = false
         }
     }
-
-    private var replacementsContent: some View {
-
-        
-        ContentUnavailableView {
-            Label("No Replacements", systemImage: "text.book.closed")
-        } description: {
-            VStack(alignment: .leading) {
-                Text("Add replacement words that should be replaced during transcription")
-                Text(
-    """
-    For example: 
-        "My website link" -> "https://vivadicta.com"
-        "Vivo dicte" -> "VivaDicta"
-    """)
-                
-            }
-            .multilineTextAlignment(.leading)
-            
-        }
-        .frame(maxHeight: .infinity)
-    }
     
-    private var addReplacementBar: some View {
-        VStack(spacing: 4) {
-            HStack {
-                TextField("Enter word", text: $newWord)
-                    .autocorrectionDisabled()
-                    .textInputAutocapitalization(.never)
-                    .padding(8)
-                    .background {
-                        Capsule()
-                            .stroke(.gray, lineWidth: 0.5)
-                    }
-                    .onSubmit {
-                        addWord()
-                    }
-                    .onChange(of: newWord) { _, newValue in
-                        // Limit input to max word length
-                        if newValue.count > CustomVocabularyService.maxWordLength {
-                            newWord = String(newValue.prefix(CustomVocabularyService.maxWordLength))
-                        }
-                    }
-
-                Button("Add", action: addWord)
-                    .buttonStyle(.borderedProminent)
-                    .disabled(newWord.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-            }
-
-            if newWord.count > 0 {
-                HStack {
-                    Spacer()
-                    Text("\(newWord.count)/\(CustomVocabularyService.maxWordLength)")
-                        .font(.caption)
-                        .foregroundStyle(newWord.count >= CustomVocabularyService.maxWordLength ? .orange : .secondary)
-                }
-            }
-        }
-        .padding(.horizontal)
-        .padding(.vertical, 8)
-    }
 
     private var addWordBar: some View {
         VStack(spacing: 4) {

--- a/VivaDicta/Views/SettingsScreen/DictionaryView.swift
+++ b/VivaDicta/Views/SettingsScreen/DictionaryView.swift
@@ -174,11 +174,64 @@ struct DictionaryView: View {
     }
 
     private var replacementsContent: some View {
+
+        
         ContentUnavailableView {
-            Label("Coming Soon", systemImage: "arrow.left.arrow.right")
+            Label("No Replacements", systemImage: "text.book.closed")
         } description: {
-            Text("Word replacements will be available in a future update")
+            VStack(alignment: .leading) {
+                Text("Add replacement words that should be replaced during transcription")
+                Text(
+    """
+    For example: 
+        "My website link" -> "https://vivadicta.com"
+        "Vivo dicte" -> "VivaDicta"
+    """)
+                
+            }
+            .multilineTextAlignment(.leading)
+            
         }
+        .frame(maxHeight: .infinity)
+    }
+    
+    private var addReplacementBar: some View {
+        VStack(spacing: 4) {
+            HStack {
+                TextField("Enter word", text: $newWord)
+                    .autocorrectionDisabled()
+                    .textInputAutocapitalization(.never)
+                    .padding(8)
+                    .background {
+                        Capsule()
+                            .stroke(.gray, lineWidth: 0.5)
+                    }
+                    .onSubmit {
+                        addWord()
+                    }
+                    .onChange(of: newWord) { _, newValue in
+                        // Limit input to max word length
+                        if newValue.count > CustomVocabularyService.maxWordLength {
+                            newWord = String(newValue.prefix(CustomVocabularyService.maxWordLength))
+                        }
+                    }
+
+                Button("Add", action: addWord)
+                    .buttonStyle(.borderedProminent)
+                    .disabled(newWord.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+
+            if newWord.count > 0 {
+                HStack {
+                    Spacer()
+                    Text("\(newWord.count)/\(CustomVocabularyService.maxWordLength)")
+                        .font(.caption)
+                        .foregroundStyle(newWord.count >= CustomVocabularyService.maxWordLength ? .orange : .secondary)
+                }
+            }
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 8)
     }
 
     private var addWordBar: some View {

--- a/VivaDicta/Views/SettingsScreen/ReplacementsView.swift
+++ b/VivaDicta/Views/SettingsScreen/ReplacementsView.swift
@@ -53,7 +53,7 @@ struct ReplacementsView: View {
                 }
             }
         }
-        .navigationTitle("Replacements")
+        .navigationTitle("Word Replacements")
         .navigationBarTitleDisplayMode(.inline)
         .sheet(item: $replacementToEdit) { item in
             EditReplacementSheet(replacementToEdit: item) { newOriginal, newReplacement in

--- a/VivaDicta/Views/SettingsScreen/ReplacementsView.swift
+++ b/VivaDicta/Views/SettingsScreen/ReplacementsView.swift
@@ -1,0 +1,350 @@
+//
+//  ReplacementsView.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2025.12.10
+//
+
+import SwiftUI
+
+struct ReplacementsView: View {
+    @State private var originalText: String = ""
+    @State private var replacementText: String = ""
+    @State private var replacementsService = ReplacementsService()
+    @State private var replacementToEdit: Replacement?
+
+    @State private var editMode = false
+    @State private var selectedReplacements: Set<Replacement> = []
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if replacementsService.replacements.isEmpty {
+                emptyStateView
+            } else {
+                if editMode {
+                    editModeToolbar
+                }
+                replacementsList
+            }
+
+            if !editMode {
+                addReplacementBar
+            }
+        }
+        .toolbar {
+            if editMode {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") {
+                        selectedReplacements.removeAll()
+                        editMode = false
+                    }
+                }
+            } else {
+                ToolbarItem(placement: .primaryAction) {
+                    Button("Edit") {
+                        editMode = true
+                    }
+                    .disabled(replacementsService.replacements.isEmpty)
+                }
+            }
+        }
+        .navigationTitle("Replacements")
+        .navigationBarTitleDisplayMode(.inline)
+        .sheet(item: $replacementToEdit) { item in
+            EditReplacementSheet(replacementToEdit: item) { newOriginal, newReplacement in
+                replacementsService.updateReplacement(item, original: newOriginal, replacement: newReplacement)
+                replacementToEdit = nil
+            }
+            .presentationDetents([.height(280)])
+        }
+    }
+
+    private var emptyStateView: some View {
+        ContentUnavailableView {
+            Label("No Replacements", systemImage: "arrow.left.arrow.right")
+        } description: {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Add text replacements that will be applied during transcription")
+                Text("""
+                    For example:
+                        "My website link" -> "https://vivadicta.com"
+                        "Vivo dicte" -> "VivaDicta"
+                    """)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .multilineTextAlignment(.leading)
+        }
+        .frame(maxHeight: .infinity)
+    }
+
+    private var editModeToolbar: some View {
+        HStack {
+            Button(allReplacementsSelected ? "Deselect All" : "Select All") {
+                if allReplacementsSelected {
+                    selectedReplacements.removeAll()
+                } else {
+                    selectedReplacements = Set(replacementsService.replacements)
+                }
+            }
+
+            Spacer()
+
+            if !selectedReplacements.isEmpty {
+                Button("Delete", role: .destructive) {
+                    deleteSelectedReplacements()
+                }
+            }
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 8)
+    }
+
+    private var allReplacementsSelected: Bool {
+        !replacementsService.replacements.isEmpty &&
+        selectedReplacements.count == replacementsService.replacements.count
+    }
+
+    private var replacementsList: some View {
+        List {
+            ForEach(replacementsService.replacements) { replacement in
+                Button {
+                    if editMode {
+                        toggleSelection(replacement)
+                    } else {
+                        replacementToEdit = replacement
+                    }
+                } label: {
+                    HStack {
+                        if editMode {
+                            Image(systemName: selectedReplacements.contains(replacement) ? "checkmark.circle.fill" : "circle")
+                                .foregroundStyle(selectedReplacements.contains(replacement) ? .blue : .secondary)
+                                .font(.title2)
+                        }
+
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(replacement.original)
+                                .font(.body)
+                            HStack(spacing: 4) {
+                                Image(systemName: "arrow.right")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                Text(replacement.replacement)
+                                    .font(.subheadline)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        Spacer()
+                    }
+                    .contentShape(.rect)
+                }
+                .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                    if !editMode {
+                        Button(role: .destructive) {
+                            replacementsService.deleteReplacement(replacement)
+                        } label: {
+                            Label("Delete", systemImage: "trash")
+                        }
+
+                        Button {
+                            replacementToEdit = replacement
+                        } label: {
+                            Label("Edit", systemImage: "pencil")
+                        }
+                        .tint(.blue)
+                    }
+                }
+            }
+        }
+        .listStyle(.plain)
+    }
+
+    private func toggleSelection(_ replacement: Replacement) {
+        if selectedReplacements.contains(replacement) {
+            selectedReplacements.remove(replacement)
+        } else {
+            selectedReplacements.insert(replacement)
+        }
+    }
+
+    private func deleteSelectedReplacements() {
+        for replacement in selectedReplacements {
+            replacementsService.deleteReplacement(replacement)
+        }
+        selectedReplacements.removeAll()
+
+        if replacementsService.replacements.isEmpty {
+            editMode = false
+        }
+    }
+
+    private var addReplacementBar: some View {
+        VStack(spacing: 8) {
+            VStack(spacing: 4) {
+                TextField("Original text", text: $originalText)
+                    .autocorrectionDisabled()
+                    .textInputAutocapitalization(.never)
+                    .padding(8)
+                    .background {
+                        Capsule()
+                            .stroke(.gray, lineWidth: 0.5)
+                    }
+                    .onChange(of: originalText) { _, newValue in
+                        if newValue.count > ReplacementsService.maxTextLength {
+                            originalText = String(newValue.prefix(ReplacementsService.maxTextLength))
+                        }
+                    }
+
+                if originalText.count > 0 {
+                    HStack {
+                        Spacer()
+                        Text("\(originalText.count)/\(ReplacementsService.maxTextLength)")
+                            .font(.caption)
+                            .foregroundStyle(originalText.count >= ReplacementsService.maxTextLength ? .orange : .secondary)
+                    }
+                }
+            }
+
+            VStack(spacing: 4) {
+                TextField("Replace with", text: $replacementText)
+                    .autocorrectionDisabled()
+                    .textInputAutocapitalization(.never)
+                    .padding(8)
+                    .background {
+                        Capsule()
+                            .stroke(.gray, lineWidth: 0.5)
+                    }
+                    .onSubmit {
+                        addReplacement()
+                    }
+                    .onChange(of: replacementText) { _, newValue in
+                        if newValue.count > ReplacementsService.maxTextLength {
+                            replacementText = String(newValue.prefix(ReplacementsService.maxTextLength))
+                        }
+                    }
+
+                if replacementText.count > 0 {
+                    HStack {
+                        Spacer()
+                        Text("\(replacementText.count)/\(ReplacementsService.maxTextLength)")
+                            .font(.caption)
+                            .foregroundStyle(replacementText.count >= ReplacementsService.maxTextLength ? .orange : .secondary)
+                    }
+                }
+            }
+
+            Button("Add Replacement", action: addReplacement)
+                .buttonStyle(.borderedProminent)
+                .disabled(!canAddReplacement)
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 8)
+    }
+
+    private var canAddReplacement: Bool {
+        !originalText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+        !replacementText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private func addReplacement() {
+        replacementsService.addReplacement(original: originalText, replacement: replacementText)
+        originalText = ""
+        replacementText = ""
+    }
+}
+
+// MARK: - Edit Replacement Sheet
+
+private struct EditReplacementSheet: View {
+    let replacementToEdit: Replacement
+    let onSave: (String, String) -> Void
+
+    @State private var editedOriginal: String
+    @State private var editedReplacement: String
+    @FocusState private var focusedField: Field?
+
+    enum Field {
+        case original, replacement
+    }
+
+    init(replacementToEdit: Replacement, onSave: @escaping (String, String) -> Void) {
+        self.replacementToEdit = replacementToEdit
+        self.onSave = onSave
+        self._editedOriginal = State(initialValue: replacementToEdit.original)
+        self._editedReplacement = State(initialValue: replacementToEdit.replacement)
+    }
+
+    private var hasChanges: Bool {
+        let trimmedOriginal = editedOriginal.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedReplacement = editedReplacement.trimmingCharacters(in: .whitespacesAndNewlines)
+        return !trimmedOriginal.isEmpty &&
+               !trimmedReplacement.isEmpty &&
+               (trimmedOriginal != replacementToEdit.original || trimmedReplacement != replacementToEdit.replacement)
+    }
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Text("Edit Replacement")
+                .font(.headline)
+
+            VStack(alignment: .trailing, spacing: 4) {
+                TextField("Original text", text: $editedOriginal)
+                    .focused($focusedField, equals: .original)
+                    .autocorrectionDisabled()
+                    .textInputAutocapitalization(.never)
+                    .padding(12)
+                    .background(Color(.systemGray5))
+                    .clipShape(.rect(cornerRadius: 10))
+                    .onChange(of: editedOriginal) { _, newValue in
+                        if newValue.count > ReplacementsService.maxTextLength {
+                            editedOriginal = String(newValue.prefix(ReplacementsService.maxTextLength))
+                        }
+                    }
+
+                Text("\(editedOriginal.count)/\(ReplacementsService.maxTextLength)")
+                    .font(.caption)
+                    .foregroundStyle(editedOriginal.count >= ReplacementsService.maxTextLength ? .orange : .secondary)
+            }
+
+            VStack(alignment: .trailing, spacing: 4) {
+                TextField("Replace with", text: $editedReplacement)
+                    .focused($focusedField, equals: .replacement)
+                    .autocorrectionDisabled()
+                    .textInputAutocapitalization(.never)
+                    .padding(12)
+                    .background(Color(.systemGray5))
+                    .clipShape(.rect(cornerRadius: 10))
+                    .onChange(of: editedReplacement) { _, newValue in
+                        if newValue.count > ReplacementsService.maxTextLength {
+                            editedReplacement = String(newValue.prefix(ReplacementsService.maxTextLength))
+                        }
+                    }
+
+                Text("\(editedReplacement.count)/\(ReplacementsService.maxTextLength)")
+                    .font(.caption)
+                    .foregroundStyle(editedReplacement.count >= ReplacementsService.maxTextLength ? .orange : .secondary)
+            }
+
+            Button("Save changes") {
+                onSave(editedOriginal, editedReplacement)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 14)
+            .background(hasChanges ? Color.blue : Color(.systemGray4))
+            .foregroundStyle(hasChanges ? .white : .secondary)
+            .clipShape(.rect(cornerRadius: 10))
+            .disabled(!hasChanges)
+        }
+        .padding()
+        .presentationDragIndicator(.hidden)
+        .onAppear {
+            focusedField = .original
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        ReplacementsView()
+    }
+}

--- a/VivaDicta/Views/SettingsScreen/ReplacementsView.swift
+++ b/VivaDicta/Views/SettingsScreen/ReplacementsView.swift
@@ -16,8 +16,13 @@ struct ReplacementsView: View {
     @State private var editMode = false
     @State private var selectedReplacements: Set<Replacement> = []
 
+    @AppStorage(UserDefaultsStorage.Keys.isReplacementsEnabled)
+    private var isReplacementsEnabled: Bool = true
+
     var body: some View {
         VStack(spacing: 0) {
+            enableToggle
+
             if replacementsService.replacements.isEmpty {
                 emptyStateView
             } else {
@@ -57,6 +62,12 @@ struct ReplacementsView: View {
             }
             .presentationDetents([.height(280)])
         }
+    }
+
+    private var enableToggle: some View {
+        Toggle("Enable Replacements", isOn: $isReplacementsEnabled)
+            .padding(.horizontal)
+            .padding(.vertical, 8)
     }
 
     private var emptyStateView: some View {
@@ -293,8 +304,7 @@ private struct EditReplacementSheet: View {
                     .autocorrectionDisabled()
                     .textInputAutocapitalization(.never)
                     .padding(12)
-                    .background(Color(.systemGray5))
-                    .clipShape(.rect(cornerRadius: 10))
+                    .background(Color(.systemGray5), in: .rect(cornerRadius: 10))
                     .onChange(of: editedOriginal) { _, newValue in
                         if newValue.count > ReplacementsService.maxTextLength {
                             editedOriginal = String(newValue.prefix(ReplacementsService.maxTextLength))

--- a/VivaDicta/Views/SettingsScreen/SettingsDestination.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsDestination.swift
@@ -11,5 +11,8 @@ enum SettingsDestination: Hashable {
     case promptsSettings
     case promptsTemplates
     case transcriptionModels
-    case dictionary
+    
+    // Dictionary
+    case correctSpelling
+    case replacements
 }

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -115,9 +115,15 @@ struct SettingsView: View {
                                 .foregroundStyle(.secondary)
                         }
                     }
-                    
-                    NavigationLink(value: SettingsDestination.dictionary) {
-                        Text("Dictionary")
+                }
+                
+                Section("Dictionary") {
+                    NavigationLink(value: SettingsDestination.correctSpelling) {
+                        Text("Spelling Corrections")
+                    }
+
+                    NavigationLink(value: SettingsDestination.replacements) {
+                        Text("Word Replacements")
                     }
                 }
                 
@@ -227,8 +233,10 @@ struct SettingsView: View {
                 case .promptsTemplates:
                     TemplateSelectionView(promptsManager: promptsManager)
 //                        .navigationTransition(.zoom(sourceID: "addPrompt", in: promptsTransition))
-                case .dictionary:
-                    DictionaryView()
+                case .correctSpelling:
+                    WordsDictionaryView()
+                case .replacements:
+                    ReplacementsView()
                 }
             }
             .navigationDestination(for: UserPrompt.self) { prompt in

--- a/VivaDictaTests/ReplacementsServiceTests.swift
+++ b/VivaDictaTests/ReplacementsServiceTests.swift
@@ -1,0 +1,378 @@
+//
+//  ReplacementsServiceTests.swift
+//  VivaDictaTests
+//
+//  Created by Anton Novoselov on 2025.12.10
+//
+
+import Foundation
+import Testing
+@testable import VivaDicta
+
+struct ReplacementsServiceTests {
+
+    private let testKey = "testTextReplacements"
+
+    private func makeService() -> ReplacementsService {
+        let defaults = UserDefaults(suiteName: "ReplacementsServiceTests")!
+        defaults.removeObject(forKey: testKey)
+        return ReplacementsService(userDefaults: defaults, storageKey: testKey)
+    }
+
+    // MARK: - Add Replacement Tests
+
+    @Test func testAddReplacement_success() {
+        let service = makeService()
+
+        service.addReplacement(original: "hello", replacement: "world")
+
+        #expect(service.replacements.count == 1)
+        #expect(service.replacements.first?.original == "hello")
+        #expect(service.replacements.first?.replacement == "world")
+    }
+
+    @Test func testAddReplacement_trimWhitespace() {
+        let service = makeService()
+
+        service.addReplacement(original: "  hello  ", replacement: "  world  ")
+
+        #expect(service.replacements.first?.original == "hello")
+        #expect(service.replacements.first?.replacement == "world")
+    }
+
+    @Test func testAddReplacement_emptyOriginal_ignored() {
+        let service = makeService()
+
+        service.addReplacement(original: "", replacement: "world")
+        service.addReplacement(original: "   ", replacement: "world")
+
+        #expect(service.replacements.isEmpty)
+    }
+
+    @Test func testAddReplacement_emptyReplacement_ignored() {
+        let service = makeService()
+
+        service.addReplacement(original: "hello", replacement: "")
+        service.addReplacement(original: "hello", replacement: "   ")
+
+        #expect(service.replacements.isEmpty)
+    }
+
+    @Test func testAddReplacement_duplicate_caseInsensitive() {
+        let service = makeService()
+
+        service.addReplacement(original: "Hello", replacement: "World")
+        service.addReplacement(original: "hello", replacement: "Universe")
+        service.addReplacement(original: "HELLO", replacement: "Galaxy")
+
+        #expect(service.replacements.count == 1)
+        #expect(service.replacements.first?.original == "Hello")
+        #expect(service.replacements.first?.replacement == "World")
+    }
+
+    @Test func testAddReplacement_insertsAtBeginning() {
+        let service = makeService()
+
+        service.addReplacement(original: "first", replacement: "1st")
+        service.addReplacement(original: "second", replacement: "2nd")
+
+        #expect(service.replacements.first?.original == "second")
+        #expect(service.replacements.last?.original == "first")
+    }
+
+    @Test func testAddReplacement_truncatesLongOriginal() {
+        let service = makeService()
+        let longText = String(repeating: "a", count: 150)
+
+        service.addReplacement(original: longText, replacement: "short")
+
+        #expect(service.replacements.first?.original.count == ReplacementsService.maxTextLength)
+    }
+
+    @Test func testAddReplacement_truncatesLongReplacement() {
+        let service = makeService()
+        let longText = String(repeating: "b", count: 150)
+
+        service.addReplacement(original: "short", replacement: longText)
+
+        #expect(service.replacements.first?.replacement.count == ReplacementsService.maxTextLength)
+    }
+
+    // MARK: - Update Replacement Tests
+
+    @Test func testUpdateReplacement_success() {
+        let service = makeService()
+        service.addReplacement(original: "hello", replacement: "world")
+        let original = service.replacements.first!
+
+        service.updateReplacement(original, original: "hi", replacement: "earth")
+
+        #expect(service.replacements.count == 1)
+        #expect(service.replacements.first?.original == "hi")
+        #expect(service.replacements.first?.replacement == "earth")
+    }
+
+    @Test func testUpdateReplacement_preservesPosition() {
+        let service = makeService()
+        service.addReplacement(original: "first", replacement: "1st")
+        service.addReplacement(original: "second", replacement: "2nd")
+        service.addReplacement(original: "third", replacement: "3rd")
+
+        let secondReplacement = service.replacements[1]
+        service.updateReplacement(secondReplacement, original: "updated", replacement: "new")
+
+        #expect(service.replacements[1].original == "updated")
+        #expect(service.replacements[1].replacement == "new")
+    }
+
+    @Test func testUpdateReplacement_duplicateOriginal_rejected() {
+        let service = makeService()
+        service.addReplacement(original: "hello", replacement: "world")
+        service.addReplacement(original: "hi", replacement: "earth")
+
+        let hiReplacement = service.replacements.first { $0.original == "hi" }!
+        service.updateReplacement(hiReplacement, original: "Hello", replacement: "universe")
+
+        // Should not update because "Hello" already exists (case-insensitive)
+        #expect(service.replacements.contains { $0.original == "hi" })
+        #expect(service.replacements.contains { $0.original == "hello" })
+    }
+
+    @Test func testUpdateReplacement_sameOriginalDifferentCase_allowed() {
+        let service = makeService()
+        service.addReplacement(original: "hello", replacement: "world")
+
+        let helloReplacement = service.replacements.first!
+        service.updateReplacement(helloReplacement, original: "Hello", replacement: "World")
+
+        #expect(service.replacements.count == 1)
+        #expect(service.replacements.first?.original == "Hello")
+    }
+
+    @Test func testUpdateReplacement_emptyValues_ignored() {
+        let service = makeService()
+        service.addReplacement(original: "hello", replacement: "world")
+
+        let original = service.replacements.first!
+        service.updateReplacement(original, original: "", replacement: "new")
+        service.updateReplacement(original, original: "new", replacement: "")
+
+        #expect(service.replacements.first?.original == "hello")
+        #expect(service.replacements.first?.replacement == "world")
+    }
+
+    @Test func testUpdateReplacement_truncatesLongText() {
+        let service = makeService()
+        service.addReplacement(original: "hello", replacement: "world")
+        let longText = String(repeating: "x", count: 150)
+
+        let original = service.replacements.first!
+        service.updateReplacement(original, original: longText, replacement: longText)
+
+        #expect(service.replacements.first?.original.count == ReplacementsService.maxTextLength)
+        #expect(service.replacements.first?.replacement.count == ReplacementsService.maxTextLength)
+    }
+
+    // MARK: - Delete Replacement Tests
+
+    @Test func testDeleteReplacement() {
+        let service = makeService()
+        service.addReplacement(original: "hello", replacement: "world")
+        service.addReplacement(original: "hi", replacement: "earth")
+
+        let helloReplacement = service.replacements.first { $0.original == "hello" }!
+        service.deleteReplacement(helloReplacement)
+
+        #expect(service.replacements.count == 1)
+        #expect(service.replacements.first?.original == "hi")
+    }
+
+    @Test func testDeleteReplacement_nonExistent_noEffect() {
+        let service = makeService()
+        service.addReplacement(original: "hello", replacement: "world")
+
+        let fakeReplacement = Replacement(original: "fake", replacement: "fake")
+        service.deleteReplacement(fakeReplacement)
+
+        #expect(service.replacements.count == 1)
+    }
+
+    @Test func testDeleteReplacementsAtOffsets() {
+        let service = makeService()
+        service.addReplacement(original: "first", replacement: "1st")
+        service.addReplacement(original: "second", replacement: "2nd")
+        service.addReplacement(original: "third", replacement: "3rd")
+
+        service.deleteReplacements(at: IndexSet([0, 2]))
+
+        #expect(service.replacements.count == 1)
+        #expect(service.replacements.first?.original == "second")
+    }
+
+    // MARK: - Persistence Tests
+
+    @Test func testPersistence() {
+        let defaults = UserDefaults(suiteName: "ReplacementsServiceTests")!
+        defaults.removeObject(forKey: testKey)
+
+        let service1 = ReplacementsService(userDefaults: defaults, storageKey: testKey)
+        service1.addReplacement(original: "persisted", replacement: "data")
+
+        let service2 = ReplacementsService(userDefaults: defaults, storageKey: testKey)
+
+        #expect(service2.replacements.count == 1)
+        #expect(service2.replacements.first?.original == "persisted")
+
+        defaults.removeObject(forKey: testKey)
+    }
+
+    @Test func testPersistence_afterUpdate() {
+        let defaults = UserDefaults(suiteName: "ReplacementsServiceTests")!
+        defaults.removeObject(forKey: testKey)
+
+        let service1 = ReplacementsService(userDefaults: defaults, storageKey: testKey)
+        service1.addReplacement(original: "original", replacement: "value")
+        let replacement = service1.replacements.first!
+        service1.updateReplacement(replacement, original: "updated", replacement: "newValue")
+
+        let service2 = ReplacementsService(userDefaults: defaults, storageKey: testKey)
+
+        #expect(service2.replacements.first?.original == "updated")
+        #expect(service2.replacements.first?.replacement == "newValue")
+
+        defaults.removeObject(forKey: testKey)
+    }
+
+    @Test func testPersistence_afterDelete() {
+        let defaults = UserDefaults(suiteName: "ReplacementsServiceTests")!
+        defaults.removeObject(forKey: testKey)
+
+        let service1 = ReplacementsService(userDefaults: defaults, storageKey: testKey)
+        service1.addReplacement(original: "toDelete", replacement: "gone")
+        service1.addReplacement(original: "toKeep", replacement: "stay")
+        let toDelete = service1.replacements.first { $0.original == "toDelete" }!
+        service1.deleteReplacement(toDelete)
+
+        let service2 = ReplacementsService(userDefaults: defaults, storageKey: testKey)
+
+        #expect(service2.replacements.count == 1)
+        #expect(service2.replacements.first?.original == "toKeep")
+
+        defaults.removeObject(forKey: testKey)
+    }
+
+    // MARK: - Word Boundary Detection Tests
+
+    @Test func testUsesWordBoundaries_english() {
+        #expect(ReplacementsService.usesWordBoundaries(for: "hello") == true)
+        #expect(ReplacementsService.usesWordBoundaries(for: "Hello World") == true)
+    }
+
+    @Test func testUsesWordBoundaries_japanese() {
+        #expect(ReplacementsService.usesWordBoundaries(for: "こんにちは") == false) // Hiragana
+        #expect(ReplacementsService.usesWordBoundaries(for: "カタカナ") == false) // Katakana
+        #expect(ReplacementsService.usesWordBoundaries(for: "漢字") == false) // Kanji
+    }
+
+    @Test func testUsesWordBoundaries_korean() {
+        #expect(ReplacementsService.usesWordBoundaries(for: "안녕하세요") == false) // Hangul
+    }
+
+    @Test func testUsesWordBoundaries_thai() {
+        #expect(ReplacementsService.usesWordBoundaries(for: "สวัสดี") == false) // Thai
+    }
+
+    @Test func testUsesWordBoundaries_mixed() {
+        // Mixed text with CJK should return false
+        #expect(ReplacementsService.usesWordBoundaries(for: "hello世界") == false)
+    }
+
+    // MARK: - Apply Replacements Tests
+
+    @Test func testApplyReplacements_basic() {
+        let replacements = [
+            Replacement(original: "hello", replacement: "hi")
+        ]
+
+        let result = ReplacementsService.applyReplacements(replacements, to: "hello world")
+
+        #expect(result == "hi world")
+    }
+
+    @Test func testApplyReplacements_caseInsensitive() {
+        let replacements = [
+            Replacement(original: "hello", replacement: "hi")
+        ]
+
+        let result = ReplacementsService.applyReplacements(replacements, to: "HELLO World")
+
+        #expect(result == "hi World")
+    }
+
+    @Test func testApplyReplacements_wordBoundaries() {
+        let replacements = [
+            Replacement(original: "cat", replacement: "dog")
+        ]
+
+        let result = ReplacementsService.applyReplacements(replacements, to: "The cat sat. Category is different.")
+
+        #expect(result == "The dog sat. Category is different.")
+    }
+
+    @Test func testApplyReplacements_multipleOccurrences() {
+        let replacements = [
+            Replacement(original: "test", replacement: "exam")
+        ]
+
+        let result = ReplacementsService.applyReplacements(replacements, to: "test one test two test three")
+
+        #expect(result == "exam one exam two exam three")
+    }
+
+    @Test func testApplyReplacements_multipleReplacements() {
+        let replacements = [
+            Replacement(original: "hello", replacement: "hi"),
+            Replacement(original: "world", replacement: "earth")
+        ]
+
+        let result = ReplacementsService.applyReplacements(replacements, to: "hello world")
+
+        #expect(result == "hi earth")
+    }
+
+    @Test func testApplyReplacements_specialCharacters() {
+        let replacements = [
+            Replacement(original: "c++", replacement: "cpp")
+        ]
+
+        let result = ReplacementsService.applyReplacements(replacements, to: "I code in c++ daily")
+
+        #expect(result == "I code in cpp daily")
+    }
+
+    @Test func testApplyReplacements_cjkWithoutBoundaries() {
+        let replacements = [
+            Replacement(original: "世界", replacement: "地球")
+        ]
+
+        let result = ReplacementsService.applyReplacements(replacements, to: "こんにちは世界")
+
+        #expect(result == "こんにちは地球")
+    }
+
+    @Test func testApplyReplacements_emptyReplacements() {
+        let result = ReplacementsService.applyReplacements([], to: "hello world")
+
+        #expect(result == "hello world")
+    }
+
+    @Test func testApplyReplacements_noMatch() {
+        let replacements = [
+            Replacement(original: "xyz", replacement: "abc")
+        ]
+
+        let result = ReplacementsService.applyReplacements(replacements, to: "hello world")
+
+        #expect(result == "hello world")
+    }
+}


### PR DESCRIPTION
## Summary
- Add ReplacementsService for storing and applying text replacements
- Implement ReplacementsView with full CRUD UI (add, edit, delete, batch edit mode)
- Integrate text replacements into transcription pipeline

## Features
- Store text replacements in UserDefaults as JSON-encoded array
- Case-insensitive matching with word boundary support (using Swift native Regex)
- Support for non-spaced scripts (CJK, Thai, Korean) without word boundaries
- Character limit (100) for replacement text fields
- Swipe actions for edit/delete
- Batch edit mode with select all/deselect all

## Test plan
- [ ] Add a replacement (e.g., "vivo dicte" → "VivaDicta")
- [ ] Perform a transcription and verify replacement is applied
- [ ] Edit an existing replacement
- [ ] Delete a replacement via swipe
- [ ] Use batch edit mode to delete multiple replacements
- [ ] Verify word boundaries work (replacing "cat" doesn't affect "category")