### PR TITLE
Replace foregroundColor with foregroundStyle in OnboardingComponents

### DIFF
--- a/VivaDicta/Views/Onboarding/OnboardingComponents.swift
+++ b/VivaDicta/Views/Onboarding/OnboardingComponents.swift
@@ -88,7 +88,7 @@ struct OnboardingSecondaryButton: View {
         Button(action: action) {
             Text(title)
                 .font(.headline)
-                .foregroundColor(.primary)
+                .foregroundStyle(.primary)
                 .frame(maxWidth: .infinity)
                 .frame(height: 56)
                 .background(Color.gray.opacity(0.3).gradient, in: .rect(cornerRadius: 16))


### PR DESCRIPTION
## Summary
- Replace deprecated `.foregroundColor(.primary)` with `.foregroundStyle(.primary)` in `OnboardingSecondaryButton`

## Test plan
- [ ] Visual check of onboarding secondary buttons