### PR TITLE
Add Ollama AI provider for AI enhancement

### DIFF
--- a/VivaDicta/Info.plist
+++ b/VivaDicta/Info.plist
@@ -12,8 +12,6 @@
 			<dict>
 				<key>NSExceptionAllowsInsecureHTTPLoads</key>
 				<true/>
-				<key>NSIncludesSubdomains</key>
-				<true/>
 			</dict>
 		</dict>
 	</dict>

--- a/VivaDicta/Info.plist
+++ b/VivaDicta/Info.plist
@@ -2,6 +2,21 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>localhost</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+			</dict>
+		</dict>
+	</dict>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/VivaDicta/Services/AIEnhance/AIProvider.swift
+++ b/VivaDicta/Services/AIEnhance/AIProvider.swift
@@ -93,13 +93,13 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
         case .huggingFace:
             "huggingface-color"
         case .ollama:
-            nil // Use SF Symbol "desktopcomputer" directly in view
+            "ollama"
         }
     }
 
     /// Returns true if this provider uses an SF Symbol instead of an asset
     var usesSFSymbol: Bool {
-        self == .apple || self == .ollama
+        self == .apple
     }
 
     /// Returns true if this provider requires an API key

--- a/VivaDicta/Services/AIEnhance/AIProvider.swift
+++ b/VivaDicta/Services/AIEnhance/AIProvider.swift
@@ -108,6 +108,7 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
     }
 
     /// Cloud-based AI providers (require API key, network connection)
+    /// Note: Ollama is included here for UI purposes but doesn't require API key
     static let cloudProviders: [AIProvider] = [
         .anthropic,
         .openAI,
@@ -118,7 +119,8 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
         .grok,
         .openRouter,
         .vercelAIGateway,
-        .huggingFace]
+        .huggingFace,
+        .ollama]
 
     /// Local AI providers that run on-device or local network (no API key needed)
     static let localProviders: [AIProvider] = [

--- a/VivaDicta/Services/AIEnhance/AIProvider.swift
+++ b/VivaDicta/Services/AIEnhance/AIProvider.swift
@@ -24,6 +24,7 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
     case soniox
     case vercelAIGateway
     case huggingFace
+    case ollama
 
     var displayName: String {
         switch self {
@@ -55,6 +56,8 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
             "Vercel AI Gateway"
         case .huggingFace:
             "HuggingFace"
+        case .ollama:
+            "Ollama"
         }
     }
 
@@ -89,17 +92,19 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
             "vercel"
         case .huggingFace:
             "huggingface-color"
+        case .ollama:
+            nil // Use SF Symbol "desktopcomputer" directly in view
         }
     }
 
     /// Returns true if this provider uses an SF Symbol instead of an asset
     var usesSFSymbol: Bool {
-        self == .apple
+        self == .apple || self == .ollama
     }
 
     /// Returns true if this provider requires an API key
     var requiresAPIKey: Bool {
-        self != .apple
+        self != .apple && self != .ollama
     }
 
     /// Cloud-based AI providers (require API key, network connection)
@@ -115,9 +120,15 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
         .vercelAIGateway,
         .huggingFace]
 
-    /// All general-purpose AI providers including on-device
+    /// Local AI providers that run on-device or local network (no API key needed)
+    static let localProviders: [AIProvider] = [
+        .apple,
+        .ollama]
+
+    /// All general-purpose AI providers including on-device and local
     static let generalProviders: [AIProvider] = [
         .apple,
+        .ollama,
         .anthropic,
         .openAI,
         .gemini,
@@ -159,8 +170,13 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
             return "https://ai-gateway.vercel.sh/v1/chat/completions"
         case .huggingFace:
             return "https://router.huggingface.co/v1/chat/completions"
+        case .ollama:
+            return "" // URL is configurable, stored in UserDefaults
         }
     }
+
+    /// Default Ollama server URL
+    static let ollamaDefaultServerURL = "http://localhost:11434"
 
     var defaultModel: String {
         switch self {
@@ -196,6 +212,8 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
             return "anthropic/claude-sonnet-4.5"
         case .huggingFace:
             return "openai/gpt-oss-120b"
+        case .ollama:
+            return "llama3.2"
         }
     }
 
@@ -274,6 +292,8 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
             return []
         case .huggingFace:
             return []
