### PR TITLE
Add duplicate mode feature

### DIFF
--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -98,6 +98,38 @@ class AIService {
         logger.logInfo("Deleted mode: \(mode.name)")
     }
 
+    public func duplicateMode(_ mode: VivaMode) -> VivaMode {
+        let newName = generateUniqueName(baseName: mode.name)
+
+        let duplicatedMode = VivaMode(
+            id: UUID(),
+            name: newName,
+            transcriptionProvider: mode.transcriptionProvider,
+            transcriptionModel: mode.transcriptionModel,
+            transcriptionLanguage: mode.transcriptionLanguage,
+            userPrompt: mode.userPrompt,
+            aiProvider: mode.aiProvider,
+            aiModel: mode.aiModel,
+            aiEnhanceEnabled: mode.aiEnhanceEnabled
+        )
+
+        addMode(duplicatedMode)
+        logger.logInfo("Duplicated mode '\(mode.name)' as '\(newName)'")
+
+        return duplicatedMode
+    }
+
+    private func generateUniqueName(baseName: String) -> String {
+        var newName = "\(baseName) Copy"
+        let existingNames = Set(modes.map { $0.name })
+
+        while existingNames.contains(newName) {
+            newName = "\(newName) Copy"
+        }
+
+        return newName
+    }
+
     /// Disables AI enhancement for all modes that use the specified AI provider.
     /// Called when an API key for that provider is deleted.
     public func disableAIEnhancementForModesUsingProvider(_ provider: AIProvider) {

--- a/VivaDicta/Views/SettingsScreen/ModeEditView.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditView.swift
@@ -155,23 +155,23 @@ struct ModeEditView: View {
             }
             
             if viewModel.isTranscriptionProviderConfigured(viewModel.transcriptionProvider) {
-                
+
                 Section(header: Text("AI Enhancement"),
                         footer: aiEnhancementSectionFooter) {
-                    
+
                     if !viewModel.aiEnhanceEnabled {
                         TipView(selectAIEnhacementTip)
                             .tipBackground(.teal.gradient)
                     }
-                    
+
                     Toggle("Enable", isOn: $viewModel.aiEnhanceEnabled)
-                    
+
                     if viewModel.aiEnhanceEnabled {
                         Picker(selection: $viewModel.aiProvider) {
                             ForEach(AIProvider.generalProviders) { provider in
                                 Text(provider.displayName).tag(provider)
                             }
-                            
+
                         } label: {
                             HStack {
                                 Image(systemName: "cpu")
@@ -185,11 +185,11 @@ struct ModeEditView: View {
                         .onAppear {
                             viewModel.selectFirstProviderIfNeeded()
                         }
-                        
+
                         if let provider = viewModel.aiProvider {
                             let hasKey = viewModel.hasAPIKey(for: provider)
                             if hasKey {
-                                
+
                                 Picker(selection: $viewModel.aiModel) {
                                     ForEach(viewModel.aiService.getAvailableModels(for: provider), id: \.self) { model in
                                         Text(model).tag(model as String?)
@@ -204,7 +204,7 @@ struct ModeEditView: View {
                                 .onChange(of: viewModel.aiModel) { _, newModel in
                                     viewModel.updateModel(newModel)
                                 }
-                                
+
                             } else {
                                 NavigationLink {
                                     AddAPIKeyView(
@@ -225,7 +225,7 @@ struct ModeEditView: View {
                                 }
                             }
                         }
-                        
+
                         if let provider = viewModel.aiProvider, viewModel.hasAPIKey(for: provider) {
                             if viewModel.promptsManager.userPrompts.isEmpty {
                                 Button(action: {
@@ -258,7 +258,21 @@ struct ModeEditView: View {
                     }
                 }
             }
-            
+
+            if viewModel.isEditing {
+                Section {
+                    Button {
+                        duplicateMode()
+                    } label: {
+                        HStack {
+                            Spacer()
+                            Label("Duplicate Mode", systemImage: "doc.on.doc")
+                            Spacer()
+                        }
+                    }
+                }
+            }
+
         }
         .onChange(of: viewModel.aiEnhanceEnabled, { oldValue, newValue in
             if newValue == true {
@@ -310,7 +324,7 @@ struct ModeEditView: View {
     }
 
     private func saveMode() {
-        
+
         do {
             let newMode = try viewModel.saveMode()
             if viewModel.isEditing {
@@ -326,7 +340,13 @@ struct ModeEditView: View {
             showingAlert = true
             modeEditViewError = .unexpectedError(error.localizedDescription)
         }
-        
+
+    }
+
+    private func duplicateMode() {
+        guard let mode = viewModel.originalMode else { return }
+        _ = viewModel.aiService.duplicateMode(mode)
+        dismiss()
     }
 }
 

--- a/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
@@ -27,7 +27,7 @@ class ModeEditViewModel {
     private let transcriptionManager: TranscriptionManager
     let promptsManager: PromptsManager
     
-    private let originalMode: VivaMode?
+    let originalMode: VivaMode?
 
     public var transcriptionFooterText: String {
         transcriptionManager.hasAvailableTranscriptionModels ? "" : "No transcription models available. Download a local model or add an API key for a cloud model."

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -50,6 +50,21 @@ struct SettingsView: View {
                         NavigationLink(value: mode) {
                             ModeInfoRow(mode: mode)
                         }
+                        .contextMenu {
+                            Button {
+                                duplicateMode(mode)
+                            } label: {
+                                Label("Duplicate", systemImage: "doc.on.doc")
+                            }
+
+                            if appState.aiService.modes.count > 1 {
+                                Button(role: .destructive) {
+                                    deleteMode(mode)
+                                } label: {
+                                    Label("Delete", systemImage: "trash")
+                                }
+                            }
+                        }
                         .swipeActions(edge: .trailing, allowsFullSwipe: false) {
                             if appState.aiService.modes.count > 1 {
                                 Button(role: .destructive) {
@@ -58,6 +73,14 @@ struct SettingsView: View {
                                     Label("Delete", systemImage: "trash")
                                 }
                             }
+                        }
+                        .swipeActions(edge: .leading, allowsFullSwipe: false) {
+                            Button {
+                                duplicateMode(mode)
+                            } label: {
+                                Label("Duplicate", systemImage: "doc.on.doc")
+                            }
+                            .tint(.blue)
                         }
                     }
                     
@@ -349,6 +372,10 @@ struct SettingsView: View {
         guard appState.aiService.modes.count > 1 else { return }
 
         appState.aiService.deleteMode(mode)
+    }
+
+    private func duplicateMode(_ mode: VivaMode) {
+        _ = appState.aiService.duplicateMode(mode)
     }
 
     // MARK: - Keyboard Recording Session Actions


### PR DESCRIPTION
## Summary
- Add ability to duplicate existing modes with all their settings
- Duplicated modes are named with " Copy" suffix (e.g., "Default" → "Default Copy")

## Changes
- Add `duplicateMode` method to AIService with unique name generation
- Add "Duplicate Mode" button at the bottom of mode edit screen
- Add context menu with duplicate option on mode rows (long-press)
- Add swipe-to-duplicate action on leading edge (swipe right)

## Test Plan
- [ ] Long-press on a mode row and select "Duplicate" from context menu
- [ ] Swipe right on a mode row and tap "Duplicate" button
- [ ] Open mode edit screen and tap "Duplicate Mode" button at the bottom
- [ ] Verify duplicated mode has " Copy" suffix in name
- [ ] Verify all settings (transcription, AI enhancement) are copied correctly
- [ ] Duplicate a mode named "X Copy" and verify it becomes "X Copy Copy"