### PR TITLE
Add Vercel AI Gateway as AI enhancement provider

### DIFF
--- a/VivaDicta/Services/AIEnhance/AIProvider.swift
+++ b/VivaDicta/Services/AIEnhance/AIProvider.swift
@@ -180,7 +180,11 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
         case .soniox:
             return "stt-async-v3"
         case .vercelAIGateway:
-            return "anthropic/claude-sonnet-4-5"
+            // Note: Vercel AI Gateway uses "provider/model" format with dots for versions
+            // (e.g., "claude-sonnet-4.5") unlike direct Anthropic API which uses hyphens
+            // (e.g., "claude-sonnet-4-5"). Models are fetched dynamically, so this must
+            // match Vercel's actual naming convention.
+            return "anthropic/claude-sonnet-4.5"
         }
     }
 

--- a/VivaDicta/Services/AIEnhance/AIProvider.swift
+++ b/VivaDicta/Services/AIEnhance/AIProvider.swift
@@ -22,6 +22,7 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
     case deepgram
     case mistral
     case soniox
+    case vercelAIGateway
 
     var displayName: String {
         switch self {
@@ -49,6 +50,8 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
             "OpenRouter"
         case .grok:
             "Grok (x.ai)"
+        case .vercelAIGateway:
+            "Vercel AI Gateway"
         }
     }
 
@@ -79,6 +82,8 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
             "deepgram"
         case .soniox:
             nil
+        case .vercelAIGateway:
+            "vercel"
         }
     }
 
@@ -101,7 +106,8 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
         .mistral,
         .cerebras,
         .grok,
-        .openRouter]
+        .openRouter,
+        .vercelAIGateway]
 
     /// All general-purpose AI providers including on-device
     static let generalProviders: [AIProvider] = [
@@ -113,7 +119,8 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
         .mistral,
         .cerebras,
         .grok,
-        .openRouter]
+        .openRouter,
+        .vercelAIGateway]
     
     var baseURL: String {
         switch self {
@@ -141,9 +148,11 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
             return "https://api.mistral.ai/v1/chat/completions"
         case .soniox:
             return "https://api.soniox.com/v1"
+        case .vercelAIGateway:
+            return "https://ai-gateway.vercel.sh/v1/chat/completions"
         }
     }
-    
+
     var defaultModel: String {
         switch self {
         case .apple:
@@ -170,9 +179,11 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
             return "openai/gpt-oss-120b"
         case .soniox:
             return "stt-async-v3"
+        case .vercelAIGateway:
+            return "anthropic/claude-sonnet-4-5"
         }
     }
-    
+
     var availableModels: [String] {
         switch self {
         case .apple:
@@ -240,6 +251,8 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
         case .soniox:
             return ["stt-async-v3"]
         case .openRouter:
+            return []
+        case .vercelAIGateway:
             return []
         }
     }

--- a/VivaDicta/Services/AIEnhance/AIProvider.swift
+++ b/VivaDicta/Services/AIEnhance/AIProvider.swift
@@ -92,12 +92,6 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
         self != .apple
     }
 
