### PR TITLE
Add custom AI provider for OpenAI-compatible endpoints

### DIFF
--- a/VivaDicta/Services/AIEnhance/AIProvider.swift
+++ b/VivaDicta/Services/AIEnhance/AIProvider.swift
@@ -25,6 +25,7 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
     case vercelAIGateway
     case huggingFace
     case ollama
+    case customOpenAI
 
     var displayName: String {
         switch self {
@@ -58,6 +59,8 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
             "HuggingFace"
         case .ollama:
             "Ollama"
+        case .customOpenAI:
+            "Custom OpenAI"
         }
     }
 
@@ -94,21 +97,24 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
             "huggingface-color"
         case .ollama:
             "ollama"
+        case .customOpenAI:
+            nil // Use SF Symbol "server.rack" directly in view
         }
     }
 
     /// Returns true if this provider uses an SF Symbol instead of an asset
     var usesSFSymbol: Bool {
-        self == .apple
+        self == .apple || self == .customOpenAI
     }
 
     /// Returns true if this provider requires an API key
+    /// Note: customOpenAI doesn't require API key through the standard flow - it's handled separately
     var requiresAPIKey: Bool {
-        self != .apple && self != .ollama
+        self != .apple && self != .ollama && self != .customOpenAI
     }
 
     /// Cloud-based AI providers (require API key, network connection)
-    /// Note: Ollama is included here for UI purposes but doesn't require API key
+    /// Note: Ollama and customOpenAI are included here for UI purposes but don't require API key through standard flow
     static let cloudProviders: [AIProvider] = [
         .anthropic,
         .openAI,
@@ -120,7 +126,8 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
         .openRouter,
         .vercelAIGateway,
         .huggingFace,
-        .ollama]
+        .ollama,
+        .customOpenAI]
 
     /// Local AI providers that run on-device or local network (no API key needed)
     static let localProviders: [AIProvider] = [
@@ -131,6 +138,7 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
     static let generalProviders: [AIProvider] = [
         .apple,
         .ollama,
+        .customOpenAI,
         .anthropic,
         .openAI,
         .gemini,
@@ -174,6 +182,8 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
             return "https://router.huggingface.co/v1/chat/completions"
         case .ollama:
             return "" // URL is configurable, stored in UserDefaults
+        case .customOpenAI:
+            return "" // URL is configurable, stored in UserDefaults
         }
     }
 
@@ -216,6 +226,8 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
             return "openai/gpt-oss-120b"
         case .ollama:
             return "llama3.2"
+        case .customOpenAI:
+            return "" // Model is configurable, stored in UserDefaults
         }
     }
 
@@ -296,6 +308,8 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
             return []
         case .ollama:
             return [] // Models are fetched dynamically from Ollama server
+        case .customOpenAI:
+            return [] // Model is configured by user
         }
     }
 }

--- a/VivaDicta/Services/AIEnhance/AIProvider.swift
+++ b/VivaDicta/Services/AIEnhance/AIProvider.swift
@@ -60,7 +60,7 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
         case .ollama:
             "Ollama"
         case .customOpenAI:
-            "Custom OpenAI"
+            "Custom"
         }
     }
 

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -32,23 +32,19 @@ class AIService {
     }
 
     /// Custom OpenAI endpoint URL (configurable)
