### PR TITLE
Add Recent Notes tab to keyboard extension

### DIFF
--- a/VivaDicta.xcodeproj/project.pbxproj
+++ b/VivaDicta.xcodeproj/project.pbxproj
@@ -245,6 +245,7 @@
 				Shared/AppGroupCoordinator.swift,
 				Shared/MicButton.swift,
 				Shared/Orb.swift,
+				Shared/RecentNotesCache.swift,
 				Shared/RecordingState.swift,
 				Shared/RippleEffect.metal,
 				Shared/RippleEffectModifier.swift,

--- a/VivaDicta/Services/RecentNotesCacheSync.swift
+++ b/VivaDicta/Services/RecentNotesCacheSync.swift
@@ -27,8 +27,7 @@ extension RecentNotesCache {
             )
         }
 
-        // Write directly to shared UserDefaults
         guard let data = try? JSONEncoder().encode(notes) else { return }
-        UserDefaults(suiteName: AppGroupCoordinator.shared.appGroupId)?.set(data, forKey: "recentNotesCache")
+        sharedDefaults?.set(data, forKey: key)
     }
 }

--- a/VivaDicta/Services/RecentNotesCacheSync.swift
+++ b/VivaDicta/Services/RecentNotesCacheSync.swift
@@ -10,16 +10,14 @@ import SwiftData
 
 extension RecentNotesCache {
     /// Syncs the cache with SwiftData, populating it with the most recent transcriptions.
-    /// Called on app foreground to ensure the cache reflects existing data.
     @MainActor
-    static func syncFromDatabase(modelContainer: ModelContainer) {
-        let context = modelContainer.mainContext
+    static func syncFromDatabase(modelContext: ModelContext) {
         var descriptor = FetchDescriptor<Transcription>(
             sortBy: [SortDescriptor(\.timestamp, order: .reverse)]
         )
         descriptor.fetchLimit = 10
 
-        guard let transcriptions = try? context.fetch(descriptor) else { return }
+        guard let transcriptions = try? modelContext.fetch(descriptor) else { return }
 
         let notes = transcriptions.map { transcription in
             RecentNote(

--- a/VivaDicta/Services/RecentNotesCacheSync.swift
+++ b/VivaDicta/Services/RecentNotesCacheSync.swift
@@ -1,0 +1,36 @@
+//
+//  RecentNotesCacheSync.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.03.22
+//
+
+import Foundation
+import SwiftData
+
+extension RecentNotesCache {
+    /// Syncs the cache with SwiftData, populating it with the most recent transcriptions.
+    /// Called on app foreground to ensure the cache reflects existing data.
+    @MainActor
+    static func syncFromDatabase(modelContainer: ModelContainer) {
+        let context = modelContainer.mainContext
+        var descriptor = FetchDescriptor<Transcription>(
+            sortBy: [SortDescriptor(\.timestamp, order: .reverse)]
+        )
+        descriptor.fetchLimit = 10
+
+        guard let transcriptions = try? context.fetch(descriptor) else { return }
+
+        let notes = transcriptions.map { transcription in
+            RecentNote(
+                id: transcription.id.uuidString,
+                text: transcription.enhancedText ?? transcription.text,
+                timestamp: transcription.timestamp
+            )
+        }
+
+        // Write directly to shared UserDefaults
+        guard let data = try? JSONEncoder().encode(notes) else { return }
+        UserDefaults(suiteName: AppGroupCoordinator.shared.appGroupId)?.set(data, forKey: "recentNotesCache")
+    }
+}

--- a/VivaDicta/Shared/RecentNotesCache.swift
+++ b/VivaDicta/Shared/RecentNotesCache.swift
@@ -1,0 +1,62 @@
+//
+//  RecentNotesCache.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.03.22
+//
+
+import Foundation
+
+/// A lightweight representation of a transcription for the keyboard extension.
+///
+/// Stored in shared UserDefaults so the keyboard can display recent notes
+/// without needing SwiftData access.
+struct RecentNote: Codable, Identifiable {
+    let id: String
+    let text: String
+    let timestamp: Date
+}
+
+/// Manages a cache of recent transcriptions in shared UserDefaults
+/// for the keyboard extension to read.
+enum RecentNotesCache {
+    private static let key = "recentNotesCache"
+    private static let maxNotes = 10
+
+    private static var sharedDefaults: UserDefaults? {
+        UserDefaults(suiteName: AppGroupCoordinator.shared.appGroupId)
+    }
+
+    /// Adds a note to the cache, keeping only the most recent entries.
+    /// Called from the main app after saving a transcription.
+    static func addNote(id: String, text: String, timestamp: Date) {
+        var notes = loadNotes()
+
+        // Remove existing entry with same ID (update case)
+        notes.removeAll { $0.id == id }
+
+        // Insert at the beginning (most recent first)
+        notes.insert(RecentNote(id: id, text: text, timestamp: timestamp), at: 0)
+
+        // Keep only the most recent
+        if notes.count > maxNotes {
+            notes = Array(notes.prefix(maxNotes))
+        }
+
+        saveNotes(notes)
+    }
+
+    /// Loads all cached recent notes.
+    static func loadNotes() -> [RecentNote] {
+        guard let data = sharedDefaults?.data(forKey: key),
+              let notes = try? JSONDecoder().decode([RecentNote].self, from: data) else {
+            return []
+        }
+        return notes
+    }
+
+    private static func saveNotes(_ notes: [RecentNote]) {
+        guard let data = try? JSONEncoder().encode(notes) else { return }
+        sharedDefaults?.set(data, forKey: key)
+    }
+}

--- a/VivaDicta/Shared/RecentNotesCache.swift
+++ b/VivaDicta/Shared/RecentNotesCache.swift
@@ -20,10 +20,10 @@ struct RecentNote: Codable, Identifiable {
 /// Manages a cache of recent transcriptions in shared UserDefaults
 /// for the keyboard extension to read.
 enum RecentNotesCache {
-    private static let key = "recentNotesCache"
+    static let key = "recentNotesCache"
     private static let maxNotes = 10
 
-    private static var sharedDefaults: UserDefaults? {
+    static var sharedDefaults: UserDefaults? {
         UserDefaults(suiteName: AppGroupCoordinator.shared.appGroupId)
     }
 

--- a/VivaDicta/Views/MainView.swift
+++ b/VivaDicta/Views/MainView.swift
@@ -463,6 +463,7 @@ struct MainView: View {
 
         do {
             try modelContext.save()
+            RecentNotesCache.syncFromDatabase(modelContext: modelContext)
         } catch {
             logger.logError("Failed to save after bulk deletion: \(error.localizedDescription)")
         }

--- a/VivaDicta/Views/RecordViewModel.swift
+++ b/VivaDicta/Views/RecordViewModel.swift
@@ -554,6 +554,13 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
                 let textToShare = enhancedText ?? transcribedText
                 AppGroupCoordinator.shared.shareTranscribedText(textToShare)
 
+                // Cache for keyboard "Recent Notes" feature
+                RecentNotesCache.addNote(
+                    id: transcription.id.uuidString,
+                    text: textToShare,
+                    timestamp: transcription.timestamp
+                )
+
                 // Auto-copy to clipboard if enabled
                 if UserDefaultsStorage.appPrivate.bool(forKey: UserDefaultsStorage.Keys.isAutoCopyAfterRecordingEnabled) {
                     ClipboardManager.copyToClipboard(textToShare)
@@ -699,6 +706,13 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
 
                     // Share with keyboard
                     AppGroupCoordinator.shared.shareTranscribedText(pending.text)
+
+                    // Cache for keyboard "Recent Notes" feature
+                    RecentNotesCache.addNote(
+                        id: transcription.id.uuidString,
+                        text: pending.text,
+                        timestamp: transcription.timestamp
+                    )
 
                     // Auto-copy to clipboard if enabled
                     if UserDefaultsStorage.appPrivate.bool(forKey: UserDefaultsStorage.Keys.isAutoCopyAfterRecordingEnabled) {

--- a/VivaDicta/Views/TranscriptionsContentView.swift
+++ b/VivaDicta/Views/TranscriptionsContentView.swift
@@ -257,6 +257,7 @@ struct TranscriptionsContentView: View {
 
         do {
             try modelContext.save()
+            RecentNotesCache.syncFromDatabase(modelContext: modelContext)
         } catch {
             logger.logError("Failed to save after deletion: \(error.localizedDescription)")
         }

--- a/VivaDicta/VivaDictaApp.swift
+++ b/VivaDicta/VivaDictaApp.swift
@@ -241,6 +241,7 @@ struct VivaDictaApp: App {
                         case .active:
                             logger.logInfo("🎬 App became active - checking for stale Live Activity")
                             appState.checkAndEndStaleLiveActivity()
+                            RecentNotesCache.syncFromDatabase(modelContainer: modelContainer)
                         case .inactive:
                             logger.logInfo("🎬 App became inactive")
                         case .background:

--- a/VivaDicta/VivaDictaApp.swift
+++ b/VivaDicta/VivaDictaApp.swift
@@ -241,12 +241,13 @@ struct VivaDictaApp: App {
                         case .active:
                             logger.logInfo("🎬 App became active - checking for stale Live Activity")
                             appState.checkAndEndStaleLiveActivity()
-                            RecentNotesCache.syncFromDatabase(modelContainer: modelContainer)
+                            RecentNotesCache.syncFromDatabase(modelContext: modelContainer.mainContext)
                         case .inactive:
                             logger.logInfo("🎬 App became inactive")
                         case .background:
                             logger.logInfo("🎬 App went to background")
                             updateShortcutItems()
+                            RecentNotesCache.syncFromDatabase(modelContext: modelContainer.mainContext)
                         @unknown default:
                             break
                         }

--- a/VivaDictaKeyboard/KeyboardCustomView.swift
+++ b/VivaDictaKeyboard/KeyboardCustomView.swift
@@ -43,7 +43,13 @@ struct KeyboardCustomView: View {
                         onNoteSelected: { text in
                             controller.textDocumentProxy.insertText(text)
                             HapticManager.heartbeat()
-                        }
+                        },
+                        onOpenApp: {
+                            openMainApp()
+                        },
+                        onBackspace: { controller.textDocumentProxy.deleteBackward() },
+                        onNewline: { controller.textDocumentProxy.insertText("\n") },
+                        onSpace: { controller.textDocumentProxy.insertText(" ") }
                     )
                 } else if dictationState.activeTab == .textProcessing {
                     RewriteModesView(

--- a/VivaDictaKeyboard/KeyboardCustomView.swift
+++ b/VivaDictaKeyboard/KeyboardCustomView.swift
@@ -38,6 +38,13 @@ struct KeyboardCustomView: View {
                             dictationState.textProcessingPhase = .idle
                         }
                     )
+                } else if dictationState.activeTab == .recentNotes {
+                    RecentNotesView(
+                        onNoteSelected: { text in
+                            controller.textDocumentProxy.insertText(text)
+                            HapticManager.heartbeat()
+                        }
+                    )
                 } else if dictationState.activeTab == .textProcessing {
                     RewriteModesView(
                         onModeSelected: { mode in

--- a/VivaDictaKeyboard/KeyboardCustomView.swift
+++ b/VivaDictaKeyboard/KeyboardCustomView.swift
@@ -48,6 +48,7 @@ struct KeyboardCustomView: View {
                             openMainApp()
                         },
                         onBackspace: { controller.textDocumentProxy.deleteBackward() },
+                        onDeleteWord: { deleteWordBeforeCursor() },
                         onNewline: { controller.textDocumentProxy.insertText("\n") },
                         onSpace: { controller.textDocumentProxy.insertText(" ") },
                         onRevert: { charCount in
@@ -71,6 +72,7 @@ struct KeyboardCustomView: View {
                             openMainApp()
                         },
                         onBackspace: { controller.textDocumentProxy.deleteBackward() },
+                        onDeleteWord: { deleteWordBeforeCursor() },
                         onNewline: { controller.textDocumentProxy.insertText("\n") },
                         onSpace: { controller.textDocumentProxy.insertText(" ") }
                     )
@@ -146,6 +148,32 @@ struct KeyboardCustomView: View {
                 .transition(.move(edge: .bottom))
                 .zIndex(1)
             }
+        }
+    }
+
+    private func deleteWordBeforeCursor() {
+        let proxy = controller.textDocumentProxy
+        guard let before = proxy.documentContextBeforeInput, !before.isEmpty else {
+            proxy.deleteBackward()
+            return
+        }
+        // Walk backward: skip trailing whitespace, then skip the word
+        var index = before.endIndex
+        // Skip trailing whitespace
+        while index > before.startIndex {
+            let prev = before.index(before: index)
+            if !before[prev].isWhitespace { break }
+            index = prev
+        }
+        // Skip word characters
+        while index > before.startIndex {
+            let prev = before.index(before: index)
+            if before[prev].isWhitespace { break }
+            index = prev
+        }
+        let charsToDelete = max(before.distance(from: index, to: before.endIndex), 1)
+        for _ in 0..<charsToDelete {
+            proxy.deleteBackward()
         }
     }
 

--- a/VivaDictaKeyboard/KeyboardCustomView.swift
+++ b/VivaDictaKeyboard/KeyboardCustomView.swift
@@ -49,7 +49,13 @@ struct KeyboardCustomView: View {
                         },
                         onBackspace: { controller.textDocumentProxy.deleteBackward() },
                         onNewline: { controller.textDocumentProxy.insertText("\n") },
-                        onSpace: { controller.textDocumentProxy.insertText(" ") }
+                        onSpace: { controller.textDocumentProxy.insertText(" ") },
+                        onRevert: { charCount in
+                            for _ in 0..<charCount {
+                                controller.textDocumentProxy.deleteBackward()
+                            }
+                            HapticManager.lightImpact()
+                        }
                     )
                 } else if dictationState.activeTab == .textProcessing {
                     RewriteModesView(

--- a/VivaDictaKeyboard/KeyboardDictationState.swift
+++ b/VivaDictaKeyboard/KeyboardDictationState.swift
@@ -27,6 +27,7 @@ final class KeyboardDictationState {
     enum KeyboardTab: Int {
         case keyboard = 0
         case textProcessing = 1
+        case recentNotes = 2
     }
 
     var activeTab: KeyboardTab = .keyboard {

--- a/VivaDictaKeyboard/KeyboardViewController.swift
+++ b/VivaDictaKeyboard/KeyboardViewController.swift
@@ -90,7 +90,11 @@ struct KeyboardTabToggle: View {
     @Bindable var dictationState: KeyboardDictationState
 
     private var icon: String {
-        dictationState.activeTab == .keyboard ? "sparkles" : "keyboard"
+        switch dictationState.activeTab {
+        case .keyboard: "sparkles"
+        case .textProcessing: "clock.arrow.trianglehead.counterclockwise.rotate.90"
+        case .recentNotes: "keyboard"
+        }
     }
 
     @State private var isGlowAnimating = false
@@ -98,8 +102,11 @@ struct KeyboardTabToggle: View {
     var body: some View {
         Button {
             HapticManager.selectionChanged()
-            dictationState.activeTab = dictationState.activeTab == .keyboard
-                ? .textProcessing : .keyboard
+            switch dictationState.activeTab {
+            case .keyboard: dictationState.activeTab = .textProcessing
+            case .textProcessing: dictationState.activeTab = .recentNotes
+            case .recentNotes: dictationState.activeTab = .keyboard
+            }
         } label: {
             Image(systemName: icon)
                 .font(.system(size: 14, weight: .medium))
@@ -220,7 +227,7 @@ struct VivaDictaKeyboardToolbarView: View {
 
     var body: some View {
         HStack(spacing: 0) {
-            // Tab segmented control + Mode selector on the left
+            // Tab switcher button + Mode selector on the left
             HStack(spacing: 16) {
                 KeyboardTabToggle(dictationState: dictationState)
                 ModeCycleSelector(dictationState: dictationState)

--- a/VivaDictaKeyboard/Views/RecentNotesView.swift
+++ b/VivaDictaKeyboard/Views/RecentNotesView.swift
@@ -36,11 +36,14 @@ struct RecentNotesView: View {
                 // Utility buttons: space, return, backspace
                 HStack(spacing: 4) {
                     
-                    utilityButton(icon: "space", action: onSpace)
+                    utilityButton(icon: "arrow.counterclockwise", color: .yellow, action: onSpace)
                         .shadow(color: .black.opacity(0.2), radius: 6)
-                    utilityButton(icon: "return", action: onNewline)
+                    
+                    utilityButton(icon: "space", color: .blue, action: onSpace)
                         .shadow(color: .black.opacity(0.2), radius: 6)
-                    utilityButton(icon: "delete.backward", action: onBackspace)
+                    utilityButton(icon: "return", color: .blue, action: onNewline)
+                        .shadow(color: .black.opacity(0.2), radius: 6)
+                    utilityButton(icon: "delete.backward", color: .red, action: onBackspace)
                         .shadow(color: .black.opacity(0.2), radius: 6)
                 }
             }
@@ -146,30 +149,42 @@ struct RecentNotesView: View {
     
     
     // MARK: - Utility Button
+    
+    enum UtilityButtonPlacement {
+        case first
+        case mid
+        case last
+    }
 
     @ViewBuilder
-    private func utilityButton(icon: String, action: @escaping () -> Void) -> some View {
-        let isBackspace = icon == "delete.backward"
-        let tintColor: Color = isBackspace ? .red : .blue
-        if #available(iOS 26.0, *) {
-            RepeatableButton(action: action) {
-                utilityButtonLabel(icon: icon)
-                    .frame(width: 36, height: 20)
+    private func utilityButton(
+        icon: String,
+        color: Color,
+        placement: UtilityButtonPlacement = .mid,
+        action: @escaping () -> Void) -> some View {
+            
+//            let isBackspace = icon == "delete.backward"
+//            let tintColor: Color = isBackspace ? .red : .blue
+            if #available(iOS 26.0, *) {
+                RepeatableButton(action: action) {
+                    utilityButtonLabel(icon: icon)
+                        .frame(width: 36, height: 20)
+                }
+                .padding(.vertical, 4)
+                .padding(.horizontal, 8)
+                .glassEffect(.regular.tint(color.opacity(0.3)).interactive())
+                .padding(.trailing, placement == .first ? 4 : 0)
+                .padding(.trailing, placement == .last ? 0 : 4)
+            } else {
+                RepeatableButton(action: action) {
+                    utilityButtonLabel(icon: icon)
+                        .frame(width: 40, height: 24)
+                        .background(color.opacity(0.5), in: .capsule(style: .continuous))
+                }
+                .padding(.vertical, 8)
+                .padding(.horizontal, 16)
             }
-            .padding(.vertical, 4)
-            .padding(.horizontal, 8)
-            .glassEffect(.regular.tint(tintColor.opacity(0.3)).interactive())
-            .padding(.trailing, isBackspace ? 0 : 4)
-        } else {
-            RepeatableButton(action: action) {
-                utilityButtonLabel(icon: icon)
-                    .frame(width: 40, height: 24)
-                    .background(tintColor.opacity(0.5), in: .capsule(style: .continuous))
-            }
-            .padding(.vertical, 8)
-            .padding(.horizontal, 16)
         }
-    }
 
     private func utilityButtonLabel(icon: String) -> some View {
         Image(systemName: icon)

--- a/VivaDictaKeyboard/Views/RecentNotesView.swift
+++ b/VivaDictaKeyboard/Views/RecentNotesView.swift
@@ -12,7 +12,6 @@ import SwiftUI
 /// Tapping a note inserts its text at the current cursor position in the host app.
 struct RecentNotesView: View {
     @Environment(KeyboardDictationState.self) var dictationState
-    @Environment(\.openURL) private var openURL
     @Environment(\.colorScheme) private var colorScheme
 
     let onNoteSelected: (String) -> Void
@@ -76,8 +75,14 @@ struct RecentNotesView: View {
         }
         .frame(height: 260)
         .onAppear {
-            guard notes.isEmpty else { return }
-            notes = Array(RecentNotesCache.loadNotes().prefix(displayLimit))
+            reloadNotes()
+        }
+    }
+
+    private func reloadNotes() {
+        let fresh = Array(RecentNotesCache.loadNotes().prefix(displayLimit))
+        if fresh.map(\.id) != notes.map(\.id) {
+            notes = fresh
         }
     }
 
@@ -99,11 +104,8 @@ struct RecentNotesView: View {
                                 .lineLimit(2)
                                 .multilineTextAlignment(.leading)
                                 .padding(.bottom, 8)
-                            
+
                             Divider()
-//                            Text(note.timestamp, format: .dateTime.month(.abbreviated).day().hour().minute())
-//                                .font(.system(size: 11))
-//                                .foregroundStyle(.tertiary)
                         }
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(.horizontal, 12)
@@ -121,9 +123,7 @@ struct RecentNotesView: View {
 
                     Button {
                         HapticManager.lightImpact()
-                        if let url = URL(string: "vivadicta://") {
-                            openURL(url)
-                        }
+                        onOpenApp()
                     } label: {
                         Label("Open VivaDicta", systemImage: "arrow.up.forward.app")
                             .font(.system(size: 13, weight: .medium))
@@ -137,7 +137,7 @@ struct RecentNotesView: View {
             .padding(.horizontal, 12)
             .padding(.vertical, 4)
         }
-        .background(colorScheme == .dark ? Color( .quaternarySystemFill).opacity(0.5) : Color.white, in: .rect(cornerRadius: 10))
+        .background(colorScheme == .dark ? Color(.quaternarySystemFill).opacity(0.5) : Color.white, in: .rect(cornerRadius: 10))
         .scrollIndicators(.hidden)
     }
 

--- a/VivaDictaKeyboard/Views/RecentNotesView.swift
+++ b/VivaDictaKeyboard/Views/RecentNotesView.swift
@@ -16,14 +16,18 @@ struct RecentNotesView: View {
     @Environment(\.colorScheme) private var colorScheme
 
     let onNoteSelected: (String) -> Void
-    
+
     let onOpenApp: () -> Void
     let onBackspace: () -> Void
     let onNewline: () -> Void
     let onSpace: () -> Void
+    /// Called with the number of characters to delete (revert last paste).
+    let onRevert: (Int) -> Void
 
     private let displayLimit = 5
     @State private var notes: [RecentNote] = []
+    /// Length of the last pasted note, used for revert. Zero means nothing to revert.
+    @State private var lastPastedLength: Int = 0
 
     var body: some View {
         VStack(spacing: 0) {
@@ -35,10 +39,16 @@ struct RecentNotesView: View {
 
                 // Utility buttons: space, return, backspace
                 HStack(spacing: 4) {
-                    
-                    utilityButton(icon: "arrow.counterclockwise", color: .yellow, action: onSpace)
+
+                    if lastPastedLength > 0 {
+                        utilityButton(icon: "arrow.uturn.backward", color: .yellow) {
+                            onRevert(lastPastedLength)
+                            lastPastedLength = 0
+                        }
                         .shadow(color: .black.opacity(0.2), radius: 6)
-                    
+                        .transition(.scale.combined(with: .opacity))
+                    }
+
                     utilityButton(icon: "space", color: .blue, action: onSpace)
                         .shadow(color: .black.opacity(0.2), radius: 6)
                     utilityButton(icon: "return", color: .blue, action: onNewline)
@@ -73,6 +83,7 @@ struct RecentNotesView: View {
                     Button {
                         HapticManager.mediumImpact()
                         onNoteSelected(note.text)
+                        withAnimation { lastPastedLength = note.text.count }
                     } label: {
                         VStack(alignment: .leading, spacing: 4) {
                             Text(note.text)

--- a/VivaDictaKeyboard/Views/RecentNotesView.swift
+++ b/VivaDictaKeyboard/Views/RecentNotesView.swift
@@ -41,10 +41,14 @@ struct RecentNotesView: View {
                 HStack(spacing: 4) {
 
                     if lastPastedLength > 0 {
-                        utilityButton(icon: "arrow.uturn.backward", color: .yellow) {
+                        Button {
+                            HapticManager.lightImpact()
                             onRevert(lastPastedLength)
-                            lastPastedLength = 0
+                            withAnimation { lastPastedLength = 0 }
+                        } label: {
+                            revertButtonLabel
                         }
+                        .buttonStyle(.plain)
                         .shadow(color: .black.opacity(0.2), radius: 6)
                         .transition(.scale.combined(with: .opacity))
                     }
@@ -196,6 +200,27 @@ struct RecentNotesView: View {
                 .padding(.horizontal, 16)
             }
         }
+
+    @ViewBuilder
+    private var revertButtonLabel: some View {
+        if #available(iOS 26.0, *) {
+            Image(systemName: "arrow.uturn.backward")
+                .font(.system(size: 16, weight: .medium))
+                .foregroundStyle(.primary)
+                .frame(width: 36, height: 20)
+                .padding(.vertical, 4)
+                .padding(.horizontal, 8)
+                .glassEffect(.regular.tint(Color.yellow.opacity(0.3)).interactive())
+        } else {
+            Image(systemName: "arrow.uturn.backward")
+                .font(.system(size: 16, weight: .medium))
+                .foregroundStyle(.primary)
+                .frame(width: 40, height: 24)
+                .background(Color.yellow.opacity(0.5), in: .capsule(style: .continuous))
+                .padding(.vertical, 8)
+                .padding(.horizontal, 16)
+        }
+    }
 
     private func utilityButtonLabel(icon: String) -> some View {
         Image(systemName: icon)

--- a/VivaDictaKeyboard/Views/RecentNotesView.swift
+++ b/VivaDictaKeyboard/Views/RecentNotesView.swift
@@ -15,16 +15,33 @@ struct RecentNotesView: View {
     @Environment(\.openURL) private var openURL
 
     let onNoteSelected: (String) -> Void
+    
+    let onOpenApp: () -> Void
+    let onBackspace: () -> Void
+    let onNewline: () -> Void
+    let onSpace: () -> Void
 
     private let displayLimit = 5
     @State private var notes: [RecentNote] = []
 
     var body: some View {
         VStack(spacing: 0) {
-            // Header
+            // Header: switcher on left, utility buttons on right
             HStack {
                 KeyboardTabToggle(dictationState: dictationState)
+
                 Spacer()
+
+                // Utility buttons: space, return, backspace
+                HStack(spacing: 4) {
+                    
+                    utilityButton(icon: "space", action: onSpace)
+                        .shadow(color: .black.opacity(0.2), radius: 6)
+                    utilityButton(icon: "return", action: onNewline)
+                        .shadow(color: .black.opacity(0.2), radius: 6)
+                    utilityButton(icon: "delete.backward", action: onBackspace)
+                        .shadow(color: .black.opacity(0.2), radius: 6)
+                }
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 16)
@@ -117,6 +134,49 @@ struct RecentNotesView: View {
                 .foregroundStyle(.tertiary)
 
             Spacer()
+        }
+    }
+    
+    
+    // MARK: - Utility Button
+
+    @ViewBuilder
+    private func utilityButton(icon: String, action: @escaping () -> Void) -> some View {
+        if #available(iOS 26.0, *) {
+            let last = icon == "delete.backward"
+            
+            Button {
+                HapticManager.lightImpact()
+                action()
+            } label: {
+                
+                Image(systemName: icon)
+                    .font(.system(size: 16, weight: .medium))
+                    .foregroundStyle(.primary)
+                    .frame(width: 36, height: 20)
+                    .contentShape(.rect)
+            }
+            .padding(.vertical, 4)
+            .padding(.horizontal, 8)
+            .buttonStyle(.plain)
+            .glassEffect(.regular.tint((last ? Color.red : .blue).opacity(0.3)).interactive())
+            .padding(.trailing, (last ? 0 : 4))
+        } else {
+            Button {
+                HapticManager.lightImpact()
+                action()
+            } label: {
+                
+                Image(systemName: icon)
+                    .font(.system(size: 16, weight: .medium))
+                    .foregroundStyle(.primary)
+                    .frame(width: 40, height: 24)
+                    .background(.quaternary, in: .capsule(style: .continuous))
+                    .contentShape(.rect)
+            }
+            .padding(.vertical, 8)
+            .padding(.horizontal, 16)
+            .buttonStyle(.plain)
         }
     }
 }

--- a/VivaDictaKeyboard/Views/RecentNotesView.swift
+++ b/VivaDictaKeyboard/Views/RecentNotesView.swift
@@ -12,9 +12,11 @@ import SwiftUI
 /// Tapping a note inserts its text at the current cursor position in the host app.
 struct RecentNotesView: View {
     @Environment(KeyboardDictationState.self) var dictationState
+    @Environment(\.openURL) private var openURL
 
     let onNoteSelected: (String) -> Void
 
+    private let displayLimit = 5
     @State private var notes: [RecentNote] = []
 
     var body: some View {
@@ -36,7 +38,7 @@ struct RecentNotesView: View {
         .frame(height: 260)
         .onAppear {
             guard notes.isEmpty else { return }
-            notes = RecentNotesCache.loadNotes()
+            notes = Array(RecentNotesCache.loadNotes().prefix(displayLimit))
         }
     }
 
@@ -68,6 +70,27 @@ struct RecentNotesView: View {
                     }
                     .buttonStyle(.plain)
                 }
+
+                // Footer: open app for all notes
+                VStack(spacing: 6) {
+                    Text("To see all notes, open VivaDicta")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.tertiary)
+
+                    Button {
+                        HapticManager.lightImpact()
+                        if let url = URL(string: "vivadicta://") {
+                            openURL(url)
+                        }
+                    } label: {
+                        Label("Open VivaDicta", systemImage: "arrow.up.forward.app")
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundStyle(.orange)
+                    }
+                    .buttonStyle(.plain)
+                }
+                .padding(.top, 8)
+                .padding(.bottom, 4)
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 4)

--- a/VivaDictaKeyboard/Views/RecentNotesView.swift
+++ b/VivaDictaKeyboard/Views/RecentNotesView.swift
@@ -26,8 +26,8 @@ struct RecentNotesView: View {
 
     private let displayLimit = 5
     @State private var notes: [RecentNote] = []
-    /// Length of the last pasted note, used for revert. Zero means nothing to revert.
-    @State private var lastPastedLength: Int = 0
+    /// Stack of pasted note lengths for multi-level revert.
+    @State private var pastedLengths: [Int] = []
 
     var body: some View {
         VStack(spacing: 0) {
@@ -40,11 +40,13 @@ struct RecentNotesView: View {
                 // Utility buttons: space, return, backspace
                 HStack(spacing: 4) {
 
-                    if lastPastedLength > 0 {
+                    if !pastedLengths.isEmpty {
                         Button {
                             HapticManager.lightImpact()
-                            onRevert(lastPastedLength)
-                            withAnimation { lastPastedLength = 0 }
+                            if let last = pastedLengths.last {
+                                onRevert(last)
+                                withAnimation { _ = pastedLengths.removeLast() }
+                            }
                         } label: {
                             revertButtonLabel
                         }
@@ -87,7 +89,7 @@ struct RecentNotesView: View {
                     Button {
                         HapticManager.mediumImpact()
                         onNoteSelected(note.text)
-                        withAnimation { lastPastedLength = note.text.count }
+                        withAnimation { pastedLengths.append(note.text.count) }
                     } label: {
                         VStack(alignment: .leading, spacing: 4) {
                             Text(note.text)

--- a/VivaDictaKeyboard/Views/RecentNotesView.swift
+++ b/VivaDictaKeyboard/Views/RecentNotesView.swift
@@ -1,0 +1,97 @@
+//
+//  RecentNotesView.swift
+//  VivaDictaKeyboard
+//
+//  Created by Anton Novoselov on 2026.03.22
+//
+
+import SwiftUI
+
+/// Displays recent transcriptions in the keyboard for quick insertion.
+///
+/// Tapping a note inserts its text at the current cursor position in the host app.
+struct RecentNotesView: View {
+    @Environment(KeyboardDictationState.self) var dictationState
+
+    let onNoteSelected: (String) -> Void
+
+    @State private var notes: [RecentNote] = []
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            HStack {
+                KeyboardTabToggle(dictationState: dictationState)
+                Spacer()
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 16)
+
+            if notes.isEmpty {
+                emptyStateView
+            } else {
+                notesListView
+            }
+        }
+        .onAppear {
+            notes = RecentNotesCache.loadNotes()
+        }
+    }
+
+    // MARK: - Notes List
+
+    private var notesListView: some View {
+        ScrollView {
+            LazyVStack(spacing: 6) {
+                ForEach(notes) { note in
+                    Button {
+                        HapticManager.mediumImpact()
+                        onNoteSelected(note.text)
+                    } label: {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(note.text)
+                                .font(.system(size: 14))
+                                .foregroundStyle(.primary)
+                                .lineLimit(2)
+                                .multilineTextAlignment(.leading)
+
+                            Text(note.timestamp, format: .dateTime.month(.abbreviated).day().hour().minute())
+                                .font(.system(size: 11))
+                                .foregroundStyle(.tertiary)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 10)
+                        .background(.quaternary.opacity(0.5), in: .rect(cornerRadius: 10))
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 4)
+        }
+        .scrollIndicators(.hidden)
+    }
+
+    // MARK: - Empty State
+
+    private var emptyStateView: some View {
+        VStack(spacing: 8) {
+            Spacer()
+
+            Image(systemName: "text.bubble")
+                .font(.system(size: 36))
+                .foregroundStyle(.tertiary)
+
+            Text("No recent notes")
+                .font(.system(size: 16, weight: .medium))
+                .foregroundStyle(.secondary)
+
+            Text("Record a transcription to see it here")
+                .font(.system(size: 13))
+                .foregroundStyle(.tertiary)
+
+            Spacer()
+        }
+    }
+}

--- a/VivaDictaKeyboard/Views/RecentNotesView.swift
+++ b/VivaDictaKeyboard/Views/RecentNotesView.swift
@@ -107,9 +107,7 @@ struct RecentNotesView: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(.horizontal, 12)
                         .padding(.top, 8)
-//                        .background(.primary, in: .rect(cornerRadius: 10))
-
-//                        .background(.quaternary.opacity(0.5), in: .rect(cornerRadius: 10))
+                        .contentShape(.rect)
                     }
                     .buttonStyle(.plain)
                 }

--- a/VivaDictaKeyboard/Views/RecentNotesView.swift
+++ b/VivaDictaKeyboard/Views/RecentNotesView.swift
@@ -149,41 +149,59 @@ struct RecentNotesView: View {
 
     @ViewBuilder
     private func utilityButton(icon: String, action: @escaping () -> Void) -> some View {
-        let last = icon == "delete.backward"
+        let isBackspace = icon == "delete.backward"
         if #available(iOS 26.0, *) {
-            
-            Button {
-                HapticManager.lightImpact()
-                action()
-            } label: {
-                
-                Image(systemName: icon)
-                    .font(.system(size: 16, weight: .medium))
-                    .foregroundStyle(.primary)
-                    .frame(width: 36, height: 20)
-                    .contentShape(.rect)
+            if isBackspace {
+                RepeatableButton(action: action) {
+                    utilityButtonLabel(icon: icon)
+                        .frame(width: 36, height: 20)
+                }
+                .padding(.vertical, 4)
+                .padding(.horizontal, 8)
+                .glassEffect(.regular.tint(Color.red.opacity(0.3)).interactive())
+            } else {
+                Button {
+                    HapticManager.lightImpact()
+                    action()
+                } label: {
+                    utilityButtonLabel(icon: icon)
+                        .frame(width: 36, height: 20)
+                }
+                .padding(.vertical, 4)
+                .padding(.horizontal, 8)
+                .buttonStyle(.plain)
+                .glassEffect(.regular.tint(Color.blue.opacity(0.3)).interactive())
+                .padding(.trailing, 4)
             }
-            .padding(.vertical, 4)
-            .padding(.horizontal, 8)
-            .buttonStyle(.plain)
-            .glassEffect(.regular.tint((last ? Color.red : .blue).opacity(0.3)).interactive())
-            .padding(.trailing, (last ? 0 : 4))
         } else {
-            Button {
-                HapticManager.lightImpact()
-                action()
-            } label: {
-                
-                Image(systemName: icon)
-                    .font(.system(size: 16, weight: .medium))
-                    .foregroundStyle(.primary)
-                    .frame(width: 40, height: 24)
-                    .background((last ? Color.red : .blue).opacity(0.5), in: .capsule(style: .continuous))
-                    .contentShape(.rect)
+            if isBackspace {
+                RepeatableButton(action: action) {
+                    utilityButtonLabel(icon: icon)
+                        .frame(width: 40, height: 24)
+                        .background(Color.red.opacity(0.5), in: .capsule(style: .continuous))
+                }
+                .padding(.vertical, 8)
+                .padding(.horizontal, 16)
+            } else {
+                Button {
+                    HapticManager.lightImpact()
+                    action()
+                } label: {
+                    utilityButtonLabel(icon: icon)
+                        .frame(width: 40, height: 24)
+                        .background(Color.blue.opacity(0.5), in: .capsule(style: .continuous))
+                }
+                .padding(.vertical, 8)
+                .padding(.horizontal, 16)
+                .buttonStyle(.plain)
             }
-            .padding(.vertical, 8)
-            .padding(.horizontal, 16)
-            .buttonStyle(.plain)
         }
+    }
+
+    private func utilityButtonLabel(icon: String) -> some View {
+        Image(systemName: icon)
+            .font(.system(size: 16, weight: .medium))
+            .foregroundStyle(.primary)
+            .contentShape(.rect)
     }
 }

--- a/VivaDictaKeyboard/Views/RecentNotesView.swift
+++ b/VivaDictaKeyboard/Views/RecentNotesView.swift
@@ -50,6 +50,7 @@ struct RecentNotesView: View {
                 emptyStateView
             } else {
                 notesListView
+                    .padding(.horizontal, 24)
             }
         }
         .frame(height: 260)
@@ -75,15 +76,19 @@ struct RecentNotesView: View {
                                 .foregroundStyle(.primary)
                                 .lineLimit(2)
                                 .multilineTextAlignment(.leading)
-
-                            Text(note.timestamp, format: .dateTime.month(.abbreviated).day().hour().minute())
-                                .font(.system(size: 11))
-                                .foregroundStyle(.tertiary)
+                                .padding(.bottom, 8)
+                            
+                            Divider()
+//                            Text(note.timestamp, format: .dateTime.month(.abbreviated).day().hour().minute())
+//                                .font(.system(size: 11))
+//                                .foregroundStyle(.tertiary)
                         }
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(.horizontal, 12)
-                        .padding(.vertical, 10)
-                        .background(.quaternary.opacity(0.5), in: .rect(cornerRadius: 10))
+                        .padding(.top, 8)
+//                        .background(.primary, in: .rect(cornerRadius: 10))
+
+//                        .background(.quaternary.opacity(0.5), in: .rect(cornerRadius: 10))
                     }
                     .buttonStyle(.plain)
                 }
@@ -112,6 +117,7 @@ struct RecentNotesView: View {
             .padding(.horizontal, 12)
             .padding(.vertical, 4)
         }
+        .background(.white, in: .rect(cornerRadius: 10))
         .scrollIndicators(.hidden)
     }
 
@@ -142,8 +148,8 @@ struct RecentNotesView: View {
 
     @ViewBuilder
     private func utilityButton(icon: String, action: @escaping () -> Void) -> some View {
+        let last = icon == "delete.backward"
         if #available(iOS 26.0, *) {
-            let last = icon == "delete.backward"
             
             Button {
                 HapticManager.lightImpact()
@@ -171,7 +177,7 @@ struct RecentNotesView: View {
                     .font(.system(size: 16, weight: .medium))
                     .foregroundStyle(.primary)
                     .frame(width: 40, height: 24)
-                    .background(.quaternary, in: .capsule(style: .continuous))
+                    .background((last ? Color.red : .blue).opacity(0.5), in: .capsule(style: .continuous))
                     .contentShape(.rect)
             }
             .padding(.vertical, 8)

--- a/VivaDictaKeyboard/Views/RecentNotesView.swift
+++ b/VivaDictaKeyboard/Views/RecentNotesView.swift
@@ -33,7 +33,9 @@ struct RecentNotesView: View {
                 notesListView
             }
         }
+        .frame(height: 260)
         .onAppear {
+            guard notes.isEmpty else { return }
             notes = RecentNotesCache.loadNotes()
         }
     }

--- a/VivaDictaKeyboard/Views/RecentNotesView.swift
+++ b/VivaDictaKeyboard/Views/RecentNotesView.swift
@@ -19,6 +19,7 @@ struct RecentNotesView: View {
 
     let onOpenApp: () -> Void
     let onBackspace: () -> Void
+    let onDeleteWord: () -> Void
     let onNewline: () -> Void
     let onSpace: () -> Void
     /// Called with the number of characters to delete (revert last paste).
@@ -59,7 +60,7 @@ struct RecentNotesView: View {
                         .shadow(color: .black.opacity(0.2), radius: 6)
                     utilityButton(icon: "return", color: .blue, action: onNewline)
                         .shadow(color: .black.opacity(0.2), radius: 6)
-                    utilityButton(icon: "delete.backward", color: .red, action: onBackspace)
+                    utilityButton(icon: "delete.backward", color: .red, action: onBackspace, longHoldAction: onDeleteWord)
                         .shadow(color: .black.opacity(0.2), radius: 6)
                 }
             }
@@ -176,30 +177,29 @@ struct RecentNotesView: View {
         icon: String,
         color: Color,
         placement: UtilityButtonPlacement = .mid,
-        action: @escaping () -> Void) -> some View {
-            
-//            let isBackspace = icon == "delete.backward"
-//            let tintColor: Color = isBackspace ? .red : .blue
-            if #available(iOS 26.0, *) {
-                RepeatableButton(action: action) {
-                    utilityButtonLabel(icon: icon)
-                        .frame(width: 36, height: 20)
-                }
-                .padding(.vertical, 4)
-                .padding(.horizontal, 8)
-                .glassEffect(.regular.tint(color.opacity(0.3)).interactive())
-                .padding(.trailing, placement == .first ? 4 : 0)
-                .padding(.trailing, placement == .last ? 0 : 4)
-            } else {
-                RepeatableButton(action: action) {
-                    utilityButtonLabel(icon: icon)
-                        .frame(width: 40, height: 24)
-                        .background(color.opacity(0.5), in: .capsule(style: .continuous))
-                }
-                .padding(.vertical, 8)
-                .padding(.horizontal, 16)
+        action: @escaping () -> Void,
+        longHoldAction: (() -> Void)? = nil
+    ) -> some View {
+        if #available(iOS 26.0, *) {
+            RepeatableButton(action: action, longHoldAction: longHoldAction) {
+                utilityButtonLabel(icon: icon)
+                    .frame(width: 36, height: 20)
             }
+            .padding(.vertical, 4)
+            .padding(.horizontal, 8)
+            .glassEffect(.regular.tint(color.opacity(0.3)).interactive())
+            .padding(.trailing, placement == .first ? 4 : 0)
+            .padding(.trailing, placement == .last ? 0 : 4)
+        } else {
+            RepeatableButton(action: action, longHoldAction: longHoldAction) {
+                utilityButtonLabel(icon: icon)
+                    .frame(width: 40, height: 24)
+                    .background(color.opacity(0.5), in: .capsule(style: .continuous))
+            }
+            .padding(.vertical, 8)
+            .padding(.horizontal, 16)
         }
+    }
 
     @ViewBuilder
     private var revertButtonLabel: some View {

--- a/VivaDictaKeyboard/Views/RecentNotesView.swift
+++ b/VivaDictaKeyboard/Views/RecentNotesView.swift
@@ -13,6 +13,7 @@ import SwiftUI
 struct RecentNotesView: View {
     @Environment(KeyboardDictationState.self) var dictationState
     @Environment(\.openURL) private var openURL
+    @Environment(\.colorScheme) private var colorScheme
 
     let onNoteSelected: (String) -> Void
     
@@ -117,7 +118,7 @@ struct RecentNotesView: View {
             .padding(.horizontal, 12)
             .padding(.vertical, 4)
         }
-        .background(.white, in: .rect(cornerRadius: 10))
+        .background(colorScheme == .dark ? Color(uiColor: .quaternarySystemFill) : Color.white, in: .rect(cornerRadius: 10))
         .scrollIndicators(.hidden)
     }
 

--- a/VivaDictaKeyboard/Views/RecentNotesView.swift
+++ b/VivaDictaKeyboard/Views/RecentNotesView.swift
@@ -118,7 +118,7 @@ struct RecentNotesView: View {
             .padding(.horizontal, 12)
             .padding(.vertical, 4)
         }
-        .background(colorScheme == .dark ? Color(uiColor: .quaternarySystemFill) : Color.white, in: .rect(cornerRadius: 10))
+        .background(colorScheme == .dark ? Color( .quaternarySystemFill).opacity(0.5) : Color.white, in: .rect(cornerRadius: 10))
         .scrollIndicators(.hidden)
     }
 

--- a/VivaDictaKeyboard/Views/RecentNotesView.swift
+++ b/VivaDictaKeyboard/Views/RecentNotesView.swift
@@ -150,51 +150,24 @@ struct RecentNotesView: View {
     @ViewBuilder
     private func utilityButton(icon: String, action: @escaping () -> Void) -> some View {
         let isBackspace = icon == "delete.backward"
+        let tintColor: Color = isBackspace ? .red : .blue
         if #available(iOS 26.0, *) {
-            if isBackspace {
-                RepeatableButton(action: action) {
-                    utilityButtonLabel(icon: icon)
-                        .frame(width: 36, height: 20)
-                }
-                .padding(.vertical, 4)
-                .padding(.horizontal, 8)
-                .glassEffect(.regular.tint(Color.red.opacity(0.3)).interactive())
-            } else {
-                Button {
-                    HapticManager.lightImpact()
-                    action()
-                } label: {
-                    utilityButtonLabel(icon: icon)
-                        .frame(width: 36, height: 20)
-                }
-                .padding(.vertical, 4)
-                .padding(.horizontal, 8)
-                .buttonStyle(.plain)
-                .glassEffect(.regular.tint(Color.blue.opacity(0.3)).interactive())
-                .padding(.trailing, 4)
+            RepeatableButton(action: action) {
+                utilityButtonLabel(icon: icon)
+                    .frame(width: 36, height: 20)
             }
+            .padding(.vertical, 4)
+            .padding(.horizontal, 8)
+            .glassEffect(.regular.tint(tintColor.opacity(0.3)).interactive())
+            .padding(.trailing, isBackspace ? 0 : 4)
         } else {
-            if isBackspace {
-                RepeatableButton(action: action) {
-                    utilityButtonLabel(icon: icon)
-                        .frame(width: 40, height: 24)
-                        .background(Color.red.opacity(0.5), in: .capsule(style: .continuous))
-                }
-                .padding(.vertical, 8)
-                .padding(.horizontal, 16)
-            } else {
-                Button {
-                    HapticManager.lightImpact()
-                    action()
-                } label: {
-                    utilityButtonLabel(icon: icon)
-                        .frame(width: 40, height: 24)
-                        .background(Color.blue.opacity(0.5), in: .capsule(style: .continuous))
-                }
-                .padding(.vertical, 8)
-                .padding(.horizontal, 16)
-                .buttonStyle(.plain)
+            RepeatableButton(action: action) {
+                utilityButtonLabel(icon: icon)
+                    .frame(width: 40, height: 24)
+                    .background(tintColor.opacity(0.5), in: .capsule(style: .continuous))
             }
+            .padding(.vertical, 8)
+            .padding(.horizontal, 16)
         }
     }
 

--- a/VivaDictaKeyboard/Views/RepeatableButton.swift
+++ b/VivaDictaKeyboard/Views/RepeatableButton.swift
@@ -9,26 +9,40 @@ import SwiftUI
 
 /// A button that fires its action repeatedly while held down.
 ///
-/// On tap: fires once. On long press and hold: fires repeatedly
-/// with a configurable interval after an initial delay.
+/// Three phases when held:
+/// 1. **Tap** (0ms): fires `action` once
+/// 2. **Character repeat** (after `initialDelay`): fires `action` at `repeatInterval`
+/// 3. **Long hold** (after `longHoldThreshold`): fires `longHoldAction` at `longHoldInterval`
+///
+/// If no `longHoldAction` is provided, phase 2 continues indefinitely.
 struct RepeatableButton<Label: View>: View {
     let action: () -> Void
+    let longHoldAction: (() -> Void)?
     let initialDelay: Duration
     let repeatInterval: Duration
+    let longHoldThreshold: Duration
+    let longHoldInterval: Duration
     @ViewBuilder let label: () -> Label
 
     @State private var timer: Timer?
+    @State private var longHoldTimer: Timer?
     @State private var isPressed = false
 
     init(
         initialDelay: Duration = .milliseconds(400),
         repeatInterval: Duration = .milliseconds(80),
+        longHoldThreshold: Duration = .seconds(2),
+        longHoldInterval: Duration = .milliseconds(150),
         action: @escaping () -> Void,
+        longHoldAction: (() -> Void)? = nil,
         @ViewBuilder label: @escaping () -> Label
     ) {
         self.action = action
+        self.longHoldAction = longHoldAction
         self.initialDelay = initialDelay
         self.repeatInterval = repeatInterval
+        self.longHoldThreshold = longHoldThreshold
+        self.longHoldInterval = longHoldInterval
         self.label = label
     }
 
@@ -47,12 +61,30 @@ struct RepeatableButton<Label: View>: View {
                             withTimeInterval: initialDelay.timeInterval,
                             repeats: false
                         ) { _ in
-                            // Switch to fast repeat
+                            // Phase 2: character-by-character repeat
                             timer = Timer.scheduledTimer(
                                 withTimeInterval: repeatInterval.timeInterval,
                                 repeats: true
                             ) { _ in
                                 action()
+                            }
+
+                            // Schedule phase 3 transition if longHoldAction provided
+                            if let longHoldAction {
+                                let delay = longHoldThreshold.timeInterval - initialDelay.timeInterval
+                                longHoldTimer = Timer.scheduledTimer(
+                                    withTimeInterval: max(delay, 0),
+                                    repeats: false
+                                ) { _ in
+                                    // Switch to word-by-word
+                                    timer?.invalidate()
+                                    timer = Timer.scheduledTimer(
+                                        withTimeInterval: longHoldInterval.timeInterval,
+                                        repeats: true
+                                    ) { _ in
+                                        longHoldAction()
+                                    }
+                                }
                             }
                         }
                     }
@@ -60,6 +92,8 @@ struct RepeatableButton<Label: View>: View {
                         isPressed = false
                         timer?.invalidate()
                         timer = nil
+                        longHoldTimer?.invalidate()
+                        longHoldTimer = nil
                     }
             )
     }

--- a/VivaDictaKeyboard/Views/RepeatableButton.swift
+++ b/VivaDictaKeyboard/Views/RepeatableButton.swift
@@ -1,0 +1,73 @@
+//
+//  RepeatableButton.swift
+//  VivaDictaKeyboard
+//
+//  Created by Anton Novoselov on 2026.03.22
+//
+
+import SwiftUI
+
+/// A button that fires its action repeatedly while held down.
+///
+/// On tap: fires once. On long press and hold: fires repeatedly
+/// with a configurable interval after an initial delay.
+struct RepeatableButton<Label: View>: View {
+    let action: () -> Void
+    let initialDelay: Duration
+    let repeatInterval: Duration
+    @ViewBuilder let label: () -> Label
+
+    @State private var timer: Timer?
+    @State private var isPressed = false
+
+    init(
+        initialDelay: Duration = .milliseconds(400),
+        repeatInterval: Duration = .milliseconds(80),
+        action: @escaping () -> Void,
+        @ViewBuilder label: @escaping () -> Label
+    ) {
+        self.action = action
+        self.initialDelay = initialDelay
+        self.repeatInterval = repeatInterval
+        self.label = label
+    }
+
+    var body: some View {
+        label()
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { _ in
+                        guard !isPressed else { return }
+                        isPressed = true
+                        action()
+                        HapticManager.lightImpact()
+
+                        // Start repeating after initial delay
+                        timer = Timer.scheduledTimer(
+                            withTimeInterval: initialDelay.timeInterval,
+                            repeats: false
+                        ) { _ in
+                            // Switch to fast repeat
+                            timer = Timer.scheduledTimer(
+                                withTimeInterval: repeatInterval.timeInterval,
+                                repeats: true
+                            ) { _ in
+                                action()
+                            }
+                        }
+                    }
+                    .onEnded { _ in
+                        isPressed = false
+                        timer?.invalidate()
+                        timer = nil
+                    }
+            )
+    }
+}
+
+private extension Duration {
+    var timeInterval: TimeInterval {
+        let (seconds, attoseconds) = components
+        return Double(seconds) + Double(attoseconds) / 1e18
+    }
+}

--- a/VivaDictaKeyboard/Views/RepeatableButton.swift
+++ b/VivaDictaKeyboard/Views/RepeatableButton.swift
@@ -89,13 +89,20 @@ struct RepeatableButton<Label: View>: View {
                         }
                     }
                     .onEnded { _ in
-                        isPressed = false
-                        timer?.invalidate()
-                        timer = nil
-                        longHoldTimer?.invalidate()
-                        longHoldTimer = nil
+                        stopTimers()
                     }
             )
+            .onDisappear {
+                stopTimers()
+            }
+    }
+
+    private func stopTimers() {
+        isPressed = false
+        timer?.invalidate()
+        timer = nil
+        longHoldTimer?.invalidate()
+        longHoldTimer = nil
     }
 }
 

--- a/VivaDictaKeyboard/Views/RewriteModesView.swift
+++ b/VivaDictaKeyboard/Views/RewriteModesView.swift
@@ -130,51 +130,24 @@ struct RewriteModesView: View {
     @ViewBuilder
     private func utilityButton(icon: String, action: @escaping () -> Void) -> some View {
         let isBackspace = icon == "delete.backward"
+        let tintColor: Color = isBackspace ? .red : .blue
         if #available(iOS 26.0, *) {
-            if isBackspace {
-                RepeatableButton(action: action) {
-                    utilityButtonLabel(icon: icon)
-                        .frame(width: 36, height: 20)
-                }
-                .padding(.vertical, 4)
-                .padding(.horizontal, 8)
-                .glassEffect(.regular.tint(Color.red.opacity(0.3)).interactive())
-            } else {
-                Button {
-                    HapticManager.lightImpact()
-                    action()
-                } label: {
-                    utilityButtonLabel(icon: icon)
-                        .frame(width: 36, height: 20)
-                }
-                .padding(.vertical, 4)
-                .padding(.horizontal, 8)
-                .buttonStyle(.plain)
-                .glassEffect(.regular.tint(Color.blue.opacity(0.3)).interactive())
-                .padding(.trailing, 4)
+            RepeatableButton(action: action) {
+                utilityButtonLabel(icon: icon)
+                    .frame(width: 36, height: 20)
             }
+            .padding(.vertical, 4)
+            .padding(.horizontal, 8)
+            .glassEffect(.regular.tint(tintColor.opacity(0.3)).interactive())
+            .padding(.trailing, isBackspace ? 0 : 4)
         } else {
-            if isBackspace {
-                RepeatableButton(action: action) {
-                    utilityButtonLabel(icon: icon)
-                        .frame(width: 40, height: 24)
-                        .background(Color.red.opacity(0.5), in: .capsule(style: .continuous))
-                }
-                .padding(.vertical, 8)
-                .padding(.horizontal, 16)
-            } else {
-                Button {
-                    HapticManager.lightImpact()
-                    action()
-                } label: {
-                    utilityButtonLabel(icon: icon)
-                        .frame(width: 40, height: 24)
-                        .background(Color.blue.opacity(0.5), in: .capsule(style: .continuous))
-                }
-                .padding(.vertical, 8)
-                .padding(.horizontal, 16)
-                .buttonStyle(.plain)
+            RepeatableButton(action: action) {
+                utilityButtonLabel(icon: icon)
+                    .frame(width: 40, height: 24)
+                    .background(tintColor.opacity(0.5), in: .capsule(style: .continuous))
             }
+            .padding(.vertical, 8)
+            .padding(.horizontal, 16)
         }
     }
 

--- a/VivaDictaKeyboard/Views/RewriteModesView.swift
+++ b/VivaDictaKeyboard/Views/RewriteModesView.swift
@@ -127,8 +127,8 @@ struct RewriteModesView: View {
 
     @ViewBuilder
     private func utilityButton(icon: String, action: @escaping () -> Void) -> some View {
+        let last = icon == "delete.backward"
         if #available(iOS 26.0, *) {
-            let last = icon == "delete.backward"
             
             Button {
                 HapticManager.lightImpact()
@@ -156,7 +156,7 @@ struct RewriteModesView: View {
                     .font(.system(size: 16, weight: .medium))
                     .foregroundStyle(.primary)
                     .frame(width: 40, height: 24)
-                    .background(.quaternary, in: .capsule(style: .continuous))
+                    .background((last ? Color.red : .blue).opacity(0.5), in: .capsule(style: .continuous))
                     .contentShape(.rect)
             }
             .padding(.vertical, 8)

--- a/VivaDictaKeyboard/Views/RewriteModesView.swift
+++ b/VivaDictaKeyboard/Views/RewriteModesView.swift
@@ -129,41 +129,59 @@ struct RewriteModesView: View {
 
     @ViewBuilder
     private func utilityButton(icon: String, action: @escaping () -> Void) -> some View {
-        let last = icon == "delete.backward"
+        let isBackspace = icon == "delete.backward"
         if #available(iOS 26.0, *) {
-            
-            Button {
-                HapticManager.lightImpact()
-                action()
-            } label: {
-                
-                Image(systemName: icon)
-                    .font(.system(size: 16, weight: .medium))
-                    .foregroundStyle(.primary)
-                    .frame(width: 36, height: 20)
-                    .contentShape(.rect)
+            if isBackspace {
+                RepeatableButton(action: action) {
+                    utilityButtonLabel(icon: icon)
+                        .frame(width: 36, height: 20)
+                }
+                .padding(.vertical, 4)
+                .padding(.horizontal, 8)
+                .glassEffect(.regular.tint(Color.red.opacity(0.3)).interactive())
+            } else {
+                Button {
+                    HapticManager.lightImpact()
+                    action()
+                } label: {
+                    utilityButtonLabel(icon: icon)
+                        .frame(width: 36, height: 20)
+                }
+                .padding(.vertical, 4)
+                .padding(.horizontal, 8)
+                .buttonStyle(.plain)
+                .glassEffect(.regular.tint(Color.blue.opacity(0.3)).interactive())
+                .padding(.trailing, 4)
             }
-            .padding(.vertical, 4)
-            .padding(.horizontal, 8)
-            .buttonStyle(.plain)
-            .glassEffect(.regular.tint((last ? Color.red : .blue).opacity(0.3)).interactive())
-            .padding(.trailing, (last ? 0 : 4))
         } else {
-            Button {
-                HapticManager.lightImpact()
-                action()
-            } label: {
-                
-                Image(systemName: icon)
-                    .font(.system(size: 16, weight: .medium))
-                    .foregroundStyle(.primary)
-                    .frame(width: 40, height: 24)
-                    .background((last ? Color.red : .blue).opacity(0.5), in: .capsule(style: .continuous))
-                    .contentShape(.rect)
+            if isBackspace {
+                RepeatableButton(action: action) {
+                    utilityButtonLabel(icon: icon)
+                        .frame(width: 40, height: 24)
+                        .background(Color.red.opacity(0.5), in: .capsule(style: .continuous))
+                }
+                .padding(.vertical, 8)
+                .padding(.horizontal, 16)
+            } else {
+                Button {
+                    HapticManager.lightImpact()
+                    action()
+                } label: {
+                    utilityButtonLabel(icon: icon)
+                        .frame(width: 40, height: 24)
+                        .background(Color.blue.opacity(0.5), in: .capsule(style: .continuous))
+                }
+                .padding(.vertical, 8)
+                .padding(.horizontal, 16)
+                .buttonStyle(.plain)
             }
-            .padding(.vertical, 8)
-            .padding(.horizontal, 16)
-            .buttonStyle(.plain)
         }
+    }
+
+    private func utilityButtonLabel(icon: String) -> some View {
+        Image(systemName: icon)
+            .font(.system(size: 16, weight: .medium))
+            .foregroundStyle(.primary)
+            .contentShape(.rect)
     }
 }

--- a/VivaDictaKeyboard/Views/RewriteModesView.swift
+++ b/VivaDictaKeyboard/Views/RewriteModesView.swift
@@ -39,11 +39,11 @@ struct RewriteModesView: View {
                 // Utility buttons: space, return, backspace
                 HStack(spacing: 4) {
                     
-                    utilityButton(icon: "space", action: onSpace)
+                    utilityButton(icon: "space", color: .blue, action: onSpace)
                         .shadow(color: .black.opacity(0.2), radius: 6)
-                    utilityButton(icon: "return", action: onNewline)
+                    utilityButton(icon: "return", color: .blue, action: onNewline)
                         .shadow(color: .black.opacity(0.2), radius: 6)
-                    utilityButton(icon: "delete.backward", action: onBackspace)
+                    utilityButton(icon: "delete.backward", color: .red, action: onBackspace)
                         .shadow(color: .black.opacity(0.2), radius: 6)
                 }
             }
@@ -127,29 +127,42 @@ struct RewriteModesView: View {
 
     // MARK: - Utility Button
 
-    @ViewBuilder
-    private func utilityButton(icon: String, action: @escaping () -> Void) -> some View {
-        let isBackspace = icon == "delete.backward"
-        let tintColor: Color = isBackspace ? .red : .blue
-        if #available(iOS 26.0, *) {
-            RepeatableButton(action: action) {
-                utilityButtonLabel(icon: icon)
-                    .frame(width: 36, height: 20)
-            }
-            .padding(.vertical, 4)
-            .padding(.horizontal, 8)
-            .glassEffect(.regular.tint(tintColor.opacity(0.3)).interactive())
-            .padding(.trailing, isBackspace ? 0 : 4)
-        } else {
-            RepeatableButton(action: action) {
-                utilityButtonLabel(icon: icon)
-                    .frame(width: 40, height: 24)
-                    .background(tintColor.opacity(0.5), in: .capsule(style: .continuous))
-            }
-            .padding(.vertical, 8)
-            .padding(.horizontal, 16)
-        }
+    
+    enum UtilityButtonPlacement {
+        case first
+        case mid
+        case last
     }
+
+    @ViewBuilder
+    private func utilityButton(
+        icon: String,
+        color: Color,
+        placement: UtilityButtonPlacement = .mid,
+        action: @escaping () -> Void) -> some View {
+            
+//            let isBackspace = icon == "delete.backward"
+//            let tintColor: Color = isBackspace ? .red : .blue
+            if #available(iOS 26.0, *) {
+                RepeatableButton(action: action) {
+                    utilityButtonLabel(icon: icon)
+                        .frame(width: 36, height: 20)
+                }
+                .padding(.vertical, 4)
+                .padding(.horizontal, 8)
+                .glassEffect(.regular.tint(color.opacity(0.3)).interactive())
+                .padding(.trailing, placement == .first ? 4 : 0)
+                .padding(.trailing, placement == .last ? 0 : 4)
+            } else {
+                RepeatableButton(action: action) {
+                    utilityButtonLabel(icon: icon)
+                        .frame(width: 40, height: 24)
+                        .background(color.opacity(0.5), in: .capsule(style: .continuous))
+                }
+                .padding(.vertical, 8)
+                .padding(.horizontal, 16)
+            }
+        }
 
     private func utilityButtonLabel(icon: String) -> some View {
         Image(systemName: icon)

--- a/VivaDictaKeyboard/Views/RewriteModesView.swift
+++ b/VivaDictaKeyboard/Views/RewriteModesView.swift
@@ -29,7 +29,7 @@ struct RewriteModesView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // Header: V/T segment on left, utility buttons on right
+            // Header: switcher on left, utility buttons on right
             HStack {
                 KeyboardTabToggle(dictationState: dictationState)
 

--- a/VivaDictaKeyboard/Views/RewriteModesView.swift
+++ b/VivaDictaKeyboard/Views/RewriteModesView.swift
@@ -21,6 +21,7 @@ struct RewriteModesView: View {
     let onModeSelected: (VivaMode) -> Void
     let onOpenApp: () -> Void
     let onBackspace: () -> Void
+    let onDeleteWord: () -> Void
     let onNewline: () -> Void
     let onSpace: () -> Void
 
@@ -43,7 +44,7 @@ struct RewriteModesView: View {
                         .shadow(color: .black.opacity(0.2), radius: 6)
                     utilityButton(icon: "return", color: .blue, action: onNewline)
                         .shadow(color: .black.opacity(0.2), radius: 6)
-                    utilityButton(icon: "delete.backward", color: .red, action: onBackspace)
+                    utilityButton(icon: "delete.backward", color: .red, action: onBackspace, longHoldAction: onDeleteWord)
                         .shadow(color: .black.opacity(0.2), radius: 6)
                 }
             }
@@ -139,30 +140,29 @@ struct RewriteModesView: View {
         icon: String,
         color: Color,
         placement: UtilityButtonPlacement = .mid,
-        action: @escaping () -> Void) -> some View {
-            
-//            let isBackspace = icon == "delete.backward"
-//            let tintColor: Color = isBackspace ? .red : .blue
-            if #available(iOS 26.0, *) {
-                RepeatableButton(action: action) {
-                    utilityButtonLabel(icon: icon)
-                        .frame(width: 36, height: 20)
-                }
-                .padding(.vertical, 4)
-                .padding(.horizontal, 8)
-                .glassEffect(.regular.tint(color.opacity(0.3)).interactive())
-                .padding(.trailing, placement == .first ? 4 : 0)
-                .padding(.trailing, placement == .last ? 0 : 4)
-            } else {
-                RepeatableButton(action: action) {
-                    utilityButtonLabel(icon: icon)
-                        .frame(width: 40, height: 24)
-                        .background(color.opacity(0.5), in: .capsule(style: .continuous))
-                }
-                .padding(.vertical, 8)
-                .padding(.horizontal, 16)
+        action: @escaping () -> Void,
+        longHoldAction: (() -> Void)? = nil
+    ) -> some View {
+        if #available(iOS 26.0, *) {
+            RepeatableButton(action: action, longHoldAction: longHoldAction) {
+                utilityButtonLabel(icon: icon)
+                    .frame(width: 36, height: 20)
             }
+            .padding(.vertical, 4)
+            .padding(.horizontal, 8)
+            .glassEffect(.regular.tint(color.opacity(0.3)).interactive())
+            .padding(.trailing, placement == .first ? 4 : 0)
+            .padding(.trailing, placement == .last ? 0 : 4)
+        } else {
+            RepeatableButton(action: action, longHoldAction: longHoldAction) {
+                utilityButtonLabel(icon: icon)
+                    .frame(width: 40, height: 24)
+                    .background(color.opacity(0.5), in: .capsule(style: .continuous))
+            }
+            .padding(.vertical, 8)
+            .padding(.horizontal, 16)
         }
+    }
 
     private func utilityButtonLabel(icon: String) -> some View {
         Image(systemName: icon)

--- a/VivaDictaKeyboard/Views/RewriteModesView.swift
+++ b/VivaDictaKeyboard/Views/RewriteModesView.swift
@@ -16,6 +16,7 @@ import SwiftUI
 /// When the main app session is not active, shows a prompt to open the main app.
 struct RewriteModesView: View {
     @Environment(KeyboardDictationState.self) var dictationState
+    @Environment(\.colorScheme) private var colorScheme
 
     let onModeSelected: (VivaMode) -> Void
     let onOpenApp: () -> Void
@@ -79,7 +80,8 @@ struct RewriteModesView: View {
                                 .frame(maxWidth: .infinity, alignment: .leading)
                             .padding(.horizontal, 16)
                             .padding(.vertical, 12)
-                            .background(.quaternary.opacity(0.5), in: .rect(cornerRadius: 10))
+                            .background(colorScheme == .dark ? Color(.quaternarySystemFill).opacity(0.5) : Color.white, in: .rect(cornerRadius: 10))
+
                         }
                         .buttonStyle(.plain)
                     }


### PR DESCRIPTION
## Summary

- New "Recent Notes" tab in the keyboard extension — users can quickly insert recent transcriptions from a scrollable list
- Toggle button cycles through 3 modes: keyboard → sparkles (text processing) → clock (recent notes) → keyboard
- Recent notes cached in shared UserDefaults (up to 10 entries) to avoid SwiftData access from the keyboard extension
- Cache synced from SwiftData on app foreground, background, and after transcription deletion

### Key features
- Tap a note to insert its full text at the cursor position
- Multi-level revert button — undo consecutive pastes one at a time (stack-based)
- RepeatableButton for space, return, backspace — hold to repeat character-by-character
- "Open VivaDicta" footer to access all notes in the main app
- Full-width tappable rows

### Files
- `VivaDicta/Shared/RecentNotesCache.swift` — lightweight cache (RecentNote struct + UserDefaults read/write)
- `VivaDicta/Services/RecentNotesCacheSync.swift` — SwiftData → cache sync (main app only)
- `VivaDictaKeyboard/Views/RecentNotesView.swift` — notes list UI with revert
- `VivaDictaKeyboard/Views/RepeatableButton.swift` — hold-to-repeat button component
- Modified: RecordViewModel (cache write), VivaDictaApp (sync on foreground/background), TranscriptionsContentView + MainView (sync after deletion), KeyboardDictationState (3rd tab), KeyboardViewController (toggle cycle), KeyboardCustomView (wiring)

## Test plan
- [ ] Open keyboard, cycle toggle to clock icon — verify recent notes appear
- [ ] Tap a note — verify text inserted at cursor
- [ ] Tap multiple notes — verify revert button undoes them one at a time
- [ ] Delete a transcription in main app, switch to keyboard — verify it's gone from recent notes
- [ ] Record a new transcription, switch to keyboard — verify it appears
- [ ] Hold space/return/backspace — verify they repeat
- [ ] Revert button hidden by default, appears only after pasting