-    /// Returns true if an API key is configured for this provider
-    var hasAPIKey: Bool {
-        guard requiresAPIKey else { return true }
-        return UserDefaultsStorage.shared.string(forKey: AppGroupCoordinator.kAPIKeyTemplate + rawValue) != nil
-    }
-
     /// Cloud-based AI providers (require API key, network connection)
     static let cloudProviders: [AIProvider] = [
         .anthropic,

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -1078,9 +1078,17 @@ class AIService {
             }
 
             // Filter for language models only (exclude embeddings, image models)
+            let totalCount = dataArray.count
             let models = dataArray
                 .filter { ($0["type"] as? String) == "language" }
                 .compactMap { $0["id"] as? String }
+
+            // Log filtering results for debugging API changes
+            if models.isEmpty && totalCount > 0 {
+                logger.logWarning("Vercel AI Gateway: Received \(totalCount) models but none matched type 'language'. API response format may have changed.")
+            } else if models.count < totalCount {
+                logger.logInfo("Vercel AI Gateway: Filtered \(totalCount) models to \(models.count) language models.")
+            }
 
             await MainActor.run {
                 self.vercelAIGatewayModels = models.sorted()

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -14,6 +14,7 @@ class AIService {
 
     public var connectedProviders: [AIProvider] = []
     public var openRouterModels: [String] = []
+    public var vercelAIGatewayModels: [String] = []
     public var modes: [VivaMode] = []
 
     public var onModeChange: ((VivaMode) -> Void)?
@@ -52,12 +53,16 @@ class AIService {
         loadModes()
         self.selectedMode = getMode(name: selectedModeName)
         loadSavedOpenRouterModels()
+        loadSavedVercelAIGatewayModels()
 
         // Refresh connected providers on main actor (needed for Apple availability check)
         Task { @MainActor in
             refreshConnectedProviders()
             if connectedProviders.contains(.openRouter) {
                 await fetchOpenRouterModels()
+            }
+            if connectedProviders.contains(.vercelAIGateway) {
+                await fetchVercelAIGatewayModels()
             }
         }
     }
@@ -342,7 +347,17 @@ class AIService {
     private func saveOpenRouterModels() {
         userDefaults.set(openRouterModels, forKey: UserDefaultsStorage.Keys.openRouterModels)
     }
-    
+
+    private func loadSavedVercelAIGatewayModels() {
+        if let savedModels = userDefaults.array(forKey: UserDefaultsStorage.Keys.vercelAIGatewayModels) as? [String] {
+            vercelAIGatewayModels = savedModels
+        }
+    }
+
+    private func saveVercelAIGatewayModels() {
+        userDefaults.set(vercelAIGatewayModels, forKey: UserDefaultsStorage.Keys.vercelAIGatewayModels)
+    }
+
     // MARK: - Configuration validation
     public func isProperlyConfigured() -> Bool {
         // Check if AI enhancement is enabled
@@ -699,14 +714,17 @@ class AIService {
             }
         }
         
-        // Fetch OpenRouter models if this is an OpenRouter key
+        // Fetch models for providers that support dynamic model fetching
         if isValid && provider == .openRouter {
             await fetchOpenRouterModels()
         }
-        
+        if isValid && provider == .vercelAIGateway {
+            await fetchVercelAIGatewayModels()
+        }
+
         return isValid
     }
-    
+
     private func getAPIKey(for provider: AIProvider) -> String? {
         return userDefaults.string(forKey: AppGroupCoordinator.kAPIKeyTemplate + provider.rawValue)
     }
@@ -728,6 +746,8 @@ class AIService {
             return await verifyMistralAPIKey(key)
         case .soniox:
             return await verifySonioxAPIKey(key)
+        case .vercelAIGateway:
+            return await verifyVercelAIGatewayAPIKey(key)
         default:
             return await verifyOpenAICompatibleAPIKey(key, provider: provider)
         }
@@ -907,7 +927,43 @@ class AIService {
             return false
         }
     }
-    
+
+    private func verifyVercelAIGatewayAPIKey(_ key: String) async -> Bool {
+        // Use /v1/credits endpoint to verify API key
+        let url = URL(string: "https://ai-gateway.vercel.sh/v1/credits")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.addValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        logger.logNotice("🔑 Verifying Vercel AI Gateway API key")
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            guard let httpResponse = response as? HTTPURLResponse else {
+                logger.logNotice("🔑 Vercel AI Gateway API key verification failed: Invalid response")
+                return false
+            }
+
+            let isValid = httpResponse.statusCode == 200
+
+            if !isValid {
+                if let exactAPIError = String(data: data, encoding: .utf8) {
+                    logger.logNotice("🔑 Vercel AI Gateway API key verification failed - Status: \(httpResponse.statusCode) - \(exactAPIError)")
+                } else {
+                    logger.logNotice("🔑 Vercel AI Gateway API key verification failed - Status: \(httpResponse.statusCode)")
+                }
+            }
+
+            return isValid
+
+        } catch {
+            logger.logNotice("🔑 Vercel AI Gateway API key verification failed: \(error.localizedDescription)")
+            return false
+        }
+    }
+
     private func verifyGrokAPIKey(_ key: String) async -> Bool {
         let url = URL(string: AIProvider.grok.baseURL)!
         var request = URLRequest(url: url)
@@ -953,10 +1009,13 @@ class AIService {
         }
     }
     
-    // MARK: - OpenRouter Models methods
+    // MARK: - Dynamic Models methods
     public func getAvailableModels(for provider: AIProvider) -> [String] {
         if provider == .openRouter {
             return openRouterModels
+        }
+        if provider == .vercelAIGateway {
+            return vercelAIGatewayModels
         }
         return provider.availableModels
     }
@@ -1001,6 +1060,54 @@ class AIService {
             await MainActor.run {
                 self.openRouterModels = []
                 self.saveOpenRouterModels()
+            }
+        }
+    }
+
+    public func fetchVercelAIGatewayModels() async {
+        let url = URL(string: "https://ai-gateway.vercel.sh/v1/models")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+                logger.logError("Failed to fetch Vercel AI Gateway models: Invalid HTTP response")
+                await MainActor.run {
+                    self.vercelAIGatewayModels = []
+                    self.saveVercelAIGatewayModels()
+                }
+                return
+            }
+
+            guard let jsonResponse = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let dataArray = jsonResponse["data"] as? [[String: Any]] else {
+                logger.logError("Failed to parse Vercel AI Gateway models JSON")
+                await MainActor.run {
+                    self.vercelAIGatewayModels = []
+                    self.saveVercelAIGatewayModels()
+                }
+                return
+            }
+
+            // Filter for language models only (exclude embeddings, image models)
+            let models = dataArray
+                .filter { ($0["type"] as? String) == "language" }
+                .compactMap { $0["id"] as? String }
+
+            await MainActor.run {
+                self.vercelAIGatewayModels = models.sorted()
+                self.saveVercelAIGatewayModels()
+            }
+            logger.logInfo("Successfully fetched \(models.count) Vercel AI Gateway models.")
+
+        } catch {
+            logger.logError("Error fetching Vercel AI Gateway models: \(error.localizedDescription)")
+            await MainActor.run {
+                self.vercelAIGatewayModels = []
+                self.saveVercelAIGatewayModels()
             }
         }
     }

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -1028,23 +1028,17 @@ class AIService {
         
         do {
             let (data, response) = try await URLSession.shared.data(for: request)
-            
+
             guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
                 logger.logError("Failed to fetch OpenRouter models: Invalid HTTP response")
-                await MainActor.run {
-                    self.openRouterModels = []
-                    self.saveOpenRouterModels()
-                }
+                // Preserve existing cached models on failure
                 return
             }
 
             guard let jsonResponse = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                   let dataArray = jsonResponse["data"] as? [[String: Any]] else {
                 logger.logError("Failed to parse OpenRouter models JSON")
-                await MainActor.run {
-                    self.openRouterModels = []
-                    self.saveOpenRouterModels()
-                }
+                // Preserve existing cached models on failure
                 return
             }
 
@@ -1057,10 +1051,7 @@ class AIService {
 
         } catch {
             logger.logError("Error fetching OpenRouter models: \(error.localizedDescription)")
-            await MainActor.run {
-                self.openRouterModels = []
-                self.saveOpenRouterModels()
-            }
+            // Preserve existing cached models on failure
         }
     }
 
