### PR TITLE
Improve Parakeet transcription quality and resilience

### DIFF
--- a/VivaDicta/Services/Transcription/ParakeetTranscriptionService.swift
+++ b/VivaDicta/Services/Transcription/ParakeetTranscriptionService.swift
@@ -66,7 +66,7 @@ class ParakeetTranscriptionService: TranscriptionService {
         // VAD setting should be shared with keyboard extension
         let isVADEnabled = UserDefaultsStorage.shared.object(forKey: AppGroupCoordinator.kIsVADEnabled) as? Bool ?? true
         
-        let speechAudio: [Float]
+        var speechAudio: [Float]
         
         if durationSeconds < 20.0 || !isVADEnabled {
             speechAudio = audioSamples
@@ -74,7 +74,14 @@ class ParakeetTranscriptionService: TranscriptionService {
             logger.logNotice("🎙️ Applying VAD for long audio (> 20s)")
             speechAudio = try await applyVAD(to: audioSamples)
         }
-        
+
+        // Add trailing silence to improve final word punctuation detection
+        let trailingSilenceSamples = 16_000 // 1 second at 16kHz
+        let maxSingleChunkSamples = 240_000
+        if speechAudio.count + trailingSilenceSamples <= maxSingleChunkSamples {
+            speechAudio += [Float](repeating: 0, count: trailingSilenceSamples)
+        }
+
         // Transcribe the audio
         let result = try await asrManager.transcribe(speechAudio)
 
@@ -100,11 +107,16 @@ class ParakeetTranscriptionService: TranscriptionService {
 
         // Initialize VAD manager if needed (uses FluidAudio's default cache)
         if vadManager == nil {
-            vadManager = try await VadManager(config: vadConfig)
+            do {
+                vadManager = try await VadManager(config: vadConfig)
+            } catch {
+                logger.logWarning("⚠️ VAD init failed, falling back to full audio: \(error.localizedDescription)")
+                return audioSamples
+            }
         }
 
         guard let vadManager = vadManager else {
-            logger.logWarning("⚠️ VAD manager initialization failed, using full audio")
+            logger.logWarning("⚠️ VAD manager not available, using full audio")
             return audioSamples
         }
 


### PR DESCRIPTION
## Summary

- Add 1s trailing silence padding before transcription to improve final word punctuation detection (only when audio fits in single chunk ≤15s)
- Gracefully handle VAD initialization failure by falling back to full audio instead of throwing

## Test plan

- [ ] Record short audio (~5s) with Parakeet — verify punctuation at end of sentence
- [ ] Record long audio (>20s) with VAD enabled — verify VAD still works normally
- [ ] Test with VAD model not downloaded — verify graceful fallback to full audio