### PR TITLE
Add mode details to Settings mode list

### DIFF
--- a/ActionExtension/ActionViewController.swift
+++ b/ActionExtension/ActionViewController.swift
@@ -117,31 +117,6 @@ final class ActionExtensionViewModel {
             }
     }
 
-    // MARK: - Display Helpers
-
-    var transcriptionProviderDisplayName: String {
-        switch selectedMode.transcriptionProvider {
-        case .whisperKit:
-            return "WhisperKit"
-        case .parakeet:
-            return "Parakeet"
-        case .openAI:
-            return "OpenAI"
-        case .groq:
-            return "Groq"
-        case .elevenLabs:
-            return "ElevenLabs"
-        case .deepgram:
-            return "Deepgram"
-        case .mistral:
-            return "Mistral"
-        case .gemini:
-            return "Gemini"
-        case .soniox:
-            return "Soniox"
-        }
-    }
-
     var transcriptionModelDisplayName: String {
         let modelName = selectedMode.transcriptionModel
         if modelName.isEmpty {
@@ -301,7 +276,7 @@ struct ActionExtensionView: View {
                 .font(.subheadline.bold())
                 .foregroundStyle(.primary)
 
-            infoRow(label: "Provider", value: viewModel.transcriptionProviderDisplayName)
+            infoRow(label: "Provider", value: viewModel.selectedMode.transcriptionProvider.displayName)
             infoRow(label: "Model", value: viewModel.transcriptionModelDisplayName)
             languagePickerRow
         }

--- a/ShareExtension/ShareViewController.swift
+++ b/ShareExtension/ShareViewController.swift
@@ -117,31 +117,7 @@ final class ShareExtensionViewModel {
             }
     }
 
-    // MARK: - Display Helpers
-
-    var transcriptionProviderDisplayName: String {
-        switch selectedMode.transcriptionProvider {
-        case .whisperKit:
-            return "WhisperKit"
-        case .parakeet:
-            return "Parakeet"
-        case .openAI:
-            return "OpenAI"
-        case .groq:
-            return "Groq"
-        case .elevenLabs:
-            return "ElevenLabs"
-        case .deepgram:
-            return "Deepgram"
-        case .mistral:
-            return "Mistral"
-        case .gemini:
-            return "Gemini"
-        case .soniox:
-            return "Soniox"
-        }
-    }
-
+    
     var transcriptionModelDisplayName: String {
         let modelName = selectedMode.transcriptionModel
         if modelName.isEmpty {
@@ -301,7 +277,7 @@ struct ShareExtensionView: View {
                 .font(.subheadline.bold())
                 .foregroundStyle(.primary)
 
-            infoRow(label: "Provider", value: viewModel.transcriptionProviderDisplayName)
+            infoRow(label: "Provider", value: viewModel.selectedMode.transcriptionProvider.displayName)
             infoRow(label: "Model", value: viewModel.transcriptionModelDisplayName)
             languagePickerRow
         }

--- a/VivaDicta/Models/TranscriptionModel.swift
+++ b/VivaDicta/Models/TranscriptionModel.swift
@@ -22,6 +22,6 @@ protocol TranscriptionModel: Identifiable, Hashable {
 
 extension TranscriptionModel {
     var language: String {
-        supportManyLanguages ? "Multilingual" : "English-only"
+        supportManyLanguages ? "All Languages" : "English-only"
     }
 }

--- a/VivaDicta/Models/TranscriptionModelProvider.swift
+++ b/VivaDicta/Models/TranscriptionModelProvider.swift
@@ -181,8 +181,8 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
             
             CloudModel(
                 name: "nova-3-multilingual",
-                displayName: "Nova 3 Multilingual",
-                description: "First AI model with real-time multilingual code-switching across 10+ languages. New signups get $200 free credits (~38,460 mins)",
+                displayName: "Nova 3 Multi-language",
+                description: "First AI model with real-time switching across 10+ languages. New signups get $200 free credits (~38,460 mins)",
                 provider: .deepgram,
                 speed: 0.95,
                 accuracy: 0.95,
@@ -254,7 +254,7 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
             CloudModel(
                 name: "gpt-4o-transcribe",
                 displayName: "GPT-4o Transcribe",
-                description: "OpenAI's latest model with reduced hallucinations and enhanced multilingual accuracy",
+                description: "OpenAI's latest model with reduced hallucinations and enhanced accuracy across all languages",
                 provider: .openAI,
                 speed: 0.7,
                 accuracy: 0.95,
@@ -308,7 +308,7 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
             ParakeetModel(
                 name: "parakeet-tdt-0.6b-v3",
                 displayName: "Nvidia Parakeet V3",
-                description: "NVIDIA's ultra-fast multilingual model supporting 25 languages with automatic language detection",
+                description: "NVIDIA's ultra-fast model supporting 25 most common languages with automatic language detection",
                 recommended: true,
                 size: "494 MB",
                 speed: 0.95,

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -232,13 +232,13 @@ class AIService {
     }
     
     private func loadSavedOpenRouterModels() {
-        if let savedModels = userDefaults.array(forKey: "openRouterModels") as? [String] {
+        if let savedModels = userDefaults.array(forKey: UserDefaultsStorage.Keys.openRouterModels) as? [String] {
             openRouterModels = savedModels
         }
     }
     
     private func saveOpenRouterModels() {
-        userDefaults.set(openRouterModels, forKey: "openRouterModels")
+        userDefaults.set(openRouterModels, forKey: UserDefaultsStorage.Keys.openRouterModels)
     }
     
     // MARK: - Configuration validation

--- a/VivaDicta/Services/Transcription/CloudTranscription/DeepgramTranscriptionService.swift
+++ b/VivaDicta/Services/Transcription/CloudTranscription/DeepgramTranscriptionService.swift
@@ -87,8 +87,8 @@ class DeepgramTranscriptionService {
         // Add custom vocabulary keywords
         let vocabularyTerms = CustomVocabulary.getTerms(maxTerms: 100)
         if !vocabularyTerms.isEmpty {
-            // Nova-3 uses keyterm, Nova-2 uses keywords
-            let paramName = modelName == "nova-3" ? "keyterm" : "keywords"
+            // Nova-3 (including nova-3-multilingual) uses keyterm, Nova-2 uses keywords
+            let paramName = modelName.hasPrefix("nova-3") ? "keyterm" : "keywords"
             for term in vocabularyTerms {
                 queryItems.append(URLQueryItem(name: paramName, value: term))
             }

--- a/VivaDicta/Services/Transcription/CloudTranscription/ElevenLabsTranscriptionService.swift
+++ b/VivaDicta/Services/Transcription/CloudTranscription/ElevenLabsTranscriptionService.swift
@@ -82,7 +82,7 @@ class ElevenLabsTranscriptionService {
         body.append(formField: "temperature", value: "0.0", boundary: boundary)
         body.append(formField: "tag_audio_events", value: "false", boundary: boundary)
         
-        let selectedLanguage = UserDefaults.standard.string(forKey: "SelectedLanguage") ?? "auto"
+        let selectedLanguage = UserDefaultsStorage.shared.string(forKey: AppGroupCoordinator.kSelectedLanguageKey) ?? "auto"
         if selectedLanguage != "auto", !selectedLanguage.isEmpty {
             body.append(formField: "language_code", value: selectedLanguage, boundary: boundary)
         }

--- a/VivaDicta/Services/Transcription/CloudTranscription/OpenAITranscriptionService.swift
+++ b/VivaDicta/Services/Transcription/CloudTranscription/OpenAITranscriptionService.swift
@@ -114,11 +114,4 @@ struct OpenAITranscriptionService {
         let language: String?
         let duration: Double?
     }
-
-    /// Use custom vocabulary words as prompt
-    private func buildPromptWithVocabulary() -> String {
-        let vocabularyWords = CustomVocabulary.getTerms()
-        guard !vocabularyWords.isEmpty else { return "" }
-        return vocabularyWords.joined(separator: ", ")
-    }
 }

--- a/VivaDicta/Services/Transcription/CloudTranscription/OpenAITranscriptionService.swift
+++ b/VivaDicta/Services/Transcription/CloudTranscription/OpenAITranscriptionService.swift
@@ -70,8 +70,7 @@ struct OpenAITranscriptionService {
         }
 
         let selectedLanguage = UserDefaultsStorage.shared.string(forKey: AppGroupCoordinator.kSelectedLanguageKey) ?? "auto"
-        let combinedPrompt = buildPromptWithVocabulary()
-
+        
         body.append("--\(boundary)\(crlf)".data(using: .utf8)!)
         body.append("Content-Disposition: form-data; name=\"file\"; filename=\"\(audioURL.lastPathComponent)\"\(crlf)".data(using: .utf8)!)
         body.append("Content-Type: audio/wav\(crlf)\(crlf)".data(using: .utf8)!)
@@ -87,14 +86,6 @@ struct OpenAITranscriptionService {
             body.append("--\(boundary)\(crlf)".data(using: .utf8)!)
             body.append("Content-Disposition: form-data; name=\"language\"\(crlf)\(crlf)".data(using: .utf8)!)
             body.append(selectedLanguage.data(using: .utf8)!)
-            body.append(crlf.data(using: .utf8)!)
-        }
-
-        // Include prompt with vocabulary for OpenAI-compatible APIs
-        if !combinedPrompt.isEmpty {
-            body.append("--\(boundary)\(crlf)".data(using: .utf8)!)
-            body.append("Content-Disposition: form-data; name=\"prompt\"\(crlf)\(crlf)".data(using: .utf8)!)
-            body.append(combinedPrompt.data(using: .utf8)!)
             body.append(crlf.data(using: .utf8)!)
         }
         

--- a/VivaDicta/Shared/UserDefaultsStorage.swift
+++ b/VivaDicta/Shared/UserDefaultsStorage.swift
@@ -34,5 +34,6 @@ enum UserDefaultsStorage {
         static let isReplacementsEnabled = "isReplacementsEnabled"
         static let isAutoAudioCleanupEnabled = "isAutoAudioCleanupEnabled"
         static let audioRetentionDays = "audioRetentionDays"
+        static let openRouterModels = "openRouterModels"
     }
 }

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -48,8 +48,7 @@ struct SettingsView: View {
                     
                     ForEach(appState.aiService.modes) { mode in
                         NavigationLink(value: mode) {
-                            Text(mode.name)
-                                .font(.body.weight(.medium))
+                            ModeInfoRow(mode: mode)
                         }
                         .swipeActions(edge: .trailing, allowsFullSwipe: false) {
                             if appState.aiService.modes.count > 1 {
@@ -379,6 +378,42 @@ struct SettingsView: View {
         .environment(AppState())
 }
 
+
+// MARK: - Mode Info Row
+
+private struct ModeInfoRow: View {
+    let mode: VivaMode
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(mode.name)
+                .font(.body.weight(.medium))
+            
+            HStack {
+                HStack {
+                    Image(systemName: "waveform")
+                        .foregroundStyle(.blue)
+                    Text("\(mode.transcriptionProvider.displayName)")
+                        .foregroundStyle(.secondary)
+                }
+                
+                if let provider = mode.aiProvider {
+                    Divider()
+                    HStack(spacing: 4) {
+                        Image(systemName: "sparkles")
+                            .font(.caption2)
+                            .foregroundStyle(.blue)
+                        Text("\(provider.displayName)")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .font(.caption2)
+            .padding(.leading, 4)
+        }
+        .padding(.vertical, 4)
+    }
+}
 
 enum SettingsError: LocalizedError {
     case duplicateModeName(String)

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -384,28 +384,41 @@ struct SettingsView: View {
 private struct ModeInfoRow: View {
     let mode: VivaMode
 
+    private var transcriptionModelDisplayName: String {
+        mode.transcriptionProvider.getTranscriptionModelDisplayName(mode.transcriptionModel)
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             Text(mode.name)
                 .font(.body.weight(.medium))
 
             if !mode.transcriptionModel.isEmpty {
-                HStack {
-                    HStack {
+                HStack(alignment: .top) {
+                    HStack(alignment: .top, spacing: 4) {
                         Image(systemName: "waveform")
                             .foregroundStyle(.blue)
-                        Text("\(mode.transcriptionProvider.displayName)")
-                            .foregroundStyle(.secondary)
+                            .accessibilityLabel("Transcription provider")
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(mode.transcriptionProvider.displayName)
+                                .foregroundStyle(.secondary)
+                            Text(transcriptionModelDisplayName)
+                                .foregroundStyle(.tertiary)
+                        }
                     }
-                    
+
                     if let provider = mode.aiProvider {
                         Divider()
-                        HStack(spacing: 4) {
+                        HStack(alignment: .top, spacing: 4) {
                             Image(systemName: "sparkles")
-                                .font(.caption2)
                                 .foregroundStyle(.blue)
-                            Text("\(provider.displayName)")
-                                .foregroundStyle(.secondary)
+                                .accessibilityLabel("AI enhancement provider")
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(provider.displayName)
+                                    .foregroundStyle(.secondary)
+                                Text(mode.aiModel)
+                                    .foregroundStyle(.tertiary)
+                            }
                         }
                     }
                 }

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -388,28 +388,30 @@ private struct ModeInfoRow: View {
         VStack(alignment: .leading, spacing: 6) {
             Text(mode.name)
                 .font(.body.weight(.medium))
-            
-            HStack {
+
+            if !mode.transcriptionModel.isEmpty {
                 HStack {
-                    Image(systemName: "waveform")
-                        .foregroundStyle(.blue)
-                    Text("\(mode.transcriptionProvider.displayName)")
-                        .foregroundStyle(.secondary)
-                }
-                
-                if let provider = mode.aiProvider {
-                    Divider()
-                    HStack(spacing: 4) {
-                        Image(systemName: "sparkles")
-                            .font(.caption2)
+                    HStack {
+                        Image(systemName: "waveform")
                             .foregroundStyle(.blue)
-                        Text("\(provider.displayName)")
+                        Text("\(mode.transcriptionProvider.displayName)")
                             .foregroundStyle(.secondary)
                     }
+                    
+                    if let provider = mode.aiProvider {
+                        Divider()
+                        HStack(spacing: 4) {
+                            Image(systemName: "sparkles")
+                                .font(.caption2)
+                                .foregroundStyle(.blue)
+                            Text("\(provider.displayName)")
+                                .foregroundStyle(.secondary)
+                        }
+                    }
                 }
+                .font(.caption2)
+                .padding(.leading, 4)
             }
-            .font(.caption2)
-            .padding(.leading, 4)
         }
         .padding(.vertical, 4)
     }


### PR DESCRIPTION
## Summary
- Add compact mode info display in Settings showing transcription provider and AI enhancement provider
- Fix Deepgram transcriber to use `hasPrefix("nova-3")` for keyterm parameter (supports both nova-3 and nova-3-multilingual)
- Replace hardcoded UserDefaults key with centralized constant
- Remove unsupported vocabulary from OpenAI transcriber
- Cleanup unused code in extensions

## Test plan
- [ ] Verify Settings mode list shows provider info for each mode
- [ ] Verify AI enhancement icon appears when mode has AI provider configured
- [ ] Test Deepgram transcription with nova-3-multilingual model
- [ ] Verify custom vocabulary terms work with nova-3 models