@@ -1075,20 +1066,14 @@ class AIService {
 
             guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
                 logger.logError("Failed to fetch Vercel AI Gateway models: Invalid HTTP response")
-                await MainActor.run {
-                    self.vercelAIGatewayModels = []
-                    self.saveVercelAIGatewayModels()
-                }
+                // Preserve existing cached models on failure
                 return
             }
 
             guard let jsonResponse = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                   let dataArray = jsonResponse["data"] as? [[String: Any]] else {
                 logger.logError("Failed to parse Vercel AI Gateway models JSON")
-                await MainActor.run {
-                    self.vercelAIGatewayModels = []
-                    self.saveVercelAIGatewayModels()
-                }
+                // Preserve existing cached models on failure
                 return
             }
 
@@ -1105,10 +1090,7 @@ class AIService {
 
         } catch {
             logger.logError("Error fetching Vercel AI Gateway models: \(error.localizedDescription)")
-            await MainActor.run {
-                self.vercelAIGatewayModels = []
-                self.saveVercelAIGatewayModels()
-            }
+            // Preserve existing cached models on failure
         }
     }
 }

--- a/VivaDicta/Shared/UserDefaultsStorage.swift
+++ b/VivaDicta/Shared/UserDefaultsStorage.swift
@@ -40,5 +40,6 @@ enum UserDefaultsStorage {
         static let isAutoAudioCleanupEnabled = "isAutoAudioCleanupEnabled"
         static let audioRetentionDays = "audioRetentionDays"
         static let openRouterModels = "openRouterModels"
+        static let vercelAIGatewayModels = "vercelAIGatewayModels"
     }
 }

