### PR TITLE
Fix model download cancellation not working properly

### DIFF
--- a/VivaDicta/Services/ModelDownloadManager.swift
+++ b/VivaDicta/Services/ModelDownloadManager.swift
@@ -112,6 +112,22 @@ class ModelDownloadManager: @unchecked Sendable {
             downloadProgress.removeValue(forKey: model.name + "_coreml")
         }
 
+        // Clean up any partially downloaded files
+        Task {
+            do {
+                if let parakeetModel = model as? ParakeetModel {
+                    try parakeetModel.deleteModel()
+                    logger.logNotice("🧹 Cleaned up partial download for \(model.name)")
+                } else if let whisperKitModel = model as? WhisperKitModel {
+                    try whisperKitModel.deleteModel()
+                    logger.logNotice("🧹 Cleaned up partial download for \(model.name)")
+                }
+            } catch {
+                // Ignore cleanup errors - folder may not exist yet
+                logger.logInfo("No partial download to clean up for \(model.name)")
+            }
+        }
+
         logger.logNotice("❌ Cancelled download of \(model.name)")
     }
 

--- a/VivaDicta/Services/ModelDownloadManager.swift
+++ b/VivaDicta/Services/ModelDownloadManager.swift
@@ -136,6 +136,8 @@ class ModelDownloadManager: @unchecked Sendable {
 
     // MARK: - Parakeet Model Download
     private func downloadParakeetModel(_ model: ParakeetModel) async throws {
+        try Task.checkCancellation()
+
         await MainActor.run {
             downloadStatuses[model.name] = .downloading
             downloadProgress[model.name] = 0.0
@@ -152,8 +154,7 @@ class ModelDownloadManager: @unchecked Sendable {
                 try? await Task.sleep(for: .seconds(1))
             }
         }
-
-        // Ensure progress task is cancelled regardless of success or failure
+        
         defer {
             progressTask.cancel()
         }
@@ -167,6 +168,8 @@ class ModelDownloadManager: @unchecked Sendable {
             )
 
             _ = try await (asrDownload, vadDownload)
+            
+            try Task.checkCancellation()
 
             await MainActor.run {
                 self.downloadProgress[model.name] = 1.0
@@ -181,6 +184,9 @@ class ModelDownloadManager: @unchecked Sendable {
                 self.onModelDownloaded?(model)
             }
 
+        } catch is CancellationError {
+            logger.logNotice("🛑 Download of \(model.displayName) was cancelled")
+            throw CancellationError()
         } catch {
             await MainActor.run {
                 self.downloadStatuses[model.name] = .download
@@ -195,6 +201,9 @@ class ModelDownloadManager: @unchecked Sendable {
     // MARK: - WhisperKit Model Download
 
     private func downloadWhisperKitModel(_ model: WhisperKitModel) async throws {
+        // Check for cancellation before starting
+        try Task.checkCancellation()
+
         await MainActor.run {
             downloadStatuses[model.name] = .downloading
             downloadProgress[model.name] = 0.0
@@ -213,6 +222,8 @@ class ModelDownloadManager: @unchecked Sendable {
             )
 
             let whisperKit = try await WhisperKit(config)
+            
+            try Task.checkCancellation()
 
             // Check if model needs downloading using consolidated path
             let modelFolder = WhisperKitModel.modelPath(for: model.whisperKitModelName)
@@ -232,6 +243,8 @@ class ModelDownloadManager: @unchecked Sendable {
                         }
                     }
                 )
+                
+                try Task.checkCancellation()
 
                 whisperKit.modelFolder = downloadedFolder
             } else {
@@ -240,6 +253,9 @@ class ModelDownloadManager: @unchecked Sendable {
                     self.downloadProgress[model.name] = 0.7
                 }
             }
+
+            // Check for cancellation before prewarm
+            try Task.checkCancellation()
 
             // Prewarm models with animated progress (critical for first-time performance)
             logger.logNotice("🔥 Prewarming model: \(model.whisperKitModelName)")
@@ -266,6 +282,10 @@ class ModelDownloadManager: @unchecked Sendable {
 
             // Cancel the animation task and set final progress
             progressTask.cancel()
+
+            // Check for cancellation after prewarm
+            try Task.checkCancellation()
+
             await MainActor.run {
                 self.downloadProgress[model.name] = 0.9
             }
@@ -290,6 +310,10 @@ class ModelDownloadManager: @unchecked Sendable {
 
             // Cancel the animation task and set final progress
             loadProgressTask.cancel()
+
+            // Check for cancellation after load
+            try Task.checkCancellation()
+
             await MainActor.run {
                 self.downloadProgress[model.name] = 1.0
                 self.downloadStatuses[model.name] = .downloaded
@@ -308,6 +332,9 @@ class ModelDownloadManager: @unchecked Sendable {
                 self.onModelDownloaded?(model)
             }
 
+        } catch is CancellationError {
+            logger.logNotice("🛑 Download of \(model.displayName) was cancelled")
+            throw CancellationError()
         } catch {
             await MainActor.run {
                 self.downloadStatuses[model.name] = .download

--- a/VivaDicta/Views/ModelsScreen/LocalModelCard.swift
+++ b/VivaDicta/Views/ModelsScreen/LocalModelCard.swift
@@ -223,11 +223,14 @@ struct LocalModelCard: View {
                 } else if let parakeetModel = model as? ParakeetModel {
                     try await downloadManager.downloadModel(parakeetModel)
                 }
-                
+
                 // Hide "Select Transcription model" tips
                 await SelectTranscriptionModelTipMainView.selectModelEvent.donate()
                 await SelectTranscriptionModelTipSettingsView.selectModelEvent.donate()
-                
+
+            } catch is CancellationError {
+                // Don't treat cancellation as an error - it was intentional
+                // Status is already reset by cancelDownload()
             } catch {
                 if let whisperModel = model as? WhisperKitModel {
                     await downloadManager.handleModelDownloadError(whisperModel, error)

--- a/VivaDicta/Views/ModelsScreen/ParakeetModelCard.swift
+++ b/VivaDicta/Views/ModelsScreen/ParakeetModelCard.swift
@@ -152,6 +152,8 @@ struct ParakeetModelCard: View {
         Task {
             do {
                 try await downloadManager.downloadModel(model)
+            } catch is CancellationError {
+                // Don't treat cancellation as an error - it was intentional
             } catch {
                 await downloadManager.handleModelDownloadError(model, error)
             }

--- a/VivaDicta/Views/ModelsScreen/WhisperKitModelCard.swift
+++ b/VivaDicta/Views/ModelsScreen/WhisperKitModelCard.swift
@@ -172,6 +172,8 @@ struct WhisperKitModelCard: View {
         Task {
             do {
                 try await downloadManager.downloadModel(model)
+            } catch is CancellationError {
+                // Don't treat cancellation as an error - it was intentional
             } catch {
                 await downloadManager.handleModelDownloadError(model, error)
             }


### PR DESCRIPTION
## Summary

Fixes the issue where tapping "Cancel" during model download would update the UI but the download would continue in the background. Additionally, partial downloads were left on disk, causing the app to incorrectly detect incomplete models as downloaded.

### Changes

- Add cooperative cancellation checks (`Task.checkCancellation()`) at key points during WhisperKit and Parakeet model downloads
- Handle `CancellationError` separately from other errors to avoid logging cancellations as failures
- Clean up partially downloaded model files when cancelling to prevent incomplete models from being detected as "downloaded"

### Files Changed

- `ModelDownloadManager.swift` - Added cancellation checks and partial download cleanup
- `LocalModelCard.swift` - Handle CancellationError separately
- `ParakeetModelCard.swift` - Handle CancellationError separately  
- `WhisperKitModelCard.swift` - Handle CancellationError separately

## Test Plan

- [ ] Start downloading a WhisperKit model, tap cancel → Download stops, UI resets, no partial files remain
- [ ] Start downloading a Parakeet model, tap cancel → Download stops, UI resets, no partial files remain
- [ ] Cancel during different phases (download, prewarm, load) → All properly cancelled
- [ ] Complete a full download → Model works correctly for transcription