### PR TITLE
Add custom cloud transcription provider

### DIFF
--- a/VivaDicta/Models/CustomTranscriptionModel.swift
+++ b/VivaDicta/Models/CustomTranscriptionModel.swift
@@ -1,0 +1,53 @@
+//
+//  CustomTranscriptionModel.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.01.17
+//
+
+import Foundation
+
+struct CustomTranscriptionModel: @MainActor TranscriptionModel, Codable {
+    let id: UUID
+    var name: String
+    var displayName: String
+    let description: String = "Custom transcription model"
+    let provider: TranscriptionModelProvider = .customTranscription
+    let recommended: Bool = false
+
+    var apiEndpoint: String
+    var modelName: String
+    var isMultilingual: Bool
+
+    var supportManyLanguages: Bool { isMultilingual }
+    var supportedLanguages: [String: String] {
+        isMultilingual ? TranscriptionModelProvider.allLanguages : ["en": "English"]
+    }
+
+    init(
+        id: UUID = UUID(),
+        name: String,
+        displayName: String,
+        apiEndpoint: String,
+        modelName: String,
+        isMultilingual: Bool = true
+    ) {
+        self.id = id
+        self.name = name
+        self.displayName = displayName
+        self.apiEndpoint = apiEndpoint
+        self.modelName = modelName
+        self.isMultilingual = isMultilingual
+    }
+
+    // Custom Codable to exclude computed properties
+    enum CodingKeys: String, CodingKey {
+        case id, name, displayName, apiEndpoint, modelName, isMultilingual
+    }
+}
+
+extension CustomTranscriptionModel {
+    var apiKey: String? {
+        CustomTranscriptionModelManager.shared.getAPIKey(forModelId: id)
+    }
+}

--- a/VivaDicta/Models/TranscriptionModelProvider.swift
+++ b/VivaDicta/Models/TranscriptionModelProvider.swift
@@ -18,6 +18,7 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
     case mistral
     case gemini
     case soniox
+    case customTranscription
     
     var id: Self { self }
     
@@ -41,6 +42,8 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
             "Gemini"
         case .soniox:
             "Soniox"
+        case .customTranscription:
+            "Custom"
         }
     }
     

--- a/VivaDicta/Models/TranscriptionModelProvider.swift
+++ b/VivaDicta/Models/TranscriptionModelProvider.swift
@@ -58,7 +58,8 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
         .deepgram,
         .openAI,
         .elevenLabs,