--- a/VivaDicta/Views/SettingsScreen/AIProvidersView.swift
+++ b/VivaDicta/Views/SettingsScreen/AIProvidersView.swift
@@ -54,7 +54,7 @@ struct AIProviders: View {
 
                             Spacer()
 
-                            if !provider.hasAPIKey {
+                            if !appState.aiService.connectedProviders.contains(provider) {
                                 HStack(spacing: 4) {
                                     Image(systemName: "exclamationmark.triangle.fill")
                                         .foregroundStyle(.orange)

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -52,7 +52,7 @@ struct SettingsView: View {
                     
                     ForEach(appState.aiService.modes) { mode in
                         NavigationLink(value: mode) {
-                            ModeInfoRow(mode: mode)
+                            ModeInfoRow(mode: mode, connectedProviders: appState.aiService.connectedProviders)
                         }
                         .contextMenu {
                             Button {
@@ -464,6 +464,7 @@ struct SettingsView: View {
 
 private struct ModeInfoRow: View {
     let mode: VivaMode
+    let connectedProviders: [AIProvider]
 
     private var transcriptionModelDisplayName: String {
         mode.transcriptionProvider.getTranscriptionModelDisplayName(mode.transcriptionModel)
@@ -530,7 +531,7 @@ private struct ModeInfoRow: View {
                         }
                     }
 
-                    if let provider = mode.aiProvider {
+                    if let provider = mode.aiProvider, connectedProviders.contains(provider) {
                         Divider()
                         HStack(alignment: .top, spacing: 4) {
                             Image(systemName: "sparkles")

--- a/VivaDicta/Views/TranscriptionDetailView.swift
+++ b/VivaDicta/Views/TranscriptionDetailView.swift
@@ -35,6 +35,7 @@ struct TranscriptionDetailView: View {
     @State private var processingTask: Task<Void, Never>?
     @State private var isShimmering: Bool = false
     @State private var showGuardrailAlert: Bool = false
+    @State private var isMetaInfoExpanded: Bool = false
 
     private var hasEnhancedText: Bool {
         transcription.enhancedText != nil
@@ -101,6 +102,7 @@ struct TranscriptionDetailView: View {
                     .padding(.bottom, 12)
                     .onChange(of: selectedTextType) { _, _ in
                         HapticManager.selectionChanged()
+                        isMetaInfoExpanded = false
                     }
                 }
             }
@@ -344,6 +346,7 @@ struct TranscriptionDetailView: View {
                             Button {
                                 HapticManager.lightImpact()
                                 isExpanded = true
+                                isMetaInfoExpanded = false
                             } label: {
                                 HStack {
                                     if processingState != .idle {
@@ -449,7 +452,7 @@ struct TranscriptionDetailView: View {
         VStack(alignment: .leading, spacing: 0) {
             Divider()
 
-            DisclosureGroup("Meta Info") {
+            DisclosureGroup("Meta Info", isExpanded: $isMetaInfoExpanded) {
                 VStack(alignment: .leading, spacing: 10) {
                     metadataRow(icon: "hourglass", label: "Audio Duration", value: transcription.getDurationFormatted(transcription.audioDuration))
                     
@@ -552,6 +555,7 @@ struct TranscriptionDetailView: View {
     private func retranscribe() {
         guard let audioURL = audioURL else { return }
         HapticManager.lightImpact()
+        isMetaInfoExpanded = false
 
         processingTask = Task {
             processingState = .transcribing
@@ -584,6 +588,7 @@ struct TranscriptionDetailView: View {
     private func enhance() {
         guard !transcription.text.isEmpty else { return }
         HapticManager.lightImpact()
+        isMetaInfoExpanded = false
 
         processingTask = Task {
             processingState = .enhancing
@@ -623,6 +628,7 @@ struct TranscriptionDetailView: View {
     private func retranscribeAndEnhance() {
         guard let audioURL = audioURL else { return }
         HapticManager.lightImpact()
+        isMetaInfoExpanded = false
 
         processingTask = Task {
             processingState = .transcribing


### PR DESCRIPTION
## Summary

- Add Vercel AI Gateway as a new AI enhancement provider, enabling access to hundreds of AI models through a single unified API
- Implement dynamic model fetching from Vercel's `/v1/models` endpoint with language model filtering
- Add API key verification using `/v1/credits` endpoint
- Cache fetched models in UserDefaults for offline access and immediate UI display
- Models refresh on app launch and after API key save

## Implementation Details

- **AIProvider.swift**: New `vercelAIGateway` case with display name, icon, base URL (`https://ai-gateway.vercel.sh/v1/chat/completions`), and default model
- **AIService.swift**: Model fetching, persistence, and API key verification methods
- **UserDefaultsStorage.swift**: Storage key for caching models

## Notes

- Vercel AI Gateway uses `provider/model` format with dots for versions (e.g., `anthropic/claude-sonnet-4.5`) unlike direct APIs which use hyphens
- Models are fetched dynamically since Vercel controls the naming convention
- No token markup - same pricing as direct provider access

## Test plan

- [ ] Add Vercel AI Gateway API key and verify it's accepted
- [ ] Verify models are fetched and displayed in the picker
- [ ] Select a model and perform AI enhancement on a transcription
- [ ] Verify models persist across app restarts
- [ ] Test with invalid API key - should show error