### PR TITLE
Defer keyboard session timeout until transcription/enhancement completes

### DIFF
--- a/VivaDicta/Services/AudioPrewarmManager.swift
+++ b/VivaDicta/Services/AudioPrewarmManager.swift
@@ -274,9 +274,10 @@ final class AudioPrewarmManager {
         logger.logInfo("🎙️ Real capture started (buffers now writing to disk)")
     }
 
-    /// Stops real recording and restarts the pre-warm session timeout
+    /// Stops real recording without restarting timeout (processing will follow)
+    /// Call `rescheduleSessionTimeout()` after all processing is complete
     func stopRealCapture() {
-        logger.logInfo("🎙️ Stopping real capture and restarting session timeout")
+        logger.logInfo("🎙️ Stopping real capture (timeout deferred until processing completes)")
 
         // Stop writing to file atomically
         captureContext?.isCapturing = false
@@ -297,6 +298,21 @@ final class AudioPrewarmManager {
             return
         }
 
+        // Note: We do NOT restart the timeout timer here
+        // The caller should call rescheduleSessionTimeout() after processing is complete
+        // This prevents the session from expiring during transcription/enhancement
+
+        logger.logInfo("🎙️ Real capture stopped, audio engine still running (awaiting processing completion)")
+    }
+
+    /// Reschedules the session timeout after all processing is complete
+    /// Should be called when transcription and enhancement are finished
+    func rescheduleSessionTimeout() {
+        guard audioEngine?.isRunning == true else {
+            logger.logInfo("⏰ Session not active, skipping timeout reschedule")
+            return
+        }
+
         // Reset the session start time
         sessionStartTime = Date()
 
@@ -308,7 +324,7 @@ final class AudioPrewarmManager {
             timeoutSeconds: audioSessionTimeout
         )
 
-        logger.logInfo("🎙️ Restarted pre-warm session timeout: \(self.audioSessionTimeout)s from now")
+        logger.logInfo("🎙️ Session timeout rescheduled: \(self.audioSessionTimeout)s from now")
     }
 
     // MARK: - Private Helpers

--- a/VivaDicta/Views/RecordViewModel.swift
+++ b/VivaDicta/Views/RecordViewModel.swift
@@ -475,6 +475,9 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
                 try Task.checkCancellation()
                 self.recordingState = .idle
 
+                // Reschedule session timeout now that all processing is complete
+                self.prewarmManager.rescheduleSessionTimeout()
+
             } catch {
                 if Task.isCancelled { return }
                 recordingState = .error(.transcribe)
@@ -482,6 +485,9 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
 
                 // Notify keyboard of error
                 AppGroupCoordinator.shared.updateTranscriptionError("Transcription failed: \(error.localizedDescription)")
+
+                // Reschedule session timeout even on error
+                self.prewarmManager.rescheduleSessionTimeout()
             }
         }
     }
@@ -511,9 +517,9 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
         transcribingSpeechTask = nil
         pendingTranscription = nil
 
-        // Stop real capture and reschedule prewarm session timeout if active
-        if prewarmManager.isSessionActive {
-            logger.logInfo("🎙️ Stopping real capture and rescheduling session timeout on cancel")
+        // Stop real capture if still recording
+        if prewarmManager.isSessionActive && prewarmManager.audioEngine?.isRunning == true {
+            logger.logInfo("🎙️ Stopping real capture on cancel")
             prewarmManager.stopRealCapture()
         }
 
@@ -523,6 +529,9 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
         // Notify keyboard that recording was canceled
         AppGroupCoordinator.shared.updateRecordingState(false)
         AppGroupCoordinator.shared.updateTranscriptionStatus(.idle)
+
+        // Reschedule session timeout after cancellation
+        prewarmManager.rescheduleSessionTimeout()
     }
 
     /// Cancels the current processing based on state:
@@ -584,8 +593,11 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
             AppGroupCoordinator.shared.updateRecordingState(false)
             AppGroupCoordinator.shared.updateTranscriptionStatus(.idle)
 
+            // Reschedule session timeout after cancellation
+            prewarmManager.rescheduleSessionTimeout()
+
         default:
-            // For other states, just use regular cancel
+            // For other states, just use regular cancel (which also reschedules timeout)
             cancelTranscribe()
         }
     }


### PR DESCRIPTION
## Summary
- Fixes issue where keyboard session would expire during long transcription/enhancement processing
- Previously, the timeout timer was rescheduled immediately when recording stopped
- Now the timeout is deferred until all processing (transcription + enhancement) is complete

## Changes
- **AudioPrewarmManager**: Modified `stopRealCapture()` to NOT reschedule timeout, added new `rescheduleSessionTimeout()` method
- **RecordViewModel**: Call `rescheduleSessionTimeout()` after processing completes, errors, or cancellation

## Test plan
- [ ] Start keyboard recording with a long audio file
- [ ] Verify session doesn't expire during transcription
- [ ] Verify session doesn't expire during AI enhancement
- [ ] Verify timeout is properly rescheduled after processing completes
- [ ] Verify cancellation also reschedules timeout correctly