### PR TITLE
VIV-239: Disable AI Enhancement when API key or prompt is deleted

### DIFF
--- a/VivaDicta/Services/AIEnhance/AIProvider.swift
+++ b/VivaDicta/Services/AIEnhance/AIProvider.swift
@@ -23,13 +23,13 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
     case soniox
     
     static let generalProviders: [AIProvider] = [
-        .cerebras,
-        .groq,
-        .gemini,
         .anthropic,
         .openAI,
-        .grok,
+        .gemini,
+        .groq,
         .mistral,
+        .cerebras,
+        .grok,
         .openRouter]
     
     var baseURL: String {

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -104,11 +104,10 @@ class AIService {
     /// Disables AI enhancement for all modes that use the specified AI provider.
     /// Called when an API key for that provider is deleted.
     public func disableAIEnhancementForModesUsingProvider(_ provider: AIProvider) {
-        var modesUpdated = false
-
-        for (index, mode) in modes.enumerated() {
-            if mode.aiEnhanceEnabled && mode.aiProvider == provider {
-                let updatedMode = FlowMode(
+        updateModesMatching(
+            { $0.aiEnhanceEnabled && $0.aiProvider == provider },
+            transform: { mode in
+                FlowMode(
                     id: mode.id,
                     name: mode.name,
                     transcriptionProvider: mode.transcriptionProvider,
@@ -119,30 +118,18 @@ class AIService {
                     aiModel: mode.aiModel,
                     aiEnhanceEnabled: false
                 )
-                modes[index] = updatedMode
-
-                if selectedMode.id == mode.id {
-                    selectedMode = updatedMode
-                }
-
-                modesUpdated = true
-                logger.logInfo("Disabled AI enhancement for mode '\(mode.name)' due to API key deletion for provider: \(provider.rawValue)")
-            }
-        }
-
-        if modesUpdated {
-            saveModes()
-        }
+            },
+            logMessage: { "Disabled AI enhancement for mode '\($0.name)' due to API key deletion for provider: \(provider.rawValue)" }
+        )
     }
 
     /// Disables AI enhancement for all modes that use the specified prompt.
     /// Called when that prompt is deleted.
     public func disableAIEnhancementForModesUsingPrompt(promptId: UUID) {
-        var modesUpdated = false
-
-        for (index, mode) in modes.enumerated() {
-            if mode.aiEnhanceEnabled && mode.userPrompt?.id == promptId {
-                let updatedMode = FlowMode(
+        updateModesMatching(
+            { $0.aiEnhanceEnabled && $0.userPrompt?.id == promptId },
+            transform: { mode in
+                FlowMode(
                     id: mode.id,
                     name: mode.name,
                     transcriptionProvider: mode.transcriptionProvider,
@@ -153,6 +140,21 @@ class AIService {
                     aiModel: mode.aiModel,
                     aiEnhanceEnabled: false
                 )
+            },
+            logMessage: { "Disabled AI enhancement for mode '\($0.name)' due to prompt deletion" }
+        )
+    }
+
+    private func updateModesMatching(
+        _ predicate: (FlowMode) -> Bool,
+        transform: (FlowMode) -> FlowMode,
+        logMessage: (FlowMode) -> String
+    ) {
+        var modesUpdated = false
+
+        for (index, mode) in modes.enumerated() {
+            if predicate(mode) {
+                let updatedMode = transform(mode)
                 modes[index] = updatedMode
 
                 if selectedMode.id == mode.id {
@@ -160,7 +162,7 @@ class AIService {
                 }
 
                 modesUpdated = true
-                logger.logInfo("Disabled AI enhancement for mode '\(mode.name)' due to prompt deletion")
+                logger.logInfo(logMessage(mode))
             }
         }
 

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -101,6 +101,74 @@ class AIService {
         logger.logInfo("Deleted mode: \(mode.name)")
     }
 
+    /// Disables AI enhancement for all modes that use the specified AI provider.
+    /// Called when an API key for that provider is deleted.
+    public func disableAIEnhancementForModesUsingProvider(_ provider: AIProvider) {
+        var modesUpdated = false
+
+        for (index, mode) in modes.enumerated() {
+            if mode.aiEnhanceEnabled && mode.aiProvider == provider {
+                let updatedMode = FlowMode(
+                    id: mode.id,
+                    name: mode.name,
+                    transcriptionProvider: mode.transcriptionProvider,
+                    transcriptionModel: mode.transcriptionModel,
+                    transcriptionLanguage: mode.transcriptionLanguage,
+                    userPrompt: mode.userPrompt,
+                    aiProvider: mode.aiProvider,
+                    aiModel: mode.aiModel,
+                    aiEnhanceEnabled: false
+                )
+                modes[index] = updatedMode
+
+                if selectedMode.id == mode.id {
+                    selectedMode = updatedMode
+                }
+
+                modesUpdated = true
+                logger.logInfo("Disabled AI enhancement for mode '\(mode.name)' due to API key deletion for provider: \(provider.rawValue)")
+            }
+        }
+
+        if modesUpdated {
+            saveModes()
+        }
+    }
+
+    /// Disables AI enhancement for all modes that use the specified prompt.
+    /// Called when that prompt is deleted.
+    public func disableAIEnhancementForModesUsingPrompt(promptId: UUID) {
+        var modesUpdated = false
+
+        for (index, mode) in modes.enumerated() {
+            if mode.aiEnhanceEnabled && mode.userPrompt?.id == promptId {
+                let updatedMode = FlowMode(
+                    id: mode.id,
+                    name: mode.name,
+                    transcriptionProvider: mode.transcriptionProvider,
+                    transcriptionModel: mode.transcriptionModel,
+                    transcriptionLanguage: mode.transcriptionLanguage,
+                    userPrompt: nil,
+                    aiProvider: mode.aiProvider,
+                    aiModel: mode.aiModel,
+                    aiEnhanceEnabled: false
+                )
+                modes[index] = updatedMode
+
+                if selectedMode.id == mode.id {
+                    selectedMode = updatedMode
+                }
+
+                modesUpdated = true
+                logger.logInfo("Disabled AI enhancement for mode '\(mode.name)' due to prompt deletion")
+            }
+        }
+
+        if modesUpdated {
+            saveModes()
+        }
+    }
+
     public func updateDefaultModeIfNeeded(provider: TranscriptionModelProvider, modelName: String) {
         // Find the default mode
         guard let defaultModeIndex = modes.firstIndex(where: { $0.name == "Default" }) else {

--- a/VivaDicta/Views/SettingsScreen/ModeEditView.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditView.swift
@@ -169,12 +169,13 @@ struct ModeEditView: View {
                             } label: {
                                 HStack {
                                     Text(viewModel.aiProvider?.rawValue.capitalized ?? "Select")
-                                        .foregroundStyle(viewModel.aiProvider == nil ? .secondary : .primary)
+                                        .foregroundStyle(.secondary)
                                     Image(systemName: "chevron.up.chevron.down")
                                         .font(.footnote)
                                         .foregroundStyle(.secondary)
                                 }
                             }
+                            .buttonStyle(.plain)
                         } label: {
                             HStack {
                                 Image(systemName: "cpu")

--- a/VivaDicta/Views/SettingsScreen/ModeEditView.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditView.swift
@@ -153,29 +153,11 @@ struct ModeEditView: View {
                     Toggle("Enable", isOn: $viewModel.aiEnhanceEnabled)
                     
                     if viewModel.aiEnhanceEnabled {
-                        LabeledContent {
-                            Menu {
-                                ForEach(AIProvider.generalProviders) { provider in
-                                    Button {
-                                        viewModel.updateProvider(provider)
-                                    } label: {
-                                        if viewModel.aiProvider == provider {
-                                            Label(provider.rawValue.capitalized, systemImage: "checkmark")
-                                        } else {
-                                            Text(provider.rawValue.capitalized)
-                                        }
-                                    }
-                                }
-                            } label: {
-                                HStack {
-                                    Text(viewModel.aiProvider?.rawValue.capitalized ?? "Select")
-                                        .foregroundStyle(.secondary)
-                                    Image(systemName: "chevron.up.chevron.down")
-                                        .font(.footnote)
-                                        .foregroundStyle(.secondary)
-                                }
+                        Picker(selection: $viewModel.aiProvider) {
+                            ForEach(AIProvider.generalProviders) { provider in
+                                Text(provider.rawValue.capitalized).tag(provider)
                             }
-                            .buttonStyle(.plain)
+                            
                         } label: {
                             HStack {
                                 Image(systemName: "cpu")
@@ -183,8 +165,11 @@ struct ModeEditView: View {
                                 Text("AI Provider")
                             }
                         }
+                        .onChange(of: viewModel.aiProvider) { _, newProvider in
+                            viewModel.updateProvider(newProvider)
+                        }
                         .onAppear {
-                            viewModel.selectFirstConnectedProviderIfNeeded()
+                            viewModel.selectFirstProviderIfNeeded()
                         }
                         
                         if let provider = viewModel.aiProvider {

--- a/VivaDicta/Views/SettingsScreen/ModeEditView.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditView.swift
@@ -153,11 +153,28 @@ struct ModeEditView: View {
                     Toggle("Enable", isOn: $viewModel.aiEnhanceEnabled)
                     
                     if viewModel.aiEnhanceEnabled {
-                        Picker(selection: $viewModel.aiProvider) {
-                            ForEach(AIProvider.generalProviders) { provider in
-                                Text(provider.rawValue.capitalized).tag(provider)
+                        LabeledContent {
+                            Menu {
+                                ForEach(AIProvider.generalProviders) { provider in
+                                    Button {
+                                        viewModel.updateProvider(provider)
+                                    } label: {
+                                        if viewModel.aiProvider == provider {
+                                            Label(provider.rawValue.capitalized, systemImage: "checkmark")
+                                        } else {
+                                            Text(provider.rawValue.capitalized)
+                                        }
+                                    }
+                                }
+                            } label: {
+                                HStack {
+                                    Text(viewModel.aiProvider?.rawValue.capitalized ?? "Select")
+                                        .foregroundStyle(viewModel.aiProvider == nil ? .secondary : .primary)
+                                    Image(systemName: "chevron.up.chevron.down")
+                                        .font(.footnote)
+                                        .foregroundStyle(.secondary)
+                                }
                             }
-                            
                         } label: {
                             HStack {
                                 Image(systemName: "cpu")
@@ -165,8 +182,8 @@ struct ModeEditView: View {
                                 Text("AI Provider")
                             }
                         }
-                        .onChange(of: viewModel.aiProvider) { _, newProvider in
-                            viewModel.updateProvider(newProvider)
+                        .onAppear {
+                            viewModel.selectFirstConnectedProviderIfNeeded()
                         }
                         
                         if let provider = viewModel.aiProvider {

--- a/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
@@ -259,6 +259,20 @@ class ModeEditViewModel {
     }
     
     // MARK: - AI Enhancement settings
+    func selectFirstConnectedProviderIfNeeded() {
+        guard aiProvider == nil else { return }
+
+        let firstConnectedProvider = AIProvider.generalProviders.first { provider in
+            aiService.connectedProviders.contains(provider)
+        }
+
+        if let provider = firstConnectedProvider {
+            aiProvider = provider
+            aiModel = provider.defaultModel
+            logger.logInfo("Auto-selected first connected provider: \(provider.rawValue)")
+        }
+    }
+
     func updateProvider(_ newProvider: AIProvider?) {
         aiProvider = newProvider
         aiModel = newProvider?.defaultModel

--- a/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
@@ -259,17 +259,21 @@ class ModeEditViewModel {
     }
     
     // MARK: - AI Enhancement settings
-    func selectFirstConnectedProviderIfNeeded() {
+    func selectFirstProviderIfNeeded() {
         guard aiProvider == nil else { return }
 
+        // First try to find a provider with API key configured
         let firstConnectedProvider = AIProvider.generalProviders.first { provider in
             aiService.connectedProviders.contains(provider)
         }
 
-        if let provider = firstConnectedProvider {
+        // If no connected provider, just select the first one (so UI shows "Add API Key")
+        let providerToSelect = firstConnectedProvider ?? AIProvider.generalProviders.first
+
+        if let provider = providerToSelect {
             aiProvider = provider
             aiModel = provider.defaultModel
-            logger.logInfo("Auto-selected first connected provider: \(provider.rawValue)")
+            logger.logInfo("Auto-selected provider: \(provider.rawValue)")
         }
     }
 

--- a/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
@@ -108,6 +108,8 @@ class ModeEditViewModel {
             aiProvider = existingMode.aiProvider
             aiModel = existingMode.aiModel
             selectedPromptID = existingMode.userPrompt?.id
+
+            validateLanguageSelection()
         } else {
             transcriptionProvider = .whisperKit
             transcriptionModel = ""
@@ -167,12 +169,28 @@ class ModeEditViewModel {
         let availableModels = getAvailableTranscriptionModels(for: newProvider)
         transcriptionModel = availableModels.first ?? ""
         logger.logInfo("Updated transcription provider to: \(newProvider.rawValue), model: \(self.transcriptionModel)")
+
+        validateLanguageSelection()
     }
 
     func updateTranscriptionModel(_ newModel: String) {
         transcriptionModel = newModel
         logger.logInfo("Updated transcription model to: \(newModel)")
 
+        validateLanguageSelection()
+    }
+
+    private func validateLanguageSelection() {
+        let grouped = getGroupedLanguages()
+        let allLanguages = grouped.recommended + grouped.other
+
+        let isCurrentLanguageValid = allLanguages.contains { $0.key == transcriptionLanguage }
+
+        if !isCurrentLanguageValid, let firstLanguage = allLanguages.first {
+            let oldLanguage = transcriptionLanguage
+            transcriptionLanguage = firstLanguage.key
+            logger.logInfo("Language '\(oldLanguage)' not supported by model, reset to '\(firstLanguage.key)'")
+        }
     }
     
     // MARK: - Language Settings

--- a/VivaDicta/Views/SettingsScreen/ModelsView.swift
+++ b/VivaDicta/Views/SettingsScreen/ModelsView.swift
@@ -135,6 +135,12 @@ struct ModelsView: View {
 
         // Update cloud models to reflect the change
         appState.transcriptionManager.updateCloudModels()
+
+        // Disable AI enhancement for modes using this provider
+        // TranscriptionModelProvider and AIProvider share raw values for common providers
+        if let aiProvider = AIProvider(rawValue: model.provider.rawValue) {
+            appState.aiService.disableAIEnhancementForModesUsingProvider(aiProvider)
+        }
     }
 }
 

--- a/VivaDicta/Views/SettingsScreen/ModelsView.swift
+++ b/VivaDicta/Views/SettingsScreen/ModelsView.swift
@@ -137,8 +137,7 @@ struct ModelsView: View {
         appState.transcriptionManager.updateCloudModels()
 
         // Disable AI enhancement for modes using this provider
-        // TranscriptionModelProvider and AIProvider share raw values for common providers
-        if let aiProvider = AIProvider(rawValue: model.provider.rawValue) {
+        if let aiProvider = model.provider.mappedAIProvider {
             appState.aiService.disableAIEnhancementForModesUsingProvider(aiProvider)
         }
     }

--- a/VivaDicta/Views/SettingsScreen/Prompts/PromptsSettings.swift
+++ b/VivaDicta/Views/SettingsScreen/Prompts/PromptsSettings.swift
@@ -9,8 +9,8 @@ import SwiftUI
 
 struct PromptsSettings: View {
     var promptsManager: PromptsManager
-//    var transition: Namespace.ID
-    
+    var aiService: AIService
+
     var body: some View {
         VStack(spacing: 0) {
             if promptsManager.userPrompts.isEmpty {
@@ -26,7 +26,7 @@ struct PromptsSettings: View {
                 }
                 .prominentButton(color: .blue)
             }
-            
+
         }
         .toolbarTitleDisplayMode(.inlineLarge)
         .navigationTitle("Prompts")
@@ -61,11 +61,18 @@ struct PromptsSettings: View {
                 }
                 .swipeActions(edge: .trailing, allowsFullSwipe: false) {
                     Button("Delete", role: .destructive) {
-                        promptsManager.deletePrompt(prompt)
+                        deletePrompt(prompt)
                     }
                 }
             }
         }
+    }
+
+    private func deletePrompt(_ prompt: UserPrompt) {
+        // Disable AI enhancement for modes using this prompt
+        aiService.disableAIEnhancementForModesUsingPrompt(promptId: prompt.id)
+        // Delete the prompt
+        promptsManager.deletePrompt(prompt)
     }
 }
 
@@ -85,6 +92,6 @@ struct PromptRowView: View {
 
 #Preview {
     @Previewable @State var promptsManager = PromptsManager()
-//    @Previewable @Namespace var transition
-    PromptsSettings(promptsManager: promptsManager)
+    @Previewable @State var aiService = AIService()
+    PromptsSettings(promptsManager: promptsManager, aiService: aiService)
 }

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -123,29 +123,6 @@ struct SettingsView: View {
                                 .foregroundStyle(.secondary)
                         }
                     }
-                    
-                    Toggle(isOn: $isAutoAudioCleanupEnabled) {
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text("Automatic Audio Cleanup")
-                                .font(.body)
-                            Text("Automatically delete old audio files to save space")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-
-                    if isAutoAudioCleanupEnabled {
-                        Picker("Keep Audio Files For", selection: $audioRetentionDays) {
-                            Text("1 day").tag(1)
-                            Text("3 days").tag(3)
-                            Text("7 days").tag(7)
-                            Text("14 days").tag(14)
-                            Text("30 days").tag(30)
-                        }
-                        .pickerStyle(.menu)
-                        .padding(.leading)
-                        .tint(.primary)
-                    }
                 }
                 
                 Section("Dictionary") {
@@ -274,6 +251,32 @@ struct SettingsView: View {
                     }
                 }
                 
+                Section("Storage") {
+                    
+                    Toggle(isOn: $isAutoAudioCleanupEnabled) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Automatic Audio Cleanup")
+                                .font(.body)
+                            Text("Automatically delete old audio files to save space")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+
+                    if isAutoAudioCleanupEnabled {
+                        Picker("Keep Audio Files For", selection: $audioRetentionDays) {
+                            Text("1 day").tag(1)
+                            Text("3 days").tag(3)
+                            Text("7 days").tag(7)
+                            Text("14 days").tag(14)
+                            Text("30 days").tag(30)
+                        }
+                        .pickerStyle(.menu)
+                        .padding(.leading)
+                        .tint(.primary)
+                    }
+                }
+                
 //                ShortcutsLink()
             }
             .navigationDestination(for: FlowMode.self) { mode in
@@ -287,7 +290,7 @@ struct SettingsView: View {
             .navigationDestination(for: SettingsDestination.self) { destination in
                 switch destination {
                 case .promptsSettings:
-                    PromptsSettings(promptsManager: promptsManager)
+                    PromptsSettings(promptsManager: promptsManager, aiService: appState.aiService)
                 case .transcriptionModels:
                     ModelsView(appState: appState)
                 case .promptsTemplates:

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -142,58 +142,6 @@ struct SettingsView: View {
                 }
 
                 Section("Keyboard") {
-                    Button(action: activateKeyboardRecordingSession) {
-                        HStack {
-                            Image(systemName: "keyboard")
-                                .foregroundStyle(.blue)
-                                .font(.body)
-                            
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text("Enable Keyboard Recording Session")
-                                    .foregroundStyle(.blue)
-                                    .font(.body)
-
-                                if prewarmManager.isSessionActiveObservable {
-                                    HStack {
-                                        Circle()
-                                            .fill(.green)
-                                            .frame(width: 6)
-
-                                        Text("Session active")
-                                            .font(.caption)
-                                            .foregroundStyle(.green)
-                                    }
-
-                                }
-                            }
-
-                            Spacer()
-                        }
-                    }
-                    .disabled(prewarmManager.isSessionActiveObservable)
-                    .buttonStyle(.plain)
-
-                    VStack(alignment: .leading, spacing: 8) {
-                        Picker("Session Timeout", selection: $audioSessionTimeout) {
-                            Text("15 seconds").tag(15)
-                            Text("30 seconds").tag(30)
-                            Text("60 seconds").tag(60)
-                            Text("90 seconds").tag(90)
-                            Text("2 minutes").tag(120)
-                            Text("3 minutes").tag(180)
-                            Text("5 minutes").tag(300)
-                            Text("15 minutes").tag(900)
-                            Text("30 minutes").tag(1800)
-                            Text("1 hour").tag(3600)
-                        }
-                        .pickerStyle(.menu)
-                        .tint(.primary)
-
-                        Text("Keep microphone session active to allow recording from keyboard")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-
                     Toggle(isOn: $isSmartFormattingEnabled) {
                         VStack(alignment: .leading, spacing: 4) {
                             Text("Smart Insert")
@@ -249,6 +197,58 @@ struct SettingsView: View {
                     .onChange(of: isSoundFeedbackEnabled) { _, newValue in
                         AppGroupCoordinator.shared.isKeyboardSoundFeedbackEnabled = newValue
                     }
+                    
+                    VStack(alignment: .leading, spacing: 8) {
+                        Picker("Session Timeout", selection: $audioSessionTimeout) {
+                            Text("15 seconds").tag(15)
+                            Text("30 seconds").tag(30)
+                            Text("60 seconds").tag(60)
+                            Text("90 seconds").tag(90)
+                            Text("2 minutes").tag(120)
+                            Text("3 minutes").tag(180)
+                            Text("5 minutes").tag(300)
+                            Text("15 minutes").tag(900)
+                            Text("30 minutes").tag(1800)
+                            Text("1 hour").tag(3600)
+                        }
+                        .pickerStyle(.menu)
+                        .tint(.primary)
+
+                        Text("Keep microphone session active to allow recording from keyboard")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    
+                    Button(action: activateKeyboardRecordingSession) {
+                        HStack {
+                            Image(systemName: "keyboard")
+                                .foregroundStyle(.blue)
+                                .font(.body)
+                            
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("Enable Keyboard Recording Session")
+                                    .foregroundStyle(.blue)
+                                    .font(.body)
+
+                                if prewarmManager.isSessionActiveObservable {
+                                    HStack {
+                                        Circle()
+                                            .fill(.green)
+                                            .frame(width: 6)
+
+                                        Text("Session active")
+                                            .font(.caption)
+                                            .foregroundStyle(.green)
+                                    }
+
+                                }
+                            }
+
+                            Spacer()
+                        }
+                    }
+                    .disabled(prewarmManager.isSessionActiveObservable)
+                    .buttonStyle(.plain)
                 }
                 
                 Section("Storage") {


### PR DESCRIPTION
## Summary
This PR ensures AI Enhancement is automatically disabled in Flow Modes when the user deletes an API key or prompt that was being used.

### Changes
- Add `disableAIEnhancementForModesUsingProvider()` to AIService - disables AI enhancement for all modes using a specific provider when its API key is deleted
- Add `disableAIEnhancementForModesUsingPrompt()` to AIService - disables AI enhancement for all modes using a specific prompt when it's deleted
- Update `ModelsView.handleAPIKeyDeletion()` to disable AI enhancement for affected modes
- Update `PromptsSettings` to disable AI enhancement before deleting a prompt

### Additional Improvements
- Auto-select first AI provider when enabling AI Enhancement
- Improve AI provider selection UX
- Fix language picker invalid selection for English-only models
- Settings layout reorganization

## Test Plan
- [ ] Create a Flow Mode with AI Enhancement enabled using a specific provider and prompt
- [ ] Delete the API key for that provider → verify AI Enhancement is disabled in the mode
- [ ] Create another Flow Mode with AI Enhancement enabled
- [ ] Delete the prompt used by that mode → verify AI Enhancement is disabled
- [ ] Verify other Flow Modes not using the deleted key/prompt remain unchanged