-    public var customOpenAIEndpointURL: String {
-        get {
-            userDefaults.string(forKey: UserDefaultsStorage.Keys.customOpenAIEndpointURL) ?? ""
-        }
-        set {
-            userDefaults.set(newValue, forKey: UserDefaultsStorage.Keys.customOpenAIEndpointURL)
+    /// Stored property so @Observable can track changes for UI updates
+    public var customOpenAIEndpointURL: String = "" {
+        didSet {
+            userDefaults.set(customOpenAIEndpointURL, forKey: UserDefaultsStorage.Keys.customOpenAIEndpointURL)
             userDefaults.synchronize()
         }
     }
 
     /// Custom OpenAI model name (configurable)
-    public var customOpenAIModelName: String {
-        get {
-            userDefaults.string(forKey: UserDefaultsStorage.Keys.customOpenAIModelName) ?? ""
-        }
-        set {
-            userDefaults.set(newValue, forKey: UserDefaultsStorage.Keys.customOpenAIModelName)
+    /// Stored property so @Observable can track changes for UI updates
+    public var customOpenAIModelName: String = "" {
+        didSet {
+            userDefaults.set(customOpenAIModelName, forKey: UserDefaultsStorage.Keys.customOpenAIModelName)
             userDefaults.synchronize()
         }
     }
@@ -86,6 +82,11 @@ class AIService {
 
     init() {
         self.selectedModeName = userDefaults.string(forKey: AppGroupCoordinator.selectedVivaModeKey) ?? VivaMode.defaultMode.name
+
+        // Load Custom OpenAI configuration from UserDefaults
+        self.customOpenAIEndpointURL = userDefaults.string(forKey: UserDefaultsStorage.Keys.customOpenAIEndpointURL) ?? ""
+        self.customOpenAIModelName = userDefaults.string(forKey: UserDefaultsStorage.Keys.customOpenAIModelName) ?? ""
+
         loadModes()
         self.selectedMode = getMode(name: selectedModeName)
         loadSavedOpenRouterModels()

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -31,6 +31,28 @@ class AIService {
         }
     }
 
+    /// Custom OpenAI endpoint URL (configurable)
+    public var customOpenAIEndpointURL: String {
+        get {
+            userDefaults.string(forKey: UserDefaultsStorage.Keys.customOpenAIEndpointURL) ?? ""
+        }
+        set {
+            userDefaults.set(newValue, forKey: UserDefaultsStorage.Keys.customOpenAIEndpointURL)
+            userDefaults.synchronize()
+        }
+    }
+
+    /// Custom OpenAI model name (configurable)
+    public var customOpenAIModelName: String {
+        get {
+            userDefaults.string(forKey: UserDefaultsStorage.Keys.customOpenAIModelName) ?? ""
+        }
+        set {
+            userDefaults.set(newValue, forKey: UserDefaultsStorage.Keys.customOpenAIModelName)
+            userDefaults.synchronize()
+        }
+    }
+
     public var onModeChange: ((VivaMode) -> Void)?
 
     public var selectedModeName: String {
@@ -453,6 +475,16 @@ class AIService {
                 logger.logWarning("No Ollama model selected")
                 return false
             }
+        } else if aiProvider == .customOpenAI {
+            // Custom OpenAI needs URL and model configured
+            guard !customOpenAIEndpointURL.isEmpty else {
+                logger.logWarning("Custom OpenAI endpoint URL not configured")
+                return false
+            }
+            guard !customOpenAIModelName.isEmpty else {
+                logger.logWarning("Custom OpenAI model name not configured")
+                return false
+            }
         } else {
             // Check if API key exists for the selected cloud provider
             guard getAPIKey(for: aiProvider) != nil else {
@@ -550,6 +582,11 @@ class AIService {
         // Handle Ollama (local server)
         if aiProvider == .ollama {
             return try await makeOllamaRequest(text: text)
+        }
+
+        // Handle Custom OpenAI (user-configured endpoint)
+        if aiProvider == .customOpenAI {
+            return try await makeCustomOpenAIRequest(text: text)
         }
 
         // Cloud providers - compute system message only when needed
@@ -965,6 +1002,355 @@ class AIService {
         return (true, "Connected successfully. Found \(ollamaModels.count) model(s).")
     }
 
+    // MARK: - Custom OpenAI Methods
+
+    /// Makes an enhancement request to the custom OpenAI-compatible endpoint
+    private func makeCustomOpenAIRequest(text: String) async throws -> String {
+        let endpointURL = customOpenAIEndpointURL
+        let modelName = customOpenAIModelName
+
+        guard !endpointURL.isEmpty else {
+            throw EnhancementError.customError("Custom OpenAI endpoint URL is not configured")
+        }
+
+        guard !modelName.isEmpty else {
+            throw EnhancementError.customError("Custom OpenAI model name is not configured")
+        }
+
+        // Build the chat completions URL
+        let chatCompletionsURL: String
+        if endpointURL.hasSuffix("/chat/completions") {
+            chatCompletionsURL = endpointURL
+        } else if endpointURL.hasSuffix("/v1") {
+            chatCompletionsURL = endpointURL + "/chat/completions"
+        } else if endpointURL.hasSuffix("/") {
+            chatCompletionsURL = endpointURL + "v1/chat/completions"
+        } else {
+            chatCompletionsURL = endpointURL + "/v1/chat/completions"
+        }
+
+        guard let url = URL(string: chatCompletionsURL) else {
+            throw EnhancementError.customError("Invalid Custom OpenAI endpoint URL: \(endpointURL)")
+        }
+
+        let systemMessage = getSystemMessage()
+        let formattedText = "\n<TRANSCRIPT>\n\(text)\n</TRANSCRIPT>"
+
+        logger.logNotice("AI Enhancement - Using Custom OpenAI at \(endpointURL)")
+        logger.logNotice("AI Enhancement - Model: \(modelName)")
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        // Add API key if configured
+        let apiKey = getAPIKey(for: .customOpenAI)
+        if let apiKey, !apiKey.isEmpty {
+            request.addValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        }
+
+        request.timeoutInterval = 120 // Longer timeout for potentially slow endpoints
+
+        let requestBody: [String: Any] = [
+            "model": modelName,
+            "messages": [
+                ["role": "system", "content": systemMessage],
+                ["role": "user", "content": formattedText]
+            ],
+            "temperature": 0.3,
+            "stream": false
+        ]
+
+        request.httpBody = try? JSONSerialization.data(withJSONObject: requestBody)
+
+        do {
+            try Task.checkCancellation()
+
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            try Task.checkCancellation()
+
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw EnhancementError.invalidResponse
+            }
+
+            switch httpResponse.statusCode {
+            case 200:
+                guard let jsonResponse = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                      let choices = jsonResponse["choices"] as? [[String: Any]],
+                      let firstChoice = choices.first,
+                      let message = firstChoice["message"] as? [String: Any],
+                      let enhancedText = message["content"] as? String else {
+                    throw EnhancementError.enhancementFailed
+                }
+
+                let filteredText = AIEnhancementOutputFilter.filter(enhancedText.trimmingCharacters(in: .whitespacesAndNewlines))
+                return filteredText
+
+            case 401:
+                throw EnhancementError.customError("Authentication failed. Check your API key.")
+
+            case 404:
+                throw EnhancementError.customError("Model '\(modelName)' not found on the server.")
+
+            case 500...599:
+                throw EnhancementError.serverError
+
+            default:
+                let errorString = String(data: data, encoding: .utf8) ?? "Unknown error"
+                throw EnhancementError.customError("Custom OpenAI error (HTTP \(httpResponse.statusCode)): \(errorString)")
+            }
+
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch let error as EnhancementError {
+            throw error
+        } catch let error as URLError {
+            if error.code == .cannotConnectToHost || error.code == .timedOut {
+                throw EnhancementError.customError("Cannot connect to \(endpointURL). Check the URL and try again.")
+            }
+            throw error
+        } catch {
+            throw EnhancementError.customError(error.localizedDescription)
+        }
+    }
+
+    /// Checks if Custom OpenAI endpoint is reachable by making a minimal chat completions request
+    public func checkCustomOpenAIConnection() async -> Bool {
+        let endpointURL = customOpenAIEndpointURL
+        let modelName = customOpenAIModelName
+
+        guard !endpointURL.isEmpty, !modelName.isEmpty else {
+            return false
+        }
+
+        // Build the chat completions URL (same logic as makeCustomOpenAIRequest)
+        let chatCompletionsURL: String
+        if endpointURL.hasSuffix("/chat/completions") {
+            chatCompletionsURL = endpointURL
+        } else if endpointURL.hasSuffix("/v1") {
+            chatCompletionsURL = endpointURL + "/chat/completions"
+        } else if endpointURL.hasSuffix("/") {
+            chatCompletionsURL = endpointURL + "v1/chat/completions"
+        } else {
+            chatCompletionsURL = endpointURL + "/v1/chat/completions"
+        }
+
+        guard let url = URL(string: chatCompletionsURL) else {
+            return false
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 10
+
+        // Add API key if configured
+        let apiKey = getAPIKey(for: .customOpenAI)
+        if let apiKey, !apiKey.isEmpty {
+            request.addValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        }
+
+        // Minimal test request - just a short message to verify the endpoint works
+        let testBody: [String: Any] = [
+            "model": modelName,
+            "messages": [
+                ["role": "user", "content": "test"]
+            ],
+            "max_tokens": 1
+        ]
+
+        request.httpBody = try? JSONSerialization.data(withJSONObject: testBody)
+
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                return false
+            }
+            // 200 = success, 401 = auth issue (server reachable), 400 = bad request but server reachable
+            return httpResponse.statusCode == 200 || httpResponse.statusCode == 401 || httpResponse.statusCode == 400
+        } catch {
+            return false
+        }
+    }
+
+    /// Verifies Custom OpenAI setup and returns status message
+    public func verifyCustomOpenAISetup() async -> (success: Bool, message: String) {
+        let endpointURL = customOpenAIEndpointURL
+        let modelName = customOpenAIModelName
+
+        // Check URL is configured
+        guard !endpointURL.isEmpty else {
+            return (false, "Endpoint URL is not configured")
+        }
+
+        // Validate URL format
+        guard URL(string: endpointURL) != nil else {
+            return (false, "Invalid endpoint URL format")
+        }
+
+        // Check model name is configured
+        guard !modelName.isEmpty else {
+            return (false, "Model name is not configured")
+        }
+
+        // Test connection with a minimal chat completions request
+        return await testCustomOpenAIEndpoint()
+    }
+
+    /// Tests the Custom OpenAI endpoint with a minimal request and returns detailed status
+    private func testCustomOpenAIEndpoint() async -> (success: Bool, message: String) {
+        let endpointURL = customOpenAIEndpointURL
+        let modelName = customOpenAIModelName
+
+        logger.logNotice("🔧 Custom OpenAI Test - Input URL: '\(endpointURL)'")
+        logger.logNotice("🔧 Custom OpenAI Test - Model: '\(modelName)'")
+
+        // Use the endpoint URL directly - user should provide the full chat/completions URL
+        // This matches VoiceInk's approach where baseURL is used directly
+        let chatCompletionsURL: String
+        if endpointURL.contains("/chat/completions") {
+            // User provided full URL, use as-is
+            chatCompletionsURL = endpointURL
+            logger.logNotice("🔧 Custom OpenAI Test - Using URL as-is (contains /chat/completions)")
+        } else if endpointURL.hasSuffix("/v1") {
+            chatCompletionsURL = endpointURL + "/chat/completions"
+            logger.logNotice("🔧 Custom OpenAI Test - Appending /chat/completions to /v1 URL")
+        } else if endpointURL.hasSuffix("/") {
+            chatCompletionsURL = endpointURL + "v1/chat/completions"
+            logger.logNotice("🔧 Custom OpenAI Test - Appending v1/chat/completions to URL ending with /")
+        } else {
+            chatCompletionsURL = endpointURL + "/v1/chat/completions"
+            logger.logNotice("🔧 Custom OpenAI Test - Appending /v1/chat/completions to URL")
+        }
+
+        logger.logNotice("🔧 Custom OpenAI Test - Final URL: '\(chatCompletionsURL)'")
+
+        guard let url = URL(string: chatCompletionsURL) else {
+            logger.logError("🔧 Custom OpenAI Test - Failed to create URL from: '\(chatCompletionsURL)'")
+            return (false, "Invalid endpoint URL format")
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 15
+
+        // Add API key if configured
+        let apiKey = getAPIKey(for: .customOpenAI)
+        let hasApiKey = apiKey != nil && !apiKey!.isEmpty
+        logger.logNotice("🔧 Custom OpenAI Test - API Key present: \(hasApiKey)")
+
+        if let apiKey, !apiKey.isEmpty {
+            request.addValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        }
+
+        // Minimal test request - match VoiceInk's approach (no max_tokens)
+        let testBody: [String: Any] = [
+            "model": modelName,
+            "messages": [
+                ["role": "user", "content": "test"]
+            ]
+        ]
+
+        guard let bodyData = try? JSONSerialization.data(withJSONObject: testBody) else {
+            logger.logError("🔧 Custom OpenAI Test - Failed to serialize request body")
+            return (false, "Failed to create request")
+        }
+        request.httpBody = bodyData
+
+        if let bodyString = String(data: bodyData, encoding: .utf8) {
+            logger.logNotice("🔧 Custom OpenAI Test - Request body: \(bodyString)")
+        }
+
+        do {
+            logger.logNotice("🔧 Custom OpenAI Test - Sending request...")
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            guard let httpResponse = response as? HTTPURLResponse else {
+                logger.logError("🔧 Custom OpenAI Test - Response is not HTTPURLResponse")
+                return (false, "Invalid response from server")
+            }
+
+            let responseString = String(data: data, encoding: .utf8) ?? "(unable to decode)"
+            logger.logNotice("🔧 Custom OpenAI Test - HTTP Status: \(httpResponse.statusCode)")
+            logger.logNotice("🔧 Custom OpenAI Test - Response: \(responseString.prefix(500))")
+
+            switch httpResponse.statusCode {
+            case 200:
+                logger.logNotice("🔧 Custom OpenAI Test - SUCCESS!")
+                return (true, "Connected successfully")
+            case 401:
+                logger.logError("🔧 Custom OpenAI Test - 401 Unauthorized")
+                return (false, "Authentication failed. Check your API key.")
+            case 404:
+                logger.logError("🔧 Custom OpenAI Test - 404 Not Found")
+                return (false, "Endpoint not found. Check the URL.")
+            case 400:
+                // 400 could mean various things - try to extract error message
+                logger.logError("🔧 Custom OpenAI Test - 400 Bad Request")
+                if let errorData = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                   let error = errorData["error"] as? [String: Any],
+                   let message = error["message"] as? String {
+                    logger.logError("🔧 Custom OpenAI Test - Error message: \(message)")
+                    return (false, message)
+                }
+                return (false, "Bad request: \(responseString.prefix(200))")
+            case 500...599:
+                logger.logError("🔧 Custom OpenAI Test - Server error")
+                return (false, "Server error (\(httpResponse.statusCode)). Try again later.")
+            default:
+                logger.logError("🔧 Custom OpenAI Test - Unexpected status: \(httpResponse.statusCode)")
+                return (false, "HTTP \(httpResponse.statusCode): \(responseString.prefix(200))")
+            }
+        } catch let error as URLError {
+            logger.logError("🔧 Custom OpenAI Test - URLError: \(error.code.rawValue) - \(error.localizedDescription)")
+            switch error.code {
+            case .cannotConnectToHost:
+                return (false, "Cannot connect to server. Check the URL and that the server is running.")
+            case .timedOut:
+                return (false, "Connection timed out. Server may be slow or unreachable.")
+            case .notConnectedToInternet:
+                return (false, "No internet connection.")
+            default:
+                return (false, "Connection error: \(error.localizedDescription)")
+            }
+        } catch {
+            logger.logError("🔧 Custom OpenAI Test - Error: \(error)")
+            return (false, "Error: \(error.localizedDescription)")
+        }
+    }
+
+    /// Clears Custom OpenAI configuration
+    public func clearCustomOpenAIConfiguration() {
+        customOpenAIEndpointURL = ""
+        customOpenAIModelName = ""
+        userDefaults.removeObject(forKey: AppGroupCoordinator.kAPIKeyTemplate + AIProvider.customOpenAI.rawValue)
+        userDefaults.synchronize()
+    }
+
+    /// Disables AI enhancement for all modes that use Custom OpenAI.
+    /// Called when Custom OpenAI configuration is cleared.
+    public func disableCustomOpenAIEnhancementForAllModes() {
+        updateModesMatching(
+            { $0.aiEnhanceEnabled && $0.aiProvider == .customOpenAI },
+            transform: { mode in
+                VivaMode(
+                    id: mode.id,
+                    name: mode.name,
+                    transcriptionProvider: mode.transcriptionProvider,
+                    transcriptionModel: mode.transcriptionModel,
+                    transcriptionLanguage: mode.transcriptionLanguage,
+                    userPrompt: mode.userPrompt,
+                    aiProvider: nil,
+                    aiModel: "",
+                    aiEnhanceEnabled: false
+                )
+            },
+            logMessage: { "Disabled AI enhancement for mode '\($0.name)' due to Custom OpenAI configuration removal" }
+        )
+    }
+
     // MARK: - API Keys methods
     @MainActor
     public func refreshConnectedProviders() {
@@ -977,6 +1363,11 @@ class AIService {
 
         // Add Ollama provider (always available, connection checked on-demand)
         providers.append(.ollama)
+
+        // Add Custom OpenAI provider if configured (URL and model name are set)
+        if !customOpenAIEndpointURL.isEmpty && !customOpenAIModelName.isEmpty {
+            providers.append(.customOpenAI)
+        }
 
         // Add cloud providers that have API keys configured
         providers += AIProvider.allCases.filter { provider in
@@ -1019,8 +1410,8 @@ class AIService {
     
     private func verifyAPIKey(_ key: String, provider: AIProvider) async -> Bool {
         switch provider {
-        case .apple, .ollama:
-            // Apple and Ollama don't require API key verification
+        case .apple, .ollama, .customOpenAI:
+            // Apple, Ollama, and Custom OpenAI don't require API key verification through standard flow
             return true
         case .anthropic:
             return await verifyAnthropicAPIKey(key)
@@ -1357,6 +1748,10 @@ class AIService {
         }
         if provider == .ollama {
             return ollamaModels
+        }
+        if provider == .customOpenAI {
+            // Return the configured model name as a single-item array
+            return customOpenAIModelName.isEmpty ? [] : [customOpenAIModelName]
         }
         return provider.availableModels
     }

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -1021,27 +1021,16 @@ class AIService {
         let modelName = customOpenAIModelName
 
         guard !endpointURL.isEmpty else {
-            throw EnhancementError.customError("Custom OpenAI endpoint URL is not configured")
+            throw EnhancementError.customError("Custom AI endpoint URL is not configured")
         }
 
         guard !modelName.isEmpty else {
-            throw EnhancementError.customError("Custom OpenAI model name is not configured")
+            throw EnhancementError.customError("Custom AI model name is not configured")
         }
 
-        // Build the chat completions URL
-        let chatCompletionsURL: String
-        if endpointURL.hasSuffix("/chat/completions") {
-            chatCompletionsURL = endpointURL
-        } else if endpointURL.hasSuffix("/v1") {
-            chatCompletionsURL = endpointURL + "/chat/completions"
-        } else if endpointURL.hasSuffix("/") {
-            chatCompletionsURL = endpointURL + "v1/chat/completions"
-        } else {
-            chatCompletionsURL = endpointURL + "/v1/chat/completions"
-        }
-
-        guard let url = URL(string: chatCompletionsURL) else {
-            throw EnhancementError.customError("Invalid Custom OpenAI endpoint URL: \(endpointURL)")
+        // Use URL directly - user provides the full chat/completions endpoint
+        guard let url = URL(string: endpointURL) else {
+            throw EnhancementError.customError("Invalid Custom AI endpoint URL: \(endpointURL)")
         }
 
         let systemMessage = getSystemMessage()
@@ -1126,65 +1115,6 @@ class AIService {
         }
     }
 
-    /// Checks if Custom OpenAI endpoint is reachable by making a minimal chat completions request
-    public func checkCustomOpenAIConnection() async -> Bool {
-        let endpointURL = customOpenAIEndpointURL
-        let modelName = customOpenAIModelName
-
-        guard !endpointURL.isEmpty, !modelName.isEmpty else {
-            return false
-        }
-
-        // Build the chat completions URL (same logic as makeCustomOpenAIRequest)
-        let chatCompletionsURL: String
-        if endpointURL.hasSuffix("/chat/completions") {
-            chatCompletionsURL = endpointURL
-        } else if endpointURL.hasSuffix("/v1") {
-            chatCompletionsURL = endpointURL + "/chat/completions"
-        } else if endpointURL.hasSuffix("/") {
-            chatCompletionsURL = endpointURL + "v1/chat/completions"
-        } else {
-            chatCompletionsURL = endpointURL + "/v1/chat/completions"
-        }
-
-        guard let url = URL(string: chatCompletionsURL) else {
-            return false
-        }
-
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.timeoutInterval = 10
-
-        // Add API key if configured
-        let apiKey = getAPIKey(for: .customOpenAI)
-        if let apiKey, !apiKey.isEmpty {
-            request.addValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
-        }
-
-        // Minimal test request - just a short message to verify the endpoint works
-        let testBody: [String: Any] = [
-            "model": modelName,
-            "messages": [
-                ["role": "user", "content": "test"]
-            ],
-            "max_tokens": 1
-        ]
-
-        request.httpBody = try? JSONSerialization.data(withJSONObject: testBody)
-
-        do {
-            let (_, response) = try await URLSession.shared.data(for: request)
-            guard let httpResponse = response as? HTTPURLResponse else {
-                return false
-            }
-            // 200 = success, 401 = auth issue (server reachable), 400 = bad request but server reachable
-            return httpResponse.statusCode == 200 || httpResponse.statusCode == 401 || httpResponse.statusCode == 400
-        } catch {
-            return false
-        }
-    }
-
     /// Verifies Custom OpenAI setup and returns status message
     public func verifyCustomOpenAISetup() async -> (success: Bool, message: String) {
         let endpointURL = customOpenAIEndpointURL
@@ -1214,31 +1144,12 @@ class AIService {
         let endpointURL = customOpenAIEndpointURL
         let modelName = customOpenAIModelName
 
-        logger.logNotice("🔧 Custom OpenAI Test - Input URL: '\(endpointURL)'")
-        logger.logNotice("🔧 Custom OpenAI Test - Model: '\(modelName)'")
+        logger.logNotice("🔧 Custom AI Test - URL: '\(endpointURL)'")
+        logger.logNotice("🔧 Custom AI Test - Model: '\(modelName)'")
 
-        // Use the endpoint URL directly - user should provide the full chat/completions URL
-        // This matches VoiceInk's approach where baseURL is used directly
-        let chatCompletionsURL: String
-        if endpointURL.contains("/chat/completions") {
-            // User provided full URL, use as-is
-            chatCompletionsURL = endpointURL
-            logger.logNotice("🔧 Custom OpenAI Test - Using URL as-is (contains /chat/completions)")
-        } else if endpointURL.hasSuffix("/v1") {
-            chatCompletionsURL = endpointURL + "/chat/completions"
-            logger.logNotice("🔧 Custom OpenAI Test - Appending /chat/completions to /v1 URL")
-        } else if endpointURL.hasSuffix("/") {
-            chatCompletionsURL = endpointURL + "v1/chat/completions"
-            logger.logNotice("🔧 Custom OpenAI Test - Appending v1/chat/completions to URL ending with /")
-        } else {
-            chatCompletionsURL = endpointURL + "/v1/chat/completions"
-            logger.logNotice("🔧 Custom OpenAI Test - Appending /v1/chat/completions to URL")
-        }
-
-        logger.logNotice("🔧 Custom OpenAI Test - Final URL: '\(chatCompletionsURL)'")
-
-        guard let url = URL(string: chatCompletionsURL) else {
-            logger.logError("🔧 Custom OpenAI Test - Failed to create URL from: '\(chatCompletionsURL)'")
+        // Use URL directly - user provides the full chat/completions endpoint (matches VoiceInk approach)
+        guard let url = URL(string: endpointURL) else {
+            logger.logError("🔧 Custom AI Test - Invalid URL: '\(endpointURL)'")
             return (false, "Invalid endpoint URL format")
         }
 

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -117,31 +117,7 @@ class AIService {
                 await fetchHuggingFaceModels()
             }
             // Ollama models are fetched on-demand when user configures Ollama
-
-            // Auto-verify Custom AI Provider on app launch if configuration exists
-            await verifyCustomOpenAIOnLaunchIfNeeded()
         }
-    }
-
-    /// Verifies Custom OpenAI configuration on app launch if saved configuration exists
-    private func verifyCustomOpenAIOnLaunchIfNeeded() async {
-        // Only verify if we have saved configuration
-        guard !customOpenAIEndpointURL.isEmpty && !customOpenAIModelName.isEmpty else {
-            return
-        }
-
-        logger.logInfo("Verifying Custom AI Provider configuration on app launch")
-        let result = await verifyCustomOpenAISetup()
-
-        if result.success {
-            customOpenAIIsVerified = true
-            logger.logInfo("Custom AI Provider verified successfully on app launch")
-        } else {
-            customOpenAIIsVerified = false
-            disableCustomOpenAIEnhancementForAllModes()
-            logger.logWarning("Custom AI Provider verification failed on app launch: \(result.message)")
-        }
-        refreshConnectedProviders()
     }
     
     public func getMode(name: String) -> VivaMode {

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -1098,7 +1098,7 @@ class AIService {
 
             default:
                 let errorString = String(data: data, encoding: .utf8) ?? "Unknown error"
-                throw EnhancementError.customError("Custom OpenAI error (HTTP \(httpResponse.statusCode)): \(errorString)")
+                throw EnhancementError.customError("Custom AI provider error (HTTP \(httpResponse.statusCode)): \(errorString)")
             }
 
         } catch is CancellationError {

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -49,6 +49,15 @@ class AIService {
         }
     }
 
+    /// Tracks whether Custom OpenAI configuration has been successfully verified
+    /// When false, the provider is not ready for use even if URL/model are set
+    public var customOpenAIIsVerified: Bool = false {
+        didSet {
+            userDefaults.set(customOpenAIIsVerified, forKey: UserDefaultsStorage.Keys.customOpenAIIsVerified)
+            userDefaults.synchronize()
+        }
+    }
+
     public var onModeChange: ((VivaMode) -> Void)?
 
     public var selectedModeName: String {
@@ -86,6 +95,7 @@ class AIService {
         // Load Custom OpenAI configuration from UserDefaults
         self.customOpenAIEndpointURL = userDefaults.string(forKey: UserDefaultsStorage.Keys.customOpenAIEndpointURL) ?? ""
         self.customOpenAIModelName = userDefaults.string(forKey: UserDefaultsStorage.Keys.customOpenAIModelName) ?? ""
+        self.customOpenAIIsVerified = userDefaults.bool(forKey: UserDefaultsStorage.Keys.customOpenAIIsVerified)
 
         loadModes()
         self.selectedMode = getMode(name: selectedModeName)
@@ -1326,6 +1336,7 @@ class AIService {
     public func clearCustomOpenAIConfiguration() {
         customOpenAIEndpointURL = ""
         customOpenAIModelName = ""
+        customOpenAIIsVerified = false
         userDefaults.removeObject(forKey: AppGroupCoordinator.kAPIKeyTemplate + AIProvider.customOpenAI.rawValue)
         userDefaults.synchronize()
     }
@@ -1365,8 +1376,8 @@ class AIService {
         // Add Ollama provider (always available, connection checked on-demand)
         providers.append(.ollama)
 
-        // Add Custom OpenAI provider if configured (URL and model name are set)
-        if !customOpenAIEndpointURL.isEmpty && !customOpenAIModelName.isEmpty {
+        // Add Custom OpenAI provider if configured AND verified
+        if !customOpenAIEndpointURL.isEmpty && !customOpenAIModelName.isEmpty && customOpenAIIsVerified {
             providers.append(.customOpenAI)
         }
 

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -117,7 +117,31 @@ class AIService {
                 await fetchHuggingFaceModels()
             }
             // Ollama models are fetched on-demand when user configures Ollama
+
+            // Auto-verify Custom AI Provider on app launch if configuration exists
+            await verifyCustomOpenAIOnLaunchIfNeeded()
         }
+    }
+
+    /// Verifies Custom OpenAI configuration on app launch if saved configuration exists
+    private func verifyCustomOpenAIOnLaunchIfNeeded() async {
+        // Only verify if we have saved configuration
+        guard !customOpenAIEndpointURL.isEmpty && !customOpenAIModelName.isEmpty else {
+            return
+        }
+
+        logger.logInfo("Verifying Custom AI Provider configuration on app launch")
+        let result = await verifyCustomOpenAISetup()
+
+        if result.success {
+            customOpenAIIsVerified = true
+            logger.logInfo("Custom AI Provider verified successfully on app launch")
+        } else {
+            customOpenAIIsVerified = false
+            disableCustomOpenAIEnhancementForAllModes()
+            logger.logWarning("Custom AI Provider verification failed on app launch: \(result.message)")
+        }
+        refreshConnectedProviders()
     }
     
     public func getMode(name: String) -> VivaMode {

--- a/VivaDicta/Shared/UserDefaultsStorage.swift
+++ b/VivaDicta/Shared/UserDefaultsStorage.swift
@@ -44,5 +44,9 @@ enum UserDefaultsStorage {
         static let huggingFaceModels = "huggingFaceModels"
         static let ollamaModels = "ollamaModels"
         static let ollamaServerURL = "ollamaServerURL"
+
+        // Custom OpenAI Provider Configuration
+        static let customOpenAIEndpointURL = "customOpenAIEndpointURL"
+        static let customOpenAIModelName = "customOpenAIModelName"
     }
 }

--- a/VivaDicta/Shared/UserDefaultsStorage.swift
+++ b/VivaDicta/Shared/UserDefaultsStorage.swift
@@ -48,5 +48,6 @@ enum UserDefaultsStorage {
         // Custom OpenAI Provider Configuration
         static let customOpenAIEndpointURL = "customOpenAIEndpointURL"
         static let customOpenAIModelName = "customOpenAIModelName"
+        static let customOpenAIIsVerified = "customOpenAIIsVerified"
     }
 }

--- a/VivaDicta/Views/SettingsScreen/AIProvidersView.swift
+++ b/VivaDicta/Views/SettingsScreen/AIProvidersView.swift
@@ -50,6 +50,11 @@ struct AIProviders: View {
                                     .resizable()
                                     .scaledToFit()
                                     .frame(width: 28, height: 28)
+                            } else if provider == .customOpenAI {
+                                Image(systemName: "server.rack")
+                                    .font(.title2)
+                                    .foregroundStyle(.secondary)
+                                    .frame(width: 28, height: 28)
                             }
 
                             Text(provider.displayName)
@@ -75,6 +80,25 @@ struct AIProviders: View {
                                             .foregroundStyle(.secondary)
                                     }
                                 }
+                            } else if provider == .customOpenAI {
+                                // Custom OpenAI has special status display
+                                if appState.aiService.customOpenAIEndpointURL.isEmpty || appState.aiService.customOpenAIModelName.isEmpty {
+                                    HStack(spacing: 4) {
+                                        Image(systemName: "gear")
+                                            .foregroundStyle(.orange)
+                                        Text("Configure")
+                                            .font(.subheadline)
+                                            .foregroundStyle(.secondary)
+                                    }
+                                } else {
+                                    HStack(spacing: 4) {
+                                        Image(systemName: "checkmark.circle.fill")
+                                            .foregroundStyle(.green)
+                                        Text("Configured")
+                                            .font(.subheadline)
+                                            .foregroundStyle(.secondary)
+                                    }
+                                }
                             } else if !appState.aiService.connectedProviders.contains(provider) {
                                 HStack(spacing: 4) {
                                     Image(systemName: "exclamationmark.triangle.fill")
@@ -94,6 +118,8 @@ struct AIProviders: View {
         .navigationDestination(for: AIProvider.self) { provider in
             if provider == .ollama {
                 OllamaConfigurationView(aiService: appState.aiService)
+            } else if provider == .customOpenAI {
+                CustomOpenAIConfigurationView(aiService: appState.aiService)
             } else {
                 AddAPIKeyView(
                     provider: provider,

--- a/VivaDicta/Views/SettingsScreen/AIProvidersView.swift
+++ b/VivaDicta/Views/SettingsScreen/AIProvidersView.swift
@@ -82,19 +82,23 @@ struct AIProviders: View {
                                 }
                             } else if provider == .customOpenAI {
                                 // Custom OpenAI has special status display
-                                if appState.aiService.customOpenAIEndpointURL.isEmpty || appState.aiService.customOpenAIModelName.isEmpty {
+                                // Must have URL, model, AND be verified (test passed)
+                                let isConfigured = !appState.aiService.customOpenAIEndpointURL.isEmpty &&
+                                                   !appState.aiService.customOpenAIModelName.isEmpty &&
+                                                   appState.aiService.customOpenAIIsVerified
+                                if isConfigured {
                                     HStack(spacing: 4) {
-                                        Image(systemName: "gear")
-                                            .foregroundStyle(.orange)
-                                        Text("Configure")
+                                        Image(systemName: "checkmark.circle.fill")
+                                            .foregroundStyle(.green)
+                                        Text("Configured")
                                             .font(.subheadline)
                                             .foregroundStyle(.secondary)
                                     }
                                 } else {
                                     HStack(spacing: 4) {
-                                        Image(systemName: "checkmark.circle.fill")
-                                            .foregroundStyle(.green)
-                                        Text("Configured")
+                                        Image(systemName: "gear")
+                                            .foregroundStyle(.orange)
+                                        Text("Configure")
                                             .font(.subheadline)
                                             .foregroundStyle(.secondary)
                                     }

--- a/VivaDicta/Views/SettingsScreen/CustomOpenAIConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/CustomOpenAIConfigurationView.swift
@@ -51,6 +51,9 @@ struct CustomOpenAIConfigurationView: View {
 
             ScrollView {
                 VStack(spacing: 20) {
+                    // Connection status
+                    connectionStatusView
+
                     // Endpoint URL input
                     VStack(alignment: .leading, spacing: 8) {
                         Text("Endpoint URL")
@@ -127,9 +130,6 @@ struct CustomOpenAIConfigurationView: View {
                             .font(.caption2)
                             .foregroundStyle(.tertiary)
                     }
-
-                    // Connection status
-                    connectionStatusView
                 }
                 .padding(.horizontal)
             }

--- a/VivaDicta/Views/SettingsScreen/CustomOpenAIConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/CustomOpenAIConfigurationView.swift
@@ -57,10 +57,9 @@ struct CustomOpenAIConfigurationView: View {
                             .font(.caption)
                             .foregroundStyle(.secondary)
 
-                        TextField("https://api.example.com/v1/chat/completions", text: $endpointURL)
+                        TextField("Server URL", text: $endpointURL)
                             .textInputAutocapitalization(.never)
                             .autocorrectionDisabled()
-                            .keyboardType(.URL)
                             .padding()
                             .background {
                                 Capsule()

--- a/VivaDicta/Views/SettingsScreen/CustomOpenAIConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/CustomOpenAIConfigurationView.swift
@@ -49,11 +49,11 @@ struct CustomOpenAIConfigurationView: View {
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
 
+            // Connection status
+            connectionStatusView
+
             ScrollView {
                 VStack(spacing: 20) {
-                    // Connection status
-                    connectionStatusView
-
                     // Endpoint URL input
                     VStack(alignment: .leading, spacing: 8) {
                         Text("Endpoint URL")

--- a/VivaDicta/Views/SettingsScreen/CustomOpenAIConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/CustomOpenAIConfigurationView.swift
@@ -1,0 +1,458 @@
+//
+//  CustomOpenAIConfigurationView.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.01.17
+//
+
+import SwiftUI
+import os
+
+private let logger = Logger(subsystem: "com.antonnovoselov.VivaDicta", category: "CustomOpenAIConfig")
+
+struct CustomOpenAIConfigurationView: View {
+    @Environment(\.dismiss) private var dismiss
+    let aiService: AIService
+
+    @State private var endpointURL: String = ""
+    @State private var modelName: String = ""
+    @State private var apiKey: String = ""
+    @State private var isChecking = false
+    @State private var connectionStatus: ConnectionStatus = .unknown
+    @State private var showingClearConfirmation = false
+
+    enum ConnectionStatus: Equatable {
+        case unknown
+        case checking
+        case connected
+        case failed(message: String)
+        case invalidURL
+        case missingModel
+    }
+
+    private var isConfigured: Bool {
+        !aiService.customOpenAIEndpointURL.isEmpty && !aiService.customOpenAIModelName.isEmpty
+    }
+
+    var body: some View {
+        VStack(spacing: 16) {
+            // Icon
+            Image(systemName: "server.rack")
+                .font(.system(size: 48))
+                .foregroundStyle(.secondary)
+                .padding(.top, 8)
+
+            Text("Custom OpenAI")
+                .font(.title2)
+
+            Text("OpenAI-Compatible API")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            ScrollView {
+                VStack(spacing: 20) {
+                    // Endpoint URL input
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Endpoint URL")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+
+                        TextField("https://api.example.com", text: $endpointURL)
+                            .textInputAutocapitalization(.never)
+                            .autocorrectionDisabled()
+                            .keyboardType(.URL)
+                            .padding()
+                            .background {
+                                Capsule()
+                                    .stroke(urlFieldBorderColor, lineWidth: urlFieldBorderWidth)
+                            }
+                            .onChange(of: endpointURL) { _, newValue in
+                                if !newValue.isEmpty && !isValidURL(newValue) {
+                                    connectionStatus = .invalidURL
+                                } else if connectionStatus == .invalidURL {
+                                    connectionStatus = .unknown
+                                }
+                            }
+
+                        Text("The base URL of your OpenAI-compatible API.\nExample: https://api.openai.com or http://localhost:8080")
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                    }
+
+                    // Model Name input
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Model Name")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+
+                        TextField("gpt-4, llama-3.1-70b, etc.", text: $modelName)
+                            .textInputAutocapitalization(.never)
+                            .autocorrectionDisabled()
+                            .padding()
+                            .background {
+                                Capsule()
+                                    .stroke(modelFieldBorderColor, lineWidth: modelFieldBorderWidth)
+                            }
+                            .onChange(of: modelName) { _, newValue in
+                                if newValue.isEmpty && connectionStatus != .unknown {
+                                    connectionStatus = .missingModel
+                                } else if connectionStatus == .missingModel && !newValue.isEmpty {
+                                    connectionStatus = .unknown
+                                }
+                            }
+
+                        Text("The model identifier as expected by your API server.")
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                    }
+
+                    // API Key input (optional)
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("API Key (Optional)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+
+                        SecureField("sk-...", text: $apiKey)
+                            .textInputAutocapitalization(.never)
+                            .autocorrectionDisabled()
+                            .privacySensitive()
+                            .padding()
+                            .background {
+                                Capsule()
+                                    .stroke(Color.gray, lineWidth: 0.5)
+                            }
+
+                        Text("Leave empty if your server doesn't require authentication.")
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                    }
+
+                    // Connection status
+                    connectionStatusView
+                }
+                .padding(.horizontal)
+            }
+
+            // Action buttons
+            VStack(spacing: 12) {
+                // Test & Save button
+                if #available(iOS 26.0, *) {
+                    Button {
+                        testAndSave()
+                    } label: {
+                        HStack {
+                            if case .checking = connectionStatus {
+                                ProgressView()
+                                    .controlSize(.small)
+                            }
+                            Text(connectionStatus == .checking ? "Connecting..." : "Test & Save")
+                                .font(.headline.weight(.medium))
+                        }
+                    }
+                    .disabled(isChecking || !canTestConnection)
+                    .padding(.vertical, 8)
+                    .padding(.horizontal, 16)
+                    .glassEffect(.regular.tint(.blue.opacity(0.3)).interactive())
+                    .buttonStyle(.plain)
+                } else {
+                    Button {
+                        testAndSave()
+                    } label: {
+                        HStack {
+                            if case .checking = connectionStatus {
+                                ProgressView()
+                                    .controlSize(.small)
+                            }
+                            Text(connectionStatus == .checking ? "Connecting..." : "Test & Save")
+                                .font(.headline.weight(.medium))
+                                .foregroundStyle(.primary)
+                        }
+                        .padding(.vertical, 8)
+                        .padding(.horizontal, 16)
+                        .background {
+                            Capsule()
+                                .stroke(.blue, lineWidth: 2)
+                        }
+                    }
+                    .disabled(isChecking || !canTestConnection)
+                    .buttonStyle(.plain)
+                }
+
+                // Clear Configuration button (only shown when configured)
+                if isConfigured {
+                    Button(role: .destructive) {
+                        showingClearConfirmation = true
+                    } label: {
+                        Label("Clear Configuration", systemImage: "trash")
+                            .font(.subheadline)
+                    }
+                }
+            }
+
+            Spacer()
+
+            // Help text
+            VStack(spacing: 8) {
+                Text("Connect to any OpenAI-compatible API server.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+
+                Text("Supports LiteLLM, vLLM, Ollama, and other compatible servers.")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                    .multilineTextAlignment(.center)
+            }
+            .padding(.bottom)
+        }
+        .padding()
+        .contentShape(Rectangle())
+        .onTapGesture {
+            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+        }
+        .navigationTitle("Custom OpenAI")
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            loadExistingConfiguration()
+        }
+        .confirmationDialog(
+            "Clear Configuration",
+            isPresented: $showingClearConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Clear", role: .destructive) {
+                clearConfiguration()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This will remove your Custom OpenAI configuration and disable AI enhancement for any modes using it.")
+        }
+    }
+
+    @ViewBuilder
+    private var connectionStatusView: some View {
+        switch connectionStatus {
+        case .unknown:
+            EmptyView()
+
+        case .checking:
+            HStack {
+                ProgressView()
+                    .controlSize(.small)
+                Text("Testing connection...")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+        case .connected:
+            HStack {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+                    .accessibilityLabel("Connection successful")
+                Text("Connected successfully")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+        case .failed(let message):
+            HStack(alignment: .top) {
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundStyle(.red)
+                    .accessibilityLabel("Connection failed")
+                Text(message)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.leading)
+            }
+
+        case .invalidURL:
+            HStack {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                    .accessibilityLabel("Invalid URL")
+                Text("Invalid URL. Use http:// or https://")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+        case .missingModel:
+            HStack {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                    .accessibilityLabel("Missing model name")
+                Text("Please enter a model name")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var canTestConnection: Bool {
+        !endpointURL.isEmpty && !modelName.isEmpty && connectionStatus != .invalidURL
+    }
+
+    private var urlFieldBorderColor: Color {
+        switch connectionStatus {
+        case .invalidURL:
+            return .orange
+        case .connected:
+            return .green
+        case .failed:
+            return .red
+        default:
+            return .gray
+        }
+    }
+
+    private var urlFieldBorderWidth: CGFloat {
+        switch connectionStatus {
+        case .unknown:
+            return 0.5
+        default:
+            return 1.5
+        }
+    }
+
+    private var modelFieldBorderColor: Color {
+        switch connectionStatus {
+        case .missingModel:
+            return .orange
+        case .connected:
+            return .green
+        default:
+            return .gray
+        }
+    }
+
+    private var modelFieldBorderWidth: CGFloat {
+        switch connectionStatus {
+        case .unknown:
+            return 0.5
+        case .connected, .missingModel:
+            return 1.5
+        default:
+            return 0.5
+        }
+    }
+
+    private func isValidURL(_ urlString: String) -> Bool {
+        guard let url = URL(string: urlString),
+              let scheme = url.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              url.host != nil else {
+            return false
+        }
+        return true
+    }
+
+    private func loadExistingConfiguration() {
+        endpointURL = aiService.customOpenAIEndpointURL
+        modelName = aiService.customOpenAIModelName
+        if let existingKey = UserDefaultsStorage.shared.string(forKey: AppGroupCoordinator.kAPIKeyTemplate + AIProvider.customOpenAI.rawValue) {
+            apiKey = existingKey
+        }
+
+        // Auto-check if already configured
+        if isConfigured {
+            Task {
+                await testConnection(saveOnSuccess: false)
+            }
+        }
+    }
+
+    private func testAndSave() {
+        isChecking = true
+        Task {
+            await testConnection(saveOnSuccess: true)
+        }
+    }
+
+    private func testConnection(saveOnSuccess: Bool) async {
+        logger.notice("🔧 CustomOpenAI Config - Starting test connection")
+        logger.notice("🔧 CustomOpenAI Config - Endpoint URL: '\(endpointURL)'")
+        logger.notice("🔧 CustomOpenAI Config - Model Name: '\(modelName)'")
+        logger.notice("🔧 CustomOpenAI Config - API Key length: \(apiKey.count)")
+
+        guard isValidURL(endpointURL) else {
+            logger.error("🔧 CustomOpenAI Config - Invalid URL")
+            await MainActor.run {
+                connectionStatus = .invalidURL
+                isChecking = false
+            }
+            return
+        }
+
+        guard !modelName.isEmpty else {
+            logger.error("🔧 CustomOpenAI Config - Missing model name")
+            await MainActor.run {
+                connectionStatus = .missingModel
+                isChecking = false
+            }
+            return
+        }
+
+        await MainActor.run {
+            connectionStatus = .checking
+        }
+
+        HapticManager.lightImpact()
+
+        // Save configuration to test
+        let apiKeyStorageKey = AppGroupCoordinator.kAPIKeyTemplate + AIProvider.customOpenAI.rawValue
+        logger.notice("🔧 CustomOpenAI Config - API Key storage key: '\(apiKeyStorageKey)'")
+
+        await MainActor.run {
+            aiService.customOpenAIEndpointURL = endpointURL
+            aiService.customOpenAIModelName = modelName
+            logger.notice("🔧 CustomOpenAI Config - Saved endpoint URL to AIService: '\(aiService.customOpenAIEndpointURL)'")
+            logger.notice("🔧 CustomOpenAI Config - Saved model name to AIService: '\(aiService.customOpenAIModelName)'")
+
+            if !apiKey.isEmpty {
+                UserDefaultsStorage.shared.set(apiKey, forKey: apiKeyStorageKey)
+                logger.notice("🔧 CustomOpenAI Config - Saved API key to UserDefaults")
+            } else {
+                UserDefaultsStorage.shared.removeObject(forKey: apiKeyStorageKey)
+                logger.notice("🔧 CustomOpenAI Config - Removed API key from UserDefaults (empty)")
+            }
+        }
+
+        logger.notice("🔧 CustomOpenAI Config - Calling verifyCustomOpenAISetup...")
+        let result = await aiService.verifyCustomOpenAISetup()
+        logger.notice("🔧 CustomOpenAI Config - Result: success=\(result.success), message='\(result.message)'")
+
+        await MainActor.run {
+            if result.success {
+                connectionStatus = .connected
+                if saveOnSuccess {
+                    aiService.refreshConnectedProviders()
+                    HapticManager.success()
+                }
+            } else {
+                connectionStatus = .failed(message: result.message)
+                if saveOnSuccess {
+                    // Don't clear on failure - let user fix the issue
+                    HapticManager.error()
+                }
+            }
+            isChecking = false
+        }
+    }
+
+    private func clearConfiguration() {
+        HapticManager.heavyImpact()
+        aiService.clearCustomOpenAIConfiguration()
+        aiService.disableCustomOpenAIEnhancementForAllModes()
+        aiService.refreshConnectedProviders()
+
+        endpointURL = ""
+        modelName = ""
+        apiKey = ""
+        connectionStatus = .unknown
+    }
+}
+
+#Preview {
+    NavigationStack {
+        CustomOpenAIConfigurationView(aiService: AIService())
+    }
+}

--- a/VivaDicta/Views/SettingsScreen/CustomOpenAIConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/CustomOpenAIConfigurationView.swift
@@ -423,16 +423,18 @@ struct CustomOpenAIConfigurationView: View {
         await MainActor.run {
             if result.success {
                 connectionStatus = .connected
-                if saveOnSuccess {
-                    aiService.refreshConnectedProviders()
-                    HapticManager.success()
-                }
+                // Mark as verified so other screens know it's ready
+                aiService.customOpenAIIsVerified = true
+                aiService.refreshConnectedProviders()
+                HapticManager.success()
             } else {
                 connectionStatus = .failed(message: result.message)
-                if saveOnSuccess {
-                    // Don't clear on failure - let user fix the issue
-                    HapticManager.error()
-                }
+                // Mark as NOT verified - this invalidates the configuration
+                aiService.customOpenAIIsVerified = false
+                // Disable AI enhancement for all modes using Custom OpenAI
+                aiService.disableCustomOpenAIEnhancementForAllModes()
+                aiService.refreshConnectedProviders()
+                HapticManager.error()
             }
             isChecking = false
         }

--- a/VivaDicta/Views/SettingsScreen/CustomOpenAIConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/CustomOpenAIConfigurationView.swift
@@ -362,11 +362,9 @@ struct CustomOpenAIConfigurationView: View {
             apiKey = existingKey
         }
 
-        // Auto-check if already configured
-        if isConfigured {
-            Task {
-                await testConnection(saveOnSuccess: false)
-            }
+        // Show connected status if already verified (verification happens on app launch)
+        if isConfigured && aiService.customOpenAIIsVerified {
+            connectionStatus = .connected
         }
     }
 

--- a/VivaDicta/Views/SettingsScreen/CustomOpenAIConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/CustomOpenAIConfigurationView.swift
@@ -57,7 +57,7 @@ struct CustomOpenAIConfigurationView: View {
                             .font(.caption)
                             .foregroundStyle(.secondary)
 
-                        TextField("https://api.example.com", text: $endpointURL)
+                        TextField("https://api.example.com/v1/chat/completions", text: $endpointURL)
                             .textInputAutocapitalization(.never)
                             .autocorrectionDisabled()
                             .keyboardType(.URL)
@@ -74,7 +74,7 @@ struct CustomOpenAIConfigurationView: View {
                                 }
                             }
 
-                        Text("The base URL of your OpenAI-compatible API.\nExample: https://api.openai.com or http://localhost:8080")
+                        Text("The full chat completions endpoint URL.\nExample: https://openrouter.ai/api/v1/chat/completions")
                             .font(.caption2)
                             .foregroundStyle(.tertiary)
                     }

--- a/VivaDicta/Views/SettingsScreen/CustomOpenAIConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/CustomOpenAIConfigurationView.swift
@@ -42,7 +42,7 @@ struct CustomOpenAIConfigurationView: View {
                 .foregroundStyle(.secondary)
                 .padding(.top, 8)
 
-            Text("Custom OpenAI")
+            Text("Custom AI provider")
                 .font(.title2)
 
             Text("OpenAI-Compatible API")
@@ -210,7 +210,7 @@ struct CustomOpenAIConfigurationView: View {
         .onTapGesture {
             UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
         }
-        .navigationTitle("Custom OpenAI")
+        .navigationTitle("Custom AI Provider")
         .navigationBarTitleDisplayMode(.inline)
         .onAppear {
             loadExistingConfiguration()

--- a/VivaDicta/Views/SettingsScreen/CustomOpenAIConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/CustomOpenAIConfigurationView.swift
@@ -67,7 +67,8 @@ struct CustomOpenAIConfigurationView: View {
                                     .stroke(urlFieldBorderColor, lineWidth: urlFieldBorderWidth)
                             }
                             .onChange(of: endpointURL) { _, newValue in
-                                if !newValue.isEmpty && !isValidURL(newValue) {
+                                let trimmed = newValue.trimmingCharacters(in: .whitespaces)
+                                if !trimmed.isEmpty && !isValidURL(trimmed) {
                                     connectionStatus = .invalidURL
                                 } else if connectionStatus == .invalidURL {
                                     connectionStatus = .unknown
@@ -94,9 +95,10 @@ struct CustomOpenAIConfigurationView: View {
                                     .stroke(modelFieldBorderColor, lineWidth: modelFieldBorderWidth)
                             }
                             .onChange(of: modelName) { _, newValue in
-                                if newValue.isEmpty && connectionStatus != .unknown {
+                                let trimmed = newValue.trimmingCharacters(in: .whitespaces)
+                                if trimmed.isEmpty && connectionStatus != .unknown {
                                     connectionStatus = .missingModel
-                                } else if connectionStatus == .missingModel && !newValue.isEmpty {
+                                } else if connectionStatus == .missingModel && !trimmed.isEmpty {
                                     connectionStatus = .unknown
                                 }
                             }
@@ -287,8 +289,16 @@ struct CustomOpenAIConfigurationView: View {
         }
     }
 
+    private var trimmedModelName: String {
+        modelName.trimmingCharacters(in: .whitespaces)
+    }
+
+    private var trimmedEndpointURL: String {
+        endpointURL.trimmingCharacters(in: .whitespaces)
+    }
+
     private var canTestConnection: Bool {
-        !endpointURL.isEmpty && !modelName.isEmpty && connectionStatus != .invalidURL
+        !trimmedEndpointURL.isEmpty && !trimmedModelName.isEmpty && connectionStatus != .invalidURL
     }
 
     private var urlFieldBorderColor: Color {
@@ -368,13 +378,14 @@ struct CustomOpenAIConfigurationView: View {
     }
 
     private func testConnection(saveOnSuccess: Bool) async {
-        logger.notice("🔧 CustomOpenAI Config - Starting test connection")
-        logger.notice("🔧 CustomOpenAI Config - Endpoint URL: '\(endpointURL)'")
-        logger.notice("🔧 CustomOpenAI Config - Model Name: '\(modelName)'")
-        logger.notice("🔧 CustomOpenAI Config - API Key length: \(apiKey.count)")
+        let urlToTest = trimmedEndpointURL
+        let modelToTest = trimmedModelName
+        let apiKeyToSave = apiKey.trimmingCharacters(in: .whitespaces)
 
-        guard isValidURL(endpointURL) else {
-            logger.error("🔧 CustomOpenAI Config - Invalid URL")
+        logger.debug("CustomOpenAI Config - Testing connection to: '\(urlToTest)' with model: '\(modelToTest)'")
+
+        guard isValidURL(urlToTest) else {
+            logger.debug("CustomOpenAI Config - Invalid URL")
             await MainActor.run {
                 connectionStatus = .invalidURL
                 isChecking = false
@@ -382,8 +393,8 @@ struct CustomOpenAIConfigurationView: View {
             return
         }
 
-        guard !modelName.isEmpty else {
-            logger.error("🔧 CustomOpenAI Config - Missing model name")
+        guard !modelToTest.isEmpty else {
+            logger.debug("CustomOpenAI Config - Missing model name")
             await MainActor.run {
                 connectionStatus = .missingModel
                 isChecking = false
@@ -399,26 +410,20 @@ struct CustomOpenAIConfigurationView: View {
 
         // Save configuration to test
         let apiKeyStorageKey = AppGroupCoordinator.kAPIKeyTemplate + AIProvider.customOpenAI.rawValue
-        logger.notice("🔧 CustomOpenAI Config - API Key storage key: '\(apiKeyStorageKey)'")
 
         await MainActor.run {
-            aiService.customOpenAIEndpointURL = endpointURL
-            aiService.customOpenAIModelName = modelName
-            logger.notice("🔧 CustomOpenAI Config - Saved endpoint URL to AIService: '\(aiService.customOpenAIEndpointURL)'")
-            logger.notice("🔧 CustomOpenAI Config - Saved model name to AIService: '\(aiService.customOpenAIModelName)'")
+            aiService.customOpenAIEndpointURL = urlToTest
+            aiService.customOpenAIModelName = modelToTest
 
-            if !apiKey.isEmpty {
-                UserDefaultsStorage.shared.set(apiKey, forKey: apiKeyStorageKey)
-                logger.notice("🔧 CustomOpenAI Config - Saved API key to UserDefaults")
+            if !apiKeyToSave.isEmpty {
+                UserDefaultsStorage.shared.set(apiKeyToSave, forKey: apiKeyStorageKey)
             } else {
                 UserDefaultsStorage.shared.removeObject(forKey: apiKeyStorageKey)
-                logger.notice("🔧 CustomOpenAI Config - Removed API key from UserDefaults (empty)")
             }
         }
 
-        logger.notice("🔧 CustomOpenAI Config - Calling verifyCustomOpenAISetup...")
         let result = await aiService.verifyCustomOpenAISetup()
-        logger.notice("🔧 CustomOpenAI Config - Result: success=\(result.success), message='\(result.message)'")
+        logger.debug("CustomOpenAI Config - Result: success=\(result.success)")
 
         await MainActor.run {
             if result.success {

--- a/VivaDicta/Views/SettingsScreen/ModeEditView.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditView.swift
@@ -414,7 +414,7 @@ struct ModeEditView: View {
                                         HStack {
                                             Image(systemName: "exclamationmark.triangle.fill")
                                                 .foregroundStyle(.orange)
-                                            Text("Configure Custom OpenAI")
+                                            Text("Configure Custom AI Provider")
                                             Spacer()
                                             Text("Required")
                                                 .font(.caption)

--- a/VivaDicta/Views/SettingsScreen/ModeEditView.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditView.swift
@@ -481,6 +481,10 @@ struct ModeEditView: View {
                         }
                     }
                 }
+                .onAppear {
+                    // Refresh model selection when returning from configuration screens
+                    viewModel.refreshAIModelSelection()
+                }
             }
 
             if viewModel.isEditing {

--- a/VivaDicta/Views/SettingsScreen/ModeEditView.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditView.swift
@@ -258,8 +258,8 @@ struct ModeEditView: View {
                                     } else {
                                         HStack(spacing: 4) {
                                             Text(provider.displayName)
-                                            // Ollama doesn't need API key, show gear instead
-                                            if provider == .ollama {
+                                            // Ollama and Custom OpenAI don't need API key, show gear instead
+                                            if provider == .ollama || provider == .customOpenAI {
                                                 Image(systemName: "gear")
                                             } else {
                                                 Image(systemName: "key.slash.fill")
@@ -325,6 +325,30 @@ struct ModeEditView: View {
                                             .foregroundStyle(.secondary)
                                     }
                                     .alignmentGuide(.listRowSeparatorLeading) { _ in 0 }
+                                } else if provider == .customOpenAI {
+                                    // Custom OpenAI - show configured model name (no picker)
+                                    HStack {
+                                        Image(systemName: "cube.fill")
+                                            .foregroundStyle(
+                                        MeshGradient(
+                                            width: 2,
+                                            height: 2,
+                                            points: [
+                                                [0, 0], [1, 0],
+                                                [0, 1], [1, 1]
+                                            ],
+                                            colors: [
+                                                .purple, .red,
+                                                .blue, .pink
+                                            ]
+                                        )
+                                    )
+                                        Text("AI Model")
+                                        Spacer()
+                                        Text(viewModel.aiService.customOpenAIModelName)
+                                            .foregroundStyle(.secondary)
+                                    }
+                                    .alignmentGuide(.listRowSeparatorLeading) { _ in 0 }
                                 } else {
                                     Picker(selection: $viewModel.aiModel) {
                                         ForEach(viewModel.aiService.getAvailableModels(for: provider), id: \.self) { model in
@@ -375,6 +399,22 @@ struct ModeEditView: View {
                                             Image(systemName: "exclamationmark.triangle.fill")
                                                 .foregroundStyle(.orange)
                                             Text("Configure Ollama")
+                                            Spacer()
+                                            Text("Required")
+                                                .font(.caption)
+                                                .foregroundStyle(.secondary)
+                                        }
+                                    }
+                                    .alignmentGuide(.listRowSeparatorLeading) { _ in 0 }
+                                } else if provider == .customOpenAI {
+                                    // Custom OpenAI needs configuration
+                                    NavigationLink {
+                                        CustomOpenAIConfigurationView(aiService: viewModel.aiService)
+                                    } label: {
+                                        HStack {
+                                            Image(systemName: "exclamationmark.triangle.fill")
+                                                .foregroundStyle(.orange)
+                                            Text("Configure Custom OpenAI")
                                             Spacer()
                                             Text("Required")
                                                 .font(.caption)

--- a/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
@@ -360,15 +360,70 @@ class ModeEditViewModel {
             } else {
                 aiModel = nil // No models available
             }
+
+            // Verify Ollama connection when selected
+            verifyOllamaConnection()
         } else if let provider = newProvider, provider == .customOpenAI {
             // For Custom OpenAI, use the configured model name
             let modelName = aiService.customOpenAIModelName
             aiModel = modelName.isEmpty ? nil : modelName
+
+            // Verify Custom OpenAI connection when selected
+            verifyCustomOpenAIConnection()
         } else {
             aiModel = newProvider?.defaultModel
         }
 
         logger.logInfo("Updated provider to: \(newProvider?.rawValue ?? "none"), model: \(aiModel ?? "none")")
+    }
+
+    /// Verifies Ollama connection when user selects it as provider
+    private func verifyOllamaConnection() {
+        Task {
+            let result = await aiService.verifyOllamaSetup()
+            await MainActor.run {
+                if result.success {
+                    logger.logInfo("Ollama connection verified: \(result.message)")
+                    // Update model selection with fresh models list
+                    if let firstModel = aiService.ollamaModels.first {
+                        if aiModel == nil || !aiService.ollamaModels.contains(aiModel!) {
+                            aiModel = firstModel
+                        }
+                    }
+                } else {
+                    logger.logWarning("Ollama connection failed: \(result.message)")
+                    // Clear models and disable for all modes
+                    aiService.ollamaModels = []
+                    aiService.disableOllamaEnhancementForAllModes()
+                    aiModel = nil
+                }
+                aiService.refreshConnectedProviders()
+            }
+        }
+    }
+
+    /// Verifies Custom OpenAI connection when user selects it as provider
+    private func verifyCustomOpenAIConnection() {
+        // Only verify if configuration exists
+        guard !aiService.customOpenAIEndpointURL.isEmpty,
+              !aiService.customOpenAIModelName.isEmpty else {
+            return
+        }
+
+        Task {
+            let result = await aiService.verifyCustomOpenAISetup()
+            await MainActor.run {
+                if result.success {
+                    aiService.customOpenAIIsVerified = true
+                    logger.logInfo("Custom OpenAI connection verified: \(result.message)")
+                } else {
+                    aiService.customOpenAIIsVerified = false
+                    aiService.disableCustomOpenAIEnhancementForAllModes()
+                    logger.logWarning("Custom OpenAI connection failed: \(result.message)")
+                }
+                aiService.refreshConnectedProviders()
+            }
+        }
     }
 
     func updateModel(_ newModel: String?) {

--- a/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
@@ -85,6 +85,9 @@ class ModeEditViewModel {
             if provider == .ollama {
                 return "Configure Ollama server in AI Providers settings"
             }
+            if provider == .customOpenAI {
+                return "Configure Custom OpenAI in AI Providers settings"
+            }
             return "Add API key to continue"
         }
         if aiModel == nil || aiModel!.isEmpty {
@@ -202,19 +205,31 @@ class ModeEditViewModel {
     }
 
     private func validateAIModelSelection() {
-        guard let provider = aiProvider, provider == .ollama else { return }
+        guard let provider = aiProvider else { return }
 
-        let availableModels = aiService.ollamaModels
-        guard let currentModel = aiModel else { return }
+        if provider == .ollama {
+            let availableModels = aiService.ollamaModels
+            guard let currentModel = aiModel else { return }
 
-        if !availableModels.contains(currentModel) {
-            let oldModel = currentModel
-            if let firstModel = availableModels.first {
-                aiModel = firstModel
-                logger.logInfo("Ollama model '\(oldModel)' not available, reset to '\(firstModel)'")
-            } else {
+            if !availableModels.contains(currentModel) {
+                let oldModel = currentModel
+                if let firstModel = availableModels.first {
+                    aiModel = firstModel
+                    logger.logInfo("Ollama model '\(oldModel)' not available, reset to '\(firstModel)'")
+                } else {
+                    aiModel = nil
+                    logger.logInfo("Ollama model '\(oldModel)' not available and no models found")
+                }
+            }
+        } else if provider == .customOpenAI {
+            // For Custom OpenAI, validate model matches configured model
+            let configuredModel = aiService.customOpenAIModelName
+            if configuredModel.isEmpty {
                 aiModel = nil
-                logger.logInfo("Ollama model '\(oldModel)' not available and no models found")
+                logger.logInfo("Custom OpenAI model not configured")
+            } else if aiModel != configuredModel {
+                aiModel = configuredModel
+                logger.logInfo("Custom OpenAI model updated to configured: '\(configuredModel)'")
             }
         }
     }
@@ -345,6 +360,10 @@ class ModeEditViewModel {
             } else {
                 aiModel = nil // No models available
             }
+        } else if let provider = newProvider, provider == .customOpenAI {
+            // For Custom OpenAI, use the configured model name
+            let modelName = aiService.customOpenAIModelName
+            aiModel = modelName.isEmpty ? nil : modelName
         } else {
             aiModel = newProvider?.defaultModel
         }
@@ -368,11 +387,16 @@ class ModeEditViewModel {
     /// Returns whether the provider is ready to use
     /// For Apple: available on device
     /// For Ollama: has models available (server configured and accessible)
+    /// For Custom OpenAI: endpoint URL and model name are configured
     /// For cloud providers: API key is configured
     func isProviderReady(_ provider: AIProvider) -> Bool {
         if provider == .ollama {
             // Ollama is ready only if models are available
             return !aiService.ollamaModels.isEmpty
+        }
+        if provider == .customOpenAI {
+            // Custom OpenAI is ready only if URL and model are configured
+            return !aiService.customOpenAIEndpointURL.isEmpty && !aiService.customOpenAIModelName.isEmpty
         }
         return aiService.connectedProviders.contains(provider)
     }

--- a/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
@@ -395,8 +395,10 @@ class ModeEditViewModel {
             return !aiService.ollamaModels.isEmpty
         }
         if provider == .customOpenAI {
-            // Custom OpenAI is ready only if URL and model are configured
-            return !aiService.customOpenAIEndpointURL.isEmpty && !aiService.customOpenAIModelName.isEmpty
+            // Custom OpenAI is ready only if URL and model are configured AND verified
+            return !aiService.customOpenAIEndpointURL.isEmpty &&
+                   !aiService.customOpenAIModelName.isEmpty &&
+                   aiService.customOpenAIIsVerified
         }
         return aiService.connectedProviders.contains(provider)
     }

--- a/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
@@ -86,7 +86,7 @@ class ModeEditViewModel {
                 return "Configure Ollama server in AI Providers settings"
             }
             if provider == .customOpenAI {
-                return "Configure Custom OpenAI in AI Providers settings"
+                return "Configure Custom AI Provider in AI Providers settings"
             }
             return "Add API key to continue"
         }

--- a/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
@@ -430,6 +430,35 @@ class ModeEditViewModel {
         aiModel = newModel
         logger.logInfo("Updated model to: \(newModel ?? "none")")
     }
+
+    /// Refreshes the AI model selection based on current provider state
+    /// Called when returning from configuration screens to sync with any changes
+    func refreshAIModelSelection() {
+        guard let provider = aiProvider else { return }
+
+        if provider == .ollama {
+            let availableModels = aiService.ollamaModels
+            if let currentModel = aiModel, availableModels.contains(currentModel) {
+                // Current model is still valid, keep it
+                return
+            }
+            // Select first available model
+            if let firstModel = availableModels.first {
+                aiModel = firstModel
+                logger.logInfo("Refreshed Ollama model to: \(firstModel)")
+            } else {
+                aiModel = nil
+            }
+        } else if provider == .customOpenAI {
+            let configuredModel = aiService.customOpenAIModelName
+            if !configuredModel.isEmpty && aiModel != configuredModel {
+                aiModel = configuredModel
+                logger.logInfo("Refreshed Custom OpenAI model to: \(configuredModel)")
+            } else if configuredModel.isEmpty {
+                aiModel = nil
+            }
+        }
+    }
     
     func hasAPIKey(for provider: AIProvider) -> Bool {
         // Apple doesn't need API key - just check if it's available

--- a/VivaDicta/Views/SettingsScreen/OllamaConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/OllamaConfigurationView.swift
@@ -49,7 +49,7 @@ struct OllamaConfigurationView: View {
                     .font(.caption2)
                     .foregroundStyle(.tertiary)
 
-                TextField("http", text: $serverURL)
+                TextField("http://host:11434", text: $serverURL)
                     .textInputAutocapitalization(.never)
                     .autocorrectionDisabled()
                     .keyboardType(.URL)
@@ -93,7 +93,7 @@ struct OllamaConfigurationView: View {
                             .font(.headline.weight(.medium))
                     }
                 }
-                .disabled(isChecking || connectionStatus == .invalidURL)
+                .disabled(isChecking || !canConnect)
                 .padding(.vertical, 8)
                 .padding(.horizontal, 16)
                 .glassEffect(.regular.tint(.blue.opacity(0.3)).interactive())
@@ -121,7 +121,7 @@ struct OllamaConfigurationView: View {
                             .stroke(.blue, lineWidth: 2)
                     }
                 }
-                .disabled(isChecking || connectionStatus == .invalidURL)
+                .disabled(isChecking || !canConnect)
                 .buttonStyle(.plain)
             }
 
@@ -169,11 +169,14 @@ struct OllamaConfigurationView: View {
         .navigationTitle("Ollama")
         .navigationBarTitleDisplayMode(.inline)
         .onAppear {
-            serverURL = aiService.ollamaServerURL
-            // Auto-check connection on appear
-            isChecking = true
-            Task {
-                await checkConnection()
+            // Only load URL if user previously saved one (not the default)
+            let savedURL = UserDefaultsStorage.shared.string(forKey: UserDefaultsStorage.Keys.ollamaServerURL)
+            if let savedURL, !savedURL.isEmpty {
+                serverURL = savedURL
+            }
+            // Show connected status if models were previously loaded (cached state)
+            if !aiService.ollamaModels.isEmpty {
+                connectionStatus = .connected(modelCount: aiService.ollamaModels.count)
             }
         }
     }
@@ -236,17 +239,32 @@ struct OllamaConfigurationView: View {
         return true
     }
 
+    private var trimmedServerURL: String {
+        serverURL.trimmingCharacters(in: .whitespaces)
+    }
+
+    private var canConnect: Bool {
+        !trimmedServerURL.isEmpty && isValidOllamaURL(trimmedServerURL)
+    }
+
     private func checkConnection() async {
-        guard connectionStatus != .invalidURL else {
-            isChecking = false
+        let urlToTest = trimmedServerURL
+
+        guard !urlToTest.isEmpty && isValidOllamaURL(urlToTest) else {
+            await MainActor.run {
+                connectionStatus = .invalidURL
+                isChecking = false
+            }
             return
         }
 
-        connectionStatus = .checking
+        await MainActor.run {
+            connectionStatus = .checking
+        }
 
         HapticManager.lightImpact()
-        
-        aiService.ollamaServerURL = serverURL
+
+        aiService.ollamaServerURL = urlToTest
 
         let result = await aiService.verifyOllamaSetup()
 

--- a/VivaDicta/Views/SettingsScreen/OllamaConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/OllamaConfigurationView.swift
@@ -49,10 +49,9 @@ struct OllamaConfigurationView: View {
                     .font(.caption2)
                     .foregroundStyle(.tertiary)
 
-                TextField("http://host:11434", text: $serverURL)
+                TextField("Server URL", text: $serverURL)
                     .textInputAutocapitalization(.never)
                     .autocorrectionDisabled()
-                    .keyboardType(.URL)
                     .padding()
                     .background {
                         Capsule()

--- a/VivaDicta/Views/SettingsScreen/Prompts/PromptInstructionsEditorView.swift
+++ b/VivaDicta/Views/SettingsScreen/Prompts/PromptInstructionsEditorView.swift
@@ -10,15 +10,38 @@ import SwiftUI
 struct PromptInstructionsEditorView: View {
     @Environment(\.dismiss) var dismiss
     @Binding var instructions: String
+    @FocusState private var isFocused: Bool
+    @State private var originalInstructions: String = ""
 
     var body: some View {
         TextEditor(text: $instructions)
+            .focused($isFocused)
             .contentMargins(.horizontal, 16, for: .scrollContent)
             .contentMargins(.bottom, 100, for: .scrollContent)
             .scrollDismissesKeyboard(.interactively)
             .navigationTitle("Prompt Instructions")
+            .onAppear {
+                originalInstructions = instructions
+                isFocused = true
+            }
             .toolbarTitleDisplayMode(.inline)
             .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    if #available(iOS 26, *) {
+                        Button(role: .cancel) {
+                            instructions = originalInstructions
+                            HapticManager.lightImpact()
+                            dismiss()
+                        }
+                    } else {
+                        Button("Cancel") {
+                            instructions = originalInstructions
+                            HapticManager.lightImpact()
+                            dismiss()
+                        }
+                    }
+                }
+
                 ToolbarItem(placement: .topBarTrailing) {
                     if #available(iOS 26, *) {
                         Button(role: .confirm) {


### PR DESCRIPTION
## Summary

- Adds support for custom OpenAI-compatible API endpoints for AI text enhancement
- Users can configure a custom endpoint URL, model name, and optional API key
- Includes connection verification to ensure the custom endpoint is reachable before use
- Updates terminology from "Custom OpenAI" to "Custom AI Provider" for clarity
- Adds cancel button to prompt instructions editor for reverting unwanted changes

## Changes

- **AIProvider**: New `customOpenAI` case with configuration UI
- **AIService**: Handles requests to custom endpoints with verification flow
- **CustomOpenAIConfigurationView**: New configuration screen for custom endpoint setup
- **ModeEditView/ViewModel**: Integration with custom AI provider selection
- **UserDefaultsStorage**: Persists custom endpoint configuration
- **PromptInstructionsEditorView**: Cancel button for discarding edits

## Test Plan

- [ ] Configure a custom OpenAI-compatible endpoint and verify connection
- [ ] Test AI enhancement with custom provider
- [ ] Verify clearing configuration disables custom AI for all modes
- [ ] Test cancel button in prompt instructions editor

Relates to VIV-301