### PR TITLE
Replace foregroundColor with foregroundStyle

### DIFF
--- a/VivaDicta/Shared/MicButton.swift
+++ b/VivaDicta/Shared/MicButton.swift
@@ -26,7 +26,7 @@ struct MicButton: View {
         } label: {
             
             Image(systemName: "microphone.circle")
-                .foregroundColor(.primary)
+                .foregroundStyle(.primary)
                 .font(.system(size: fontSize))
                 .padding(padding)
                 .background(backgroundColor.gradient, in: .circle)

--- a/VivaDicta/Views/HudView.swift
+++ b/VivaDicta/Views/HudView.swift
@@ -154,7 +154,7 @@ struct HudContentView: View {
             cancelButtonTimer?.invalidate()
             cancelButtonTimer = nil
         }
-        .foregroundColor(.white)
+        .foregroundStyle(.white)
         .padding()
     }
 

--- a/VivaDicta/Views/HudViewDarkBounceOnly.swift
+++ b/VivaDicta/Views/HudViewDarkBounceOnly.swift
@@ -29,7 +29,7 @@ struct HudViewDarkBounceOnly: View {
                 .font(.system(size: 17, weight: .semibold))
                 .animation(.easeInOut(duration: 0.3), value: statusText)
         }
-        .foregroundColor(.white)
+        .foregroundStyle(.white)
         .padding()
         
         .background(

--- a/VivaDicta/Views/HudViewLightBounceOnly.swift
+++ b/VivaDicta/Views/HudViewLightBounceOnly.swift
@@ -29,7 +29,7 @@ struct HudViewLightBounceOnly: View {
                 .font(.system(size: 17, weight: .semibold))
                 .animation(.easeInOut(duration: 0.3), value: statusText)
         }
-        .foregroundColor(.white)
+        .foregroundStyle(.white)
         .padding()
         
         .background(

--- a/VivaDicta/Views/ScrollToTopButton.swift
+++ b/VivaDicta/Views/ScrollToTopButton.swift
@@ -18,7 +18,7 @@ struct ScrollToTopButton: View {
         } label: {
             Image(systemName: "arrow.up")
                 .font(.system(size: 20, weight: .semibold))
-                .foregroundColor(Color(.systemBackground))
+                .foregroundStyle(Color(.systemBackground))
                 .frame(width: 44, height: 44)
                 .background(backgroundColor)
                 .clipShape(.circle)

--- a/VivaDictaKeyboard/KeyboardCustomView.swift
+++ b/VivaDictaKeyboard/KeyboardCustomView.swift
@@ -130,7 +130,7 @@ struct ErrorStateView: View {
             // Error icon
             Image(systemName: "exclamationmark.triangle.fill")
                 .font(.system(size: 50))
-                .foregroundColor(.orange)
+                .foregroundStyle(.orange)
                 .padding(.bottom, 10)
 
             // Error message
@@ -139,7 +139,7 @@ struct ErrorStateView: View {
 
             Text(errorMessage)
                 .font(.system(size: 16))
-                .foregroundColor(.secondary)
+                .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 40)
 
@@ -147,7 +147,7 @@ struct ErrorStateView: View {
             Button(action: onDismiss) {
                 Text("Dismiss")
                     .font(.system(size: 17, weight: .medium))
-                    .foregroundColor(.white)
+                    .foregroundStyle(.white)
                     .frame(width: 120, height: 44)
                     .background(Color.blue)
                     .cornerRadius(22)

--- a/VivaDictaWidget/VivaDictaLiveActivity.swift
+++ b/VivaDictaWidget/VivaDictaLiveActivity.swift
@@ -21,7 +21,7 @@ struct VivaDictaLiveActivity: Widget {
                     HStack {
                         
                         Text("VivaDicta")
-                            .foregroundColor(.primary)
+                            .foregroundStyle(.primary)
                             .font(.system(size: 20, weight: .semibold))
                             .padding(.leading, 24)
                         
@@ -30,7 +30,7 @@ struct VivaDictaLiveActivity: Widget {
                         Button(intent: ToggleSessionIntent(isSessionActive: false)) {
                             Image(systemName: "power.circle.fill")
                                 .font(.system(size: 40))
-                                .foregroundColor(.orange)
+                                .foregroundStyle(.orange)
                         }
                         .buttonStyle(.plain)
                         .padding(.trailing, 24)
@@ -48,7 +48,7 @@ struct VivaDictaLiveActivity: Widget {
                     Spacer()
                     VStack(alignment: .leading, spacing: 4) {
                         Text("VivaDicta")
-                            .foregroundColor(.primary)
+                            .foregroundStyle(.primary)
                             .font(.system(size: 20, weight: .semibold))
                         Text(context.state.state.statusText)
                             .foregroundStyle(.secondary)
@@ -68,13 +68,13 @@ struct VivaDictaLiveActivity: Widget {
                             Button(intent: ToggleSessionIntent(isSessionActive: false)) {
                                 Image(systemName: context.state.state.iconName)
                                     .font(.system(size: 40))
-                                    .foregroundColor(context.state.state.iconColor == "orange" ? .orange : .blue)
+                                    .foregroundStyle(context.state.state.iconColor == "orange" ? .orange : .blue)
                             }
                             .buttonStyle(.plain)
                         } else {
                             Image(systemName: context.state.state.iconName)
                                 .font(.system(size: 40))
-                                .foregroundColor(context.state.state.iconColor == "orange" ? .orange : .blue)
+                                .foregroundStyle(context.state.state.iconColor == "orange" ? .orange : .blue)
                         }
                     }
                     .padding(.trailing, 12)
@@ -86,10 +86,10 @@ struct VivaDictaLiveActivity: Widget {
                 EmptyView()
             } compactTrailing: {
                 Image(systemName: context.state.state.iconName)
-                    .foregroundColor(context.state.state.iconColor == "orange" ? .orange : .blue)
+                    .foregroundStyle(context.state.state.iconColor == "orange" ? .orange : .blue)
             } minimal: {
                 Image(systemName: context.state.state.iconName)
-                    .foregroundColor(context.state.state.iconColor == "orange" ? .orange : .blue)
+                    .foregroundStyle(context.state.state.iconColor == "orange" ? .orange : .blue)
             }
         }
     }


### PR DESCRIPTION
## Summary
- Replace all remaining `foregroundColor()` usages with `foregroundStyle()` across 7 files
- Affected: LiveActivity, KeyboardCustomView, HudView variants, ScrollToTopButton, MicButton

## Test plan
- [ ] Verify Live Activity appearance (recording, transcribing, enhancing states)
- [ ] Verify keyboard extension error state styling
- [ ] Verify HUD views in light and dark mode
- [ ] Verify scroll-to-top button and mic button colors