### PR TITLE
Rate App: Request review after successful transcription with smart throttling

### DIFF
--- a/VivaDicta/Shared/UserDefaultsStorage.swift
+++ b/VivaDicta/Shared/UserDefaultsStorage.swift
@@ -26,6 +26,7 @@ enum UserDefaultsStorage {
     enum Keys {
         static let appLaunchCount = "appLaunchCount"
         static let firstLaunchDate = "firstLaunchDate"
+        static let allLaunchDates = "allLaunchDates"
         static let lastRatingRequestDate = "lastRatingRequestDate"
         static let hasCompletedOnboarding = "hasCompletedOnboarding"
         static let didTapOpenSettingsInOnboarding = "didTapOpenSettingsInOnboarding"

--- a/VivaDicta/Shared/UserDefaultsStorage.swift
+++ b/VivaDicta/Shared/UserDefaultsStorage.swift
@@ -25,6 +25,8 @@ enum UserDefaultsStorage {
 
     enum Keys {
         static let appLaunchCount = "appLaunchCount"
+        static let firstLaunchDate = "firstLaunchDate"
+        static let lastRatingRequestDate = "lastRatingRequestDate"
         static let hasCompletedOnboarding = "hasCompletedOnboarding"
         static let didTapOpenSettingsInOnboarding = "didTapOpenSettingsInOnboarding"
         static let audioSessionTimeout = "audioSessionTimeout"

--- a/VivaDicta/Utilities/AppLaunchTracker.swift
+++ b/VivaDicta/Utilities/AppLaunchTracker.swift
@@ -20,8 +20,26 @@ enum AppLaunchTracker {
         defaults.integer(forKey: UserDefaultsStorage.Keys.appLaunchCount)
     }
 
-    /// Call this once during app initialization to increment the launch count.
+    /// The date of the first app launch. Returns nil if never launched.
+    static var firstLaunchDate: Date? {
+        defaults.object(forKey: UserDefaultsStorage.Keys.firstLaunchDate) as? Date
+    }
+
+    /// The number of days since the first app launch.
+    /// Returns 0 if first launch date is not recorded.
+    static var daysSinceFirstLaunch: Int {
+        guard let firstLaunch = firstLaunchDate else { return 0 }
+        let components = Calendar.current.dateComponents([.day], from: firstLaunch, to: Date())
+        return components.day ?? 0
+    }
+
+    /// Call this once during app initialization to increment the launch count and record first launch date.
     static func recordLaunch() {
+        // Record first launch date if not already set
+        if firstLaunchDate == nil {
+            defaults.set(Date(), forKey: UserDefaultsStorage.Keys.firstLaunchDate)
+        }
+
         let currentCount = launchCount
         defaults.set(currentCount + 1, forKey: UserDefaultsStorage.Keys.appLaunchCount)
     }

--- a/VivaDicta/Utilities/AppLaunchTracker.swift
+++ b/VivaDicta/Utilities/AppLaunchTracker.swift
@@ -25,6 +25,11 @@ enum AppLaunchTracker {
         defaults.object(forKey: UserDefaultsStorage.Keys.firstLaunchDate) as? Date
     }
 
+    /// All app launch dates, ordered from oldest to newest.
+    static var allLaunchDates: [Date] {
+        defaults.object(forKey: UserDefaultsStorage.Keys.allLaunchDates) as? [Date] ?? []
+    }
+
     /// The number of days since the first app launch.
     /// Returns 0 if first launch date is not recorded.
     static var daysSinceFirstLaunch: Int {
@@ -33,13 +38,21 @@ enum AppLaunchTracker {
         return components.day ?? 0
     }
 
-    /// Call this once during app initialization to increment the launch count and record first launch date.
+    /// Call this once during app initialization to increment the launch count and record launch dates.
     static func recordLaunch() {
+        let now = Date()
+
         // Record first launch date if not already set
         if firstLaunchDate == nil {
-            defaults.set(Date(), forKey: UserDefaultsStorage.Keys.firstLaunchDate)
+            defaults.set(now, forKey: UserDefaultsStorage.Keys.firstLaunchDate)
         }
 
+        // Record this launch date to the history
+        var dates = allLaunchDates
+        dates.append(now)
+        defaults.set(dates, forKey: UserDefaultsStorage.Keys.allLaunchDates)
+
+        // Increment launch count
         let currentCount = launchCount
         defaults.set(currentCount + 1, forKey: UserDefaultsStorage.Keys.appLaunchCount)
     }

--- a/VivaDicta/Utilities/RateAppManager.swift
+++ b/VivaDicta/Utilities/RateAppManager.swift
@@ -21,6 +21,10 @@ enum RateAppManager {
     /// Minimum number of days since first launch before requesting a rating.
     private static let minimumDaysSinceInstall = 3
 
+    /// Minimum days since install for passive users who may not launch frequently.
+    /// Used as an alternative to launch-count-based conditions.
+    private static let minimumDaysSinceInstallWide = 30
+
     /// Minimum number of days between rating requests.
     private static let minimumDaysBetweenRequests = 90
 
@@ -58,7 +62,10 @@ enum RateAppManager {
     /// - Parameter transcriptionCount: The number of saved transcriptions.
     static func requestReviewOnAppStartIfAppropriate(transcriptionCount: Int) {
         guard transcriptionCount >= 1 else { return }
-        guard shouldRequestReview() else { return }
+        
+        let usualRule = shouldRequestReview()
+        let wideRule = shouldRequestReviewWide()
+        guard usualRule || wideRule else { return }
         presentReviewRequest()
     }
 
@@ -84,6 +91,24 @@ enum RateAppManager {
 
         // Check minimum days since install
         guard AppLaunchTracker.daysSinceFirstLaunch >= minimumDaysSinceInstall else {
+            return false
+        }
+
+        // Check if enough time has passed since last request
+        if let daysSinceLast = daysSinceLastRequest {
+            guard daysSinceLast >= minimumDaysBetweenRequests else {
+                return false
+            }
+        }
+
+        return true
+    }
+    
+    /// Returns true if all conditions are met for requesting a review WIDE vers.
+    private static func shouldRequestReviewWide() -> Bool {
+        
+        // Check minimum days since install
+        guard AppLaunchTracker.daysSinceFirstLaunch >= minimumDaysSinceInstallWide else {
             return false
         }
 

--- a/VivaDicta/Utilities/RateAppManager.swift
+++ b/VivaDicta/Utilities/RateAppManager.swift
@@ -49,7 +49,22 @@ enum RateAppManager {
     /// Call this after successful user actions (transcription, enhancement, etc.).
     static func requestReviewIfAppropriate() {
         guard shouldRequestReview() else { return }
+        presentReviewRequest()
+    }
 
+    /// Checks if conditions are met for app start rating request.
+    /// Requires at least one saved transcription in addition to standard conditions.
+    /// Call this at app start (e.g., in MainView.onAppear).
+    /// - Parameter transcriptionCount: The number of saved transcriptions.
+    static func requestReviewOnAppStartIfAppropriate(transcriptionCount: Int) {
+        guard transcriptionCount >= 1 else { return }
+        guard shouldRequestReview() else { return }
+        presentReviewRequest()
+    }
+
+    // MARK: - Private
+
+    private static func presentReviewRequest() {
         // Record the request date before showing
         lastRatingRequestDate = Date()
 
@@ -61,7 +76,7 @@ enum RateAppManager {
     }
 
     /// Returns true if all conditions are met for requesting a review.
-    static func shouldRequestReview() -> Bool {
+    private static func shouldRequestReview() -> Bool {
         // Check minimum launch count
         guard AppLaunchTracker.launchCount >= minimumLaunchCount else {
             return false

--- a/VivaDicta/Utilities/RateAppManager.swift
+++ b/VivaDicta/Utilities/RateAppManager.swift
@@ -47,6 +47,12 @@ enum RateAppManager {
         return components.day
     }
 
+    /// Returns true if enough time has passed since the last rating request (or if never requested).
+    private static var hasEnoughTimeSinceLastRequest: Bool {
+        guard let daysSinceLast = daysSinceLastRequest else { return true }
+        return daysSinceLast >= minimumDaysBetweenRequests
+    }
+
     // MARK: - Public
 
     /// Checks if conditions are met and requests an app rating if appropriate.
@@ -95,10 +101,8 @@ enum RateAppManager {
         }
 
         // Check if enough time has passed since last request
-        if let daysSinceLast = daysSinceLastRequest {
-            guard daysSinceLast >= minimumDaysBetweenRequests else {
-                return false
-            }
+        guard hasEnoughTimeSinceLastRequest else {
+            return false
         }
 
         return true
@@ -106,17 +110,14 @@ enum RateAppManager {
     
     /// Returns true if all conditions are met for requesting a review WIDE vers.
     private static func shouldRequestReviewWide() -> Bool {
-        
         // Check minimum days since install
         guard AppLaunchTracker.daysSinceFirstLaunch >= minimumDaysSinceInstallWide else {
             return false
         }
 
         // Check if enough time has passed since last request
-        if let daysSinceLast = daysSinceLastRequest {
-            guard daysSinceLast >= minimumDaysBetweenRequests else {
-                return false
-            }
+        guard hasEnoughTimeSinceLastRequest else {
+            return false
         }
 
         return true

--- a/VivaDicta/Utilities/RateAppManager.swift
+++ b/VivaDicta/Utilities/RateAppManager.swift
@@ -1,0 +1,84 @@
+//
+//  RateAppManager.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.01.16
+//
+
+import Foundation
+import StoreKit
+
+/// Manager for handling app rating requests.
+/// Requests are throttled based on launch count, days since install, and time since last request.
+@MainActor
+enum RateAppManager {
+
+    // MARK: - Configuration
+
+    /// Minimum number of app launches before requesting a rating.
+    private static let minimumLaunchCount = 5
+
+    /// Minimum number of days since first launch before requesting a rating.
+    private static let minimumDaysSinceInstall = 3
+
+    /// Minimum number of days between rating requests.
+    private static let minimumDaysBetweenRequests = 90
+
+    // MARK: - Private
+
+    private static var defaults: UserDefaults {
+        UserDefaultsStorage.appPrivate
+    }
+
+    /// The date when we last requested a rating from the user.
+    private static var lastRatingRequestDate: Date? {
+        get { defaults.object(forKey: UserDefaultsStorage.Keys.lastRatingRequestDate) as? Date }
+        set { defaults.set(newValue, forKey: UserDefaultsStorage.Keys.lastRatingRequestDate) }
+    }
+
+    /// Number of days since the last rating request.
+    private static var daysSinceLastRequest: Int? {
+        guard let lastRequest = lastRatingRequestDate else { return nil }
+        let components = Calendar.current.dateComponents([.day], from: lastRequest, to: Date())
+        return components.day
+    }
+
+    // MARK: - Public
+
+    /// Checks if conditions are met and requests an app rating if appropriate.
+    /// Call this after successful user actions (transcription, enhancement, etc.).
+    static func requestReviewIfAppropriate() {
+        guard shouldRequestReview() else { return }
+
+        // Record the request date before showing
+        lastRatingRequestDate = Date()
+
+        // Request review using StoreKit
+        if let scene = UIApplication.shared.connectedScenes
+            .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene {
+            AppStore.requestReview(in: scene)
+        }
+    }
+
+    /// Returns true if all conditions are met for requesting a review.
+    static func shouldRequestReview() -> Bool {
+        // Check minimum launch count
+        guard AppLaunchTracker.launchCount >= minimumLaunchCount else {
+            return false
+        }
+
+        // Check minimum days since install
+        guard AppLaunchTracker.daysSinceFirstLaunch >= minimumDaysSinceInstall else {
+            return false
+        }
+
+        // Check if enough time has passed since last request
+        if let daysSinceLast = daysSinceLastRequest {
+            guard daysSinceLast >= minimumDaysBetweenRequests else {
+                return false
+            }
+        }
+
+        return true
+    }
+}

--- a/VivaDicta/Utilities/RateAppManager.swift
+++ b/VivaDicta/Utilities/RateAppManager.swift
@@ -67,6 +67,8 @@ enum RateAppManager {
     /// Call this at app start (e.g., in MainView.onAppear).
     /// - Parameter transcriptionCount: The number of saved transcriptions.
     static func requestReviewOnAppStartIfAppropriate(transcriptionCount: Int) {
+        // Require at least one transcription to ensure the user has actually used
+        // the app's core functionality before being asked to rate
         guard transcriptionCount >= 1 else { return }
         
         let usualRule = shouldRequestReview()
@@ -108,7 +110,8 @@ enum RateAppManager {
         return true
     }
     
-    /// Returns true if all conditions are met for requesting a review WIDE vers.
+    /// Alternative conditions for passive users who don't launch frequently.
+    /// Only requires time since install (no launch count requirement).
     private static func shouldRequestReviewWide() -> Bool {
         // Check minimum days since install
         guard AppLaunchTracker.daysSinceFirstLaunch >= minimumDaysSinceInstallWide else {

--- a/VivaDicta/Utils/Extensions/View+Ext.swift
+++ b/VivaDicta/Utils/Extensions/View+Ext.swift
@@ -318,18 +318,37 @@ extension View {
 }
 
 struct RecordButtonButtonStyle: ButtonStyle {
-    /// External scale for bounce animation on app start. Defaults to 1.0.
-    var bounceScale: CGFloat = 1.0
+    /// Trigger for bounce animation. Change this value to trigger a double bounce.
+    var bounceTrigger: Int = 0
+
+    private struct BounceValue {
+        var scale: CGFloat = 1.0
+    }
 
     func makeBody(configuration: Configuration) -> some View {
-        Image(systemName: "microphone.circle")
-            .font(.system(size: 28))
-            .foregroundStyle(.white)
-            .padding(8)
-            .background(.orange.gradient, in: .circle)
-            .scaleEffect(configuration.isPressed ? 1.5 : bounceScale)
-            .animation(.spring(response: 0.3, dampingFraction: 0.7), value: configuration.isPressed)
-            .animation(.spring(response: 0.3, dampingFraction: 0.4), value: bounceScale)
+        KeyframeAnimator(
+            initialValue: BounceValue(),
+            trigger: bounceTrigger
+        ) { value in
+            Image(systemName: "microphone.circle")
+                .font(.system(size: 28))
+                .foregroundStyle(.white)
+                .padding(8)
+                .background(.orange.gradient, in: .circle)
+                .scaleEffect(configuration.isPressed ? 1.5 : value.scale)
+                .animation(.spring(response: 0.3, dampingFraction: 0.7), value: configuration.isPressed)
+        } keyframes: { _ in
+            KeyframeTrack(\.scale) {
+                // First bounce
+                SpringKeyframe(1.25, duration: 0.15, spring: .bouncy)
+                SpringKeyframe(1.0, duration: 0.15, spring: .bouncy)
+                // Pause
+                LinearKeyframe(1.0, duration: 0.1)
+                // Second bounce
+                SpringKeyframe(1.25, duration: 0.15, spring: .bouncy)
+                SpringKeyframe(1.0, duration: 0.15, spring: .bouncy)
+            }
+        }
     }
 }
 

--- a/VivaDicta/Utils/Extensions/View+Ext.swift
+++ b/VivaDicta/Utils/Extensions/View+Ext.swift
@@ -318,14 +318,18 @@ extension View {
 }
 
 struct RecordButtonButtonStyle: ButtonStyle {
+    /// External scale for bounce animation on app start. Defaults to 1.0.
+    var bounceScale: CGFloat = 1.0
+
     func makeBody(configuration: Configuration) -> some View {
         Image(systemName: "microphone.circle")
             .font(.system(size: 28))
             .foregroundStyle(.white)
             .padding(8)
             .background(.orange.gradient, in: .circle)
-            .scaleEffect(configuration.isPressed ? 1.5 : 1.0)
+            .scaleEffect(configuration.isPressed ? 1.5 : bounceScale)
             .animation(.spring(response: 0.3, dampingFraction: 0.7), value: configuration.isPressed)
+            .animation(.spring(response: 0.3, dampingFraction: 0.4), value: bounceScale)
     }
 }
 

--- a/VivaDicta/Views/MainView.swift
+++ b/VivaDicta/Views/MainView.swift
@@ -27,7 +27,6 @@ struct MainView: View {
     @State private var showFileErrorAlert = false
     @State private var fileErrorMessage = ""
     @State private var recordButtonBounceCount = 0
-    @State private var recordButtonBounceScale: CGFloat = 1.0
 
     private let logger = Logger(category: .mainView)
 
@@ -157,7 +156,7 @@ struct MainView: View {
                             Button("") {
                                 startRecording()
                             }
-                            .buttonStyle(RecordButtonButtonStyle(bounceScale: recordButtonBounceScale))
+                            .buttonStyle(RecordButtonButtonStyle(bounceTrigger: recordButtonBounceCount))
                         }
                     }
                 }
@@ -321,35 +320,11 @@ struct MainView: View {
             SelectTranscriptionModelTipSettingsView.isTranscriptionReady = appState.transcriptionManager.hasAvailableTranscriptionModels
 
             // Trigger record button bounce animation on app start (first 10 launches only)
+            // iOS 26+ uses symbolEffect, iOS 18 uses KeyframeAnimator - both trigger on count change
             if recordButtonBounceCount == 0 && AppLaunchTracker.isWithinFirstLaunches(10) {
                 Task {
                     try? await Task.sleep(for: .milliseconds(500))
-
-                    if #available(iOS 26.0, *) {
-                        // iOS 26+: Use symbolEffect
-                        recordButtonBounceCount += 1
-                    } else {
-                        // iOS 18: Animate scale for double bounce
-                        // First bounce
-                        withAnimation(.spring(response: 0.3, dampingFraction: 0.4)) {
-                            recordButtonBounceScale = 1.25
-                        }
-                        try? await Task.sleep(for: .milliseconds(300))
-                        withAnimation(.spring(response: 0.3, dampingFraction: 0.4)) {
-                            recordButtonBounceScale = 1.0
-                        }
-                        try? await Task.sleep(for: .milliseconds(200))
-                        // Second bounce
-                        withAnimation(.spring(response: 0.3, dampingFraction: 0.4)) {
-                            recordButtonBounceScale = 1.25
-                        }
-                        try? await Task.sleep(for: .milliseconds(300))
-                        withAnimation(.spring(response: 0.3, dampingFraction: 0.4)) {
-                            recordButtonBounceScale = 1.0
-                        }
-                        // Mark as done so it doesn't trigger again
-                        recordButtonBounceCount = 1
-                    }
+                    recordButtonBounceCount += 1
                 }
             }
 

--- a/VivaDicta/Views/MainView.swift
+++ b/VivaDicta/Views/MainView.swift
@@ -354,9 +354,11 @@ struct MainView: View {
             }
 
             // Request app rating on app start (with delay to not be jarring)
+            // Note: transcriptions.count is evaluated after sleep, ensuring @Query has loaded
             Task {
                 try? await Task.sleep(for: .seconds(2))
-                RateAppManager.requestReviewOnAppStartIfAppropriate(transcriptionCount: transcriptions.count)
+                let count = transcriptions.count
+                RateAppManager.requestReviewOnAppStartIfAppropriate(transcriptionCount: count)
             }
         }
         .task {

--- a/VivaDicta/Views/MainView.swift
+++ b/VivaDicta/Views/MainView.swift
@@ -26,7 +26,7 @@ struct MainView: View {
     @State private var showNoModelAlert = false
     @State private var showFileErrorAlert = false
     @State private var fileErrorMessage = ""
-    @State private var recordButtonBounceCount = 0
+    @State private var recordButtonBounceTrigger = 0
 
     private let logger = Logger(category: .mainView)
 
@@ -145,7 +145,7 @@ struct MainView: View {
                             } label: {
                                 Image(systemName: "microphone.circle")
                                     .font(.system(size: 24))
-                                    .symbolEffect(.bounce.up.byLayer, options: .repeat(2), value: recordButtonBounceCount)
+                                    .symbolEffect(.bounce.up.byLayer, options: .repeat(2), value: recordButtonBounceTrigger)
                             }
                             .buttonStyle(.glassProminent)
                             .tint(.orange)
@@ -156,7 +156,7 @@ struct MainView: View {
                             Button("") {
                                 startRecording()
                             }
-                            .buttonStyle(RecordButtonButtonStyle(bounceTrigger: recordButtonBounceCount))
+                            .buttonStyle(RecordButtonButtonStyle(bounceTrigger: recordButtonBounceTrigger))
                         }
                     }
                 }
@@ -321,10 +321,10 @@ struct MainView: View {
 
             // Trigger record button bounce animation on app start (first 10 launches only)
             // iOS 26+ uses symbolEffect, iOS 18 uses KeyframeAnimator - both trigger on count change
-            if recordButtonBounceCount == 0 && AppLaunchTracker.isWithinFirstLaunches(10) {
+            if recordButtonBounceTrigger == 0 && AppLaunchTracker.isWithinFirstLaunches(10) {
                 Task {
                     try? await Task.sleep(for: .milliseconds(500))
-                    recordButtonBounceCount += 1
+                    recordButtonBounceTrigger += 1
                 }
             }
 

--- a/VivaDicta/Views/MainView.swift
+++ b/VivaDicta/Views/MainView.swift
@@ -27,6 +27,7 @@ struct MainView: View {
     @State private var showFileErrorAlert = false
     @State private var fileErrorMessage = ""
     @State private var recordButtonBounceCount = 0
+    @State private var recordButtonBounceScale: CGFloat = 1.0
 
     private let logger = Logger(category: .mainView)
 
@@ -156,7 +157,7 @@ struct MainView: View {
                             Button("") {
                                 startRecording()
                             }
-                            .buttonStyle(RecordButtonButtonStyle())
+                            .buttonStyle(RecordButtonButtonStyle(bounceScale: recordButtonBounceScale))
                         }
                     }
                 }
@@ -323,7 +324,32 @@ struct MainView: View {
             if recordButtonBounceCount == 0 && AppLaunchTracker.isWithinFirstLaunches(10) {
                 Task {
                     try? await Task.sleep(for: .milliseconds(500))
-                    recordButtonBounceCount += 1
+
+                    if #available(iOS 26.0, *) {
+                        // iOS 26+: Use symbolEffect
+                        recordButtonBounceCount += 1
+                    } else {
+                        // iOS 18: Animate scale for double bounce
+                        // First bounce
+                        withAnimation(.spring(response: 0.3, dampingFraction: 0.4)) {
+                            recordButtonBounceScale = 1.25
+                        }
+                        try? await Task.sleep(for: .milliseconds(300))
+                        withAnimation(.spring(response: 0.3, dampingFraction: 0.4)) {
+                            recordButtonBounceScale = 1.0
+                        }
+                        try? await Task.sleep(for: .milliseconds(200))
+                        // Second bounce
+                        withAnimation(.spring(response: 0.3, dampingFraction: 0.4)) {
+                            recordButtonBounceScale = 1.25
+                        }
+                        try? await Task.sleep(for: .milliseconds(300))
+                        withAnimation(.spring(response: 0.3, dampingFraction: 0.4)) {
+                            recordButtonBounceScale = 1.0
+                        }
+                        // Mark as done so it doesn't trigger again
+                        recordButtonBounceCount = 1
+                    }
                 }
             }
 

--- a/VivaDicta/Views/MainView.swift
+++ b/VivaDicta/Views/MainView.swift
@@ -14,6 +14,7 @@ import os
 struct MainView: View {
     @Environment(AppState.self) var appState
     @Environment(Router.self) var router
+    @Query private var transcriptions: [Transcription]
 
     @State private var showingRecordingSheet = false
     @State private var showingSettings = false
@@ -324,6 +325,12 @@ struct MainView: View {
                     try? await Task.sleep(for: .milliseconds(500))
                     recordButtonBounceCount += 1
                 }
+            }
+
+            // Request app rating on app start (with delay to not be jarring)
+            Task {
+                try? await Task.sleep(for: .seconds(2))
+                RateAppManager.requestReviewOnAppStartIfAppropriate(transcriptionCount: transcriptions.count)
             }
         }
         .task {

--- a/VivaDicta/Views/RecordViewModel.swift
+++ b/VivaDicta/Views/RecordViewModel.swift
@@ -503,6 +503,9 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
                 HapticManager.heartbeat()
                 self.recordingState = .idle
 
+                // Request app rating after successful transcription
+                RateAppManager.requestReviewIfAppropriate()
+
                 // Reschedule session timeout now that all processing is complete
                 self.prewarmManager.rescheduleSessionTimeout()
 
@@ -617,6 +620,9 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
 
                     // Share with keyboard
                     AppGroupCoordinator.shared.shareTranscribedText(pending.text)
+
+                    // Request app rating after successful transcription
+                    RateAppManager.requestReviewIfAppropriate()
                 } catch {
                     logger.logError("📱 Failed to save transcription: \(error.localizedDescription)")
                 }

--- a/VivaDicta/Views/TranscriptionDetailView.swift
+++ b/VivaDicta/Views/TranscriptionDetailView.swift
@@ -570,6 +570,9 @@ struct TranscriptionDetailView: View {
                 await appState.updateTranscriptionInSpotlight(transcription)
 
                 HapticManager.heartbeat()
+
+                // Request app rating after successful retranscribe
+                RateAppManager.requestReviewIfAppropriate()
             } catch {
                 HapticManager.error()
             }
@@ -601,6 +604,9 @@ struct TranscriptionDetailView: View {
                 await appState.updateTranscriptionInSpotlight(transcription)
 
                 HapticManager.heartbeat()
+
+                // Request app rating after successful enhance
+                RateAppManager.requestReviewIfAppropriate()
             } catch let error as AppleFoundationModelError {
                 if case .guardrailViolation = error {
                     showGuardrailAlert = true
@@ -661,6 +667,9 @@ struct TranscriptionDetailView: View {
                 await appState.updateTranscriptionInSpotlight(transcription)
 
                 HapticManager.heartbeat()
+
+                // Request app rating after successful retranscribe and enhance
+                RateAppManager.requestReviewIfAppropriate()
             } catch {
                 HapticManager.error()
             }


### PR DESCRIPTION
## Summary

- Add app rating request functionality triggered by successful user actions
- Track app launch count and first launch date for engagement-based triggers
- Add bounce animation to record button on first 10 app launches (iOS 18 & 26)

## Changes

### New Files
- `RateAppManager.swift` - Manages app rating requests with configurable thresholds

### Updated Files
- `UserDefaultsStorage.swift` - Added keys for `firstLaunchDate` and `lastRatingRequestDate`
- `AppLaunchTracker.swift` - Now tracks first launch date and days since install
- `MainView.swift` - Added bounce animation for record button on app start, rating request on app start
- `RecordViewModel.swift` - Triggers rating request after successful transcription
- `TranscriptionDetailView.swift` - Triggers rating request after retranscribe/enhance
- `View+Ext.swift` - `RecordButtonButtonStyle` now accepts `bounceScale` for iOS 18 bounce animation

## Rating Request Conditions

| Rule | Conditions |
|------|------------|
| **Regular** | ≥5 launches + ≥3 days since install + ≥90 days since last request |
| **Wide** (passive users) | ≥30 days since install + ≥90 days since last request |

### Triggers
- After successful new transcription
- After successful retranscribe/enhance/retranscribe+enhance
- On app start (requires at least 1 saved transcription)

## Test Plan

- [ ] Verify bounce animation plays on record button for first 10 launches (iOS 18 and iOS 26)
- [ ] Verify rating request does not appear before meeting conditions
- [ ] Verify rating request appears after successful transcription when conditions are met
- [ ] Verify 90-day throttle prevents repeated requests