### PR TITLE
Add keyboard haptic and sound feedback settings

### DIFF
--- a/VivaDicta/Shared/AppGroupCoordinator.swift
+++ b/VivaDicta/Shared/AppGroupCoordinator.swift
@@ -30,6 +30,8 @@ public final class AppGroupCoordinator {
     public static let kSmartFormattingOnPaste = "smartFormattingOnPaste"
     public static let kKeepTranscriptInClipboard = "keepTranscriptInClipboard"
     public static let kIsVADEnabled = "IsVADEnabled"
+    public static let kIsKeyboardHapticFeedbackEnabled = "isKeyboardHapticFeedbackEnabled"
+    public static let kIsKeyboardSoundFeedbackEnabled = "isKeyboardSoundFeedbackEnabled"
     
     
     nonisolated private enum UserDefaultsKeys {
@@ -344,6 +346,36 @@ public final class AppGroupCoordinator {
         }
         set {
             sharedDefaults?.set(newValue, forKey: AppGroupCoordinator.kKeepTranscriptInClipboard)
+            sharedDefaults?.synchronize()
+        }
+    }
+
+    /// Whether haptic feedback is enabled for keyboard key presses
+    /// Defaults to true if not set
+    public var isKeyboardHapticFeedbackEnabled: Bool {
+        get {
+            if sharedDefaults?.object(forKey: AppGroupCoordinator.kIsKeyboardHapticFeedbackEnabled) == nil {
+                return true
+            }
+            return sharedDefaults?.bool(forKey: AppGroupCoordinator.kIsKeyboardHapticFeedbackEnabled) ?? true
+        }
+        set {
+            sharedDefaults?.set(newValue, forKey: AppGroupCoordinator.kIsKeyboardHapticFeedbackEnabled)
+            sharedDefaults?.synchronize()
+        }
+    }
+    
+    /// Whether sound feedback is enabled for keyboard key presses
+    /// Defaults to true if not set
+    public var isKeyboardSoundFeedbackEnabled: Bool {
+        get {
+            if sharedDefaults?.object(forKey: AppGroupCoordinator.kIsKeyboardSoundFeedbackEnabled) == nil {
+                return true
+            }
+            return sharedDefaults?.bool(forKey: AppGroupCoordinator.kIsKeyboardSoundFeedbackEnabled) ?? true
+        }
+        set {
+            sharedDefaults?.set(newValue, forKey: AppGroupCoordinator.kIsKeyboardSoundFeedbackEnabled)
             sharedDefaults?.synchronize()
         }
     }

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -30,6 +30,8 @@ struct SettingsView: View {
     @AppStorage(UserDefaultsStorage.Keys.displaySiriTip) private var displaySiriTip: Bool = true
     @State private var isSmartFormattingEnabled = AppGroupCoordinator.shared.isSmartFormattingOnPasteEnabled
     @State private var isKeepInClipboardEnabled = AppGroupCoordinator.shared.isKeepTranscriptInClipboardEnabled
+    @State private var isHapticFeedbackEnabled = AppGroupCoordinator.shared.isKeyboardHapticFeedbackEnabled
+    @State private var isSoundFeedbackEnabled = AppGroupCoordinator.shared.isKeyboardSoundFeedbackEnabled
 
     let selectTranscriptionModelTipSettingsView = SelectTranscriptionModelTipSettingsView()
     
@@ -211,6 +213,36 @@ struct SettingsView: View {
                     }
                     .onChange(of: isKeepInClipboardEnabled) { _, newValue in
                         AppGroupCoordinator.shared.isKeepTranscriptInClipboardEnabled = newValue
+                    }
+
+                    Toggle(isOn: $isHapticFeedbackEnabled) {
+                        Text("Haptic Feedback")
+                            .font(.body)
+//                        VStack(alignment: .leading, spacing: 4) {
+//                            Text("Haptic Feedback")
+//                                .font(.body)
+//                            Text("Vibrate on key press")
+//                                .font(.caption)
+//                                .foregroundStyle(.secondary)
+//                        }
+                    }
+                    .onChange(of: isHapticFeedbackEnabled) { _, newValue in
+                        AppGroupCoordinator.shared.isKeyboardHapticFeedbackEnabled = newValue
+                    }
+                    
+                    Toggle(isOn: $isSoundFeedbackEnabled) {
+                        Text("Sound")
+                            .font(.body)
+//                        VStack(alignment: .leading, spacing: 4) {
+//                            Text("Haptic Feedback")
+//                                .font(.body)
+//                            Text("Vibrate on key press")
+//                                .font(.caption)
+//                                .foregroundStyle(.secondary)
+//                        }
+                    }
+                    .onChange(of: isSoundFeedbackEnabled) { _, newValue in
+                        AppGroupCoordinator.shared.isKeyboardSoundFeedbackEnabled = newValue
                     }
                 }
                 

--- a/VivaDictaKeyboard/KeyboardViewController.swift
+++ b/VivaDictaKeyboard/KeyboardViewController.swift
@@ -57,6 +57,12 @@ class KeyboardViewController: KeyboardInputViewController {
         setup(for: keyboardApp) { [weak self] result in
             self?.logger.logInfo("Keyboard setup result: \(String(describing: result))")
         }
+
+        // Configure haptic feedback based on user preference
+        state.feedbackContext.settings.isHapticFeedbackEnabled = AppGroupCoordinator.shared.isKeyboardHapticFeedbackEnabled
+        
+        // Configure sound feedback based on user preference
+        state.feedbackContext.settings.isAudioFeedbackEnabled = AppGroupCoordinator.shared.isKeyboardSoundFeedbackEnabled
     }
     
     override func viewWillSetupKeyboardView() {


### PR DESCRIPTION
## Summary
- Add toggles in Settings → Keyboard section to enable/disable haptic and sound feedback for the custom keyboard
- Settings are stored in shared App Group UserDefaults so the keyboard extension can access them
- KeyboardKit's FeedbackContext is configured on keyboard load based on user preferences

## Changes
- **AppGroupCoordinator**: Added `isKeyboardHapticFeedbackEnabled` and `isKeyboardSoundFeedbackEnabled` properties with shared storage
- **SettingsView**: Added "Haptic Feedback" and "Sound" toggles in the Keyboard section
- **KeyboardViewController**: Configure `state.feedbackContext.settings` based on user preferences on load

## Test plan
- [ ] Open Settings → Keyboard section
- [ ] Toggle "Haptic Feedback" off and verify keyboard no longer vibrates on key press
- [ ] Toggle "Sound" off and verify keyboard no longer plays sounds on key press
- [ ] Verify settings persist after app restart
- [ ] Verify settings take effect when keyboard is reopened after changing