### PR TITLE
Fix mode picker not updating after renaming a mode

### DIFF
--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -211,7 +211,7 @@ class AIService {
             saveModes()
             
             if selectedMode.id == mode.id {
-                selectedMode = mode
+                selectedModeName = mode.name
             }
             
             logger.logInfo("Updated mode: \(mode.name)")


### PR DESCRIPTION
## Summary
- Fix mode picker on main screen showing stale name after renaming a mode in Edit Mode
- Fix keyboard extension falling back to "Default" mode when the selected mode was renamed

## Root cause
`AIService.updateMode()` set `selectedMode` directly but did not update `selectedModeName`, which is the persisted key in shared UserDefaults. After a rename, the stored name no longer matched any mode, causing lookups to fall back to the default mode.

## Fix
Set `selectedModeName = mode.name` instead of `selectedMode = mode` in `updateMode()`. This triggers the `didSet` chain that:
1. Persists the new name to shared UserDefaults
2. Updates `selectedMode` via `getMode(name:)`
3. Triggers `onModeChange` callback

One-line change in `AIService.swift`.

## Test plan
- [ ] Rename the currently selected mode → verify the main screen picker shows the new name immediately
- [ ] Rename a mode, open the picker → verify the renamed mode is selected (checkmark)
- [ ] Rename a mode, open the keyboard extension → verify the renamed mode appears (not "Default")
- [ ] Rename a mode, start recording from keyboard → verify the correct mode is used