### PR TITLE
Add automatic audio cleanup setting

### DIFF
--- a/VivaDicta/Models/Transcription.swift
+++ b/VivaDicta/Models/Transcription.swift
@@ -68,10 +68,10 @@ class Transcription {
     nonisolated func getAudioFileSize() -> Int64? {
         guard let audioFileName = audioFileName else { return nil }
 
-        // Construct audio directory path directly to avoid MainActor isolation issues
-        let documentsDirectory = URL.documentsDirectory
-        let audioDirectory = documentsDirectory.appendingPathComponent("Audio")
-        let audioURL = audioDirectory.appendingPathComponent(audioFileName)
+        // Construct path directly to avoid MainActor isolation of FileManager.appDirectory
+        let audioURL = URL.documentsDirectory
+            .appendingPathComponent("Audio")
+            .appendingPathComponent(audioFileName)
 
         guard FileManager.default.fileExists(atPath: audioURL.path) else { return nil }
 

--- a/VivaDicta/Services/AudioCleanupService.swift
+++ b/VivaDicta/Services/AudioCleanupService.swift
@@ -40,11 +40,14 @@ final class AudioCleanupService {
         logger.logInfo("Audio cleanup: Starting with \(effectiveRetentionDays) day retention")
 
         // Calculate cutoff date
-        let cutoffDate = Calendar.current.date(
+        guard let cutoffDate = Calendar.current.date(
             byAdding: .day,
             value: -effectiveRetentionDays,
             to: Date()
-        ) ?? Date()
+        ) else {
+            logger.logError("Audio cleanup: Failed to calculate cutoff date, aborting")
+            return
+        }
 
         await cleanupAudioFiles(olderThan: cutoffDate, modelContext: modelContext)
     }

--- a/VivaDicta/Services/AudioCleanupService.swift
+++ b/VivaDicta/Services/AudioCleanupService.swift
@@ -22,9 +22,8 @@ final class AudioCleanupService {
     /// - Parameter modelContext: The SwiftData model context to use for queries
     func performCleanupIfNeeded(modelContext: ModelContext) async {
         // Check if auto cleanup is enabled
-        let isEnabled = UserDefaults.standard.bool(
-            forKey: UserDefaultsStorage.Keys.isAutoAudioCleanupEnabled
-        )
+        
+        let isEnabled = UserDefaultsStorage.appPrivate.bool(forKey: UserDefaultsStorage.Keys.isAutoAudioCleanupEnabled)
 
         guard isEnabled else {
             logger.logInfo("Audio cleanup: Disabled, skipping")
@@ -32,7 +31,8 @@ final class AudioCleanupService {
         }
 
         // Get retention days (default to 7 if not set)
-        let retentionDays = UserDefaults.standard.integer(
+        
+        let retentionDays = UserDefaultsStorage.appPrivate.integer(
             forKey: UserDefaultsStorage.Keys.audioRetentionDays
         )
         let effectiveRetentionDays = retentionDays > 0 ? retentionDays : 7

--- a/VivaDicta/Services/AudioCleanupService.swift
+++ b/VivaDicta/Services/AudioCleanupService.swift
@@ -14,19 +14,25 @@ import os
 final class AudioCleanupService {
     static let shared = AudioCleanupService()
 
+    private static let lastCleanupKey = "lastAudioCleanupDate"
+    private static let cleanupIntervalSeconds: TimeInterval = 24 * 60 * 60 // 24 hours
+
     private let logger = Logger(category: .app)
     private let userDefaults: UserDefaults
     private let audioDirectory: URL
     private let fileManager: FileManager
+    private let minimumCleanupInterval: TimeInterval
 
     init(
         userDefaults: UserDefaults = UserDefaultsStorage.appPrivate,
         audioDirectory: URL = FileManager.appDirectory(for: .audio),
-        fileManager: FileManager = .default
+        fileManager: FileManager = .default,
+        minimumCleanupInterval: TimeInterval = cleanupIntervalSeconds
     ) {
         self.userDefaults = userDefaults
         self.audioDirectory = audioDirectory
         self.fileManager = fileManager
+        self.minimumCleanupInterval = minimumCleanupInterval
     }
 
     /// Performs audio cleanup based on user settings
@@ -38,6 +44,17 @@ final class AudioCleanupService {
         guard isEnabled else {
             logger.logInfo("Audio cleanup: Disabled, skipping")
             return
+        }
+
+        // Check if enough time has passed since last cleanup
+        let lastCleanup = userDefaults.object(forKey: Self.lastCleanupKey) as? Date
+        if let lastCleanup = lastCleanup {
+            let timeSinceLastCleanup = Date().timeIntervalSince(lastCleanup)
+            if timeSinceLastCleanup < minimumCleanupInterval {
+                let hoursRemaining = (minimumCleanupInterval - timeSinceLastCleanup) / 3600
+                logger.logInfo("Audio cleanup: Skipping, last cleanup was \(Int(timeSinceLastCleanup / 3600))h ago (next in \(Int(hoursRemaining))h)")
+                return
+            }
         }
 
         // Get retention days (default to 7 if not set)
@@ -57,6 +74,9 @@ final class AudioCleanupService {
         }
 
         await cleanupAudioFiles(olderThan: cutoffDate, modelContext: modelContext)
+
+        // Update last cleanup timestamp
+        userDefaults.set(Date(), forKey: Self.lastCleanupKey)
     }
 
     /// Deletes audio files for transcriptions older than the specified date

--- a/VivaDicta/Services/AudioCleanupService.swift
+++ b/VivaDicta/Services/AudioCleanupService.swift
@@ -15,15 +15,25 @@ final class AudioCleanupService {
     static let shared = AudioCleanupService()
 
     private let logger = Logger(category: .app)
+    private let userDefaults: UserDefaults
+    private let audioDirectory: URL
+    private let fileManager: FileManager
 
-    private init() {}
+    init(
+        userDefaults: UserDefaults = UserDefaultsStorage.appPrivate,
+        audioDirectory: URL = FileManager.appDirectory(for: .audio),
+        fileManager: FileManager = .default
+    ) {
+        self.userDefaults = userDefaults
+        self.audioDirectory = audioDirectory
+        self.fileManager = fileManager
+    }
 
     /// Performs audio cleanup based on user settings
     /// - Parameter modelContext: The SwiftData model context to use for queries
     func performCleanupIfNeeded(modelContext: ModelContext) async {
         // Check if auto cleanup is enabled
-        
-        let isEnabled = UserDefaultsStorage.appPrivate.bool(forKey: UserDefaultsStorage.Keys.isAutoAudioCleanupEnabled)
+        let isEnabled = userDefaults.bool(forKey: UserDefaultsStorage.Keys.isAutoAudioCleanupEnabled)
 
         guard isEnabled else {
             logger.logInfo("Audio cleanup: Disabled, skipping")
@@ -31,10 +41,7 @@ final class AudioCleanupService {
         }
 
         // Get retention days (default to 7 if not set)
-        
-        let retentionDays = UserDefaultsStorage.appPrivate.integer(
-            forKey: UserDefaultsStorage.Keys.audioRetentionDays
-        )
+        let retentionDays = userDefaults.integer(forKey: UserDefaultsStorage.Keys.audioRetentionDays)
         let effectiveRetentionDays = retentionDays > 0 ? retentionDays : 7
 
         logger.logInfo("Audio cleanup: Starting with \(effectiveRetentionDays) day retention")
@@ -73,7 +80,6 @@ final class AudioCleanupService {
 
             logger.logInfo("Audio cleanup: Found \(transcriptions.count) transcriptions with old audio files")
 
-            let audioDirectory = FileManager.appDirectory(for: .audio)
             var deletedCount = 0
 
             for transcription in transcriptions {
@@ -82,9 +88,9 @@ final class AudioCleanupService {
                 let audioURL = audioDirectory.appendingPathComponent(audioFileName)
 
                 // Delete the file
-                if FileManager.default.fileExists(atPath: audioURL.path) {
+                if fileManager.fileExists(atPath: audioURL.path) {
                     do {
-                        try FileManager.default.removeItem(at: audioURL)
+                        try fileManager.removeItem(at: audioURL)
                         deletedCount += 1
                     } catch {
                         logger.logError("Audio cleanup: Failed to delete \(audioFileName): \(error.localizedDescription)")

--- a/VivaDicta/Services/AudioCleanupService.swift
+++ b/VivaDicta/Services/AudioCleanupService.swift
@@ -1,0 +1,111 @@
+//
+//  AudioCleanupService.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2025.12.11
+//
+
+import Foundation
+import SwiftData
+import os
+
+/// Service responsible for cleaning up old audio files based on user settings
+@MainActor
+final class AudioCleanupService {
+    static let shared = AudioCleanupService()
+
+    private let logger = Logger(category: .app)
+
+    private init() {}
+
+    /// Performs audio cleanup based on user settings
+    /// - Parameter modelContext: The SwiftData model context to use for queries
+    func performCleanupIfNeeded(modelContext: ModelContext) async {
+        // Check if auto cleanup is enabled
+        let isEnabled = UserDefaults.standard.bool(
+            forKey: UserDefaultsStorage.Keys.isAutoAudioCleanupEnabled
+        )
+
+        guard isEnabled else {
+            logger.logInfo("Audio cleanup: Disabled, skipping")
+            return
+        }
+
+        // Get retention days (default to 7 if not set)
+        let retentionDays = UserDefaults.standard.integer(
+            forKey: UserDefaultsStorage.Keys.audioRetentionDays
+        )
+        let effectiveRetentionDays = retentionDays > 0 ? retentionDays : 7
+
+        logger.logInfo("Audio cleanup: Starting with \(effectiveRetentionDays) day retention")
+
+        // Calculate cutoff date
+        let cutoffDate = Calendar.current.date(
+            byAdding: .day,
+            value: -effectiveRetentionDays,
+            to: Date()
+        ) ?? Date()
+
+        await cleanupAudioFiles(olderThan: cutoffDate, modelContext: modelContext)
+    }
+
+    /// Deletes audio files for transcriptions older than the specified date
+    /// - Parameters:
+    ///   - cutoffDate: Delete audio files for transcriptions before this date
+    ///   - modelContext: The SwiftData model context
+    private func cleanupAudioFiles(olderThan cutoffDate: Date, modelContext: ModelContext) async {
+        do {
+            // Fetch transcriptions older than cutoff date that have audio files
+            let predicate = #Predicate<Transcription> { transcription in
+                transcription.timestamp < cutoffDate && transcription.audioFileName != nil
+            }
+
+            let descriptor = FetchDescriptor<Transcription>(predicate: predicate)
+            let transcriptions = try modelContext.fetch(descriptor)
+
+            guard !transcriptions.isEmpty else {
+                logger.logInfo("Audio cleanup: No old audio files to clean up")
+                return
+            }
+
+            logger.logInfo("Audio cleanup: Found \(transcriptions.count) transcriptions with old audio files")
+
+            let audioDirectory = FileManager.appDirectory(for: .audio)
+            var deletedCount = 0
+            var freedBytes: Int64 = 0
+
+            for transcription in transcriptions {
+                guard let audioFileName = transcription.audioFileName else { continue }
+
+                let audioURL = audioDirectory.appendingPathComponent(audioFileName)
+
+                // Get file size before deletion for logging
+                if let fileSize = transcription.getAudioFileSize() {
+                    freedBytes += fileSize
+                }
+
+                // Delete the file
+                if FileManager.default.fileExists(atPath: audioURL.path) {
+                    do {
+                        try FileManager.default.removeItem(at: audioURL)
+                        deletedCount += 1
+                    } catch {
+                        logger.logError("Audio cleanup: Failed to delete \(audioFileName): \(error.localizedDescription)")
+                    }
+                }
+
+                // Clear the audio file reference in the transcription
+                transcription.audioFileName = nil
+            }
+
+            // Save changes
+            try modelContext.save()
+
+            let freedMB = Double(freedBytes) / 1_048_576.0
+            logger.logInfo("Audio cleanup: Deleted \(deletedCount) files, freed \(freedMB.formatted(.number.precision(.fractionLength(1)))) MB")
+
+        } catch {
+            logger.logError("Audio cleanup: Failed to fetch transcriptions: \(error.localizedDescription)")
+        }
+    }
+}

--- a/VivaDicta/Services/AudioCleanupService.swift
+++ b/VivaDicta/Services/AudioCleanupService.swift
@@ -75,17 +75,11 @@ final class AudioCleanupService {
 
             let audioDirectory = FileManager.appDirectory(for: .audio)
             var deletedCount = 0
-            var freedBytes: Int64 = 0
 
             for transcription in transcriptions {
                 guard let audioFileName = transcription.audioFileName else { continue }
 
                 let audioURL = audioDirectory.appendingPathComponent(audioFileName)
-
-                // Get file size before deletion for logging
-                if let fileSize = transcription.getAudioFileSize() {
-                    freedBytes += fileSize
-                }
 
                 // Delete the file
                 if FileManager.default.fileExists(atPath: audioURL.path) {
@@ -104,8 +98,7 @@ final class AudioCleanupService {
             // Save changes
             try modelContext.save()
 
-            let freedMB = Double(freedBytes) / 1_048_576.0
-            logger.logInfo("Audio cleanup: Deleted \(deletedCount) files, freed \(freedMB.formatted(.number.precision(.fractionLength(1)))) MB")
+            logger.logInfo("Audio cleanup: Deleted \(deletedCount) files")
 
         } catch {
             logger.logError("Audio cleanup: Failed to fetch transcriptions: \(error.localizedDescription)")

--- a/VivaDicta/Utils/UserDefaultsStorage.swift
+++ b/VivaDicta/Utils/UserDefaultsStorage.swift
@@ -32,5 +32,7 @@ enum UserDefaultsStorage {
         static let customVocabularyWords = "customVocabularyWords"
         static let textReplacements = "textReplacements"
         static let isReplacementsEnabled = "isReplacementsEnabled"
+        static let isAutoAudioCleanupEnabled = "isAutoAudioCleanupEnabled"
+        static let audioRetentionDays = "audioRetentionDays"
     }
 }

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -134,7 +134,7 @@ struct SettingsView: View {
                     }
 
                     if isAutoAudioCleanupEnabled {
-                        Picker("    Keep Audio Files For", selection: $audioRetentionDays) {
+                        Picker("Keep Audio Files For", selection: $audioRetentionDays) {
                             Text("1 day").tag(1)
                             Text("3 days").tag(3)
                             Text("7 days").tag(7)
@@ -142,6 +142,7 @@ struct SettingsView: View {
                             Text("30 days").tag(30)
                         }
                         .pickerStyle(.menu)
+                        .padding(.leading)
                         .tint(.primary)
                     }
                 }

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -324,6 +324,7 @@ struct SettingsView: View {
             }
 
         }
+        .animation(.default, value: isAutoAudioCleanupEnabled)
         .onAppear {
             if appState.shouldNavigateToModels {
                 appState.shouldNavigateToModels = false

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -33,6 +33,11 @@ struct SettingsView: View {
     @State private var isHapticFeedbackEnabled = AppGroupCoordinator.shared.isKeyboardHapticFeedbackEnabled
     @State private var isSoundFeedbackEnabled = AppGroupCoordinator.shared.isKeyboardSoundFeedbackEnabled
 
+    @AppStorage(UserDefaultsStorage.Keys.isAutoAudioCleanupEnabled)
+    private var isAutoAudioCleanupEnabled = false
+    @AppStorage(UserDefaultsStorage.Keys.audioRetentionDays)
+    private var audioRetentionDays = 7
+
     let selectTranscriptionModelTipSettingsView = SelectTranscriptionModelTipSettingsView()
     
     var body: some View {
@@ -116,6 +121,28 @@ struct SettingsView: View {
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                         }
+                    }
+                    
+                    Toggle(isOn: $isAutoAudioCleanupEnabled) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Automatic Audio Cleanup")
+                                .font(.body)
+                            Text("Automatically delete old audio files to save space")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+
+                    if isAutoAudioCleanupEnabled {
+                        Picker("Keep Audio Files For", selection: $audioRetentionDays) {
+                            Text("1 day").tag(1)
+                            Text("3 days").tag(3)
+                            Text("7 days").tag(7)
+                            Text("14 days").tag(14)
+                            Text("30 days").tag(30)
+                        }
+                        .pickerStyle(.menu)
+                        .tint(.primary)
                     }
                 }
                 

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -134,7 +134,7 @@ struct SettingsView: View {
                     }
 
                     if isAutoAudioCleanupEnabled {
-                        Picker("Keep Audio Files For", selection: $audioRetentionDays) {
+                        Picker("    Keep Audio Files For", selection: $audioRetentionDays) {
                             Text("1 day").tag(1)
                             Text("3 days").tag(3)
                             Text("7 days").tag(7)

--- a/VivaDicta/Views/TranscriptionDetailView.swift
+++ b/VivaDicta/Views/TranscriptionDetailView.swift
@@ -46,8 +46,7 @@ struct TranscriptionDetailView: View {
 
     private var audioURL: URL? {
         guard let audioFileName = transcription.audioFileName, !audioFileName.isEmpty else { return nil }
-        let audioDirectory = URL.documentsDirectory.appendingPathComponent("Audio")
-        let url = audioDirectory.appendingPathComponent(audioFileName)
+        let url = FileManager.appDirectory(for: .audio).appendingPathComponent(audioFileName)
         return FileManager.default.fileExists(atPath: url.path) ? url : nil
     }
 

--- a/VivaDicta/Views/TranscriptionDetailView.swift
+++ b/VivaDicta/Views/TranscriptionDetailView.swift
@@ -63,7 +63,8 @@ struct TranscriptionDetailView: View {
         VStack(alignment: .leading, spacing: 0) {
             // Fixed header section
             VStack(alignment: .leading, spacing: 8) {
-                if let audioFileName = transcription.audioFileName {
+                if let audioURL = audioURL,
+                   let audioFileName = audioURL.lastPathComponent as String? {
                     AudioPlayerView(audioFileName: audioFileName)
                         .padding(.bottom, 8)
                 }

--- a/VivaDicta/Views/TranscriptionDetailView.swift
+++ b/VivaDicta/Views/TranscriptionDetailView.swift
@@ -421,7 +421,7 @@ struct TranscriptionDetailView: View {
             DisclosureGroup("Meta Info") {
                 VStack(alignment: .leading, spacing: 10) {
                     metadataRow(icon: "hourglass", label: "Audio Duration", value: transcription.getDurationFormatted(transcription.audioDuration))
-                    if transcription.audioFileName != nil {
+                    if audioURL != nil {
                         metadataRow(icon: "doc.fill", label: "Audio File Size", value: transcription.getAudioFileSizeFormatted())
                     }
                     if let modelName = transcription.transcriptionModelName {

--- a/VivaDicta/Views/TranscriptionDetailView.swift
+++ b/VivaDicta/Views/TranscriptionDetailView.swift
@@ -62,9 +62,8 @@ struct TranscriptionDetailView: View {
         VStack(alignment: .leading, spacing: 0) {
             // Fixed header section
             VStack(alignment: .leading, spacing: 8) {
-                if let audioURL = audioURL,
-                   let audioFileName = audioURL.lastPathComponent as String? {
-                    AudioPlayerView(audioFileName: audioFileName)
+                if let audioURL = audioURL {
+                    AudioPlayerView(audioFileName: audioURL.lastPathComponent)
                         .padding(.bottom, 8)
                 }
 

--- a/VivaDicta/VivaDictaApp.swift
+++ b/VivaDicta/VivaDictaApp.swift
@@ -53,6 +53,12 @@ struct VivaDictaApp: App {
             }
         }
 
+        // Clean up old audio files on cold start (based on user settings)
+        Task { @MainActor in
+            let context = Persistence.container.mainContext
+            await AudioCleanupService.shared.performCleanupIfNeeded(modelContext: context)
+        }
+
         // Reset session state on app launch to prevent stale state issues
         AppGroupCoordinator.shared.resetSessionStateOnAppLaunch()
 

--- a/VivaDictaTests/AudioCleanupServiceTests.swift
+++ b/VivaDictaTests/AudioCleanupServiceTests.swift
@@ -1,0 +1,487 @@
+//
+//  AudioCleanupServiceTests.swift
+//  VivaDictaTests
+//
+//  Created by Anton Novoselov on 2025.12.11
+//
+
+import Foundation
+import Testing
+import SwiftData
+@testable import VivaDicta
+
+@MainActor
+struct AudioCleanupServiceTests {
+
+    private let testSuiteName = "AudioCleanupServiceTests"
+
+    private func makeTestDefaults() -> UserDefaults {
+        let defaults = UserDefaults(suiteName: testSuiteName)!
+        defaults.removePersistentDomain(forName: testSuiteName)
+        return defaults
+    }
+
+    private func makeTestDirectory() throws -> URL {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AudioCleanupTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        return tempDir
+    }
+
+    private func makeModelContainer() throws -> ModelContainer {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        return try ModelContainer(for: Transcription.self, configurations: config)
+    }
+
+    private func createTranscription(
+        text: String = "Test transcription",
+        audioFileName: String? = nil,
+        daysAgo: Int = 0,
+        in context: ModelContext
+    ) -> Transcription {
+        let transcription = Transcription(
+            text: text,
+            audioDuration: 10.0,
+            audioFileName: audioFileName
+        )
+        // Set timestamp to specified days ago
+        if daysAgo > 0 {
+            transcription.timestamp = Calendar.current.date(
+                byAdding: .day,
+                value: -daysAgo,
+                to: Date()
+            ) ?? Date()
+        }
+        context.insert(transcription)
+        return transcription
+    }
+
+    private func createAudioFile(named fileName: String, in directory: URL) throws {
+        let fileURL = directory.appendingPathComponent(fileName)
+        let testData = "test audio data".data(using: .utf8)!
+        try testData.write(to: fileURL)
+    }
+
+    // MARK: - Cleanup Disabled Tests
+
+    @Test func cleanupSkippedWhenDisabled() async throws {
+        let defaults = makeTestDefaults()
+        let audioDir = try makeTestDirectory()
+        let container = try makeModelContainer()
+        let context = container.mainContext
+
+        // Setup: cleanup disabled (default is false)
+        defaults.set(false, forKey: UserDefaultsStorage.Keys.isAutoAudioCleanupEnabled)
+
+        // Create old transcription with audio
+        let fileName = "old-audio.m4a"
+        try createAudioFile(named: fileName, in: audioDir)
+        let transcription = createTranscription(
+            audioFileName: fileName,
+            daysAgo: 30,
+            in: context
+        )
+        try context.save()
+
+        // Run cleanup
+        let service = AudioCleanupService(
+            userDefaults: defaults,
+            audioDirectory: audioDir
+        )
+        await service.performCleanupIfNeeded(modelContext: context)
+
+        // Verify: audio file still exists, transcription unchanged
+        #expect(FileManager.default.fileExists(atPath: audioDir.appendingPathComponent(fileName).path))
+        #expect(transcription.audioFileName == fileName)
+
+        // Cleanup
+        try? FileManager.default.removeItem(at: audioDir)
+    }
+
+    // MARK: - Retention Period Tests
+
+    @Test func cleanupWithDefaultRetentionDays() async throws {
+        let defaults = makeTestDefaults()
+        let audioDir = try makeTestDirectory()
+        let container = try makeModelContainer()
+        let context = container.mainContext
+
+        // Setup: cleanup enabled, retention days not set (should default to 7)
+        defaults.set(true, forKey: UserDefaultsStorage.Keys.isAutoAudioCleanupEnabled)
+        // Don't set audioRetentionDays - should default to 7
+
+        // Create transcriptions of various ages
+        let oldFileName = "old-audio.m4a"
+        let recentFileName = "recent-audio.m4a"
+        try createAudioFile(named: oldFileName, in: audioDir)
+        try createAudioFile(named: recentFileName, in: audioDir)
+
+        let oldTranscription = createTranscription(
+            text: "Old transcription",
+            audioFileName: oldFileName,
+            daysAgo: 10,
+            in: context
+        )
+        let recentTranscription = createTranscription(
+            text: "Recent transcription",
+            audioFileName: recentFileName,
+            daysAgo: 3,
+            in: context
+        )
+        try context.save()
+
+        // Run cleanup
+        let service = AudioCleanupService(
+            userDefaults: defaults,
+            audioDirectory: audioDir
+        )
+        await service.performCleanupIfNeeded(modelContext: context)
+
+        // Verify: old file deleted, recent file kept
+        #expect(!FileManager.default.fileExists(atPath: audioDir.appendingPathComponent(oldFileName).path))
+        #expect(FileManager.default.fileExists(atPath: audioDir.appendingPathComponent(recentFileName).path))
+        #expect(oldTranscription.audioFileName == nil)
+        #expect(recentTranscription.audioFileName == recentFileName)
+
+        // Cleanup
+        try? FileManager.default.removeItem(at: audioDir)
+    }
+
+    @Test func cleanupWithCustomRetentionDays() async throws {
+        let defaults = makeTestDefaults()
+        let audioDir = try makeTestDirectory()
+        let container = try makeModelContainer()
+        let context = container.mainContext
+
+        // Setup: cleanup enabled with 3 day retention
+        defaults.set(true, forKey: UserDefaultsStorage.Keys.isAutoAudioCleanupEnabled)
+        defaults.set(3, forKey: UserDefaultsStorage.Keys.audioRetentionDays)
+
+        // Create transcription 5 days old (should be deleted with 3 day retention)
+        let fileName = "audio.m4a"
+        try createAudioFile(named: fileName, in: audioDir)
+        let transcription = createTranscription(
+            audioFileName: fileName,
+            daysAgo: 5,
+            in: context
+        )
+        try context.save()
+
+        // Run cleanup
+        let service = AudioCleanupService(
+            userDefaults: defaults,
+            audioDirectory: audioDir
+        )
+        await service.performCleanupIfNeeded(modelContext: context)
+
+        // Verify: file deleted
+        #expect(!FileManager.default.fileExists(atPath: audioDir.appendingPathComponent(fileName).path))
+        #expect(transcription.audioFileName == nil)
+
+        // Cleanup
+        try? FileManager.default.removeItem(at: audioDir)
+    }
+
+    @Test func cleanupWithZeroRetentionDays_defaultsToSeven() async throws {
+        let defaults = makeTestDefaults()
+        let audioDir = try makeTestDirectory()
+        let container = try makeModelContainer()
+        let context = container.mainContext
+
+        // Setup: cleanup enabled with 0 retention (should default to 7)
+        defaults.set(true, forKey: UserDefaultsStorage.Keys.isAutoAudioCleanupEnabled)
+        defaults.set(0, forKey: UserDefaultsStorage.Keys.audioRetentionDays)
+
+        // Create transcription 5 days old (should NOT be deleted with default 7 day retention)
+        let fileName = "audio.m4a"
+        try createAudioFile(named: fileName, in: audioDir)
+        let transcription = createTranscription(
+            audioFileName: fileName,
+            daysAgo: 5,
+            in: context
+        )
+        try context.save()
+
+        // Run cleanup
+        let service = AudioCleanupService(
+            userDefaults: defaults,
+            audioDirectory: audioDir
+        )
+        await service.performCleanupIfNeeded(modelContext: context)
+
+        // Verify: file still exists (5 days < 7 day default retention)
+        #expect(FileManager.default.fileExists(atPath: audioDir.appendingPathComponent(fileName).path))
+        #expect(transcription.audioFileName == fileName)
+
+        // Cleanup
+        try? FileManager.default.removeItem(at: audioDir)
+    }
+
+    // MARK: - Audio File Name Cleared Tests
+
+    @Test func audioFileNameClearedAfterCleanup() async throws {
+        let defaults = makeTestDefaults()
+        let audioDir = try makeTestDirectory()
+        let container = try makeModelContainer()
+        let context = container.mainContext
+
+        // Setup
+        defaults.set(true, forKey: UserDefaultsStorage.Keys.isAutoAudioCleanupEnabled)
+        defaults.set(7, forKey: UserDefaultsStorage.Keys.audioRetentionDays)
+
+        let fileName = "test-audio.m4a"
+        try createAudioFile(named: fileName, in: audioDir)
+        let transcription = createTranscription(
+            audioFileName: fileName,
+            daysAgo: 10,
+            in: context
+        )
+        try context.save()
+
+        #expect(transcription.audioFileName == fileName)
+
+        // Run cleanup
+        let service = AudioCleanupService(
+            userDefaults: defaults,
+            audioDirectory: audioDir
+        )
+        await service.performCleanupIfNeeded(modelContext: context)
+
+        // Verify: audioFileName is cleared
+        #expect(transcription.audioFileName == nil)
+
+        // Cleanup
+        try? FileManager.default.removeItem(at: audioDir)
+    }
+
+    // MARK: - Transcription Text Preserved Tests
+
+    @Test func transcriptionTextPreservedAfterCleanup() async throws {
+        let defaults = makeTestDefaults()
+        let audioDir = try makeTestDirectory()
+        let container = try makeModelContainer()
+        let context = container.mainContext
+
+        // Setup
+        defaults.set(true, forKey: UserDefaultsStorage.Keys.isAutoAudioCleanupEnabled)
+        defaults.set(7, forKey: UserDefaultsStorage.Keys.audioRetentionDays)
+
+        let originalText = "This is the original transcription text that should be preserved"
+        let enhancedText = "This is enhanced text"
+        let fileName = "test-audio.m4a"
+        try createAudioFile(named: fileName, in: audioDir)
+
+        let transcription = createTranscription(
+            text: originalText,
+            audioFileName: fileName,
+            daysAgo: 10,
+            in: context
+        )
+        transcription.enhancedText = enhancedText
+        try context.save()
+
+        // Run cleanup
+        let service = AudioCleanupService(
+            userDefaults: defaults,
+            audioDirectory: audioDir
+        )
+        await service.performCleanupIfNeeded(modelContext: context)
+
+        // Verify: text preserved, audio cleared
+        #expect(transcription.text == originalText)
+        #expect(transcription.enhancedText == enhancedText)
+        #expect(transcription.audioFileName == nil)
+
+        // Cleanup
+        try? FileManager.default.removeItem(at: audioDir)
+    }
+
+    // MARK: - No Matching Transcriptions Tests
+
+    @Test func cleanupWithNoOldTranscriptions() async throws {
+        let defaults = makeTestDefaults()
+        let audioDir = try makeTestDirectory()
+        let container = try makeModelContainer()
+        let context = container.mainContext
+
+        // Setup
+        defaults.set(true, forKey: UserDefaultsStorage.Keys.isAutoAudioCleanupEnabled)
+        defaults.set(7, forKey: UserDefaultsStorage.Keys.audioRetentionDays)
+
+        // Create only recent transcriptions
+        let fileName = "recent-audio.m4a"
+        try createAudioFile(named: fileName, in: audioDir)
+        let transcription = createTranscription(
+            audioFileName: fileName,
+            daysAgo: 1,
+            in: context
+        )
+        try context.save()
+
+        // Run cleanup
+        let service = AudioCleanupService(
+            userDefaults: defaults,
+            audioDirectory: audioDir
+        )
+        await service.performCleanupIfNeeded(modelContext: context)
+
+        // Verify: nothing changed
+        #expect(FileManager.default.fileExists(atPath: audioDir.appendingPathComponent(fileName).path))
+        #expect(transcription.audioFileName == fileName)
+
+        // Cleanup
+        try? FileManager.default.removeItem(at: audioDir)
+    }
+
+    @Test func cleanupWithNoAudioFiles() async throws {
+        let defaults = makeTestDefaults()
+        let audioDir = try makeTestDirectory()
+        let container = try makeModelContainer()
+        let context = container.mainContext
+
+        // Setup
+        defaults.set(true, forKey: UserDefaultsStorage.Keys.isAutoAudioCleanupEnabled)
+        defaults.set(7, forKey: UserDefaultsStorage.Keys.audioRetentionDays)
+
+        // Create old transcription WITHOUT audio
+        let transcription = createTranscription(
+            text: "Old transcription without audio",
+            audioFileName: nil,
+            daysAgo: 30,
+            in: context
+        )
+        try context.save()
+
+        // Run cleanup - should complete without errors
+        let service = AudioCleanupService(
+            userDefaults: defaults,
+            audioDirectory: audioDir
+        )
+        await service.performCleanupIfNeeded(modelContext: context)
+
+        // Verify: transcription unchanged
+        #expect(transcription.text == "Old transcription without audio")
+        #expect(transcription.audioFileName == nil)
+
+        // Cleanup
+        try? FileManager.default.removeItem(at: audioDir)
+    }
+
+    // MARK: - File Deletion Tests
+
+    @Test func fileActuallyDeletedFromDisk() async throws {
+        let defaults = makeTestDefaults()
+        let audioDir = try makeTestDirectory()
+        let container = try makeModelContainer()
+        let context = container.mainContext
+
+        // Setup
+        defaults.set(true, forKey: UserDefaultsStorage.Keys.isAutoAudioCleanupEnabled)
+        defaults.set(7, forKey: UserDefaultsStorage.Keys.audioRetentionDays)
+
+        let fileName = "to-delete.m4a"
+        let filePath = audioDir.appendingPathComponent(fileName)
+        try createAudioFile(named: fileName, in: audioDir)
+
+        // Verify file exists before cleanup
+        #expect(FileManager.default.fileExists(atPath: filePath.path))
+
+        _ = createTranscription(
+            audioFileName: fileName,
+            daysAgo: 10,
+            in: context
+        )
+        try context.save()
+
+        // Run cleanup
+        let service = AudioCleanupService(
+            userDefaults: defaults,
+            audioDirectory: audioDir
+        )
+        await service.performCleanupIfNeeded(modelContext: context)
+
+        // Verify file deleted from disk
+        #expect(!FileManager.default.fileExists(atPath: filePath.path))
+
+        // Cleanup
+        try? FileManager.default.removeItem(at: audioDir)
+    }
+
+    @Test func cleanupHandlesMissingAudioFile() async throws {
+        let defaults = makeTestDefaults()
+        let audioDir = try makeTestDirectory()
+        let container = try makeModelContainer()
+        let context = container.mainContext
+
+        // Setup
+        defaults.set(true, forKey: UserDefaultsStorage.Keys.isAutoAudioCleanupEnabled)
+        defaults.set(7, forKey: UserDefaultsStorage.Keys.audioRetentionDays)
+
+        // Create transcription with audioFileName but NO actual file on disk
+        let transcription = createTranscription(
+            audioFileName: "nonexistent-file.m4a",
+            daysAgo: 10,
+            in: context
+        )
+        try context.save()
+
+        // Run cleanup - should complete without errors
+        let service = AudioCleanupService(
+            userDefaults: defaults,
+            audioDirectory: audioDir
+        )
+        await service.performCleanupIfNeeded(modelContext: context)
+
+        // Verify: audioFileName still cleared even if file didn't exist
+        #expect(transcription.audioFileName == nil)
+
+        // Cleanup
+        try? FileManager.default.removeItem(at: audioDir)
+    }
+
+    // MARK: - Multiple Transcriptions Tests
+
+    @Test func cleanupMultipleOldTranscriptions() async throws {
+        let defaults = makeTestDefaults()
+        let audioDir = try makeTestDirectory()
+        let container = try makeModelContainer()
+        let context = container.mainContext
+
+        // Setup
+        defaults.set(true, forKey: UserDefaultsStorage.Keys.isAutoAudioCleanupEnabled)
+        defaults.set(7, forKey: UserDefaultsStorage.Keys.audioRetentionDays)
+
+        // Create multiple old transcriptions
+        var transcriptions: [Transcription] = []
+        for i in 1...5 {
+            let fileName = "audio-\(i).m4a"
+            try createAudioFile(named: fileName, in: audioDir)
+            let t = createTranscription(
+                text: "Transcription \(i)",
+                audioFileName: fileName,
+                daysAgo: 10 + i,
+                in: context
+            )
+            transcriptions.append(t)
+        }
+        try context.save()
+
+        // Run cleanup
+        let service = AudioCleanupService(
+            userDefaults: defaults,
+            audioDirectory: audioDir
+        )
+        await service.performCleanupIfNeeded(modelContext: context)
+
+        // Verify: all files deleted, all audioFileNames cleared
+        for (i, transcription) in transcriptions.enumerated() {
+            let fileName = "audio-\(i + 1).m4a"
+            #expect(!FileManager.default.fileExists(atPath: audioDir.appendingPathComponent(fileName).path))
+            #expect(transcription.audioFileName == nil)
+            #expect(transcription.text == "Transcription \(i + 1)")
+        }
+
+        // Cleanup
+        try? FileManager.default.removeItem(at: audioDir)
+    }
+}

--- a/VivaDictaTests/AudioCleanupServiceTests.swift
+++ b/VivaDictaTests/AudioCleanupServiceTests.swift
@@ -86,7 +86,8 @@ struct AudioCleanupServiceTests {
         // Run cleanup
         let service = AudioCleanupService(
             userDefaults: defaults,
-            audioDirectory: audioDir
+            audioDirectory: audioDir,
+            minimumCleanupInterval: 0
         )
         await service.performCleanupIfNeeded(modelContext: context)
 
@@ -133,7 +134,8 @@ struct AudioCleanupServiceTests {
         // Run cleanup
         let service = AudioCleanupService(
             userDefaults: defaults,
-            audioDirectory: audioDir
+            audioDirectory: audioDir,
+            minimumCleanupInterval: 0
         )
         await service.performCleanupIfNeeded(modelContext: context)
 
@@ -170,7 +172,8 @@ struct AudioCleanupServiceTests {
         // Run cleanup
         let service = AudioCleanupService(
             userDefaults: defaults,
-            audioDirectory: audioDir
+            audioDirectory: audioDir,
+            minimumCleanupInterval: 0
         )
         await service.performCleanupIfNeeded(modelContext: context)
 
@@ -205,7 +208,8 @@ struct AudioCleanupServiceTests {
         // Run cleanup
         let service = AudioCleanupService(
             userDefaults: defaults,
-            audioDirectory: audioDir
+            audioDirectory: audioDir,
+            minimumCleanupInterval: 0
         )
         await service.performCleanupIfNeeded(modelContext: context)
 
@@ -243,7 +247,8 @@ struct AudioCleanupServiceTests {
         // Run cleanup
         let service = AudioCleanupService(
             userDefaults: defaults,
-            audioDirectory: audioDir
+            audioDirectory: audioDir,
+            minimumCleanupInterval: 0
         )
         await service.performCleanupIfNeeded(modelContext: context)
 
@@ -283,7 +288,8 @@ struct AudioCleanupServiceTests {
         // Run cleanup
         let service = AudioCleanupService(
             userDefaults: defaults,
-            audioDirectory: audioDir
+            audioDirectory: audioDir,
+            minimumCleanupInterval: 0
         )
         await service.performCleanupIfNeeded(modelContext: context)
 
@@ -321,7 +327,8 @@ struct AudioCleanupServiceTests {
         // Run cleanup
         let service = AudioCleanupService(
             userDefaults: defaults,
-            audioDirectory: audioDir
+            audioDirectory: audioDir,
+            minimumCleanupInterval: 0
         )
         await service.performCleanupIfNeeded(modelContext: context)
 
@@ -355,7 +362,8 @@ struct AudioCleanupServiceTests {
         // Run cleanup - should complete without errors
         let service = AudioCleanupService(
             userDefaults: defaults,
-            audioDirectory: audioDir
+            audioDirectory: audioDir,
+            minimumCleanupInterval: 0
         )
         await service.performCleanupIfNeeded(modelContext: context)
 
@@ -396,7 +404,8 @@ struct AudioCleanupServiceTests {
         // Run cleanup
         let service = AudioCleanupService(
             userDefaults: defaults,
-            audioDirectory: audioDir
+            audioDirectory: audioDir,
+            minimumCleanupInterval: 0
         )
         await service.performCleanupIfNeeded(modelContext: context)
 
@@ -428,7 +437,8 @@ struct AudioCleanupServiceTests {
         // Run cleanup - should complete without errors
         let service = AudioCleanupService(
             userDefaults: defaults,
-            audioDirectory: audioDir
+            audioDirectory: audioDir,
+            minimumCleanupInterval: 0
         )
         await service.performCleanupIfNeeded(modelContext: context)
 
@@ -469,7 +479,8 @@ struct AudioCleanupServiceTests {
         // Run cleanup
         let service = AudioCleanupService(
             userDefaults: defaults,
-            audioDirectory: audioDir
+            audioDirectory: audioDir,
+            minimumCleanupInterval: 0
         )
         await service.performCleanupIfNeeded(modelContext: context)
 
@@ -480,6 +491,162 @@ struct AudioCleanupServiceTests {
             #expect(transcription.audioFileName == nil)
             #expect(transcription.text == "Transcription \(i + 1)")
         }
+
+        // Cleanup
+        try? FileManager.default.removeItem(at: audioDir)
+    }
+
+    // MARK: - Throttling Tests
+
+    @Test func cleanupSkippedWhenRunRecently() async throws {
+        let defaults = makeTestDefaults()
+        let audioDir = try makeTestDirectory()
+        let container = try makeModelContainer()
+        let context = container.mainContext
+
+        // Setup
+        defaults.set(true, forKey: UserDefaultsStorage.Keys.isAutoAudioCleanupEnabled)
+        defaults.set(7, forKey: UserDefaultsStorage.Keys.audioRetentionDays)
+
+        // Set last cleanup to 1 hour ago
+        let oneHourAgo = Date().addingTimeInterval(-3600)
+        defaults.set(oneHourAgo, forKey: "lastAudioCleanupDate")
+
+        let fileName = "old-audio.m4a"
+        try createAudioFile(named: fileName, in: audioDir)
+        let transcription = createTranscription(
+            audioFileName: fileName,
+            daysAgo: 10,
+            in: context
+        )
+        try context.save()
+
+        // Run cleanup with 24 hour interval (default)
+        let service = AudioCleanupService(
+            userDefaults: defaults,
+            audioDirectory: audioDir,
+            minimumCleanupInterval: 24 * 60 * 60
+        )
+        await service.performCleanupIfNeeded(modelContext: context)
+
+        // Verify: file NOT deleted because cleanup ran recently
+        #expect(FileManager.default.fileExists(atPath: audioDir.appendingPathComponent(fileName).path))
+        #expect(transcription.audioFileName == fileName)
+
+        // Cleanup
+        try? FileManager.default.removeItem(at: audioDir)
+    }
+
+    @Test func cleanupRunsWhenIntervalPassed() async throws {
+        let defaults = makeTestDefaults()
+        let audioDir = try makeTestDirectory()
+        let container = try makeModelContainer()
+        let context = container.mainContext
+
+        // Setup
+        defaults.set(true, forKey: UserDefaultsStorage.Keys.isAutoAudioCleanupEnabled)
+        defaults.set(7, forKey: UserDefaultsStorage.Keys.audioRetentionDays)
+
+        // Set last cleanup to 25 hours ago
+        let twentyFiveHoursAgo = Date().addingTimeInterval(-25 * 3600)
+        defaults.set(twentyFiveHoursAgo, forKey: "lastAudioCleanupDate")
+
+        let fileName = "old-audio.m4a"
+        try createAudioFile(named: fileName, in: audioDir)
+        let transcription = createTranscription(
+            audioFileName: fileName,
+            daysAgo: 10,
+            in: context
+        )
+        try context.save()
+
+        // Run cleanup with 24 hour interval
+        let service = AudioCleanupService(
+            userDefaults: defaults,
+            audioDirectory: audioDir,
+            minimumCleanupInterval: 24 * 60 * 60
+        )
+        await service.performCleanupIfNeeded(modelContext: context)
+
+        // Verify: file deleted because enough time passed
+        #expect(!FileManager.default.fileExists(atPath: audioDir.appendingPathComponent(fileName).path))
+        #expect(transcription.audioFileName == nil)
+
+        // Cleanup
+        try? FileManager.default.removeItem(at: audioDir)
+    }
+
+    @Test func cleanupRunsOnFirstLaunch() async throws {
+        let defaults = makeTestDefaults()
+        let audioDir = try makeTestDirectory()
+        let container = try makeModelContainer()
+        let context = container.mainContext
+
+        // Setup - no lastCleanupDate set (first launch)
+        defaults.set(true, forKey: UserDefaultsStorage.Keys.isAutoAudioCleanupEnabled)
+        defaults.set(7, forKey: UserDefaultsStorage.Keys.audioRetentionDays)
+
+        let fileName = "old-audio.m4a"
+        try createAudioFile(named: fileName, in: audioDir)
+        let transcription = createTranscription(
+            audioFileName: fileName,
+            daysAgo: 10,
+            in: context
+        )
+        try context.save()
+
+        // Run cleanup with 24 hour interval
+        let service = AudioCleanupService(
+            userDefaults: defaults,
+            audioDirectory: audioDir,
+            minimumCleanupInterval: 24 * 60 * 60
+        )
+        await service.performCleanupIfNeeded(modelContext: context)
+
+        // Verify: file deleted on first launch
+        #expect(!FileManager.default.fileExists(atPath: audioDir.appendingPathComponent(fileName).path))
+        #expect(transcription.audioFileName == nil)
+
+        // Cleanup
+        try? FileManager.default.removeItem(at: audioDir)
+    }
+
+    @Test func cleanupUpdatesLastCleanupTimestamp() async throws {
+        let defaults = makeTestDefaults()
+        let audioDir = try makeTestDirectory()
+        let container = try makeModelContainer()
+        let context = container.mainContext
+
+        // Setup
+        defaults.set(true, forKey: UserDefaultsStorage.Keys.isAutoAudioCleanupEnabled)
+        defaults.set(7, forKey: UserDefaultsStorage.Keys.audioRetentionDays)
+
+        // Verify no timestamp initially
+        #expect(defaults.object(forKey: "lastAudioCleanupDate") == nil)
+
+        let fileName = "old-audio.m4a"
+        try createAudioFile(named: fileName, in: audioDir)
+        _ = createTranscription(
+            audioFileName: fileName,
+            daysAgo: 10,
+            in: context
+        )
+        try context.save()
+
+        let beforeCleanup = Date()
+
+        // Run cleanup
+        let service = AudioCleanupService(
+            userDefaults: defaults,
+            audioDirectory: audioDir,
+            minimumCleanupInterval: 0
+        )
+        await service.performCleanupIfNeeded(modelContext: context)
+
+        // Verify timestamp was set
+        let lastCleanup = defaults.object(forKey: "lastAudioCleanupDate") as? Date
+        #expect(lastCleanup != nil)
+        #expect(lastCleanup! >= beforeCleanup)
 
         // Cleanup
         try? FileManager.default.removeItem(at: audioDir)


### PR DESCRIPTION
## Summary
- Add toggle and retention days picker to Settings for automatic deletion of old audio files
- Implement AudioCleanupService that runs on cold start to delete audio files older than configured retention period
- Hide audio player in TranscriptionDetailView when audio file doesn't exist on disk

## Changes
- **Settings UI**: New "Storage" section with toggle for auto cleanup and picker for retention days (1, 3, 7, 14, 30 days)
- **AudioCleanupService**: Queries transcriptions older than cutoff date, deletes audio files, clears `audioFileName` on transcription records
- **TranscriptionDetailView**: Check file existence before showing AudioPlayerView

## Test plan
- [ ] Enable automatic audio cleanup in Settings
- [ ] Verify picker appears only when toggle is on
- [ ] Create transcriptions, wait for retention period, restart app
- [ ] Verify old audio files are deleted but transcription text remains
- [ ] Open transcription detail view for record without audio file
- [ ] Verify no audio player/waveform is shown