### PR TITLE
Add GPT-5.4 mini and nano models

### DIFF
--- a/VivaDicta/Services/AIEnhance/AIProvider.swift
+++ b/VivaDicta/Services/AIEnhance/AIProvider.swift
@@ -323,6 +323,8 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
         case .openAI:
             return [
                 "gpt-5.4",
+                "gpt-5.4-mini",
+                "gpt-5.4-nano",
                 "gpt-5.4-thinking",
                 "gpt-5.3-chat-latest",
                 "gpt-5.3-instant",

--- a/VivaDicta/Services/AIEnhance/ReasoningConfig.swift
+++ b/VivaDicta/Services/AIEnhance/ReasoningConfig.swift
@@ -14,6 +14,8 @@ struct ReasoningConfig {
     ]
 
     static let openAIReasoningModels: Set<String> = [
+        "gpt-5.4-mini",
+        "gpt-5.4-nano",
         "gpt-5-mini",
         "gpt-5-nano"
     ]


### PR DESCRIPTION
## Changes

Adds the latest OpenAI GPT-5.4 family models:

- **gpt-5.4-mini** — Fastest 5.4-class model, optimized for high-volume workloads ($0.75/$4.50 per 1M tokens, 400K context)
- **gpt-5.4-nano** — Cheapest 5.4-class model for classification, extraction, ranking ($0.20/$1.25 per 1M tokens, 400K context)

### Files changed
- `AIProvider.swift` — Added both models to `availableModels` for the OpenAI provider
- `ReasoningConfig.swift` — Added both to `openAIReasoningModels` set (they support reasoning tokens)

Older gpt-5-mini/nano kept for backward compatibility.