-        .soniox]
+        .soniox,
+        .customTranscription]
     
     var cloudTranscriptionModelsNames: [String] {
         switch self {
@@ -75,11 +76,16 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
         case .parakeet:
             guard let model = TranscriptionModelProvider.allParakeetModels.first(where: {$0.name == modelName}) else { return modelName }
             return model.displayName
-            
+
         case .whisperKit:
             guard let model = TranscriptionModelProvider.allWhisperKitModels.first(where: {$0.name == modelName}) else { return modelName }
             return model.displayName
-            
+
+        case .customTranscription:
+            // Custom transcription uses the display name "Custom"
+            // The actual model name is shown in the configuration screen
+            return "Custom"
+
         default:
             guard let model = TranscriptionModelProvider.allCloudModels.first(where: {$0.name == modelName}) else { return modelName }
             return model.displayName

--- a/VivaDicta/Services/Transcription/CloudTranscription/CloudTranscriptionService.swift
+++ b/VivaDicta/Services/Transcription/CloudTranscription/CloudTranscriptionService.swift
@@ -74,6 +74,7 @@ class CloudTranscriptionService: TranscriptionService {
     private lazy var geminiService = GeminiTranscriptionService()
     private lazy var mistralService = MistralTranscriptionService()
     private lazy var sonioxService = SonioxTranscriptionService()
+    private lazy var customService = CustomTranscriptionService()
 
     func transcribe(audioURL: URL, model: any TranscriptionModel) async throws -> String {
         var text: String
@@ -93,6 +94,11 @@ class CloudTranscriptionService: TranscriptionService {
             text = try await mistralService.transcribe(audioURL: audioURL, model: model)
         case .soniox:
             text = try await sonioxService.transcribe(audioURL: audioURL, model: model)
+        case .customTranscription:
+            guard let customModel = model as? CustomTranscriptionModel else {
+                throw CloudTranscriptionError.unsupportedProvider
+            }
+            text = try await customService.transcribe(audioURL: audioURL, model: customModel)
         default:
             throw CloudTranscriptionError.unsupportedProvider
         }

--- a/VivaDicta/Services/Transcription/CustomTranscription/CustomTranscriptionModelManager.swift
+++ b/VivaDicta/Services/Transcription/CustomTranscription/CustomTranscriptionModelManager.swift
@@ -1,0 +1,158 @@
+//
+//  CustomTranscriptionModelManager.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.01.17
+//
+
+import Foundation
+import os
+
+@Observable
+@MainActor
+final class CustomTranscriptionModelManager {
+    static let shared = CustomTranscriptionModelManager()
+
+    private let logger = Logger(category: .customTranscriptionService)
+
+    /// The single custom transcription model configuration
+    private(set) var customModel: CustomTranscriptionModel
+
+    private let userDefaultsKey = "customTranscriptionModel"
+    private let apiKeyKey = "apiKey.customTranscription"
+
+    /// Fixed model ID for the singleton custom model
+    private static let fixedModelId = UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
+
+    private init() {
+        // Initialize with empty model first
+        customModel = CustomTranscriptionModel(
+            id: Self.fixedModelId,
+            name: "custom",
+            displayName: "Custom",
+            apiEndpoint: "",
+            modelName: "",
+            isMultilingual: true
+        )
+        loadModel()
+    }
+
+    /// Whether the custom model is configured (has endpoint and model name)
+    var isConfigured: Bool {
+        !customModel.apiEndpoint.isEmpty && !customModel.modelName.isEmpty
+    }
+
+    /// Returns the custom model only if it's configured, otherwise nil
+    var configuredModel: CustomTranscriptionModel? {
+        isConfigured ? customModel : nil
+    }
+
+    // MARK: - Save/Update
+
+    func saveConfiguration(apiEndpoint: String, apiKey: String, modelName: String, isMultilingual: Bool) -> Bool {
+        let errors = validateConfiguration(apiEndpoint: apiEndpoint, modelName: modelName)
+        guard errors.isEmpty else {
+            return false
+        }
+
+        // Save API key
+        if !apiKey.isEmpty {
+            UserDefaultsStorage.shared.set(apiKey, forKey: apiKeyKey)
+        } else {
+            UserDefaultsStorage.shared.removeObject(forKey: apiKeyKey)
+        }
+
+        // Update model
+        customModel = CustomTranscriptionModel(
+            id: Self.fixedModelId,
+            name: "custom",
+            displayName: "Custom",
+            apiEndpoint: apiEndpoint.trimmingCharacters(in: .whitespaces),
+            modelName: modelName.trimmingCharacters(in: .whitespaces),
+            isMultilingual: isMultilingual
+        )
+
+        saveModel()
+        logger.logInfo("Custom transcription model configuration saved")
+        return true
+    }
+
+    func clearConfiguration() {
+        UserDefaultsStorage.shared.removeObject(forKey: apiKeyKey)
+        customModel = CustomTranscriptionModel(
+            id: Self.fixedModelId,
+            name: "custom",
+            displayName: "Custom",
+            apiEndpoint: "",
+            modelName: "",
+            isMultilingual: true
+        )
+        saveModel()
+        logger.logInfo("Custom transcription model configuration cleared")
+    }
+
+    // MARK: - API Key Management
+
+    func getAPIKey(forModelId id: UUID) -> String? {
+        guard id == Self.fixedModelId else { return nil }
+        return UserDefaultsStorage.shared.string(forKey: apiKeyKey)
+    }
+
+    var apiKey: String? {
+        UserDefaultsStorage.shared.string(forKey: apiKeyKey)
+    }
+
+    // MARK: - Persistence
+
+    private func loadModel() {
+        guard let data = UserDefaultsStorage.shared.data(forKey: userDefaultsKey) else {
+            return
+        }
+
+        do {
+            let decoder = JSONDecoder()
+            customModel = try decoder.decode(CustomTranscriptionModel.self, from: data)
+            logger.logInfo("Loaded custom transcription model configuration")
+        } catch {
+            logger.logError("Failed to load custom transcription model: \(error.localizedDescription)")
+        }
+    }
+
+    private func saveModel() {
+        do {
+            let encoder = JSONEncoder()
+            let data = try encoder.encode(customModel)
+            UserDefaultsStorage.shared.set(data, forKey: userDefaultsKey)
+        } catch {
+            logger.logError("Failed to save custom transcription model: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Validation
+
+    func validateConfiguration(apiEndpoint: String, modelName: String) -> [String] {
+        var errors: [String] = []
+
+        if apiEndpoint.trimmingCharacters(in: .whitespaces).isEmpty {
+            errors.append("API endpoint is required")
+        } else if !isValidURL(apiEndpoint) {
+            errors.append("Invalid API endpoint URL")
+        }
+
+        if modelName.trimmingCharacters(in: .whitespaces).isEmpty {
+            errors.append("Model name is required")
+        }
+
+        return errors
+    }
+
+    private func isValidURL(_ urlString: String) -> Bool {
+        guard let url = URL(string: urlString),
+              let scheme = url.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              url.host != nil else {
+            return false
+        }
+        return true
+    }
+}

--- a/VivaDicta/Services/Transcription/CustomTranscription/CustomTranscriptionService.swift
+++ b/VivaDicta/Services/Transcription/CustomTranscription/CustomTranscriptionService.swift
@@ -1,0 +1,116 @@
+//
+//  CustomTranscriptionService.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.01.17
+//
+
+import Foundation
+import os
+
+struct CustomTranscriptionService {
+    private let logger = Logger(category: .customTranscriptionService)
+
+    func transcribe(audioURL: URL, model: CustomTranscriptionModel) async throws -> String {
+        try await NetworkRetry.withRetry(logger: logger) {
+            try await makeTranscriptionRequest(audioURL: audioURL, model: model)
+        }
+    }
+
+    private func makeTranscriptionRequest(audioURL: URL, model: CustomTranscriptionModel) async throws -> String {
+        guard let url = URL(string: model.apiEndpoint) else {
+            throw CloudTranscriptionError.unsupportedProvider
+        }
+
+        let boundary = "Boundary-\(UUID().uuidString)"
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+
+        // API key is optional - only add Authorization header if provided
+        if let apiKey = model.apiKey, !apiKey.isEmpty {
+            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        }
+
+        request.timeoutInterval = NetworkRetry.defaultTimeout
+
+        let body = try createRequestBody(audioURL: audioURL, modelName: model.modelName, boundary: boundary)
+
+        logger.logInfo("Sending request to custom endpoint: \(model.apiEndpoint)")
+
+        let (data, response) = try await URLSession.shared.upload(for: request, from: body)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw CloudTranscriptionError.networkError(URLError(.badServerResponse))
+        }
+
+        if !(200...299).contains(httpResponse.statusCode) {
+            let errorMessage = String(data: data, encoding: .utf8) ?? "No error message"
+            logger.logError("Custom API request failed with status \(httpResponse.statusCode): \(errorMessage)")
+            throw CloudTranscriptionError.apiRequestFailed(statusCode: httpResponse.statusCode, message: errorMessage)
+        }
+
+        do {
+            let transcriptionResponse = try JSONDecoder().decode(TranscriptionResponse.self, from: data)
+            logger.logInfo("Transcription successful, received \(transcriptionResponse.text.count) characters")
+            return transcriptionResponse.text
+        } catch {
+            logger.logError("Failed to decode API response: \(error.localizedDescription)")
+            throw CloudTranscriptionError.noTranscriptionReturned
+        }
+    }
+
+    private func createRequestBody(audioURL: URL, modelName: String, boundary: String) throws -> Data {
+        var body = Data()
+        let crlf = "\r\n"
+
+        guard let audioData = try? Data(contentsOf: audioURL) else {
+            throw CloudTranscriptionError.audioFileNotFound
+        }
+
+        let selectedLanguage = UserDefaultsStorage.shared.string(forKey: AppGroupCoordinator.kSelectedLanguageKey) ?? "auto"
+
+        // Audio file
+        body.append("--\(boundary)\(crlf)".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"file\"; filename=\"\(audioURL.lastPathComponent)\"\(crlf)".data(using: .utf8)!)
+        body.append("Content-Type: audio/wav\(crlf)\(crlf)".data(using: .utf8)!)
+        body.append(audioData)
+        body.append(crlf.data(using: .utf8)!)
+
+        // Model name
+        body.append("--\(boundary)\(crlf)".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"model\"\(crlf)\(crlf)".data(using: .utf8)!)
+        body.append(modelName.data(using: .utf8)!)
+        body.append(crlf.data(using: .utf8)!)
+
+        // Language (if not auto)
+        if selectedLanguage != "auto", !selectedLanguage.isEmpty {
+            body.append("--\(boundary)\(crlf)".data(using: .utf8)!)
+            body.append("Content-Disposition: form-data; name=\"language\"\(crlf)\(crlf)".data(using: .utf8)!)
+            body.append(selectedLanguage.data(using: .utf8)!)
+            body.append(crlf.data(using: .utf8)!)
+        }
+
+        // Response format
+        body.append("--\(boundary)\(crlf)".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"response_format\"\(crlf)\(crlf)".data(using: .utf8)!)
+        body.append("json".data(using: .utf8)!)
+        body.append(crlf.data(using: .utf8)!)
+
+        // Temperature
+        body.append("--\(boundary)\(crlf)".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"temperature\"\(crlf)\(crlf)".data(using: .utf8)!)
+        body.append("0".data(using: .utf8)!)
+        body.append(crlf.data(using: .utf8)!)
+
+        body.append("--\(boundary)--\(crlf)".data(using: .utf8)!)
+
+        return body
+    }
+
+    private struct TranscriptionResponse: Decodable {
+        let text: String
+        let language: String?
+        let duration: Double?
+    }
+}

--- a/VivaDicta/Services/Transcription/TranscriptionManager.swift
+++ b/VivaDicta/Services/Transcription/TranscriptionManager.swift
@@ -88,6 +88,11 @@ class TranscriptionManager {
         let provider = currentMode.transcriptionProvider
         let modelName = currentMode.transcriptionModel
 
+        // Check for custom model first
+        if provider == .customTranscription && modelName == "custom" {
+            return CustomTranscriptionModelManager.shared.configuredModel
+        }
+
         let allModels: [any TranscriptionModel] =
         TranscriptionModelProvider.allParakeetModels +
         TranscriptionModelProvider.allWhisperKitModels +

--- a/VivaDicta/Services/Transcription/TranscriptionManager.swift
+++ b/VivaDicta/Services/Transcription/TranscriptionManager.swift
@@ -36,7 +36,10 @@ class TranscriptionManager {
             model.apiKey != nil
         }
 
-        return hasParakeetModels || hasWhisperKitModels || hasConfiguredCloudModels
+        // Check if custom transcription model is configured
+        let hasCustomModel = CustomTranscriptionModelManager.shared.isConfigured
+
+        return hasParakeetModels || hasWhisperKitModels || hasConfiguredCloudModels || hasCustomModel
     }
 
     var selectedLanguage: String {

--- a/VivaDicta/Utilities/LoggerExtension.swift
+++ b/VivaDicta/Utilities/LoggerExtension.swift
@@ -37,6 +37,7 @@ public enum LogCategory: String {
     case geminiService = "GeminiService"
     case mistralTranscriptionService = "MistralTranscriptionService"
     case sonioxTranscriptionService = "SonioxTranscriptionService"
+    case customTranscriptionService = "CustomTranscriptionService"
 
     // MARK: - Services - Other
     case aiService = "AIService"

--- a/VivaDicta/Views/ModelsScreen/AddCustomTranscriptionModelView.swift
+++ b/VivaDicta/Views/ModelsScreen/AddCustomTranscriptionModelView.swift
@@ -19,6 +19,13 @@ struct AddCustomTranscriptionModelView: View {
     @State private var isChecking = false
     @State private var connectionStatus: ConnectionStatus = .unknown
     @State private var showingClearConfirmation = false
+    @FocusState private var focusedField: Field?
+
+    private enum Field {
+        case apiEndpoint
+        case apiKey
+        case modelName
+    }
 
     private var manager: CustomTranscriptionModelManager {
         CustomTranscriptionModelManager.shared
@@ -71,6 +78,7 @@ struct AddCustomTranscriptionModelView: View {
                                 .foregroundStyle(.secondary)
 
                             TextField("", text: $apiEndpoint)
+                                .focused($focusedField, equals: .apiEndpoint)
                                 .textInputAutocapitalization(.never)
                                 .autocorrectionDisabled()
                                 .keyboardType(.URL)
@@ -100,6 +108,7 @@ struct AddCustomTranscriptionModelView: View {
                                 .foregroundStyle(.secondary)
 
                             SecureField("your-api-key", text: $apiKey)
+                                .focused($focusedField, equals: .apiKey)
                                 .textInputAutocapitalization(.never)
                                 .autocorrectionDisabled()
                                 .privacySensitive()
@@ -121,6 +130,7 @@ struct AddCustomTranscriptionModelView: View {
                                 .foregroundStyle(.secondary)
 
                             TextField("large-v3-turbo", text: $modelName)
+                                .focused($focusedField, equals: .modelName)
                                 .textInputAutocapitalization(.never)
                                 .autocorrectionDisabled()
                                 .padding()
@@ -211,7 +221,7 @@ struct AddCustomTranscriptionModelView: View {
             .padding()
             .contentShape(Rectangle())
             .onTapGesture {
-                UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+                focusedField = nil
             }
             .navigationTitle("Custom Model")
             .navigationBarTitleDisplayMode(.inline)

--- a/VivaDicta/Views/ModelsScreen/AddCustomTranscriptionModelView.swift
+++ b/VivaDicta/Views/ModelsScreen/AddCustomTranscriptionModelView.swift
@@ -83,7 +83,7 @@ struct AddCustomTranscriptionModelView: View {
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
 
-                            TextField("https://api.example.com/v1/audio/transcriptions", text: $apiEndpoint)
+                            TextField("", text: $apiEndpoint)
                                 .textInputAutocapitalization(.never)
                                 .autocorrectionDisabled()
                                 .keyboardType(.URL)

--- a/VivaDicta/Views/ModelsScreen/AddCustomTranscriptionModelView.swift
+++ b/VivaDicta/Views/ModelsScreen/AddCustomTranscriptionModelView.swift
@@ -59,19 +59,6 @@ struct AddCustomTranscriptionModelView: View {
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
 
-                // Warning banner
-                HStack {
-                    Image(systemName: "exclamationmark.triangle.fill")
-                        .foregroundStyle(.orange)
-                    Text("Only OpenAI-compatible transcription APIs are supported")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-                .padding(.horizontal, 12)
-                .padding(.vertical, 8)
-                .background(Color.orange.opacity(0.1))
-                .clipShape(.rect(cornerRadius: 8))
-
                 // Connection status
                 connectionStatusView
 
@@ -157,7 +144,7 @@ struct AddCustomTranscriptionModelView: View {
                                     .foregroundStyle(.secondary)
                             }
                         }
-                        .tint(.blue)
+//                        .tint(.blue)
                         .padding(.vertical, 8)
                     }
                     .padding(.horizontal)

--- a/VivaDicta/Views/ModelsScreen/AddCustomTranscriptionModelView.swift
+++ b/VivaDicta/Views/ModelsScreen/AddCustomTranscriptionModelView.swift
@@ -1,0 +1,416 @@
+//
+//  AddCustomTranscriptionModelView.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.01.17
+//
+
+import SwiftUI
+
+struct AddCustomTranscriptionModelView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    var onSave: () -> Void
+
+    @State private var apiEndpoint: String = ""
+    @State private var apiKey: String = ""
+    @State private var modelName: String = ""
+    @State private var isMultilingual: Bool = true
+    @State private var isChecking = false
+    @State private var connectionStatus: ConnectionStatus = .unknown
+    @State private var showingClearConfirmation = false
+
+    private var manager: CustomTranscriptionModelManager {
+        CustomTranscriptionModelManager.shared
+    }
+
+    enum ConnectionStatus: Equatable {
+        case unknown
+        case checking
+        case connected
+        case failed(message: String)
+        case invalidURL
+        case validationError(message: String)
+    }
+
+    private var canSave: Bool {
+        !apiEndpoint.trimmingCharacters(in: .whitespaces).isEmpty &&
+        !modelName.trimmingCharacters(in: .whitespaces).isEmpty &&
+        connectionStatus != .invalidURL
+    }
+
+    private var hasExistingConfiguration: Bool {
+        manager.isConfigured
+    }
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 16) {
+                // Icon
+                Image(systemName: "server.rack")
+                    .font(.system(size: 48))
+                    .foregroundStyle(.secondary)
+                    .padding(.top, 8)
+
+                Text("Custom Model")
+                    .font(.title2)
+
+                Text("OpenAI-Compatible Transcription API")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+
+                // Warning banner
+                HStack {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.orange)
+                    Text("Only OpenAI-compatible transcription APIs are supported")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(Color.orange.opacity(0.1))
+                .clipShape(.rect(cornerRadius: 8))
+
+                // Connection status
+                connectionStatusView
+
+                ScrollView {
+                    VStack(spacing: 20) {
+                        // API Endpoint input
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("API Endpoint")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+
+                            TextField("https://api.example.com/v1/audio/transcriptions", text: $apiEndpoint)
+                                .textInputAutocapitalization(.never)
+                                .autocorrectionDisabled()
+                                .keyboardType(.URL)
+                                .padding()
+                                .background {
+                                    Capsule()
+                                        .stroke(urlFieldBorderColor, lineWidth: urlFieldBorderWidth)
+                                }
+                                .onChange(of: apiEndpoint) { _, newValue in
+                                    let trimmed = newValue.trimmingCharacters(in: .whitespaces)
+                                    if !trimmed.isEmpty && !isValidURL(trimmed) {
+                                        connectionStatus = .invalidURL
+                                    } else if connectionStatus == .invalidURL {
+                                        connectionStatus = .unknown
+                                    }
+                                }
+
+                            Text("The full transcription endpoint URL")
+                                .font(.caption2)
+                                .foregroundStyle(.tertiary)
+                        }
+
+                        // API Key input (optional)
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("API Key (Optional)")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+
+                            SecureField("your-api-key", text: $apiKey)
+                                .textInputAutocapitalization(.never)
+                                .autocorrectionDisabled()
+                                .privacySensitive()
+                                .padding()
+                                .background {
+                                    Capsule()
+                                        .stroke(Color.gray, lineWidth: 0.5)
+                                }
+
+                            Text("Leave empty if your server doesn't require authentication")
+                                .font(.caption2)
+                                .foregroundStyle(.tertiary)
+                        }
+
+                        // Model Name input
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("Model Name")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+
+                            TextField("large-v3-turbo", text: $modelName)
+                                .textInputAutocapitalization(.never)
+                                .autocorrectionDisabled()
+                                .padding()
+                                .background {
+                                    Capsule()
+                                        .stroke(Color.gray, lineWidth: 0.5)
+                                }
+
+                            Text("The model identifier as expected by your API server")
+                                .font(.caption2)
+                                .foregroundStyle(.tertiary)
+                        }
+
+                        // Multilingual toggle
+                        Toggle(isOn: $isMultilingual) {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("Multilingual Model")
+                                    .font(.subheadline)
+                                Text("Enable if the model supports multiple languages")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        .tint(.blue)
+                        .padding(.vertical, 8)
+                    }
+                    .padding(.horizontal)
+                }
+
+                // Action buttons
+                VStack(spacing: 12) {
+                    // Save button
+                    if #available(iOS 26.0, *) {
+                        Button {
+                            saveConfiguration()
+                        } label: {
+                            HStack {
+                                if case .checking = connectionStatus {
+                                    ProgressView()
+                                        .controlSize(.small)
+                                }
+                                Text(connectionStatus == .checking ? "Saving..." : "Save")
+                                    .font(.headline.weight(.medium))
+                            }
+                        }
+                        .disabled(isChecking || !canSave)
+                        .padding(.vertical, 8)
+                        .padding(.horizontal, 16)
+                        .glassEffect(.regular.tint(.blue.opacity(0.3)).interactive())
+                        .buttonStyle(.plain)
+                    } else {
+                        Button {
+                            saveConfiguration()
+                        } label: {
+                            HStack {
+                                if case .checking = connectionStatus {
+                                    ProgressView()
+                                        .controlSize(.small)
+                                }
+                                Text(connectionStatus == .checking ? "Saving..." : "Save")
+                                    .font(.headline.weight(.medium))
+                                    .foregroundStyle(.primary)
+                            }
+                            .padding(.vertical, 8)
+                            .padding(.horizontal, 16)
+                            .background {
+                                Capsule()
+                                    .stroke(.blue, lineWidth: 2)
+                            }
+                        }
+                        .disabled(isChecking || !canSave)
+                        .buttonStyle(.plain)
+                    }
+
+                    // Clear configuration button (only if configured)
+                    if hasExistingConfiguration {
+                        Button(role: .destructive) {
+                            showingClearConfirmation = true
+                        } label: {
+                            Label("Clear Configuration", systemImage: "trash")
+                                .font(.subheadline)
+                        }
+                    }
+                }
+
+                Spacer()
+            }
+            .padding()
+            .contentShape(Rectangle())
+            .onTapGesture {
+                UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+            }
+            .navigationTitle("Custom Model")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+            }
+            .onAppear {
+                loadExistingConfiguration()
+            }
+            .confirmationDialog(
+                "Clear Configuration",
+                isPresented: $showingClearConfirmation,
+                titleVisibility: .visible
+            ) {
+                Button("Clear", role: .destructive) {
+                    clearConfiguration()
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text("This will remove all custom model settings.")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var connectionStatusView: some View {
+        switch connectionStatus {
+        case .unknown:
+            EmptyView()
+
+        case .checking:
+            HStack {
+                ProgressView()
+                    .controlSize(.small)
+                Text("Validating...")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+        case .connected:
+            HStack {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+                    .accessibilityLabel("Saved successfully")
+                Text("Configuration saved")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+        case .failed(let message):
+            HStack(alignment: .top) {
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundStyle(.red)
+                    .accessibilityLabel("Save failed")
+                Text(message)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.leading)
+            }
+
+        case .invalidURL:
+            HStack {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                    .accessibilityLabel("Invalid URL")
+                Text("Invalid URL. Use http:// or https://")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+        case .validationError(let message):
+            HStack {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                    .accessibilityLabel("Validation error")
+                Text(message)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var urlFieldBorderColor: Color {
+        switch connectionStatus {
+        case .invalidURL:
+            return .orange
+        case .connected:
+            return .green
+        case .failed:
+            return .red
+        default:
+            return .gray
+        }
+    }
+
+    private var urlFieldBorderWidth: CGFloat {
+        switch connectionStatus {
+        case .unknown:
+            return 0.5
+        default:
+            return 1.5
+        }
+    }
+
+    private func isValidURL(_ urlString: String) -> Bool {
+        guard let url = URL(string: urlString),
+              let scheme = url.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              url.host != nil else {
+            return false
+        }
+        return true
+    }
+
+    private func loadExistingConfiguration() {
+        let model = manager.customModel
+        apiEndpoint = model.apiEndpoint
+        modelName = model.modelName
+        isMultilingual = model.isMultilingual
+
+        if let existingKey = manager.apiKey {
+            apiKey = existingKey
+        }
+    }
+
+    private func saveConfiguration() {
+        let trimmedEndpoint = apiEndpoint.trimmingCharacters(in: .whitespaces)
+        let trimmedApiKey = apiKey.trimmingCharacters(in: .whitespaces)
+        let trimmedModelName = modelName.trimmingCharacters(in: .whitespaces)
+
+        // Validate
+        let errors = manager.validateConfiguration(apiEndpoint: trimmedEndpoint, modelName: trimmedModelName)
+
+        if !errors.isEmpty {
+            connectionStatus = .validationError(message: errors.first ?? "Validation failed")
+            HapticManager.error()
+            return
+        }
+
+        isChecking = true
+        connectionStatus = .checking
+        HapticManager.lightImpact()
+
+        let success = manager.saveConfiguration(
+            apiEndpoint: trimmedEndpoint,
+            apiKey: trimmedApiKey,
+            modelName: trimmedModelName,
+            isMultilingual: isMultilingual
+        )
+
+        handleSaveResult(success)
+    }
+
+    private func handleSaveResult(_ success: Bool) {
+        isChecking = false
+
+        if success {
+            connectionStatus = .connected
+            HapticManager.success()
+
+            // Dismiss after short delay
+            Task {
+                try? await Task.sleep(for: .milliseconds(500))
+                await MainActor.run {
+                    onSave()
+                    dismiss()
+                }
+            }
+        } else {
+            connectionStatus = .failed(message: "Failed to save configuration")
+            HapticManager.error()
+        }
+    }
+
+    private func clearConfiguration() {
+        HapticManager.heavyImpact()
+        manager.clearConfiguration()
+        onSave()
+        dismiss()
+    }
+}
+
+#Preview {
+    AddCustomTranscriptionModelView(onSave: {})
+}

--- a/VivaDicta/Views/ModelsScreen/CustomTranscriptionModelCard.swift
+++ b/VivaDicta/Views/ModelsScreen/CustomTranscriptionModelCard.swift
@@ -1,0 +1,119 @@
+//
+//  CustomTranscriptionModelCard.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.01.17
+//
+
+import SwiftUI
+
+struct CustomTranscriptionModelCard: View {
+    let onConfigure: () -> Void
+
+    private var manager: CustomTranscriptionModelManager {
+        CustomTranscriptionModelManager.shared
+    }
+
+    private var isConfigured: Bool {
+        manager.isConfigured
+    }
+
+    private var model: CustomTranscriptionModel {
+        manager.customModel
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            // Header with name and Custom badge
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack(spacing: 8) {
+                        Text("Custom")
+                            .font(.title3)
+                            .fontWeight(.semibold)
+
+                        // Custom badge
+                        Text("Custom")
+                            .font(.caption)
+                            .fontWeight(.medium)
+                            .foregroundStyle(.orange)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 4)
+                            .background(Color.orange.opacity(0.15))
+                            .clipShape(.rect(cornerRadius: 8))
+                    }
+
+                    // Model name (if configured)
+                    if isConfigured {
+                        Text(model.modelName)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    // Info row with icons
+                    HStack(spacing: 16) {
+                        // Language support
+                        Label(
+                            isConfigured ? (model.isMultilingual ? "Multilingual" : "English-only") : "Not configured",
+                            systemImage: isConfigured ? "globe" : "questionmark.circle"
+                        )
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    }
+
+                    // OpenAI Compatible badge
+                    HStack(spacing: 4) {
+                        Image(systemName: "checkmark.seal")
+                            .font(.caption)
+                        Text("OpenAI Compatible")
+                            .font(.caption)
+                    }
+                    .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                // Configuration button - gear icon
+                Button {
+                    HapticManager.lightImpact()
+                    onConfigure()
+                } label: {
+                    VStack(spacing: 4) {
+                        Image(systemName: isConfigured ? "gearshape.fill" : "gearshape")
+                            .font(.title2)
+                            .foregroundStyle(isConfigured ? .green : .blue)
+                        Text(isConfigured ? "Configured" : "Configure")
+                            .font(.caption2)
+                            .foregroundStyle(isConfigured ? .green : .blue)
+                    }
+                }
+                .buttonStyle(.plain)
+            }
+
+            // Description
+            Text(isConfigured ? "Custom transcription model" : "Add your own OpenAI-compatible transcription API")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .padding(20)
+        .background(.background.secondary)
+        .clipShape(.rect(cornerRadius: 20, style: .continuous))
+        .shadow(color: .primary.opacity(0.5), radius: 2, x: 2, y: 2)
+        .overlay {
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .stroke(.primary.opacity(0.3), lineWidth: 0.5)
+        }
+        .contentShape(.rect)
+        .onTapGesture {
+            HapticManager.lightImpact()
+            onConfigure()
+        }
+    }
+}
+
+#Preview("Not Configured") {
+    VStack(spacing: 20) {
+        CustomTranscriptionModelCard(onConfigure: {})
+    }
+    .padding()
+}

--- a/VivaDicta/Views/ModelsScreen/CustomTranscriptionModelCard.swift
+++ b/VivaDicta/Views/ModelsScreen/CustomTranscriptionModelCard.swift
@@ -31,16 +31,6 @@ struct CustomTranscriptionModelCard: View {
                         Text("Custom")
                             .font(.title3)
                             .fontWeight(.semibold)
-
-                        // Custom badge
-                        Text("Custom")
-                            .font(.caption)
-                            .fontWeight(.medium)
-                            .foregroundStyle(.orange)
-                            .padding(.horizontal, 8)
-                            .padding(.vertical, 4)
-                            .background(Color.orange.opacity(0.15))
-                            .clipShape(.rect(cornerRadius: 8))
                     }
 
                     // Model name (if configured)
@@ -61,14 +51,6 @@ struct CustomTranscriptionModelCard: View {
                         .foregroundStyle(.secondary)
                     }
 
-                    // OpenAI Compatible badge
-                    HStack(spacing: 4) {
-                        Image(systemName: "checkmark.seal")
-                            .font(.caption)
-                        Text("OpenAI Compatible")
-                            .font(.caption)
-                    }
-                    .foregroundStyle(.secondary)
                 }
 
                 Spacer()
@@ -79,10 +61,10 @@ struct CustomTranscriptionModelCard: View {
                     onConfigure()
                 } label: {
                     VStack(spacing: 4) {
-                        Image(systemName: isConfigured ? "gearshape.fill" : "gearshape")
+                        Image(systemName: isConfigured ? "checkmark.circle.fill" : "gearshape.circle")
                             .font(.title2)
                             .foregroundStyle(isConfigured ? .green : .blue)
-                        Text(isConfigured ? "Configured" : "Configure")
+                        Text(isConfigured ? "" : "Configure")
                             .font(.caption2)
                             .foregroundStyle(isConfigured ? .green : .blue)
                     }

--- a/VivaDicta/Views/ModelsScreen/CustomTranscriptionModelCard.swift
+++ b/VivaDicta/Views/ModelsScreen/CustomTranscriptionModelCard.swift
@@ -36,18 +36,18 @@ struct CustomTranscriptionModelCard: View {
                     // Model name (if configured)
                     if isConfigured {
                         Text(model.modelName)
-                            .font(.subheadline)
-                            .foregroundStyle(.secondary)
+                            .font(.title3)
+                            .fontWeight(.regular)
                     }
 
                     // Info row with icons
                     HStack(spacing: 16) {
                         // Language support
                         Label(
-                            isConfigured ? (model.isMultilingual ? "Multilingual" : "English-only") : "Not configured",
+                            isConfigured ? (model.isMultilingual ? "All Languages" : "English-only") : "Not configured",
                             systemImage: isConfigured ? "globe" : "questionmark.circle"
                         )
-                        .font(.caption)
+                        .font(.subheadline)
                         .foregroundStyle(.secondary)
                     }
 
@@ -62,10 +62,10 @@ struct CustomTranscriptionModelCard: View {
                 } label: {
                     VStack(spacing: 4) {
                         Image(systemName: isConfigured ? "checkmark.circle.fill" : "gearshape.circle")
-                            .font(.title2)
+                            .font(.system(size: 30))
                             .foregroundStyle(isConfigured ? .green : .blue)
                         Text(isConfigured ? "" : "Configure")
-                            .font(.caption2)
+                            .font(.system(size: 10))
                             .foregroundStyle(isConfigured ? .green : .blue)
                     }
                 }

--- a/VivaDicta/Views/ModelsScreen/CustomTranscriptionModelCard.swift
+++ b/VivaDicta/Views/ModelsScreen/CustomTranscriptionModelCard.swift
@@ -66,7 +66,7 @@ struct CustomTranscriptionModelCard: View {
                             .foregroundStyle(isConfigured ? .green : .blue)
                         Text(isConfigured ? "" : "Configure")
                             .font(.system(size: 10))
-                            .foregroundStyle(isConfigured ? .green : .blue)
+                            .foregroundStyle(isConfigured ? .green : .secondary)
                     }
                 }
                 .buttonStyle(.plain)

--- a/VivaDicta/Views/SettingsScreen/ModeEditView.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditView.swift
@@ -17,6 +17,7 @@ struct ModeEditView: View {
     
     @State private var showingAlert: Bool = false
     @State private var modeEditViewError: SettingsError = .duplicateModeName("")
+    @State private var showCustomTranscriptionConfiguration: Bool = false
     
     let selectAIEnhacementTip = SelectAIEnhacementTip()
     
@@ -68,7 +69,8 @@ struct ModeEditView: View {
                             } else {
                                 HStack(spacing: 4) {
                                     Text(provider.displayName)
-                                    Image(systemName: "key.slash.fill")
+                                    // Show gear icon for custom transcription, key icon for others
+                                    Image(systemName: provider == .customTranscription ? "gearshape" : "key.slash.fill")
                                 }
                                 .tag(provider)
                             }
@@ -178,6 +180,24 @@ struct ModeEditView: View {
                                 Image(systemName: "exclamationmark.triangle.fill")
                                     .foregroundStyle(.orange)
                                 Text("Download Model")
+                                Spacer()
+                                Text("Required")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                Image(systemName: "chevron.right")
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        .foregroundStyle(.primary)
+                    } else if viewModel.transcriptionProvider == .customTranscription {
+                        // Custom transcription needs configuration
+                        Button {
+                            showCustomTranscriptionConfiguration = true
+                        } label: {
+                            HStack {
+                                Image(systemName: "exclamationmark.triangle.fill")
+                                    .foregroundStyle(.orange)
+                                Text("Configure Custom Model")
                                 Spacer()
                                 Text("Required")
                                     .font(.caption)
@@ -552,6 +572,11 @@ struct ModeEditView: View {
                 }
             }
         }
+        .sheet(isPresented: $showCustomTranscriptionConfiguration) {
+            AddCustomTranscriptionModelView(onSave: {
+                handleCustomTranscriptionSaved()
+            })
+        }
     }
     @ViewBuilder
     private var transcriptionSectionFooter: some View {
@@ -612,6 +637,13 @@ struct ModeEditView: View {
         HapticManager.heavyImpact()
         viewModel.aiService.deleteMode(mode)
         dismiss()
+    }
+
+    private func handleCustomTranscriptionSaved() {
+        // Update the transcription model selection after custom model is saved
+        if CustomTranscriptionModelManager.shared.isConfigured {
+            viewModel.transcriptionModel = "custom"
+        }
     }
 }
 

--- a/VivaDicta/Views/SettingsScreen/ModeEditView.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditView.swift
@@ -105,12 +105,8 @@ struct ModeEditView: View {
                 }
                 
                 if viewModel.isTranscriptionProviderConfigured(viewModel.transcriptionProvider) {
-                    Picker(selection: $viewModel.transcriptionModel) {
-                        ForEach(viewModel.getAvailableTranscriptionModels(for: viewModel.transcriptionProvider), id: \.self) { model in
-                            Text(viewModel.transcriptionProvider.getTranscriptionModelDisplayName(model))
-                                .tag(model)
-                        }
-                    } label: {
+                    // Custom transcription - show configured model name directly (no picker needed)
+                    if viewModel.transcriptionProvider == .customTranscription {
                         HStack {
                             Image(systemName: "character.bubble")
                                 .foregroundStyle(
@@ -128,17 +124,47 @@ struct ModeEditView: View {
                                     )
                                 )
                             Text("Model")
+                            Spacer()
+                            Text(CustomTranscriptionModelManager.shared.customModel.modelName)
+                                .foregroundStyle(.secondary)
                         }
-                    }
-                    .alignmentGuide(.listRowSeparatorLeading) { _ in 0 }
-                    .onChange(of: viewModel.transcriptionModel) { _, newModel in
-                        viewModel.updateTranscriptionModel(newModel)
-                        HapticManager.selectionChanged()
-                    }
-                    .onAppear {
-                        let availableModels = viewModel.getAvailableTranscriptionModels(for: viewModel.transcriptionProvider)
-                        if !availableModels.contains(viewModel.transcriptionModel) && !availableModels.isEmpty {
-                            viewModel.transcriptionModel = availableModels.first ?? ""
+                        .alignmentGuide(.listRowSeparatorLeading) { _ in 0 }
+                    } else {
+                        Picker(selection: $viewModel.transcriptionModel) {
+                            ForEach(viewModel.getAvailableTranscriptionModels(for: viewModel.transcriptionProvider), id: \.self) { model in
+                                Text(viewModel.transcriptionProvider.getTranscriptionModelDisplayName(model))
+                                    .tag(model)
+                            }
+                        } label: {
+                            HStack {
+                                Image(systemName: "character.bubble")
+                                    .foregroundStyle(
+                                        MeshGradient(
+                                            width: 2,
+                                            height: 2,
+                                            points: [
+                                                [0, 0], [1, 0],
+                                                [0, 1], [1, 1]
+                                            ],
+                                            colors: [
+                                                .blue, .green,
+                                                .indigo, .teal
+                                            ]
+                                        )
+                                    )
+                                Text("Model")
+                            }
+                        }
+                        .alignmentGuide(.listRowSeparatorLeading) { _ in 0 }
+                        .onChange(of: viewModel.transcriptionModel) { _, newModel in
+                            viewModel.updateTranscriptionModel(newModel)
+                            HapticManager.selectionChanged()
+                        }
+                        .onAppear {
+                            let availableModels = viewModel.getAvailableTranscriptionModels(for: viewModel.transcriptionProvider)
+                            if !availableModels.contains(viewModel.transcriptionModel) && !availableModels.isEmpty {
+                                viewModel.transcriptionModel = availableModels.first ?? ""
+                            }
                         }
                     }
                     

--- a/VivaDicta/Views/SettingsScreen/ModeEditView.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditView.swift
@@ -20,8 +20,37 @@ struct ModeEditView: View {
     @State private var showCustomTranscriptionConfiguration: Bool = false
     
     let selectAIEnhacementTip = SelectAIEnhacementTip()
-    
+
     let selectLanguageTip = SelectLanguageTip()
+
+    // MARK: - Gradients
+
+    private var transcriptionGradient: MeshGradient {
+        MeshGradient(
+            width: 2,
+            height: 2,
+            points: [[0, 0], [1, 0], [0, 1], [1, 1]],
+            colors: [.blue, .orange, .green, .mint]
+        )
+    }
+
+    private var transcriptionModelGradient: MeshGradient {
+        MeshGradient(
+            width: 2,
+            height: 2,
+            points: [[0, 0], [1, 0], [0, 1], [1, 1]],
+            colors: [.blue, .green, .indigo, .teal]
+        )
+    }
+
+    private var aiEnhancementGradient: MeshGradient {
+        MeshGradient(
+            width: 2,
+            height: 2,
+            points: [[0, 0], [1, 0], [0, 1], [1, 1]],
+            colors: [.purple, .red, .blue, .pink]
+        )
+    }
 
     
     init(mode: VivaMode?,
@@ -79,20 +108,7 @@ struct ModeEditView: View {
                 } label: {
                     HStack {
                         Image(systemName: "waveform")
-                            .foregroundStyle(
-                                MeshGradient(
-                                    width: 2,
-                                    height: 2,
-                                    points: [
-                                        [0, 0], [1, 0],
-                                        [0, 1], [1, 1]
-                                    ],
-                                    colors: [
-                                        .blue, .orange,
-                                        .green, .mint
-                                    ]
-                                )
-                            )
+                            .foregroundStyle(transcriptionGradient)
                         Text("Provider")
                     }
                 }
@@ -109,20 +125,7 @@ struct ModeEditView: View {
                     if viewModel.transcriptionProvider == .customTranscription {
                         HStack {
                             Image(systemName: "character.bubble")
-                                .foregroundStyle(
-                                    MeshGradient(
-                                        width: 2,
-                                        height: 2,
-                                        points: [
-                                            [0, 0], [1, 0],
-                                            [0, 1], [1, 1]
-                                        ],
-                                        colors: [
-                                            .blue, .green,
-                                            .indigo, .teal
-                                        ]
-                                    )
-                                )
+                                .foregroundStyle(transcriptionModelGradient)
                             Text("Model")
                             Spacer()
                             Text(CustomTranscriptionModelManager.shared.customModel.modelName)
@@ -138,20 +141,7 @@ struct ModeEditView: View {
                         } label: {
                             HStack {
                                 Image(systemName: "character.bubble")
-                                    .foregroundStyle(
-                                        MeshGradient(
-                                            width: 2,
-                                            height: 2,
-                                            points: [
-                                                [0, 0], [1, 0],
-                                                [0, 1], [1, 1]
-                                            ],
-                                            colors: [
-                                                .blue, .green,
-                                                .indigo, .teal
-                                            ]
-                                        )
-                                    )
+                                    .foregroundStyle(transcriptionModelGradient)
                                 Text("Model")
                             }
                         }
@@ -268,21 +258,7 @@ struct ModeEditView: View {
 
                     if !viewModel.aiEnhanceEnabled {
                         TipView(selectAIEnhacementTip)
-                            .tipBackground(
-                                MeshGradient(
-                                    width: 2,
-                                    height: 2,
-                                    points: [
-                                        [0, 0], [1, 0],
-                                        [0, 1], [1, 1]
-                                    ],
-                                    colors: [
-                                        .purple, .red,
-                                        .blue, .pink
-                                    ]
-                                )
-                                .opacity(0.3)
-                            )
+                            .tipBackground(aiEnhancementGradient.opacity(0.3))
                     }
 
                     Toggle("Enable", isOn: $viewModel.aiEnhanceEnabled)
@@ -318,20 +294,7 @@ struct ModeEditView: View {
                         } label: {
                             HStack {
                                 Image(systemName: "sparkles")
-                                    .foregroundStyle(
-                                        MeshGradient(
-                                            width: 2,
-                                            height: 2,
-                                            points: [
-                                                [0, 0], [1, 0],
-                                                [0, 1], [1, 1]
-                                            ],
-                                            colors: [
-                                                .purple, .red,
-                                                .blue, .pink
-                                            ]
-                                        )
-                                    )
+                                    .foregroundStyle(aiEnhancementGradient)
                                 Text("AI Provider")
                             }
                         }
@@ -351,20 +314,7 @@ struct ModeEditView: View {
                                 if provider == .apple {
                                     HStack {
                                         Image(systemName: "wand.and.sparkles")
-                                            .foregroundStyle(
-                                        MeshGradient(
-                                            width: 2,
-                                            height: 2,
-                                            points: [
-                                                [0, 0], [1, 0],
-                                                [0, 1], [1, 1]
-                                            ],
-                                            colors: [
-                                                .purple, .red,
-                                                .blue, .pink
-                                            ]
-                                        )
-                                    )
+                                            .foregroundStyle(aiEnhancementGradient)
                                         Text("AI Model")
                                         Spacer()
                                         Text("Foundation Model")
@@ -375,20 +325,7 @@ struct ModeEditView: View {
                                     // Custom OpenAI - show configured model name (no picker)
                                     HStack {
                                         Image(systemName: "cube.fill")
-                                            .foregroundStyle(
-                                        MeshGradient(
-                                            width: 2,
-                                            height: 2,
-                                            points: [
-                                                [0, 0], [1, 0],
-                                                [0, 1], [1, 1]
-                                            ],
-                                            colors: [
-                                                .purple, .red,
-                                                .blue, .pink
-                                            ]
-                                        )
-                                    )
+                                            .foregroundStyle(aiEnhancementGradient)
                                         Text("AI Model")
                                         Spacer()
                                         Text(viewModel.aiService.customOpenAIModelName)
@@ -403,20 +340,7 @@ struct ModeEditView: View {
                                     } label: {
                                         HStack {
                                             Image(systemName: "cube.fill")
-                                                .foregroundStyle(
-                                        MeshGradient(
-                                            width: 2,
-                                            height: 2,
-                                            points: [
-                                                [0, 0], [1, 0],
-                                                [0, 1], [1, 1]
-                                            ],
-                                            colors: [
-                                                .purple, .red,
-                                                .blue, .pink
-                                            ]
-                                        )
-                                    )
+                                                .foregroundStyle(aiEnhancementGradient)
                                             Text("AI Model")
                                         }
                                     }

--- a/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
@@ -244,11 +244,16 @@ class ModeEditViewModel {
     // MARK: - Language Settings
     public func isLanguageSelectionAvailable() -> Bool {
         guard isTranscriptionProviderConfigured(transcriptionProvider) else { return false }
-        
+
         if transcriptionProvider == .gemini { return false }
-        
+
         if transcriptionProvider == .parakeet { return transcriptionModel == "parakeet-tdt-0.6b-v2" }
-        
+
+        // Custom transcription - only show language picker if multilingual
+        if transcriptionProvider == .customTranscription {
+            return CustomTranscriptionModelManager.shared.customModel.isMultilingual
+        }
+
         return true
 
     }
@@ -261,6 +266,11 @@ class ModeEditViewModel {
     public func getGroupedLanguages() -> GroupedLanguages {
         guard isLanguageSelectionAvailable() else {
             return GroupedLanguages(recommended: [], other: [])
+        }
+
+        // Custom transcription - use all languages if multilingual
+        if transcriptionProvider == .customTranscription {
+            return groupLanguages(Array(TranscriptionModelProvider.allLanguages))
         }
 
         let models: [any TranscriptionModel]

--- a/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
@@ -63,6 +63,8 @@ class ModeEditViewModel {
         if !isTranscriptionProviderConfigured(transcriptionProvider) {
             if transcriptionProvider == .parakeet || transcriptionProvider == .whisperKit {
                 return "Download a model to continue"
+            } else if transcriptionProvider == .customTranscription {
+                return "Configure custom model to continue"
             } else {
                 return "Add API key to continue"
             }
@@ -159,6 +161,8 @@ class ModeEditViewModel {
             return !TranscriptionModelProvider.allParakeetModels.filter { $0.isDownloaded }.isEmpty
         case .whisperKit:
             return !TranscriptionModelProvider.allWhisperKitModels.filter { $0.isDownloaded }.isEmpty
+        case .customTranscription:
+            return CustomTranscriptionModelManager.shared.isConfigured
         default: // Cloud transcription models
             guard let mappedAIProvider = provider.mappedAIProvider else { return false }
             return self.hasAPIKey(for: mappedAIProvider)
@@ -171,6 +175,9 @@ class ModeEditViewModel {
             return TranscriptionModelProvider.allParakeetModels.filter { $0.isDownloaded }.compactMap { $0.name }
         case .whisperKit:
             return TranscriptionModelProvider.allWhisperKitModels.filter { $0.isDownloaded }.compactMap { $0.name }
+        case .customTranscription:
+            // Custom transcription has a single fixed model name
+            return CustomTranscriptionModelManager.shared.isConfigured ? ["custom"] : []
         default: // Cloud transcription models
             return provider.cloudTranscriptionModelsNames
         }

--- a/VivaDicta/Views/SettingsScreen/ModelsView.swift
+++ b/VivaDicta/Views/SettingsScreen/ModelsView.swift
@@ -13,6 +13,7 @@ struct ModelsView: View {
 
     @State var modelType: TranscriptionModelType = .local
     @State var cloudModelToConfigure: CloudModel?
+    @State private var showCustomModelConfiguration = false
 
     @Namespace var zoomNamespace
 
@@ -40,7 +41,7 @@ struct ModelsView: View {
                                     model: model,
                                     downloadManager: appState.downloadManager
                                 )
-                                
+
                             } else if let cloudModel = model as? CloudModel {
                                 CloudModelCard(
                                     model: cloudModel,
@@ -56,6 +57,16 @@ struct ModelsView: View {
                         }
                         .padding(.horizontal)
                     }
+
+                    // Custom Model card (always shown in cloud tab)
+                    if modelType == .cloud {
+                        CustomTranscriptionModelCard(
+                            onConfigure: {
+                                showCustomModelConfiguration = true
+                            }
+                        )
+                        .padding(.horizontal)
+                    }
                 }
                 .padding(.vertical)
             }
@@ -69,6 +80,11 @@ struct ModelsView: View {
                 })
             .navigationTransition(.zoom(sourceID: model.id, in: zoomNamespace))
         })
+        .sheet(isPresented: $showCustomModelConfiguration) {
+            AddCustomTranscriptionModelView(onSave: {
+                handleCustomModelSaved()
+            })
+        }
         .navigationTitle("Transcription Models")
         .navigationBarTitleDisplayMode(.large)
     }
@@ -134,6 +150,18 @@ struct ModelsView: View {
         // Disable AI enhancement for modes using this provider
         if let aiProvider = model.provider.mappedAIProvider {
             appState.aiService.disableAIEnhancementForModesUsingProvider(aiProvider)
+        }
+    }
+
+    // MARK: - Custom Model Management
+
+    private func handleCustomModelSaved() {
+        appState.transcriptionManager.updateCloudModels()
+
+        Task {
+            // Hide "Select Transcription model" tips
+            await SelectTranscriptionModelTipMainView.selectModelEvent.donate()
+            await SelectTranscriptionModelTipSettingsView.selectModelEvent.donate()
         }
     }
 }

--- a/VivaDicta/Views/SettingsScreen/Prompts/TemplateSectionView.swift
+++ b/VivaDicta/Views/SettingsScreen/Prompts/TemplateSectionView.swift
@@ -56,6 +56,8 @@ struct TemplateSelectionView: View {
         }
         .alert("Enter your full name for email prompt", isPresented: $showEmailNameAlert) {
             TextField("Full Name", text: $emailUserName)
+                .autocapitalization(.words)
+                .autocorrectionDisabled()
             Button("Cancel", role: .cancel) {
                 emailUserName = ""
                 selectedTemplate = pendingEmailTemplate

--- a/VivaDicta/Views/SettingsScreen/Prompts/TemplateSectionView.swift
+++ b/VivaDicta/Views/SettingsScreen/Prompts/TemplateSectionView.swift
@@ -56,7 +56,7 @@ struct TemplateSelectionView: View {
         }
         .alert("Enter your full name for email prompt", isPresented: $showEmailNameAlert) {
             TextField("Full Name", text: $emailUserName)
-                .autocapitalization(.words)
+                .textInputAutocapitalization(.words)
                 .autocorrectionDisabled()
             Button("Cancel", role: .cancel) {
                 emailUserName = ""

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -467,7 +467,12 @@ private struct ModeInfoRow: View {
     let connectedProviders: [AIProvider]
 
     private var transcriptionModelDisplayName: String {
-        mode.transcriptionProvider.getTranscriptionModelDisplayName(mode.transcriptionModel)
+        // For custom transcription, show the actual configured model name
+        if mode.transcriptionProvider == .customTranscription {
+            let manager = CustomTranscriptionModelManager.shared
+            return manager.isConfigured ? manager.customModel.modelName : "Custom"
+        }
+        return mode.transcriptionProvider.getTranscriptionModelDisplayName(mode.transcriptionModel)
     }
     
     private var isLanguageSelectionAvailable: Bool {


### PR DESCRIPTION
## Summary
- Adds support for custom OpenAI-compatible transcription API endpoints
- Users can configure their own transcription server with custom endpoint URL, API key, and model name
- Includes language selection support for custom models (multilingual or English-only)
- Real-time URL validation with connection status feedback during configuration

## Changes
- New `CustomTranscriptionModel` conforming to `TranscriptionModel` protocol
- `CustomTranscriptionService` for OpenAI-compatible API requests
- `CustomTranscriptionModelManager` for configuration persistence
- Configuration UI with `AddCustomTranscriptionModelView`
- `CustomTranscriptionModelCard` for displaying custom provider in models list
- Integration with mode selection in `ModeEditView`

## Test plan
- [ ] Configure custom transcription endpoint with valid URL
- [ ] Verify URL validation shows appropriate status (valid/invalid)
- [ ] Test transcription with custom provider
- [ ] Verify language selection works for custom models
- [ ] Test clearing configuration
- [ ] Verify custom model appears in mode transcription picker