### PR TITLE
Add Claude CLI Server client for Anthropic AI processing

### DIFF
--- a/VivaDicta/Info.plist
+++ b/VivaDicta/Info.plist
@@ -90,6 +90,8 @@
 		<key>NSAllowsLocalNetworking</key>
 		<true/>
 	</dict>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>VivaDicta connects to Claude CLI Server running on your Mac for AI text processing.</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -602,6 +602,9 @@ class AIService {
                 logger.logWarning("Custom OpenAI model name not configured")
                 return false
             }
+        } else if aiProvider == .anthropic && ClaudeCLIServerClient.isEnabled,
+                  let serverURL = ClaudeCLIServerClient.serverURL, !serverURL.isEmpty {
+            // Anthropic with Claude CLI Server doesn't need API key
         } else {
             // Check if API key exists for the selected cloud provider
             guard getAPIKey(for: aiProvider) != nil else {
@@ -796,6 +799,31 @@ class AIService {
 
         // Cloud providers - compute system message only when needed
         let resolvedSystemMessage = systemMessage ?? getSystemMessage()
+
+        // Claude CLI Server: route Anthropic requests through remote server when enabled
+        if aiProvider == .anthropic && ClaudeCLIServerClient.isEnabled,
+           let serverURL = ClaudeCLIServerClient.serverURL, !serverURL.isEmpty {
+            let formattedText = preFormattedUserMessage ?? formatTranscriptForLLM(text)
+            lastSystemMessageSent = resolvedSystemMessage
+            lastUserMessageSent = formattedText
+            logger.logDebug("AI Processing - Using Claude CLI Server at \(serverURL)")
+            do {
+                let result = try await ClaudeCLIServerClient.enhance(
+                    text: formattedText,
+                    systemPrompt: resolvedSystemMessage,
+                    model: selectedMode.aiModel
+                )
+                let filteredResult = AIEnhancementOutputFilter.filter(result.trimmingCharacters(in: .whitespacesAndNewlines))
+                return filteredResult
+            } catch {
+                // Fall back to API key if server fails and key exists
+                if self.getAPIKey(for: aiProvider) != nil {
+                    logger.logWarning("Claude CLI Server failed, falling back to API key: \(error.localizedDescription)")
+                } else {
+                    throw EnhancementError.customError(error.localizedDescription)
+                }
+            }
+        }
 
         // Cloud providers require API key
         guard let apiKey = self.getAPIKey(for: aiProvider) else {
@@ -1490,8 +1518,14 @@ class AIService {
 
         // Add cloud providers that have API keys configured
         providers += AIProvider.allCases.filter { provider in
-            provider.requiresAPIKey &&
-            provider.apiKey != nil
+            if provider == .anthropic {
+                // Anthropic is connected if it has an API key OR Claude CLI Server is enabled
+                let serverConfigured = ClaudeCLIServerClient.isEnabled
+                    && ClaudeCLIServerClient.serverURL != nil
+                    && !ClaudeCLIServerClient.serverURL!.isEmpty
+                return serverConfigured || provider.apiKey != nil
+            }
+            return provider.requiresAPIKey && provider.apiKey != nil
         }
 
         connectedProviders = providers

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -602,9 +602,8 @@ class AIService {
                 logger.logWarning("Custom OpenAI model name not configured")
                 return false
             }
-        } else if aiProvider == .anthropic && ClaudeCLIServerClient.isEnabled,
-                  let serverURL = ClaudeCLIServerClient.serverURL, !serverURL.isEmpty {
-            // Anthropic with Claude CLI Server doesn't need API key
+        } else if aiProvider == .anthropic && ClaudeCLIServerClient.isEnabled && ClaudeCLIServerClient.isVerified {
+            // Anthropic with verified Claude CLI Server doesn't need API key
         } else {
             // Check if API key exists for the selected cloud provider
             guard getAPIKey(for: aiProvider) != nil else {
@@ -1519,10 +1518,9 @@ class AIService {
         // Add cloud providers that have API keys configured
         providers += AIProvider.allCases.filter { provider in
             if provider == .anthropic {
-                // Anthropic is connected if it has an API key OR Claude CLI Server is enabled
+                // Anthropic is connected if it has an API key OR Claude CLI Server is verified
                 let serverConfigured = ClaudeCLIServerClient.isEnabled
-                    && ClaudeCLIServerClient.serverURL != nil
-                    && !ClaudeCLIServerClient.serverURL!.isEmpty
+                    && ClaudeCLIServerClient.isVerified
                 return serverConfigured || provider.apiKey != nil
             }
             return provider.requiresAPIKey && provider.apiKey != nil

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -120,7 +120,7 @@ class AIService {
     private let userDefaults: UserDefaults
     private let modesStorageKey: String
     private let selectedModeStorageKey: String
-    private let baseTimeout: TimeInterval = 30
+    private let baseTimeout: TimeInterval = 300
 
     /// Service for Apple's on-device Foundation Models (type-erased for iOS version compatibility)
     private var _appleFoundationModelService: Any?

--- a/VivaDicta/Services/AIEnhance/ClaudeCLIServerClient.swift
+++ b/VivaDicta/Services/AIEnhance/ClaudeCLIServerClient.swift
@@ -1,0 +1,183 @@
+//
+//  ClaudeCLIServerClient.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.03.25
+//
+
+import Foundation
+
+enum ClaudeCLIServerClient {
+
+    struct EnhanceRequest: Encodable {
+        let text: String
+        let systemPrompt: String
+        let model: String
+    }
+
+    struct EnhanceResponse: Decodable {
+        let result: String
+        let model: String?
+        let duration: Double?
+    }
+
+    struct ErrorResponse: Decodable {
+        let error: String
+        let code: String?
+    }
+
+    struct HealthResponse: Decodable {
+        let status: String
+        let claudeAvailable: Bool
+        let claudePath: String?
+
+        enum CodingKeys: String, CodingKey {
+            case status
+            case claudeAvailable = "claude_available"
+            case claudePath = "claude_path"
+        }
+    }
+
+    struct ModelsResponse: Decodable {
+        let models: [String]
+        let `default`: String?
+    }
+
+    // MARK: - UserDefaults Keys
+
+    static let isEnabledKey = "isClaudeCLIServerClientEnabled"
+    static let serverURLKey = "claudeCLIServerClientURL"
+
+    // MARK: - Keychain Keys
+
+    static let authTokenKeychainKey = "claudeCLIServerClientToken"
+
+    // MARK: - Configuration
+
+    static var isEnabled: Bool {
+        UserDefaults.standard.bool(forKey: isEnabledKey)
+    }
+
+    static var serverURL: String? {
+        UserDefaults.standard.string(forKey: serverURLKey)
+    }
+
+    static var authToken: String? {
+        KeychainService.shared.getString(forKey: authTokenKeychainKey, syncable: false)
+    }
+
+    // MARK: - Enhance
+
+    static func enhance(
+        text: String,
+        systemPrompt: String,
+        model: String
+    ) async throws -> String {
+        guard let baseURL = serverURL, !baseURL.isEmpty else {
+            throw ClaudeCLIServerError.invalidURL
+        }
+
+        let urlString = baseURL.trimmingCharacters(in: CharacterSet(charactersIn: "/")) + "/enhance"
+        guard let url = URL(string: urlString) else {
+            throw ClaudeCLIServerError.invalidURL
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 120
+
+        if let token = authToken, !token.isEmpty {
+            request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+
+        let body = EnhanceRequest(text: text, systemPrompt: systemPrompt, model: model)
+        request.httpBody = try JSONEncoder().encode(body)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw ClaudeCLIServerError.invalidResponse
+        }
+
+        if httpResponse.statusCode == 200 {
+            let result = try JSONDecoder().decode(EnhanceResponse.self, from: data)
+            return result.result
+        } else {
+            if let errorResponse = try? JSONDecoder().decode(ErrorResponse.self, from: data) {
+                throw ClaudeCLIServerError.serverError(errorResponse.error)
+            }
+            throw ClaudeCLIServerError.httpError(httpResponse.statusCode)
+        }
+    }
+
+    // MARK: - Test Connection
+
+    static func testConnection() async -> Bool {
+        guard let baseURL = serverURL, !baseURL.isEmpty else { return false }
+
+        let urlString = baseURL.trimmingCharacters(in: CharacterSet(charactersIn: "/")) + "/health"
+        guard let url = URL(string: urlString) else { return false }
+
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 10
+
+        if let token = authToken, !token.isEmpty {
+            request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200 else { return false }
+            let health = try JSONDecoder().decode(HealthResponse.self, from: data)
+            return health.claudeAvailable
+        } catch {
+            return false
+        }
+    }
+
+    // MARK: - Fetch Models
+
+    static func fetchModels() async -> [String] {
+        guard let baseURL = serverURL, !baseURL.isEmpty else { return [] }
+
+        let urlString = baseURL.trimmingCharacters(in: CharacterSet(charactersIn: "/")) + "/models"
+        guard let url = URL(string: urlString) else { return [] }
+
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 10
+
+        if let token = authToken, !token.isEmpty {
+            request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+
+        do {
+            let (data, _) = try await URLSession.shared.data(for: request)
+            let result = try JSONDecoder().decode(ModelsResponse.self, from: data)
+            return result.models
+        } catch {
+            return []
+        }
+    }
+}
+
+enum ClaudeCLIServerError: LocalizedError {
+    case invalidURL
+    case invalidResponse
+    case serverError(String)
+    case httpError(Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidURL:
+            "Invalid Claude CLI Server URL."
+        case .invalidResponse:
+            "Invalid response from Claude CLI server."
+        case .serverError(let message):
+            message
+        case .httpError(let code):
+            "Claude CLI server returned HTTP \(code)."
+        }
+    }
+}

--- a/VivaDicta/Services/AIEnhance/ClaudeCLIServerClient.swift
+++ b/VivaDicta/Services/AIEnhance/ClaudeCLIServerClient.swift
@@ -38,11 +38,6 @@ enum ClaudeCLIServerClient {
         }
     }
 
-    struct ModelsResponse: Decodable {
-        let models: [String]
-        let `default`: String?
-    }
-
     // MARK: - UserDefaults Keys
 
     static let isEnabledKey = "isClaudeCLIServerClientEnabled"
@@ -142,29 +137,6 @@ enum ClaudeCLIServerClient {
         }
     }
 
-    // MARK: - Fetch Models
-
-    static func fetchModels() async -> [String] {
-        guard let baseURL = serverURL, !baseURL.isEmpty else { return [] }
-
-        let urlString = baseURL.trimmingCharacters(in: CharacterSet(charactersIn: "/")) + "/models"
-        guard let url = URL(string: urlString) else { return [] }
-
-        var request = URLRequest(url: url)
-        request.timeoutInterval = 10
-
-        if let token = authToken, !token.isEmpty {
-            request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-        }
-
-        do {
-            let (data, _) = try await URLSession.shared.data(for: request)
-            let result = try JSONDecoder().decode(ModelsResponse.self, from: data)
-            return result.models
-        } catch {
-            return []
-        }
-    }
 }
 
 enum ClaudeCLIServerError: LocalizedError {

--- a/VivaDicta/Services/AIEnhance/ClaudeCLIServerClient.swift
+++ b/VivaDicta/Services/AIEnhance/ClaudeCLIServerClient.swift
@@ -47,6 +47,7 @@ enum ClaudeCLIServerClient {
 
     static let isEnabledKey = "isClaudeCLIServerClientEnabled"
     static let serverURLKey = "claudeCLIServerClientURL"
+    static let isVerifiedKey = "isClaudeCLIServerClientVerified"
 
     // MARK: - Keychain Keys
 
@@ -64,6 +65,10 @@ enum ClaudeCLIServerClient {
 
     static var authToken: String? {
         KeychainService.shared.getString(forKey: authTokenKeychainKey, syncable: false)
+    }
+
+    static var isVerified: Bool {
+        UserDefaults.standard.bool(forKey: isVerifiedKey)
     }
 
     // MARK: - Enhance

--- a/VivaDicta/Views/SettingsScreen/AIProvidersView.swift
+++ b/VivaDicta/Views/SettingsScreen/AIProvidersView.swift
@@ -127,6 +127,8 @@ struct AIProviders: View {
                 OllamaConfigurationView(aiService: appState.aiService)
             } else if provider == .customOpenAI {
                 CustomOpenAIConfigurationView(aiService: appState.aiService)
+            } else if provider == .anthropic {
+                AnthropicConfigurationView(aiService: appState.aiService)
             } else {
                 AddAPIKeyView(
                     provider: provider,

--- a/VivaDicta/Views/SettingsScreen/AddAPIKeyView.swift
+++ b/VivaDicta/Views/SettingsScreen/AddAPIKeyView.swift
@@ -19,13 +19,6 @@ struct AddAPIKeyView: View {
     @State private var showDeleteConfirmation = false
     @State private var hasExistingKey = false
 
-    // Claude CLI Server state (Anthropic only)
-    @State private var isServerEnabled = UserDefaults.standard.bool(forKey: ClaudeCLIServerClient.isEnabledKey)
-    @State private var serverURL = UserDefaults.standard.string(forKey: ClaudeCLIServerClient.serverURLKey) ?? ""
-    @State private var serverToken = KeychainService.shared.getString(forKey: ClaudeCLIServerClient.authTokenKeychainKey, syncable: false) ?? ""
-    @State private var isTestingConnection = false
-    @State private var connectionTestResult: Bool?
-
     var onSave: (AIProvider) -> Void
     
     var body: some View {
@@ -173,11 +166,6 @@ struct AddAPIKeyView: View {
                 }
             }
 
-            // Claude CLI Server section (Anthropic only)
-            if provider == .anthropic {
-                claudeCLIServerSection
-            }
-
             Spacer()
         }
         .animation(.easeInOut(duration: 0.2), value: clearButtonVisible)
@@ -222,100 +210,6 @@ struct AddAPIKeyView: View {
             }
         } message: {
             Text("Are you sure you want to delete the API key for \(provider.displayName)? This action cannot be undone.")
-        }
-    }
-
-    // MARK: - Claude CLI Server Section
-
-    private var claudeCLIServerSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Divider()
-                .padding(.top, 8)
-
-            Text("Claude CLI Server")
-                .font(.headline)
-
-            Text("Use your Claude subscription via a Mac running VivaDicta with Claude CLI. No API key needed.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-
-            Toggle("Use Claude CLI Server", isOn: $isServerEnabled)
-                .onChange(of: isServerEnabled) { _, newValue in
-                    UserDefaults.standard.set(newValue, forKey: ClaudeCLIServerClient.isEnabledKey)
-                    if !newValue {
-                        UserDefaults.standard.set(false, forKey: ClaudeCLIServerClient.isVerifiedKey)
-                    }
-                    connectionTestResult = nil
-                    aiService.refreshConnectedProviders()
-                }
-
-            if isServerEnabled {
-                TextField("Server URL (e.g. http://192.168.1.5:3456)", text: $serverURL)
-                    .textInputAutocapitalization(.never)
-                    .autocorrectionDisabled()
-                    .keyboardType(.URL)
-                    .padding()
-                    .background {
-                        Capsule()
-                            .stroke(.gray, lineWidth: 0.5)
-                    }
-                    .onChange(of: serverURL) { _, _ in
-                        connectionTestResult = nil
-                    }
-
-                SecureField("Auth Token", text: $serverToken)
-                    .textInputAutocapitalization(.never)
-                    .autocorrectionDisabled()
-                    .padding()
-                    .background {
-                        Capsule()
-                            .stroke(.gray, lineWidth: 0.5)
-                    }
-                    .onChange(of: serverToken) { _, _ in
-                        connectionTestResult = nil
-                    }
-
-                HStack {
-                    Button {
-                        saveAndTestConnection()
-                    } label: {
-                        HStack(spacing: 6) {
-                            if isTestingConnection {
-                                ProgressView()
-                                    .controlSize(.small)
-                            }
-                            Text("Test Connection")
-                        }
-                    }
-                    .disabled(serverURL.isEmpty || isTestingConnection)
-
-                    if let result = connectionTestResult {
-                        HStack(spacing: 4) {
-                            Image(systemName: result ? "checkmark.circle.fill" : "xmark.circle.fill")
-                                .foregroundStyle(result ? .green : .red)
-                            Text(result ? "Connected" : "Failed")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-                }
-            }
-        }
-        .padding(.horizontal)
-    }
-
-    private func saveAndTestConnection() {
-        // Save URL and token when user explicitly taps Test Connection
-        UserDefaults.standard.set(serverURL, forKey: ClaudeCLIServerClient.serverURLKey)
-        KeychainService.shared.save(serverToken, forKey: ClaudeCLIServerClient.authTokenKeychainKey, syncable: false)
-
-        Task {
-            isTestingConnection = true
-            let success = await ClaudeCLIServerClient.testConnection()
-            connectionTestResult = success
-            UserDefaults.standard.set(success, forKey: ClaudeCLIServerClient.isVerifiedKey)
-            isTestingConnection = false
-            aiService.refreshConnectedProviders()
         }
     }
 

--- a/VivaDicta/Views/SettingsScreen/AddAPIKeyView.swift
+++ b/VivaDicta/Views/SettingsScreen/AddAPIKeyView.swift
@@ -242,6 +242,9 @@ struct AddAPIKeyView: View {
             Toggle("Use Claude CLI Server", isOn: $isServerEnabled)
                 .onChange(of: isServerEnabled) { _, newValue in
                     UserDefaults.standard.set(newValue, forKey: ClaudeCLIServerClient.isEnabledKey)
+                    if !newValue {
+                        UserDefaults.standard.set(false, forKey: ClaudeCLIServerClient.isVerifiedKey)
+                    }
                     connectionTestResult = nil
                     aiService.refreshConnectedProviders()
                 }
@@ -256,8 +259,7 @@ struct AddAPIKeyView: View {
                         Capsule()
                             .stroke(.gray, lineWidth: 0.5)
                     }
-                    .onChange(of: serverURL) { _, newValue in
-                        UserDefaults.standard.set(newValue, forKey: ClaudeCLIServerClient.serverURLKey)
+                    .onChange(of: serverURL) { _, _ in
                         connectionTestResult = nil
                     }
 
@@ -269,18 +271,13 @@ struct AddAPIKeyView: View {
                         Capsule()
                             .stroke(.gray, lineWidth: 0.5)
                     }
-                    .onChange(of: serverToken) { _, newValue in
-                        KeychainService.shared.save(newValue, forKey: ClaudeCLIServerClient.authTokenKeychainKey, syncable: false)
+                    .onChange(of: serverToken) { _, _ in
                         connectionTestResult = nil
                     }
 
                 HStack {
                     Button {
-                        Task {
-                            isTestingConnection = true
-                            connectionTestResult = await ClaudeCLIServerClient.testConnection()
-                            isTestingConnection = false
-                        }
+                        saveAndTestConnection()
                     } label: {
                         HStack(spacing: 6) {
                             if isTestingConnection {
@@ -305,6 +302,21 @@ struct AddAPIKeyView: View {
             }
         }
         .padding(.horizontal)
+    }
+
+    private func saveAndTestConnection() {
+        // Save URL and token when user explicitly taps Test Connection
+        UserDefaults.standard.set(serverURL, forKey: ClaudeCLIServerClient.serverURLKey)
+        KeychainService.shared.save(serverToken, forKey: ClaudeCLIServerClient.authTokenKeychainKey, syncable: false)
+
+        Task {
+            isTestingConnection = true
+            let success = await ClaudeCLIServerClient.testConnection()
+            connectionTestResult = success
+            UserDefaults.standard.set(success, forKey: ClaudeCLIServerClient.isVerifiedKey)
+            isTestingConnection = false
+            aiService.refreshConnectedProviders()
+        }
     }
 
     private func deleteAPIKey() {

--- a/VivaDicta/Views/SettingsScreen/AddAPIKeyView.swift
+++ b/VivaDicta/Views/SettingsScreen/AddAPIKeyView.swift
@@ -11,14 +11,21 @@ struct AddAPIKeyView: View {
     @Environment(\.dismiss) var dismiss
     let provider: AIProvider
     let aiService: AIService
-    
+
     @State private var apiKey: String = ""
     @State private var isVerifying: Bool = false
     @State private var verificationError: String? = nil
     @State private var clearButtonVisible = false
     @State private var showDeleteConfirmation = false
     @State private var hasExistingKey = false
-    
+
+    // Claude CLI Server state (Anthropic only)
+    @State private var isServerEnabled = UserDefaults.standard.bool(forKey: ClaudeCLIServerClient.isEnabledKey)
+    @State private var serverURL = UserDefaults.standard.string(forKey: ClaudeCLIServerClient.serverURLKey) ?? ""
+    @State private var serverToken = KeychainService.shared.getString(forKey: ClaudeCLIServerClient.authTokenKeychainKey, syncable: false) ?? ""
+    @State private var isTestingConnection = false
+    @State private var connectionTestResult: Bool?
+
     var onSave: (AIProvider) -> Void
     
     var body: some View {
@@ -166,6 +173,11 @@ struct AddAPIKeyView: View {
                 }
             }
 
+            // Claude CLI Server section (Anthropic only)
+            if provider == .anthropic {
+                claudeCLIServerSection
+            }
+
             Spacer()
         }
         .animation(.easeInOut(duration: 0.2), value: clearButtonVisible)
@@ -177,6 +189,10 @@ struct AddAPIKeyView: View {
             clearButtonVisible = !apiKey.isEmpty
         }
         .padding()
+        .contentShape(.rect)
+        .onTapGesture {
+            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+        }
         .navigationTitle("API Key")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
@@ -207,6 +223,88 @@ struct AddAPIKeyView: View {
         } message: {
             Text("Are you sure you want to delete the API key for \(provider.displayName)? This action cannot be undone.")
         }
+    }
+
+    // MARK: - Claude CLI Server Section
+
+    private var claudeCLIServerSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Divider()
+                .padding(.top, 8)
+
+            Text("Claude CLI Server")
+                .font(.headline)
+
+            Text("Use your Claude subscription via a Mac running VivaDicta with Claude CLI. No API key needed.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Toggle("Use Claude CLI Server", isOn: $isServerEnabled)
+                .onChange(of: isServerEnabled) { _, newValue in
+                    UserDefaults.standard.set(newValue, forKey: ClaudeCLIServerClient.isEnabledKey)
+                    connectionTestResult = nil
+                    aiService.refreshConnectedProviders()
+                }
+
+            if isServerEnabled {
+                TextField("Server URL (e.g. http://192.168.1.5:3456)", text: $serverURL)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .keyboardType(.URL)
+                    .padding()
+                    .background {
+                        Capsule()
+                            .stroke(.gray, lineWidth: 0.5)
+                    }
+                    .onChange(of: serverURL) { _, newValue in
+                        UserDefaults.standard.set(newValue, forKey: ClaudeCLIServerClient.serverURLKey)
+                        connectionTestResult = nil
+                    }
+
+                SecureField("Auth Token", text: $serverToken)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .padding()
+                    .background {
+                        Capsule()
+                            .stroke(.gray, lineWidth: 0.5)
+                    }
+                    .onChange(of: serverToken) { _, newValue in
+                        KeychainService.shared.save(newValue, forKey: ClaudeCLIServerClient.authTokenKeychainKey, syncable: false)
+                        connectionTestResult = nil
+                    }
+
+                HStack {
+                    Button {
+                        Task {
+                            isTestingConnection = true
+                            connectionTestResult = await ClaudeCLIServerClient.testConnection()
+                            isTestingConnection = false
+                        }
+                    } label: {
+                        HStack(spacing: 6) {
+                            if isTestingConnection {
+                                ProgressView()
+                                    .controlSize(.small)
+                            }
+                            Text("Test Connection")
+                        }
+                    }
+                    .disabled(serverURL.isEmpty || isTestingConnection)
+
+                    if let result = connectionTestResult {
+                        HStack(spacing: 4) {
+                            Image(systemName: result ? "checkmark.circle.fill" : "xmark.circle.fill")
+                                .foregroundStyle(result ? .green : .red)
+                            Text(result ? "Connected" : "Failed")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+        }
+        .padding(.horizontal)
     }
 
     private func deleteAPIKey() {

--- a/VivaDicta/Views/SettingsScreen/AnthropicConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/AnthropicConfigurationView.swift
@@ -1,0 +1,290 @@
+//
+//  AnthropicConfigurationView.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.03.26
+//
+
+import SwiftUI
+
+struct AnthropicConfigurationView: View {
+    @Environment(\.dismiss) private var dismiss
+    let aiService: AIService
+
+    // API Key state
+    @State private var apiKey: String = ""
+    @State private var isVerifying = false
+    @State private var verificationError: String?
+    @State private var hasExistingKey = false
+    @State private var showDeleteConfirmation = false
+
+    // Claude CLI Server state
+    @State private var isServerEnabled = UserDefaults.standard.bool(forKey: ClaudeCLIServerClient.isEnabledKey)
+    @State private var serverURL = UserDefaults.standard.string(forKey: ClaudeCLIServerClient.serverURLKey) ?? ""
+    @State private var serverToken = KeychainService.shared.getString(forKey: ClaudeCLIServerClient.authTokenKeychainKey, syncable: false) ?? ""
+    @State private var isTestingConnection = false
+    @State private var connectionTestResult: Bool?
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 24) {
+                // Header
+                VStack(spacing: 8) {
+                    if let iconName = AIProvider.anthropic.iconName {
+                        Image(iconName)
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 64, height: 64)
+                    }
+
+                    Text("Anthropic")
+                        .font(.title2)
+                }
+                .padding(.top, 8)
+
+                // Claude CLI Server section
+                cliServerSection
+
+                // API Key section
+                apiKeySection
+            }
+            .padding()
+        }
+        .contentShape(.rect)
+        .onTapGesture {
+            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+        }
+        .navigationTitle("Anthropic")
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            let existingKey = AIProvider.anthropic.apiKey
+            apiKey = existingKey ?? ""
+            hasExistingKey = existingKey != nil
+
+            // Show verified status if previously verified
+            if isServerEnabled && ClaudeCLIServerClient.isVerified {
+                connectionTestResult = true
+            }
+        }
+        .alert("Delete API Key", isPresented: $showDeleteConfirmation) {
+            Button("Cancel", role: .cancel) { }
+            Button("Delete", role: .destructive) {
+                deleteAPIKey()
+            }
+        } message: {
+            Text("Are you sure you want to delete the API key for Anthropic? This action cannot be undone.")
+        }
+    }
+
+    // MARK: - Claude CLI Server Section
+
+    private var cliServerSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Claude CLI Server")
+                .font(.headline)
+
+            Text("Use your Claude subscription via a Mac running VivaDicta with Claude CLI. No API key needed.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Toggle("Use Claude CLI Server", isOn: $isServerEnabled)
+                .onChange(of: isServerEnabled) { _, newValue in
+                    UserDefaults.standard.set(newValue, forKey: ClaudeCLIServerClient.isEnabledKey)
+                    if !newValue {
+                        UserDefaults.standard.set(false, forKey: ClaudeCLIServerClient.isVerifiedKey)
+                    }
+                    connectionTestResult = nil
+                    aiService.refreshConnectedProviders()
+                }
+
+            if isServerEnabled {
+                TextField("Server URL (e.g. http://192.168.1.5:3456)", text: $serverURL)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .keyboardType(.URL)
+                    .padding()
+                    .background {
+                        Capsule()
+                            .stroke(.gray, lineWidth: 0.5)
+                    }
+                    .onChange(of: serverURL) { _, _ in
+                        connectionTestResult = nil
+                    }
+
+                SecureField("Auth Token", text: $serverToken)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .padding()
+                    .background {
+                        Capsule()
+                            .stroke(.gray, lineWidth: 0.5)
+                    }
+                    .onChange(of: serverToken) { _, _ in
+                        connectionTestResult = nil
+                    }
+
+                HStack {
+                    Button {
+                        saveAndTestConnection()
+                    } label: {
+                        HStack(spacing: 6) {
+                            if isTestingConnection {
+                                ProgressView()
+                                    .controlSize(.small)
+                            }
+                            Text("Test Connection")
+                        }
+                    }
+                    .disabled(serverURL.isEmpty || isTestingConnection)
+
+                    if let result = connectionTestResult {
+                        HStack(spacing: 4) {
+                            Image(systemName: result ? "checkmark.circle.fill" : "xmark.circle.fill")
+                                .foregroundStyle(result ? .green : .red)
+                            Text(result ? "Connected" : "Failed")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+        }
+        .padding()
+        .background {
+            RoundedRectangle(cornerRadius: 12)
+                .fill(.background.secondary)
+        }
+    }
+
+    // MARK: - API Key Section
+
+    private var apiKeySection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("API Key")
+                .font(.headline)
+
+            Text("Or use an Anthropic API key directly.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            TextField("API Key", text: $apiKey)
+                .privacySensitive()
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .padding()
+                .background {
+                    Capsule()
+                        .stroke(verificationError != nil ? .red : .gray, lineWidth: verificationError != nil ? 1.5 : 0.5)
+                }
+                .onChange(of: apiKey) { _, _ in
+                    verificationError = nil
+                }
+
+            if let error = verificationError {
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+
+            HStack {
+                Button {
+                    saveAPIKey()
+                } label: {
+                    HStack(spacing: 6) {
+                        if isVerifying {
+                            ProgressView()
+                                .controlSize(.small)
+                        }
+                        Text("Save API Key")
+                    }
+                }
+                .disabled(apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isVerifying)
+
+                Button {
+                    if let clipboardString = UIPasteboard.general.string {
+                        let trimmed = clipboardString.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if !trimmed.isEmpty {
+                            apiKey = trimmed
+                            saveAPIKey()
+                        }
+                    }
+                } label: {
+                    Text("Paste & Save")
+                }
+            }
+
+            if hasExistingKey {
+                Button(role: .destructive) {
+                    showDeleteConfirmation = true
+                    HapticManager.warning()
+                } label: {
+                    Text("Delete API Key")
+                        .font(.subheadline)
+                }
+                .padding(.top, 4)
+            }
+        }
+        .padding()
+        .background {
+            RoundedRectangle(cornerRadius: 12)
+                .fill(.background.secondary)
+        }
+    }
+
+    // MARK: - Actions
+
+    private func saveAndTestConnection() {
+        UserDefaults.standard.set(serverURL, forKey: ClaudeCLIServerClient.serverURLKey)
+        KeychainService.shared.save(serverToken, forKey: ClaudeCLIServerClient.authTokenKeychainKey, syncable: false)
+
+        Task {
+            isTestingConnection = true
+            let success = await ClaudeCLIServerClient.testConnection()
+            connectionTestResult = success
+            UserDefaults.standard.set(success, forKey: ClaudeCLIServerClient.isVerifiedKey)
+            isTestingConnection = false
+            aiService.refreshConnectedProviders()
+            if success {
+                HapticManager.success()
+            } else {
+                HapticManager.error()
+            }
+        }
+    }
+
+    private func saveAPIKey() {
+        Task {
+            isVerifying = true
+            verificationError = nil
+            HapticManager.mediumImpact()
+
+            let isValid = await aiService.saveAPIKey(apiKey, for: .anthropic)
+
+            isVerifying = false
+            if isValid {
+                hasExistingKey = true
+                HapticManager.success()
+            } else {
+                verificationError = "Invalid API key. Please check your key and try again."
+                HapticManager.error()
+            }
+        }
+    }
+
+    private func deleteAPIKey() {
+        HapticManager.heavyImpact()
+        KeychainService.shared.delete(forKey: AIProvider.anthropic.keychainKey)
+        apiKey = ""
+        hasExistingKey = false
+        aiService.refreshConnectedProviders()
+        aiService.disableAIEnhancementForModesUsingProvider(.anthropic)
+    }
+}
+
+#if DEBUG || QA
+#Preview {
+    NavigationStack {
+        AnthropicConfigurationView(aiService: AIService())
+    }
+}
+#endif

--- a/VivaDicta/Views/SettingsScreen/AnthropicConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/AnthropicConfigurationView.swift
@@ -39,6 +39,16 @@ struct AnthropicConfigurationView: View {
 
                     Text("Anthropic")
                         .font(.title2)
+
+                    if aiService.connectedProviders.contains(.anthropic) {
+                        HStack(spacing: 4) {
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundStyle(.green)
+                            Text(isServerEnabled && ClaudeCLIServerClient.isVerified ? "CLI Server Connected" : "API Key Configured")
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
                 }
                 .padding(.top, 8)
 

--- a/VivaDicta/Views/SettingsScreen/AnthropicConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/AnthropicConfigurationView.swift
@@ -134,18 +134,47 @@ struct AnthropicConfigurationView: View {
                     }
 
                 HStack {
-                    Button {
-                        saveAndTestConnection()
-                    } label: {
-                        HStack(spacing: 6) {
-                            if isTestingConnection {
-                                ProgressView()
-                                    .controlSize(.small)
+                    if #available(iOS 26.0, *) {
+                        Button {
+                            saveAndTestConnection()
+                        } label: {
+                            HStack(spacing: 6) {
+                                if isTestingConnection {
+                                    ProgressView()
+                                        .controlSize(.small)
+                                }
+                                Text("Test & Save")
+                                    .font(.headline.weight(.medium))
                             }
-                            Text("Test Connection")
                         }
+                        .disabled(serverURL.isEmpty || isTestingConnection)
+                        .padding(.vertical, 8)
+                        .padding(.horizontal, 16)
+                        .glassEffect(.regular.tint(.blue.opacity(0.3)).interactive())
+                        .buttonStyle(.plain)
+                    } else {
+                        Button {
+                            saveAndTestConnection()
+                        } label: {
+                            HStack(spacing: 6) {
+                                if isTestingConnection {
+                                    ProgressView()
+                                        .controlSize(.small)
+                                }
+                                Text("Test & Save")
+                                    .font(.headline.weight(.medium))
+                                    .foregroundStyle(.primary)
+                            }
+                            .padding(.vertical, 8)
+                            .padding(.horizontal, 16)
+                            .background {
+                                Capsule()
+                                    .stroke(.blue, lineWidth: 2)
+                            }
+                        }
+                        .disabled(serverURL.isEmpty || isTestingConnection)
+                        .buttonStyle(.plain)
                     }
-                    .disabled(serverURL.isEmpty || isTestingConnection)
 
                     if let result = connectionTestResult {
                         HStack(spacing: 4) {
@@ -196,42 +225,121 @@ struct AnthropicConfigurationView: View {
                     .foregroundStyle(.red)
             }
 
-            HStack {
-                Button {
-                    saveAPIKey()
-                } label: {
-                    HStack(spacing: 6) {
-                        if isVerifying {
-                            ProgressView()
-                                .controlSize(.small)
-                        }
-                        Text("Save API Key")
-                    }
-                }
-                .disabled(apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isVerifying)
-
-                Button {
-                    if let clipboardString = UIPasteboard.general.string {
-                        let trimmed = clipboardString.trimmingCharacters(in: .whitespacesAndNewlines)
-                        if !trimmed.isEmpty {
-                            apiKey = trimmed
-                            saveAPIKey()
+            if #available(iOS 26.0, *) {
+                HStack {
+                    Button {
+                        saveAPIKey()
+                    } label: {
+                        HStack(spacing: 6) {
+                            if isVerifying {
+                                ProgressView()
+                                    .controlSize(.small)
+                            }
+                            Text("Save API Key")
+                                .font(.headline.weight(.medium))
                         }
                     }
-                } label: {
-                    Text("Paste & Save")
-                }
-            }
+                    .disabled(apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isVerifying)
+                    .padding(.vertical, 8)
+                    .padding(.horizontal, 16)
+                    .glassEffect(.regular.tint(.blue.opacity(0.3)).interactive())
+                    .buttonStyle(.plain)
 
-            if hasExistingKey {
-                Button(role: .destructive) {
-                    showDeleteConfirmation = true
-                    HapticManager.warning()
-                } label: {
-                    Text("Delete API Key")
-                        .font(.subheadline)
+                    Button {
+                        if let clipboardString = UIPasteboard.general.string {
+                            let trimmed = clipboardString.trimmingCharacters(in: .whitespacesAndNewlines)
+                            if !trimmed.isEmpty {
+                                apiKey = trimmed
+                                saveAPIKey()
+                            }
+                        }
+                    } label: {
+                        Text("Paste")
+                            .font(.headline.weight(.medium))
+                    }
+                    .padding(.vertical, 8)
+                    .padding(.horizontal, 16)
+                    .glassEffect(.regular.tint(.gray.opacity(0.3)).interactive())
+                    .buttonStyle(.plain)
                 }
-                .padding(.top, 4)
+
+                if hasExistingKey {
+                    Button {
+                        showDeleteConfirmation = true
+                        HapticManager.warning()
+                    } label: {
+                        Text("Delete API Key")
+                            .font(.headline.weight(.semibold))
+                            .foregroundStyle(.red)
+                    }
+                    .padding(.vertical, 8)
+                    .padding(.horizontal, 16)
+                    .glassEffect(.regular.tint(.red.opacity(0.2)).interactive())
+                    .padding(.top, 4)
+                }
+            } else {
+                HStack {
+                    Button {
+                        saveAPIKey()
+                    } label: {
+                        HStack(spacing: 6) {
+                            if isVerifying {
+                                ProgressView()
+                                    .controlSize(.small)
+                            }
+                            Text("Save API Key")
+                                .font(.headline.weight(.medium))
+                                .foregroundStyle(.primary)
+                        }
+                        .padding(.vertical, 8)
+                        .padding(.horizontal, 16)
+                        .background {
+                            Capsule()
+                                .stroke(.blue, lineWidth: 2)
+                        }
+                    }
+                    .disabled(apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isVerifying)
+                    .buttonStyle(.plain)
+
+                    Button {
+                        if let clipboardString = UIPasteboard.general.string {
+                            let trimmed = clipboardString.trimmingCharacters(in: .whitespacesAndNewlines)
+                            if !trimmed.isEmpty {
+                                apiKey = trimmed
+                                saveAPIKey()
+                            }
+                        }
+                    } label: {
+                        Text("Paste")
+                            .font(.headline.weight(.medium))
+                            .foregroundStyle(.primary)
+                            .padding(.vertical, 8)
+                            .padding(.horizontal, 16)
+                            .background {
+                                Capsule()
+                                    .stroke(.gray, lineWidth: 2)
+                            }
+                    }
+                    .buttonStyle(.plain)
+                }
+
+                if hasExistingKey {
+                    Button {
+                        showDeleteConfirmation = true
+                        HapticManager.warning()
+                    } label: {
+                        Text("Delete API Key")
+                            .font(.headline.weight(.semibold))
+                            .foregroundStyle(.red)
+                    }
+                    .padding(.vertical, 8)
+                    .padding(.horizontal, 16)
+                    .overlay {
+                        Capsule()
+                            .stroke(Color.red, lineWidth: 1.5)
+                    }
+                    .padding(.top, 4)
+                }
             }
         }
         .padding()

--- a/VivaDicta/Views/SettingsScreen/ModeEditView.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditView.swift
@@ -447,6 +447,22 @@ struct ModeEditView: View {
                                         }
                                     }
                                     .alignmentGuide(.listRowSeparatorLeading) { _ in 0 }
+                                } else if provider == .anthropic {
+                                    // Anthropic has dedicated config (API key + CLI Server)
+                                    NavigationLink {
+                                        AnthropicConfigurationView(aiService: viewModel.aiService)
+                                    } label: {
+                                        HStack {
+                                            Image(systemName: "exclamationmark.triangle.fill")
+                                                .foregroundStyle(.orange)
+                                            Text("Configure Anthropic")
+                                            Spacer()
+                                            Text("Required")
+                                                .font(.caption)
+                                                .foregroundStyle(.secondary)
+                                        }
+                                    }
+                                    .alignmentGuide(.listRowSeparatorLeading) { _ in 0 }
                                 } else {
                                     // Cloud provider needs API key
                                     NavigationLink {


### PR DESCRIPTION
## Summary
- Add Claude CLI Server support to route Anthropic AI processing through a Mac running VivaDicta with Claude CLI, using Claude subscription instead of API keys
- New `ClaudeCLIServerClient` HTTP client with enhance, health check, and model fetching endpoints
- Settings UI in Anthropic provider screen: toggle, server URL, auth token, and connection test
- Fallback chain: CLI Server first, then API key if server fails

## Test plan
- [ ] Enable Claude CLI Server toggle in Anthropic settings
- [ ] Enter server URL and auth token from Mac app
- [ ] Tap "Test Connection" — verify green checkmark
- [ ] Run AI processing — verify it routes through CLI Server
- [ ] Disable toggle — verify it falls back to API key
- [ ] Verify local network permission prompt appears on first connection