+        case .ollama:
+            return [] // Models are fetched dynamically from Ollama server
         }
     }
 }

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -792,7 +792,7 @@ class AIService {
                 return filteredText
 
             case 404:
-                throw EnhancementError.customError("Model '\(self.selectedMode.aiModel)' not found. Run 'ollama pull \(self.selectedMode.aiModel)' to download it.")
+                throw EnhancementError.customError("Model '\(self.selectedMode.aiModel)' not found. Run 'ollama pull \(self.selectedMode.aiModel)' on your Mac/server to download it.")
 
             case 500...599:
                 throw EnhancementError.serverError
@@ -937,7 +937,7 @@ class AIService {
         await fetchOllamaModels()
 
         if ollamaModels.isEmpty {
-            return (false, "Connected to Ollama but no models found. Run 'ollama pull llama3.2' to download a model.")
+            return (false, "Connected to Ollama but no models found. Run 'ollama pull llama3.2' on your Mac/server to download a model.")
         }
 
         return (true, "Connected successfully. Found \(ollamaModels.count) model(s).")

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -16,7 +16,20 @@ class AIService {
     public var openRouterModels: [String] = []
     public var vercelAIGatewayModels: [String] = []
     public var huggingFaceModels: [String] = []
+    public var ollamaModels: [String] = []
     public var modes: [VivaMode] = []
+
+    /// Ollama server URL (configurable, defaults to localhost:11434)
+    public var ollamaServerURL: String {
+        get {
+            userDefaults.string(forKey: UserDefaultsStorage.Keys.ollamaServerURL)
+                ?? AIProvider.ollamaDefaultServerURL
+        }
+        set {
+            userDefaults.set(newValue, forKey: UserDefaultsStorage.Keys.ollamaServerURL)
+            userDefaults.synchronize()
+        }
+    }
 
     public var onModeChange: ((VivaMode) -> Void)?
 
@@ -56,6 +69,7 @@ class AIService {
         loadSavedOpenRouterModels()
         loadSavedVercelAIGatewayModels()
         loadSavedHuggingFaceModels()
+        loadSavedOllamaModels()
 
         // Refresh connected providers on main actor (needed for Apple availability check)
         Task { @MainActor in
@@ -69,6 +83,7 @@ class AIService {
             if connectedProviders.contains(.huggingFace) {
                 await fetchHuggingFaceModels()
             }
+            // Ollama models are fetched on-demand when user configures Ollama
         }
     }
     
@@ -373,6 +388,16 @@ class AIService {
         userDefaults.set(huggingFaceModels, forKey: UserDefaultsStorage.Keys.huggingFaceModels)
     }
 
+    private func loadSavedOllamaModels() {
+        if let savedModels = userDefaults.array(forKey: UserDefaultsStorage.Keys.ollamaModels) as? [String] {
+            ollamaModels = savedModels
+        }
+    }
+
+    private func saveOllamaModels() {
+        userDefaults.set(ollamaModels, forKey: UserDefaultsStorage.Keys.ollamaModels)
+    }
+
     // MARK: - Configuration validation
     public func isProperlyConfigured() -> Bool {
         // Check if AI enhancement is enabled
@@ -397,6 +422,13 @@ class AIService {
         if aiProvider == .apple {
             guard connectedProviders.contains(.apple) else {
                 logger.logWarning("Apple Foundation Model not available on this device")
+                return false
+            }
+        } else if aiProvider == .ollama {
+            // Ollama doesn't need API key, just needs model selected
+            // Connection will be verified at enhancement time
+            guard !selectedMode.aiModel.isEmpty else {
+                logger.logWarning("No Ollama model selected")
                 return false
             }
         } else {
@@ -491,6 +523,11 @@ class AIService {
             } else {
                 throw EnhancementError.notConfigured
             }
+        }
+
+        // Handle Ollama (local server)
+        if aiProvider == .ollama {
+            return try await makeOllamaRequest(text: text)
         }
 
         // Cloud providers - compute system message only when needed
@@ -696,8 +733,216 @@ class AIService {
             return promptInstructions
         }
     }
-    
-    
+
+    // MARK: - Ollama Methods
+
+    /// Makes an enhancement request to the local Ollama server
+    private func makeOllamaRequest(text: String) async throws -> String {
+        let serverURL = ollamaServerURL
+        guard let url = URL(string: "\(serverURL)/v1/chat/completions") else {
+            throw EnhancementError.customError("Invalid Ollama server URL: \(serverURL)")
+        }
+
+        let systemMessage = getSystemMessage()
+        let formattedText = "\n<TRANSCRIPT>\n\(text)\n</TRANSCRIPT>"
+
+        logger.logNotice("AI Enhancement - Using Ollama at \(serverURL)")
+        logger.logNotice("AI Enhancement - Model: \(self.selectedMode.aiModel)")
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        // No Authorization header needed for Ollama
+        request.timeoutInterval = 120 // Longer timeout for local inference
+
+        let requestBody: [String: Any] = [
+            "model": selectedMode.aiModel,
+            "messages": [
+                ["role": "system", "content": systemMessage],
+                ["role": "user", "content": formattedText]
+            ],
+            "temperature": 0.3,
+            "stream": false
+        ]
+
+        request.httpBody = try? JSONSerialization.data(withJSONObject: requestBody)
+
+        do {
+            try Task.checkCancellation()
+
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            try Task.checkCancellation()
+
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw EnhancementError.invalidResponse
+            }
+
+            switch httpResponse.statusCode {
+            case 200:
+                guard let jsonResponse = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                      let choices = jsonResponse["choices"] as? [[String: Any]],
+                      let firstChoice = choices.first,
+                      let message = firstChoice["message"] as? [String: Any],
+                      let enhancedText = message["content"] as? String else {
+                    throw EnhancementError.enhancementFailed
+                }
+
+                let filteredText = AIEnhancementOutputFilter.filter(enhancedText.trimmingCharacters(in: .whitespacesAndNewlines))
+                return filteredText
+
+            case 404:
+                throw EnhancementError.customError("Model '\(self.selectedMode.aiModel)' not found. Run 'ollama pull \(self.selectedMode.aiModel)' to download it.")
+
+            case 500...599:
+                throw EnhancementError.serverError
+
+            default:
+                let errorString = String(data: data, encoding: .utf8) ?? "Unknown error"
+                throw EnhancementError.customError("Ollama error (HTTP \(httpResponse.statusCode)): \(errorString)")
+            }
+
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch let error as EnhancementError {
+            throw error
+        } catch let error as URLError {
+            if error.code == .cannotConnectToHost || error.code == .timedOut {
+                throw EnhancementError.customError("Cannot connect to Ollama at \(serverURL). Make sure Ollama is running.")
+            }
+            throw error
+        } catch {
+            throw EnhancementError.customError(error.localizedDescription)
+        }
+    }
+
+    /// Fetches available models from the Ollama server
+    public func fetchOllamaModels() async {
+        let serverURL = ollamaServerURL
+
+        // Try OpenAI-compatible endpoint first
+        guard let url = URL(string: "\(serverURL)/v1/models") else {
+            logger.logError("Invalid Ollama server URL: \(serverURL)")
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 5 // Short timeout for local service
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200 else {
+                logger.logWarning("Ollama OpenAI-compatible endpoint not responding, trying native endpoint")
+                await fetchOllamaModelsNative()
+                return
+            }
+
+            // Parse OpenAI-compatible response
+            guard let jsonResponse = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let dataArray = jsonResponse["data"] as? [[String: Any]] else {
+                logger.logError("Failed to parse Ollama models response")
+                await fetchOllamaModelsNative()
+                return
+            }
+
+            let models = dataArray.compactMap { $0["id"] as? String }.sorted()
+
+            await MainActor.run {
+                self.ollamaModels = models
+                self.saveOllamaModels()
+            }
+
+            logger.logInfo("Successfully fetched \(models.count) Ollama models via OpenAI endpoint")
+
+        } catch {
+            logger.logWarning("Failed to fetch Ollama models via OpenAI endpoint: \(error.localizedDescription)")
+            await fetchOllamaModelsNative()
+        }
+    }
+
+    /// Fallback to native Ollama API endpoint for fetching models
+    private func fetchOllamaModelsNative() async {
+        let serverURL = ollamaServerURL
+        guard let url = URL(string: "\(serverURL)/api/tags") else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 5
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200 else {
+                logger.logError("Ollama native endpoint not responding")
+                return
+            }
+
+            // Parse native Ollama response
+            guard let jsonResponse = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let modelsArray = jsonResponse["models"] as? [[String: Any]] else {
+                logger.logError("Failed to parse Ollama native models response")
+                return
+            }
+
+            let models = modelsArray.compactMap { $0["name"] as? String }.sorted()
+
+            await MainActor.run {
+                self.ollamaModels = models
+                self.saveOllamaModels()
+            }
+
+            logger.logInfo("Successfully fetched \(models.count) Ollama models via native endpoint")
+
+        } catch {
+            logger.logError("Failed to fetch Ollama models via native endpoint: \(error.localizedDescription)")
+        }
+    }
+
+    /// Checks if Ollama server is reachable
+    public func checkOllamaConnection() async -> Bool {
+        let serverURL = ollamaServerURL
+        guard let url = URL(string: "\(serverURL)/api/tags") else {
+            return false
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 3
+
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                return false
+            }
+            return httpResponse.statusCode == 200
+        } catch {
+            return false
+        }
+    }
+
+    /// Verifies Ollama setup and returns status message
+    public func verifyOllamaSetup() async -> (success: Bool, message: String) {
+        // Check server connectivity
+        let isConnected = await checkOllamaConnection()
+
+        if !isConnected {
+            return (false, "Cannot connect to Ollama server at \(ollamaServerURL)")
+        }
+
+        // Fetch available models
+        await fetchOllamaModels()
+
+        if ollamaModels.isEmpty {
+            return (false, "Connected to Ollama but no models found. Run 'ollama pull llama3.2' to download a model.")
+        }
+
+        return (true, "Connected successfully. Found \(ollamaModels.count) model(s).")
+    }
+
     // MARK: - API Keys methods
     @MainActor
     public func refreshConnectedProviders() {
@@ -707,6 +952,9 @@ class AIService {
         if AppleFoundationModelAvailability.isAvailable {
             providers.append(.apple)
         }
+
+        // Add Ollama provider (always available, connection checked on-demand)
+        providers.append(.ollama)
 
         // Add cloud providers that have API keys configured
         providers += AIProvider.allCases.filter { provider in
@@ -749,8 +997,8 @@ class AIService {
     
     private func verifyAPIKey(_ key: String, provider: AIProvider) async -> Bool {
         switch provider {
-        case .apple:
-            // Apple doesn't require API key verification
+        case .apple, .ollama:
+            // Apple and Ollama don't require API key verification
             return true
         case .anthropic:
             return await verifyAnthropicAPIKey(key)
@@ -1084,6 +1332,9 @@ class AIService {
         }
         if provider == .huggingFace {
             return huggingFaceModels
+        }
+        if provider == .ollama {
+            return ollamaModels
         }
         return provider.availableModels
     }

--- a/VivaDicta/Shared/UserDefaultsStorage.swift
+++ b/VivaDicta/Shared/UserDefaultsStorage.swift
@@ -42,5 +42,7 @@ enum UserDefaultsStorage {
         static let openRouterModels = "openRouterModels"
         static let vercelAIGatewayModels = "vercelAIGatewayModels"
         static let huggingFaceModels = "huggingFaceModels"
+        static let ollamaModels = "ollamaModels"
+        static let ollamaServerURL = "ollamaServerURL"
     }
 }

--- a/VivaDicta/Views/SettingsScreen/AIProvidersView.swift
+++ b/VivaDicta/Views/SettingsScreen/AIProvidersView.swift
@@ -40,8 +40,36 @@ struct AIProviders: View {
                 }
             }
 
-            // Local Server Section (Ollama)
-            Section {
+            // Cloud Section
+            Section("Cloud") {
+                ForEach(AIProvider.cloudProviders) { provider in
+                    NavigationLink(value: provider) {
+                        HStack(spacing: 12) {
+                            if let iconName = provider.iconName {
+                                Image(iconName)
+                                    .resizable()
+                                    .scaledToFit()
+                                    .frame(width: 28, height: 28)
+                            }
+
+                            Text(provider.displayName)
+
+                            Spacer()
+
+                            if !appState.aiService.connectedProviders.contains(provider) {
+                                HStack(spacing: 4) {
+                                    Image(systemName: "exclamationmark.triangle.fill")
+                                        .foregroundStyle(.orange)
+                                    Text("Add API Key")
+                                        .font(.subheadline)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Ollama (Local Server) - at bottom of Cloud section
                 NavigationLink(value: AIProvider.ollama) {
                     HStack(spacing: 12) {
                         Image(systemName: "desktopcomputer")
@@ -68,40 +96,6 @@ struct AIProviders: View {
                                 Text("\(appState.aiService.ollamaModels.count) models")
                                     .font(.subheadline)
                                     .foregroundStyle(.secondary)
-                            }
-                        }
-                    }
-                }
-            } header: {
-                Text("Local Server")
-            } footer: {
-                Text("Ollama runs AI models locally on your Mac or any server on your network. Free and private — no API key required.")
-            }
-
-            // Cloud Section
-            Section("Cloud") {
-                ForEach(AIProvider.cloudProviders) { provider in
-                    NavigationLink(value: provider) {
-                        HStack(spacing: 12) {
-                            if let iconName = provider.iconName {
-                                Image(iconName)
-                                    .resizable()
-                                    .scaledToFit()
-                                    .frame(width: 28, height: 28)
-                            }
-
-                            Text(provider.displayName)
-
-                            Spacer()
-
-                            if !appState.aiService.connectedProviders.contains(provider) {
-                                HStack(spacing: 4) {
-                                    Image(systemName: "exclamationmark.triangle.fill")
-                                        .foregroundStyle(.orange)
-                                    Text("Add API Key")
-                                        .font(.subheadline)
-                                        .foregroundStyle(.secondary)
-                                }
                             }
                         }
                     }

--- a/VivaDicta/Views/SettingsScreen/AIProvidersView.swift
+++ b/VivaDicta/Views/SettingsScreen/AIProvidersView.swift
@@ -56,7 +56,26 @@ struct AIProviders: View {
 
                             Spacer()
 
-                            if !appState.aiService.connectedProviders.contains(provider) {
+                            // Ollama has special status display
+                            if provider == .ollama {
+                                if appState.aiService.ollamaModels.isEmpty {
+                                    HStack(spacing: 4) {
+                                        Image(systemName: "gear")
+                                            .foregroundStyle(.blue)
+                                        Text("Configure")
+                                            .font(.subheadline)
+                                            .foregroundStyle(.secondary)
+                                    }
+                                } else {
+                                    HStack(spacing: 4) {
+                                        Image(systemName: "checkmark.circle.fill")
+                                            .foregroundStyle(.green)
+                                        Text("\(appState.aiService.ollamaModels.count) models")
+                                            .font(.subheadline)
+                                            .foregroundStyle(.secondary)
+                                    }
+                                }
+                            } else if !appState.aiService.connectedProviders.contains(provider) {
                                 HStack(spacing: 4) {
                                     Image(systemName: "exclamationmark.triangle.fill")
                                         .foregroundStyle(.orange)
@@ -64,38 +83,6 @@ struct AIProviders: View {
                                         .font(.subheadline)
                                         .foregroundStyle(.secondary)
                                 }
-                            }
-                        }
-                    }
-                }
-
-                // Ollama (Local Server) - at bottom of Cloud section
-                NavigationLink(value: AIProvider.ollama) {
-                    HStack(spacing: 12) {
-                        Image("ollama")
-                            .resizable()
-                            .scaledToFit()
-                            .frame(width: 28, height: 28)
-
-                        Text(AIProvider.ollama.displayName)
-
-                        Spacer()
-
-                        if appState.aiService.ollamaModels.isEmpty {
-                            HStack(spacing: 4) {
-                                Image(systemName: "gear")
-                                    .foregroundStyle(.blue)
-                                Text("Configure")
-                                    .font(.subheadline)
-                                    .foregroundStyle(.secondary)
-                            }
-                        } else {
-                            HStack(spacing: 4) {
-                                Image(systemName: "checkmark.circle.fill")
-                                    .foregroundStyle(.green)
-                                Text("\(appState.aiService.ollamaModels.count) models")
-                                    .font(.subheadline)
-                                    .foregroundStyle(.secondary)
                             }
                         }
                     }

--- a/VivaDicta/Views/SettingsScreen/AIProvidersView.swift
+++ b/VivaDicta/Views/SettingsScreen/AIProvidersView.swift
@@ -72,9 +72,9 @@ struct AIProviders: View {
                 // Ollama (Local Server) - at bottom of Cloud section
                 NavigationLink(value: AIProvider.ollama) {
                     HStack(spacing: 12) {
-                        Image(systemName: "desktopcomputer")
-                            .font(.title2)
-                            .foregroundStyle(.primary)
+                        Image("ollama")
+                            .resizable()
+                            .scaledToFit()
                             .frame(width: 28, height: 28)
 
                         Text(AIProvider.ollama.displayName)

--- a/VivaDicta/Views/SettingsScreen/AIProvidersView.swift
+++ b/VivaDicta/Views/SettingsScreen/AIProvidersView.swift
@@ -12,6 +12,7 @@ struct AIProviders: View {
 
     var body: some View {
         List {
+            // On-Device Section (Apple Foundation Model)
             if AppleFoundationModelAvailability.isAvailable {
                 Section {
                     HStack(spacing: 12) {
@@ -39,6 +40,45 @@ struct AIProviders: View {
                 }
             }
 
+            // Local Server Section (Ollama)
+            Section {
+                NavigationLink(value: AIProvider.ollama) {
+                    HStack(spacing: 12) {
+                        Image(systemName: "desktopcomputer")
+                            .font(.title2)
+                            .foregroundStyle(.primary)
+                            .frame(width: 28, height: 28)
+
+                        Text(AIProvider.ollama.displayName)
+
+                        Spacer()
+
+                        if appState.aiService.ollamaModels.isEmpty {
+                            HStack(spacing: 4) {
+                                Image(systemName: "gear")
+                                    .foregroundStyle(.blue)
+                                Text("Configure")
+                                    .font(.subheadline)
+                                    .foregroundStyle(.secondary)
+                            }
+                        } else {
+                            HStack(spacing: 4) {
+                                Image(systemName: "checkmark.circle.fill")
+                                    .foregroundStyle(.green)
+                                Text("\(appState.aiService.ollamaModels.count) models")
+                                    .font(.subheadline)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                }
+            } header: {
+                Text("Local Server")
+            } footer: {
+                Text("Ollama runs AI models locally on your Mac or any server on your network. Free and private — no API key required.")
+            }
+
+            // Cloud Section
             Section("Cloud") {
                 ForEach(AIProvider.cloudProviders) { provider in
                     NavigationLink(value: provider) {
@@ -71,11 +111,15 @@ struct AIProviders: View {
         .navigationTitle("AI Providers")
         .navigationBarTitleDisplayMode(.large)
         .navigationDestination(for: AIProvider.self) { provider in
-            AddAPIKeyView(
-                provider: provider,
-                aiService: appState.aiService,
-                onSave: { _ in }
-            )
+            if provider == .ollama {
+                OllamaConfigurationView(aiService: appState.aiService)
+            } else {
+                AddAPIKeyView(
+                    provider: provider,
+                    aiService: appState.aiService,
+                    onSave: { _ in }
+                )
+            }
         }
     }
 }

--- a/VivaDicta/Views/SettingsScreen/ModeEditView.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditView.swift
@@ -258,7 +258,12 @@ struct ModeEditView: View {
                                     } else {
                                         HStack(spacing: 4) {
                                             Text(provider.displayName)
-                                            Image(systemName: "key.slash.fill")
+                                            // Ollama doesn't need API key, show gear instead
+                                            if provider == .ollama {
+                                                Image(systemName: "gear")
+                                            } else {
+                                                Image(systemName: "key.slash.fill")
+                                            }
                                         }
                                         .tag(provider)
                                     }
@@ -359,6 +364,22 @@ struct ModeEditView: View {
                                             .foregroundStyle(.orange)
                                         Text(viewModel.appleFoundationModelStatusMessage)
                                             .font(.callout)
+                                    }
+                                    .alignmentGuide(.listRowSeparatorLeading) { _ in 0 }
+                                } else if provider == .ollama {
+                                    // Ollama needs configuration
+                                    NavigationLink {
+                                        OllamaConfigurationView(aiService: viewModel.aiService)
+                                    } label: {
+                                        HStack {
+                                            Image(systemName: "exclamationmark.triangle.fill")
+                                                .foregroundStyle(.orange)
+                                            Text("Configure Ollama")
+                                            Spacer()
+                                            Text("Required")
+                                                .font(.caption)
+                                                .foregroundStyle(.secondary)
+                                        }
                                     }
                                     .alignmentGuide(.listRowSeparatorLeading) { _ in 0 }
                                 } else {

--- a/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
@@ -82,6 +82,9 @@ class ModeEditViewModel {
             if provider == .apple {
                 return "Apple Intelligence is not available on this device"
             }
+            if provider == .ollama {
+                return "Configure Ollama server in AI Providers settings"
+            }
             return "Add API key to continue"
         }
         if aiModel == nil || aiModel!.isEmpty {
@@ -317,8 +320,13 @@ class ModeEditViewModel {
 
     /// Returns whether the provider is ready to use
     /// For Apple: available on device
+    /// For Ollama: has models available (server configured and accessible)
     /// For cloud providers: API key is configured
     func isProviderReady(_ provider: AIProvider) -> Bool {
+        if provider == .ollama {
+            // Ollama is ready only if models are available
+            return !aiService.ollamaModels.isEmpty
+        }
         return aiService.connectedProviders.contains(provider)
     }
 

--- a/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
@@ -294,15 +294,43 @@ class ModeEditViewModel {
 
         if let provider = providerToSelect {
             aiProvider = provider
-            aiModel = provider.defaultModel
+
+            // For Ollama, select first available model if default isn't available
+            if provider == .ollama {
+                let availableModels = aiService.ollamaModels
+                if availableModels.contains(provider.defaultModel) {
+                    aiModel = provider.defaultModel
+                } else if let firstModel = availableModels.first {
+                    aiModel = firstModel
+                } else {
+                    aiModel = provider.defaultModel
+                }
+            } else {
+                aiModel = provider.defaultModel
+            }
+
             logger.logInfo("Auto-selected provider: \(provider.rawValue)")
         }
     }
 
     func updateProvider(_ newProvider: AIProvider?) {
         aiProvider = newProvider
-        aiModel = newProvider?.defaultModel
-        logger.logInfo("Updated provider to: \(newProvider?.rawValue ?? "none")")
+
+        // For Ollama, select first available model if default isn't available
+        if let provider = newProvider, provider == .ollama {
+            let availableModels = aiService.ollamaModels
+            if availableModels.contains(provider.defaultModel) {
+                aiModel = provider.defaultModel
+            } else if let firstModel = availableModels.first {
+                aiModel = firstModel
+            } else {
+                aiModel = provider.defaultModel
+            }
+        } else {
+            aiModel = newProvider?.defaultModel
+        }
+
+        logger.logInfo("Updated provider to: \(newProvider?.rawValue ?? "none"), model: \(aiModel ?? "none")")
     }
 
     func updateModel(_ newModel: String?) {

--- a/VivaDicta/Views/SettingsScreen/OllamaConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/OllamaConfigurationView.swift
@@ -20,6 +20,7 @@ struct OllamaConfigurationView: View {
         case checking
         case connected(modelCount: Int)
         case failed(message: String)
+        case invalidURL
     }
 
     var body: some View {
@@ -54,8 +55,15 @@ struct OllamaConfigurationView: View {
                             .stroke(connectionStatus.borderColor, lineWidth: connectionStatus.borderWidth)
                     }
                     .onChange(of: serverURL) { _, newValue in
-                        connectionStatus = .unknown
-                        aiService.ollamaServerURL = newValue.isEmpty ? AIProvider.ollamaDefaultServerURL : newValue
+                        if newValue.isEmpty {
+                            connectionStatus = .unknown
+                            aiService.ollamaServerURL = AIProvider.ollamaDefaultServerURL
+                        } else if isValidOllamaURL(newValue) {
+                            connectionStatus = .unknown
+                            aiService.ollamaServerURL = newValue
+                        } else {
+                            connectionStatus = .invalidURL
+                        }
                     }
             }
             .padding(.horizontal)
@@ -67,6 +75,7 @@ struct OllamaConfigurationView: View {
             // Test Connection button
             if #available(iOS 26.0, *) {
                 Button {
+                    isChecking = true
                     Task {
                         await checkConnection()
                     }
@@ -80,13 +89,14 @@ struct OllamaConfigurationView: View {
                             .font(.headline.weight(.medium))
                     }
                 }
-                .disabled(isChecking)
+                .disabled(isChecking || connectionStatus == .invalidURL)
                 .padding(.vertical, 8)
                 .padding(.horizontal, 16)
                 .glassEffect(.regular.tint(.blue.opacity(0.3)).interactive())
                 .buttonStyle(.plain)
             } else {
                 Button {
+                    isChecking = true
                     Task {
                         await checkConnection()
                     }
@@ -107,7 +117,7 @@ struct OllamaConfigurationView: View {
                             .stroke(.blue, lineWidth: 2)
                     }
                 }
-                .disabled(isChecking)
+                .disabled(isChecking || connectionStatus == .invalidURL)
                 .buttonStyle(.plain)
             }
 
@@ -162,6 +172,7 @@ struct OllamaConfigurationView: View {
         .onAppear {
             serverURL = aiService.ollamaServerURL
             // Auto-check connection on appear
+            isChecking = true
             Task {
                 await checkConnection()
             }
@@ -203,12 +214,36 @@ struct OllamaConfigurationView: View {
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.leading)
             }
+
+        case .invalidURL:
+            HStack {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                    .accessibilityLabel("Invalid URL")
+                Text("Invalid URL. Use http:// or https://")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
         }
     }
 
+    private func isValidOllamaURL(_ urlString: String) -> Bool {
+        guard let url = URL(string: urlString),
+              let scheme = url.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              url.host != nil else {
+            return false
+        }
+        return true
+    }
+
     private func checkConnection() async {
+        guard connectionStatus != .invalidURL else {
+            isChecking = false
+            return
+        }
+
         connectionStatus = .checking
-        isChecking = true
 
         HapticManager.lightImpact()
 
@@ -236,6 +271,8 @@ extension OllamaConfigurationView.ConnectionStatus {
             return .green
         case .failed:
             return .red
+        case .invalidURL:
+            return .orange
         }
     }
 
@@ -243,7 +280,7 @@ extension OllamaConfigurationView.ConnectionStatus {
         switch self {
         case .unknown:
             return 0.5
-        case .checking, .connected, .failed:
+        case .checking, .connected, .failed, .invalidURL:
             return 1.5
         }
     }

--- a/VivaDicta/Views/SettingsScreen/OllamaConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/OllamaConfigurationView.swift
@@ -1,0 +1,244 @@
+//
+//  OllamaConfigurationView.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.01.16
+//
+
+import SwiftUI
+
+struct OllamaConfigurationView: View {
+    @Environment(\.dismiss) private var dismiss
+    let aiService: AIService
+
+    @State private var serverURL: String = ""
+    @State private var isChecking = false
+    @State private var connectionStatus: ConnectionStatus = .unknown
+
+    enum ConnectionStatus: Equatable {
+        case unknown
+        case checking
+        case connected(modelCount: Int)
+        case failed(message: String)
+    }
+
+    var body: some View {
+        VStack(spacing: 16) {
+            // Icon
+            Image(systemName: "desktopcomputer")
+                .font(.system(size: 48))
+                .foregroundStyle(.primary)
+                .padding(.top, 8)
+
+            Text("Ollama")
+                .font(.title2)
+
+            Text("Local AI Server")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            // Server URL input
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Server URL")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                TextField("http://localhost:11434", text: $serverURL)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .keyboardType(.URL)
+                    .padding()
+                    .background {
+                        Capsule()
+                            .stroke(connectionStatus.borderColor, lineWidth: connectionStatus.borderWidth)
+                    }
+                    .onChange(of: serverURL) { _, newValue in
+                        connectionStatus = .unknown
+                        aiService.ollamaServerURL = newValue.isEmpty ? AIProvider.ollamaDefaultServerURL : newValue
+                    }
+            }
+            .padding(.horizontal)
+
+            // Connection status
+            connectionStatusView
+                .padding(.horizontal)
+
+            // Test Connection button
+            if #available(iOS 26.0, *) {
+                Button {
+                    Task {
+                        await checkConnection()
+                    }
+                } label: {
+                    HStack {
+                        if case .checking = connectionStatus {
+                            ProgressView()
+                                .controlSize(.small)
+                        }
+                        Text(connectionStatus == .checking ? "Checking..." : "Test Connection")
+                            .font(.headline.weight(.medium))
+                    }
+                }
+                .disabled(isChecking)
+                .padding(.vertical, 8)
+                .padding(.horizontal, 16)
+                .glassEffect(.regular.tint(.blue.opacity(0.3)).interactive())
+                .buttonStyle(.plain)
+            } else {
+                Button {
+                    Task {
+                        await checkConnection()
+                    }
+                } label: {
+                    HStack {
+                        if case .checking = connectionStatus {
+                            ProgressView()
+                                .controlSize(.small)
+                        }
+                        Text(connectionStatus == .checking ? "Checking..." : "Test Connection")
+                            .font(.headline.weight(.medium))
+                            .foregroundStyle(.primary)
+                    }
+                    .padding(.vertical, 8)
+                    .padding(.horizontal, 16)
+                    .background {
+                        Capsule()
+                            .stroke(.blue, lineWidth: 2)
+                    }
+                }
+                .disabled(isChecking)
+                .buttonStyle(.plain)
+            }
+
+            // Models list (if connected)
+            if case .connected = connectionStatus, !aiService.ollamaModels.isEmpty {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Available Models")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal)
+
+                    ScrollView {
+                        LazyVStack(alignment: .leading, spacing: 4) {
+                            ForEach(aiService.ollamaModels, id: \.self) { model in
+                                Text(model)
+                                    .font(.system(.body, design: .monospaced))
+                                    .padding(.horizontal)
+                                    .padding(.vertical, 4)
+                            }
+                        }
+                    }
+                    .frame(maxHeight: 200)
+                }
+            }
+
+            Spacer()
+
+            // Help text
+            VStack(spacing: 8) {
+                Text("Ollama runs AI models locally on your Mac or server.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+
+                Link("Get Ollama →", destination: URL(string: "https://ollama.com")!)
+                    .font(.caption)
+            }
+            .padding(.bottom)
+        }
+        .padding()
+        .navigationTitle("Ollama")
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            serverURL = aiService.ollamaServerURL
+            // Auto-check connection on appear
+            Task {
+                await checkConnection()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var connectionStatusView: some View {
+        switch connectionStatus {
+        case .unknown:
+            EmptyView()
+
+        case .checking:
+            HStack {
+                ProgressView()
+                    .controlSize(.small)
+                Text("Checking connection...")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+        case .connected(let modelCount):
+            HStack {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+                Text("Connected • \(modelCount) model\(modelCount == 1 ? "" : "s") available")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+        case .failed(let message):
+            HStack(alignment: .top) {
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundStyle(.red)
+                Text(message)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.leading)
+            }
+        }
+    }
+
+    private func checkConnection() async {
+        connectionStatus = .checking
+        isChecking = true
+
+        HapticManager.lightImpact()
+
+        let result = await aiService.verifyOllamaSetup()
+
+        await MainActor.run {
+            if result.success {
+                connectionStatus = .connected(modelCount: aiService.ollamaModels.count)
+                HapticManager.success()
+            } else {
+                connectionStatus = .failed(message: result.message)
+                HapticManager.error()
+            }
+            isChecking = false
+        }
+    }
+}
+
+extension OllamaConfigurationView.ConnectionStatus {
+    var borderColor: Color {
+        switch self {
+        case .unknown, .checking:
+            return .gray
+        case .connected:
+            return .green
+        case .failed:
+            return .red
+        }
+    }
+
+    var borderWidth: CGFloat {
+        switch self {
+        case .unknown:
+            return 0.5
+        case .checking, .connected, .failed:
+            return 1.5
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        OllamaConfigurationView(aiService: AIService())
+    }
+}

--- a/VivaDicta/Views/SettingsScreen/OllamaConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/OllamaConfigurationView.swift
@@ -142,6 +142,11 @@ struct OllamaConfigurationView: View {
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
 
+                Text("Tip: To connect from iPhone, run Ollama with:\nOLLAMA_HOST=0.0.0.0:11434 ollama serve")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+
                 Link("Get Ollama →", destination: URL(string: "https://ollama.com")!)
                     .font(.caption)
             }
@@ -182,6 +187,7 @@ struct OllamaConfigurationView: View {
             HStack {
                 Image(systemName: "checkmark.circle.fill")
                     .foregroundStyle(.green)
+                    .accessibilityLabel("Connection successful")
                 Text("Connected • \(modelCount) model\(modelCount == 1 ? "" : "s") available")
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
@@ -191,6 +197,7 @@ struct OllamaConfigurationView: View {
             HStack(alignment: .top) {
                 Image(systemName: "xmark.circle.fill")
                     .foregroundStyle(.red)
+                    .accessibilityLabel("Connection failed")
                 Text(message)
                     .font(.subheadline)
                     .foregroundStyle(.secondary)

--- a/VivaDicta/Views/SettingsScreen/OllamaConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/OllamaConfigurationView.swift
@@ -25,9 +25,10 @@ struct OllamaConfigurationView: View {
     var body: some View {
         VStack(spacing: 16) {
             // Icon
-            Image(systemName: "desktopcomputer")
-                .font(.system(size: 48))
-                .foregroundStyle(.primary)
+            Image("ollama")
+                .resizable()
+                .scaledToFit()
+                .frame(width: 64, height: 64)
                 .padding(.top, 8)
 
             Text("Ollama")

--- a/VivaDicta/Views/SettingsScreen/OllamaConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/OllamaConfigurationView.swift
@@ -147,6 +147,10 @@ struct OllamaConfigurationView: View {
             .padding(.bottom)
         }
         .padding()
+        .contentShape(Rectangle())
+        .onTapGesture {
+            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+        }
         .navigationTitle("Ollama")
         .navigationBarTitleDisplayMode(.inline)
         .onAppear {


### PR DESCRIPTION
## Summary
- Adds Ollama as a new AI provider for text enhancement, enabling local LLM inference
- Creates OllamaConfigurationView for server URL configuration and connection testing
- Integrates Ollama into AI provider picker in mode editing
- Uses OpenAI-compatible API endpoint (`/v1/chat/completions`) for flexibility

## Changes
- **AIProvider.swift**: Added `.ollama` case with display name, icon, and properties
- **AIService.swift**: Added Ollama model fetching, connection verification, and enhancement request methods
- **OllamaConfigurationView.swift**: New view for configuring Ollama server URL, testing connection, and displaying available models
- **AIProvidersView.swift**: Added Ollama to cloud providers section with status display
- **ModeEditView.swift**: Added Ollama to AI provider picker with configuration link
- **ModeEditViewModel.swift**: Added Ollama validation and smart model selection (falls back to first available model if default not found)
- **Info.plist**: Added ATS exceptions for localhost HTTP connections
- **UserDefaultsStorage.swift**: Added storage keys for Ollama models and server URL

## Test plan
- [x] Verified Ollama connection works on iOS Simulator
- [x] Verified Ollama connection works on real iPhone (requires `OLLAMA_HOST=0.0.0.0:11434` on Mac)
- [x] Tested model fetching and display
- [x] Tested AI enhancement with Ollama provider
- [x] Verified model picker selects first available model when default is not installed