### PR TITLE
Clean up Swift Concurrency patterns

### DIFF
--- a/VivaDicta/Views/AnimatedCopyButton.swift
+++ b/VivaDicta/Views/AnimatedCopyButton.swift
@@ -49,7 +49,7 @@ struct AnimatedCopyButton: View {
         isCopied = true
         onCopy?()
 
-        Task { @MainActor in
+        Task {
             try? await Task.sleep(for: .seconds(1.5))
             isCopied = false
         }

--- a/VivaDicta/Views/Onboarding/KeyboardIllustration.swift
+++ b/VivaDicta/Views/Onboarding/KeyboardIllustration.swift
@@ -35,7 +35,7 @@ struct KeyboardIllustration: View {
                     withAnimation(.spring.delay(1.0)) {
                         animate = true
 
-                        Task { @MainActor in
+                        Task {
                             try await Task.sleep(for: .seconds(1.3))
                             withAnimation {
                                 animate = false

--- a/VivaDicta/Views/Onboarding/OnboardingView.swift
+++ b/VivaDicta/Views/Onboarding/OnboardingView.swift
@@ -183,7 +183,7 @@ struct OnboardingView: View {
                 permissionState = granted ? .granted : .denied
                 if granted {
                     // Small delay before continuing
-                    try? await Task.sleep(nanoseconds: 300_000_000)
+                    try? await Task.sleep(for: .milliseconds(300))
                     navigateTo(.keyboard)
                 }
             }

--- a/VivaDicta/Views/RecordViewModel.swift
+++ b/VivaDicta/Views/RecordViewModel.swift
@@ -287,7 +287,7 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
             // In prewarm mode, we need a small delay to ensure file is flushed to disk
             // before trying to move it
             Task { @MainActor in
-                try? await Task.sleep(nanoseconds: 100_000_000) // 100ms delay
+                try? await Task.sleep(for: .milliseconds(100))
 
                 resetValues()
 

--- a/VivaDicta/Views/TranscriptionDetailView.swift
+++ b/VivaDicta/Views/TranscriptionDetailView.swift
@@ -401,7 +401,7 @@ struct TranscriptionDetailView: View {
 
     private func triggerCopyAnimation() {
         isShimmering = true
-        Task { @MainActor in
+        Task {
             try? await Task.sleep(for: .seconds(0.6))
             isShimmering = false
         }

--- a/VivaDicta/Views/TranscriptionRowView.swift
+++ b/VivaDicta/Views/TranscriptionRowView.swift
@@ -47,7 +47,7 @@ struct TranscriptionRowView: View {
                     ClipboardManager.copyToClipboard(displayText)
                     HapticManager.success()
                     showCopied = true
-                    Task { @MainActor in
+                    Task {
                         try? await Task.sleep(for: .seconds(1.5))
                         showCopied = false
                     }

--- a/VivaDicta/VivaDictaApp.swift
+++ b/VivaDicta/VivaDictaApp.swift
@@ -304,7 +304,7 @@ struct VivaDictaApp: App {
                     vm.startCaptureAudio()
                     
                     // Small delay to ensure recording is fully started
-                    try? await Task.sleep(nanoseconds: 200_000_000) // 0.2 seconds
+                    try? await Task.sleep(for: .milliseconds(200))
                     
                     // Now return to the host app
                     UIApplication.shared.open(url, options: [:]) { success in


### PR DESCRIPTION
## Summary
- Remove redundant `@MainActor` from `Task` closures in SwiftUI views where the context is already MainActor-isolated (Button actions, `.onAppear`, view methods)
- Replace `Task.sleep(nanoseconds:)` with modern `Task.sleep(for:)` API across the codebase

## Test plan
- [ ] Verify copy button animations still work (TranscriptionRowView, AnimatedCopyButton)
- [ ] Verify onboarding flow mic permission and navigation
- [ ] Verify recording start/cancel behavior
- [ ] Verify keyboard illustration animation
- [ ] Verify shimmer animation on TranscriptionDetailView copy