### PR TITLE
Add section headers to provider picker menu

### DIFF
--- a/VivaDicta/Models/TranscriptionModelProvider.swift
+++ b/VivaDicta/Models/TranscriptionModelProvider.swift
@@ -20,7 +20,10 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
     case soniox
     
     var id: Self { self }
-    
+
+    static let localProviders: [TranscriptionModelProvider] = [.parakeet, .whisperKit]
+    static let cloudProviders: [TranscriptionModelProvider] = [.openAI, .groq, .elevenLabs, .deepgram, .mistral, .gemini, .soniox]
+
     var cloudTranscriptionModelsNames: [String] {
         switch self {
         case .parakeet, .whisperKit:

--- a/VivaDicta/Views/SettingsScreen/ModeEditView.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditView.swift
@@ -48,12 +48,15 @@ struct ModeEditView: View {
                     footer: transcriptionSectionFooter) {
                 
                 Picker("Provider", selection: $viewModel.transcriptionProvider) {
-                    ForEach(TranscriptionModelProvider.localProviders) { provider in
-                        Text(provider.rawValue.capitalized).tag(provider)
+                    Section("Local") {
+                        ForEach(TranscriptionModelProvider.localProviders) { provider in
+                            Text(provider.rawValue.capitalized).tag(provider)
+                        }
                     }
-                    Divider()
-                    ForEach(TranscriptionModelProvider.cloudProviders) { provider in
-                        Text(provider.rawValue.capitalized).tag(provider)
+                    Section("Cloud") {
+                        ForEach(TranscriptionModelProvider.cloudProviders) { provider in
+                            Text(provider.rawValue.capitalized).tag(provider)
+                        }
                     }
                 }
 //                .tint(.primary)

--- a/VivaDicta/Views/SettingsScreen/ModeEditView.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditView.swift
@@ -48,7 +48,11 @@ struct ModeEditView: View {
                     footer: transcriptionSectionFooter) {
                 
                 Picker("Provider", selection: $viewModel.transcriptionProvider) {
-                    ForEach(TranscriptionModelProvider.allCases) { provider in
+                    ForEach(TranscriptionModelProvider.localProviders) { provider in
+                        Text(provider.rawValue.capitalized).tag(provider)
+                    }
+                    Divider()
+                    ForEach(TranscriptionModelProvider.cloudProviders) { provider in
                         Text(provider.rawValue.capitalized).tag(provider)
                     }
                 }


### PR DESCRIPTION
## Summary
- Adds "Local" and "Cloud" section headers in the transcription provider picker
- Groups Parakeet and WhisperKit under "Local" section
- Groups cloud providers (OpenAI, Groq, ElevenLabs, etc.) under "Cloud" section
- Improves menu organization and user experience

## Changes
- Added `localProviders` and `cloudProviders` static properties to `TranscriptionModelProvider`
- Updated provider picker in `ModeEditView` to use `Section` with headers

## Test plan
- [x] Build succeeds
- [ ] Verify provider picker shows "Local" and "Cloud" section headers
- [ ] Verify all providers are selectable and work correctly