### PR TITLE
Add ChatGPT OAuth sign-in for OpenAI provider

### DIFF
--- a/VivaDicta/Services/AIEnhance/AIProvider.swift
+++ b/VivaDicta/Services/AIEnhance/AIProvider.swift
@@ -325,15 +325,16 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
                 "gpt-5.4",
                 "gpt-5.4-mini",
                 "gpt-5.4-nano",
-                "gpt-5.4-thinking",
-                "gpt-5.3-chat-latest",
-                "gpt-5.3-instant",
                 "gpt-5.2",
                 "gpt-5.1",
-                "gpt-5-mini",
-                "gpt-5-nano",
+                "o4-mini",
+                "o3",
+                "o3-mini",
                 "gpt-4.1",
-                "gpt-4.1-mini"
+                "gpt-4.1-mini",
+                "gpt-4.1-nano",
+                "gpt-4o",
+                "gpt-4o-mini"
             ]
         case .grok:
             return [

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -45,6 +45,13 @@ class AIService {
 
     /// List of AI providers that have valid API keys or are otherwise available.
     public var connectedProviders: [AIProvider] = []
+
+    // MARK: - ChatGPT OAuth
+    public var isChatGPTSignedIn: Bool = false
+    public var chatGPTEmail: String?
+    public var isChatGPTSigningIn: Bool = false
+    public var chatGPTModels: [String] = []
+
     public var openRouterModels: [String] = []
     public var vercelAIGatewayModels: [String] = []
     public var huggingFaceModels: [String] = []
@@ -155,6 +162,7 @@ class AIService {
 
         // Refresh connected providers on main actor (needed for Apple availability check)
         Task { @MainActor in
+            refreshChatGPTOAuthState()
             refreshConnectedProviders()
             await dismissTranscriptionTipsIfModelConfigured()
             await autoAssignCloudTranscriptionIfAvailable()
@@ -604,6 +612,8 @@ class AIService {
             }
         } else if aiProvider == .anthropic && connectedProviders.contains(.anthropic) {
             // Anthropic is connected (via API key or CLI Server)
+        } else if aiProvider == .openAI && connectedProviders.contains(.openAI) {
+            // OpenAI is connected (via ChatGPT OAuth or API key)
         } else {
             // Check if API key exists for the selected cloud provider
             guard getAPIKey(for: aiProvider) != nil else {
@@ -824,13 +834,39 @@ class AIService {
             }
         }
 
+        // Use pre-formatted text if provided (variation mode), otherwise format using selected mode's preset
+        let formattedText = preFormattedUserMessage ?? formatTranscriptForLLM(text)
+
+        // ChatGPT OAuth: route OpenAI requests through ChatGPT backend API when signed in
+        if aiProvider == .openAI && isChatGPTSignedIn {
+            lastSystemMessageSent = resolvedSystemMessage
+            lastUserMessageSent = formattedText
+            do {
+                let provider = OpenAIChatGPTOAuthProvider()
+                let (token, accountId, _) = try await OAuthManager.shared.validAccessToken(for: provider)
+                let model = selectedMode.aiModel.isEmpty ? ChatGPTAPIClient.defaultModel : selectedMode.aiModel
+                let result = try await ChatGPTAPIClient.enhance(
+                    text: formattedText,
+                    systemPrompt: resolvedSystemMessage,
+                    model: model,
+                    accessToken: token,
+                    accountId: accountId
+                )
+                return AIEnhancementOutputFilter.filter(result)
+            } catch let error as OAuthError {
+                // If OAuth fails and we have an API key, fall through to standard path
+                if self.getAPIKey(for: aiProvider) != nil {
+                    logger.logWarning("ChatGPT OAuth failed, falling back to API key: \(error.localizedDescription)")
+                } else {
+                    throw EnhancementError.customError(error.errorDescription ?? "ChatGPT OAuth error")
+                }
+            }
+        }
+
         // Cloud providers require API key
         guard let apiKey = self.getAPIKey(for: aiProvider) else {
             throw EnhancementError.notConfigured
         }
-
-        // Use pre-formatted text if provided (variation mode), otherwise format using selected mode's preset
-        let formattedText = preFormattedUserMessage ?? formatTranscriptForLLM(text)
 
         // Store for TranscriptionVariation
         lastSystemMessageSent = resolvedSystemMessage
@@ -1515,13 +1551,16 @@ class AIService {
             providers.append(.customOpenAI)
         }
 
-        // Add cloud providers that have API keys configured
+        // Add cloud providers that have API keys configured or OAuth signed in
         providers += AIProvider.allCases.filter { provider in
             if provider == .anthropic {
                 // Anthropic is connected if it has an API key OR Claude CLI Server is verified
                 let serverConfigured = ClaudeCLIServerClient.isEnabled
                     && ClaudeCLIServerClient.isVerified
                 return serverConfigured || provider.apiKey != nil
+            }
+            if provider == .openAI {
+                return isChatGPTSignedIn || provider.apiKey != nil
             }
             return provider.requiresAPIKey && provider.apiKey != nil
         }
@@ -2102,5 +2141,50 @@ enum EnhancementError: LocalizedError {
         case .customError(let message):
             return "An error occurred: \(message)"
         }
+    }
+}
+
+// MARK: - ChatGPT OAuth
+
+extension AIService {
+    /// Refreshes the ChatGPT OAuth state from stored credentials.
+    @MainActor
+    func refreshChatGPTOAuthState() {
+        let provider = OpenAIChatGPTOAuthProvider()
+        isChatGPTSignedIn = OAuthManager.shared.isSignedIn(provider: provider)
+        chatGPTEmail = OAuthManager.shared.accountEmail(for: provider)
+    }
+
+    /// Signs in to ChatGPT via OAuth.
+    @MainActor
+    func signInWithChatGPT() async throws {
+        isChatGPTSigningIn = true
+        defer { isChatGPTSigningIn = false }
+
+        let provider = OpenAIChatGPTOAuthProvider()
+        let credential = try await OAuthManager.shared.signIn(provider: provider)
+        isChatGPTSignedIn = true
+        chatGPTEmail = credential.accountEmail
+        refreshConnectedProviders()
+    }
+
+    /// Signs out from ChatGPT OAuth.
+    @MainActor
+    func signOutFromChatGPT() {
+        let provider = OpenAIChatGPTOAuthProvider()
+        OAuthManager.shared.signOut(provider: provider)
+        isChatGPTSignedIn = false
+        chatGPTEmail = nil
+        chatGPTModels = []
+        refreshConnectedProviders()
+    }
+
+    /// Returns the list of available models for the OpenAI provider,
+    /// preferring ChatGPT OAuth models when signed in.
+    func chatGPTAvailableModels() -> [String] {
+        if isChatGPTSignedIn {
+            return chatGPTModels.isEmpty ? ChatGPTAPIClient.supportedModels : chatGPTModels
+        }
+        return AIProvider.openAI.availableModels
     }
 }

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -50,7 +50,6 @@ class AIService {
     public var isChatGPTSignedIn: Bool = false
     public var chatGPTEmail: String?
     public var isChatGPTSigningIn: Bool = false
-    public var chatGPTModels: [String] = []
 
     public var openRouterModels: [String] = []
     public var vercelAIGatewayModels: [String] = []
@@ -2179,16 +2178,7 @@ extension AIService {
         OAuthManager.shared.signOut(provider: provider)
         isChatGPTSignedIn = false
         chatGPTEmail = nil
-        chatGPTModels = []
         refreshConnectedProviders()
     }
 
-    /// Returns the list of available models for the OpenAI provider,
-    /// preferring ChatGPT OAuth models when signed in.
-    func chatGPTAvailableModels() -> [String] {
-        if isChatGPTSignedIn {
-            return chatGPTModels.isEmpty ? ChatGPTAPIClient.supportedModels : chatGPTModels
-        }
-        return AIProvider.openAI.availableModels
-    }
 }

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -1943,6 +1943,10 @@ class AIService {
             // Return the configured model name as a single-item array
             return customOpenAIModelName.isEmpty ? [] : [customOpenAIModelName]
         }
+        // ChatGPT OAuth: show only Codex-supported models when signed in
+        if provider == .openAI && isChatGPTSignedIn {
+            return ChatGPTAPIClient.supportedModels
+        }
         return provider.availableModels
     }
     

--- a/VivaDicta/Services/KeychainService.swift
+++ b/VivaDicta/Services/KeychainService.swift
@@ -27,6 +27,11 @@ final class KeychainService: Sendable {
             logger.logError("Failed to convert value to data for key: \(key)")
             return false
         }
+        return save(data: data, forKey: key, syncable: syncable)
+    }
+
+    @discardableResult
+    func save(data: Data, forKey key: String, syncable: Bool = true) -> Bool {
         delete(forKey: key, syncable: syncable)
 
         var query = baseQuery(forKey: key, syncable: syncable)

--- a/VivaDicta/Services/OAuth/ASWebAuthSessionContextProvider.swift
+++ b/VivaDicta/Services/OAuth/ASWebAuthSessionContextProvider.swift
@@ -1,0 +1,16 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import AuthenticationServices
+import UIKit
+
+class ASWebAuthSessionContextProvider: NSObject, ASWebAuthenticationPresentationContextProviding {
+    static let shared = ASWebAuthSessionContextProvider()
+
+    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+              let window = scene.windows.first(where: { $0.isKeyWindow }) else {
+            return UIWindow()
+        }
+        return window
+    }
+}

--- a/VivaDicta/Services/OAuth/ASWebAuthSessionContextProvider.swift
+++ b/VivaDicta/Services/OAuth/ASWebAuthSessionContextProvider.swift
@@ -3,6 +3,7 @@
 import AuthenticationServices
 import UIKit
 
+@MainActor
 class ASWebAuthSessionContextProvider: NSObject, ASWebAuthenticationPresentationContextProviding {
     static let shared = ASWebAuthSessionContextProvider()
 

--- a/VivaDicta/Services/OAuth/ChatGPTAPIClient.swift
+++ b/VivaDicta/Services/OAuth/ChatGPTAPIClient.swift
@@ -1,0 +1,142 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import os
+
+/// Client for ChatGPT's backend API using OAuth tokens.
+enum ChatGPTAPIClient {
+    private static let logger = Logger(category: .chatGPTAPI)
+
+    /// Originator header required by the Codex endpoint.
+    private static let originator = "codex_cli_rs"
+
+    /// Default model for ChatGPT OAuth requests.
+    static let defaultModel = "gpt-5.4-mini"
+
+    /// Models supported by the Codex endpoint (ChatGPT OAuth).
+    static let supportedModels: [String] = [
+        "gpt-5.4",
+        "gpt-5.4-mini",
+        "gpt-5.4-nano",
+        "gpt-5.2",
+        "gpt-5.1"
+    ]
+
+    /// Returns the model to use for the Codex endpoint.
+    /// Falls back to default if the requested model isn't supported.
+    static func resolveModel(_ requestedModel: String) -> String {
+        if requestedModel.isEmpty {
+            return defaultModel
+        }
+        if supportedModels.contains(requestedModel) {
+            return requestedModel
+        }
+        return defaultModel
+    }
+
+    /// Sends an AI enhancement request via ChatGPT's backend API.
+    static func enhance(
+        text: String,
+        systemPrompt: String,
+        model: String,
+        accessToken: String,
+        accountId: String?
+    ) async throws -> String {
+        guard let url = URL(string: OpenAIChatGPTOAuthProvider.completionsEndpoint) else {
+            throw OAuthError.invalidResponse
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.addValue(originator, forHTTPHeaderField: "originator")
+        request.timeoutInterval = 60
+
+        if let accountId {
+            request.addValue(accountId, forHTTPHeaderField: "chatgpt-account-id")
+        }
+
+        let effectiveModel = resolveModel(model)
+        logger.logInfo("ChatGPT OAuth: using model '\(effectiveModel)' (requested: '\(model)')")
+
+        let requestBody: [String: Any] = [
+            "model": effectiveModel,
+            "instructions": systemPrompt,
+            "input": [
+                ["role": "user", "content": text]
+            ],
+            "store": false,
+            "stream": true
+        ]
+
+        request.addValue("text/event-stream", forHTTPHeaderField: "Accept")
+        request.httpBody = try? JSONSerialization.data(withJSONObject: requestBody)
+
+        let (bytes, response) = try await URLSession.shared.bytes(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw OAuthError.invalidResponse
+        }
+
+        guard httpResponse.statusCode == 200 else {
+            // Collect error body from stream
+            var errorData = Data()
+            for try await byte in bytes { errorData.append(byte) }
+            let errorBody = String(data: errorData, encoding: .utf8) ?? "Unknown error"
+            logger.logError("ChatGPT API error: HTTP \(httpResponse.statusCode) — \(errorBody)")
+            throw OAuthError.tokenExchangeFailed("HTTP \(httpResponse.statusCode): \(errorBody)")
+        }
+
+        // Parse SSE stream, collect output_text.delta events
+        var result = ""
+        for try await line in bytes.lines {
+            guard line.hasPrefix("data: ") else { continue }
+            let jsonStr = String(line.dropFirst(6))
+            if jsonStr == "[DONE]" { break }
+
+            guard let data = jsonStr.data(using: .utf8),
+                  let event = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let type = event["type"] as? String else { continue }
+
+            if type == "response.output_text.delta",
+               let delta = event["delta"] as? String {
+                result += delta
+            }
+        }
+
+        guard !result.isEmpty else {
+            logger.logError("No output text received from ChatGPT stream")
+            throw OAuthError.invalidResponse
+        }
+
+        return result.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Fetches available models from ChatGPT's backend.
+    static func fetchModels(accessToken: String) async throws -> [String] {
+        guard let url = URL(string: OpenAIChatGPTOAuthProvider.modelsEndpoint) else {
+            return [defaultModel]
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.addValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.addValue(originator, forHTTPHeaderField: "originator")
+        request.timeoutInterval = 15
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            return [defaultModel]
+        }
+
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let models = json["models"] as? [[String: Any]] else {
+            return [defaultModel]
+        }
+
+        let modelIds = models.compactMap { $0["id"] as? String ?? $0["model"] as? String }
+        return modelIds.isEmpty ? [defaultModel] : modelIds
+    }
+}

--- a/VivaDicta/Services/OAuth/ChatGPTAPIClient.swift
+++ b/VivaDicta/Services/OAuth/ChatGPTAPIClient.swift
@@ -17,7 +17,6 @@ enum ChatGPTAPIClient {
     static let supportedModels: [String] = [
         "gpt-5.4",
         "gpt-5.4-mini",
-        "gpt-5.4-nano",
         "gpt-5.2",
         "gpt-5.1"
     ]

--- a/VivaDicta/Services/OAuth/OAuthCallbackServer.swift
+++ b/VivaDicta/Services/OAuth/OAuthCallbackServer.swift
@@ -1,0 +1,83 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import Network
+import os
+
+/// Minimal TCP server that listens on localhost for an OAuth redirect callback.
+/// On iOS, it bridges the localhost redirect to a custom URL scheme so that
+/// ASWebAuthenticationSession can intercept it.
+final class OAuthCallbackServer: Sendable {
+    private let logger = Logger(category: .oauthManager)
+    let port: UInt16
+    /// The custom URL scheme to redirect to after capturing the OAuth callback.
+    let customSchemeRedirectBase: String
+
+    init(port: UInt16 = 1455, customSchemeRedirectBase: String = "vivadicta://auth/callback") {
+        self.port = port
+        self.customSchemeRedirectBase = customSchemeRedirectBase
+    }
+
+    /// Starts the local server. When the OAuth provider redirects to localhost,
+    /// this server responds with an HTTP 302 redirect to the custom URL scheme,
+    /// forwarding the authorization code and state parameters.
+    func start() async throws -> NWListener {
+        let listener = try NWListener(using: .tcp, on: NWEndpoint.Port(rawValue: port)!)
+
+        listener.newConnectionHandler = { [logger, customSchemeRedirectBase] connection in
+            connection.start(queue: .global(qos: .userInitiated))
+            connection.receive(minimumIncompleteLength: 1, maximumLength: 8192) { data, _, _, _ in
+                guard let data, let requestString = String(data: data, encoding: .utf8) else {
+                    connection.cancel()
+                    return
+                }
+
+                logger.logInfo("OAuth callback server received request")
+
+                // Extract the request path from the HTTP request line
+                guard let firstLine = requestString.components(separatedBy: "\r\n").first,
+                      let pathPart = firstLine.split(separator: " ").dropFirst().first,
+                      let components = URLComponents(string: String(pathPart)) else {
+                    Self.sendHTTPResponse(connection: connection, html: "<h1>Error</h1><p>Invalid request.</p>")
+                    return
+                }
+
+                // Build the custom scheme redirect URL with the same query parameters
+                let queryString = components.query ?? ""
+                let redirectURL = queryString.isEmpty
+                    ? customSchemeRedirectBase
+                    : "\(customSchemeRedirectBase)?\(queryString)"
+
+                // Respond with 302 redirect to the custom scheme
+                let response = "HTTP/1.1 302 Found\r\nLocation: \(redirectURL)\r\nConnection: close\r\n\r\n"
+                connection.send(content: response.data(using: .utf8), contentContext: .finalMessage, isComplete: true, completion: .contentProcessed { _ in
+                    connection.cancel()
+                })
+            }
+        }
+
+        return try await withCheckedThrowingContinuation { continuation in
+            listener.stateUpdateHandler = { state in
+                switch state {
+                case .ready:
+                    continuation.resume(returning: listener)
+                case .failed(let error):
+                    continuation.resume(throwing: OAuthError.tokenExchangeFailed("Callback server failed: \(error.localizedDescription)"))
+                default:
+                    break
+                }
+            }
+            listener.start(queue: .global(qos: .userInitiated))
+        }
+    }
+
+    // MARK: - Helpers
+
+    private static func sendHTTPResponse(connection: NWConnection, html: String) {
+        let fullHTML = "<!DOCTYPE html><html><head><title>OAuth</title></head><body style=\"font-family:-apple-system,sans-serif;display:flex;justify-content:center;align-items:center;height:100vh;margin:0;\">\(html)</body></html>"
+        let response = "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nConnection: close\r\n\r\n\(fullHTML)"
+        connection.send(content: response.data(using: .utf8), contentContext: .finalMessage, isComplete: true, completion: .contentProcessed { _ in
+            connection.cancel()
+        })
+    }
+}

--- a/VivaDicta/Services/OAuth/OAuthCredential.swift
+++ b/VivaDicta/Services/OAuth/OAuthCredential.swift
@@ -1,0 +1,32 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+
+/// OAuth credential with access/refresh tokens and account info.
+struct OAuthCredential: Codable, Sendable {
+    let accessToken: String
+    let refreshToken: String
+    let expiresAt: Date
+    let accountId: String?
+    let accountEmail: String?
+    /// Provider-specific project ID (e.g., Google Cloud project for Gemini).
+    let projectId: String?
+
+    init(accessToken: String, refreshToken: String, expiresAt: Date, accountId: String?, accountEmail: String?, projectId: String? = nil) {
+        self.accessToken = accessToken
+        self.refreshToken = refreshToken
+        self.expiresAt = expiresAt
+        self.accountId = accountId
+        self.accountEmail = accountEmail
+        self.projectId = projectId
+    }
+
+    /// Whether the token will expire within the next 5 minutes.
+    var isExpiringSoon: Bool {
+        Date().addingTimeInterval(300) >= expiresAt
+    }
+
+    var isExpired: Bool {
+        Date() >= expiresAt
+    }
+}

--- a/VivaDicta/Services/OAuth/OAuthError.swift
+++ b/VivaDicta/Services/OAuth/OAuthError.swift
@@ -1,0 +1,33 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+
+/// Errors that can occur during the OAuth flow.
+enum OAuthError: LocalizedError {
+    case timeout
+    case stateMismatch
+    case authorizationDenied(String)
+    case tokenExchangeFailed(String)
+    case tokenRefreshFailed(String)
+    case noCredential
+    case invalidResponse
+
+    var errorDescription: String? {
+        switch self {
+        case .timeout:
+            return "Sign-in timed out. Please try again."
+        case .stateMismatch:
+            return "Invalid response from server. Please try again."
+        case .authorizationDenied(let reason):
+            return "Authorization denied: \(reason)"
+        case .tokenExchangeFailed(let reason):
+            return "Failed to exchange token: \(reason)"
+        case .tokenRefreshFailed(let reason):
+            return "Failed to refresh token: \(reason)"
+        case .noCredential:
+            return "Not signed in."
+        case .invalidResponse:
+            return "Invalid response from server."
+        }
+    }
+}

--- a/VivaDicta/Services/OAuth/OAuthManager.swift
+++ b/VivaDicta/Services/OAuth/OAuthManager.swift
@@ -1,0 +1,327 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import AuthenticationServices
+import Network
+import os
+
+/// Manages OAuth authentication flows — sign-in, token refresh, and credential storage.
+/// MainActor-isolated for safe interaction with UI and Keychain in Swift 6.
+@MainActor
+final class OAuthManager: Sendable {
+    static let shared = OAuthManager()
+
+    private let logger = Logger(category: .oauthManager)
+
+    /// In-memory cache of credentials.
+    private var credentials: [String: OAuthCredential] = [:]
+
+    private init() {}
+
+    // MARK: - Public API
+
+    /// Whether the user is signed in for a given provider.
+    func isSignedIn(provider: some OAuthProvider) -> Bool {
+        loadCredential(for: provider) != nil
+    }
+
+    /// Returns the account email for a given provider, if signed in.
+    func accountEmail(for provider: some OAuthProvider) -> String? {
+        loadCredential(for: provider)?.accountEmail
+    }
+
+    /// iOS sign-in using ASWebAuthenticationSession.
+    func signIn(provider: some OAuthProvider) async throws -> OAuthCredential {
+        let pkce = PKCEGenerator.generate()
+        let state = PKCEGenerator.generateState()
+
+        // Build authorization URL
+        var components = URLComponents(string: provider.authorizeURL)!
+        var queryItems = [
+            URLQueryItem(name: "response_type", value: "code"),
+            URLQueryItem(name: "client_id", value: provider.clientId),
+            URLQueryItem(name: "redirect_uri", value: provider.redirectURI),
+            URLQueryItem(name: "scope", value: provider.scopes),
+            URLQueryItem(name: "state", value: state),
+            URLQueryItem(name: "code_challenge", value: pkce.challenge),
+            URLQueryItem(name: "code_challenge_method", value: "S256")
+        ]
+        for (key, value) in provider.extraAuthParams {
+            queryItems.append(URLQueryItem(name: key, value: value))
+        }
+        components.queryItems = queryItems
+
+        guard let authURL = components.url else {
+            throw OAuthError.tokenExchangeFailed("Invalid authorization URL")
+        }
+
+        // Start local callback server that bridges localhost redirect → custom scheme
+        let callbackServer = OAuthCallbackServer(port: 1455, customSchemeRedirectBase: "vivadicta://auth/callback")
+        let listener = try await callbackServer.start()
+        defer { listener.cancel() }
+
+        logger.logInfo("OAuth callback server started on port \(callbackServer.port)")
+
+        // Use ASWebAuthenticationSession with custom scheme interception
+        // The flow: browser → OpenAI → redirect to localhost → local server → 302 to vivadicta:// → session intercepts
+        let callbackURL = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<URL, Error>) in
+            let session = ASWebAuthenticationSession(
+                url: authURL,
+                callbackURLScheme: "vivadicta"
+            ) { url, error in
+                if let error {
+                    continuation.resume(throwing: OAuthError.authorizationDenied(error.localizedDescription))
+                } else if let url {
+                    continuation.resume(returning: url)
+                } else {
+                    continuation.resume(throwing: OAuthError.timeout)
+                }
+            }
+            session.presentationContextProvider = ASWebAuthSessionContextProvider.shared
+            session.prefersEphemeralWebBrowserSession = false
+            session.start()
+        }
+
+        // Parse callback URL for code + state
+        guard let callbackComponents = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false) else {
+            throw OAuthError.invalidResponse
+        }
+        let params = Dictionary(uniqueKeysWithValues: (callbackComponents.queryItems ?? []).compactMap { item in
+            item.value.map { (item.name, $0) }
+        })
+        guard let returnedState = params["state"], returnedState == state else {
+            throw OAuthError.stateMismatch
+        }
+        guard let code = params["code"] else {
+            throw OAuthError.authorizationDenied(params["error_description"] ?? params["error"] ?? "Unknown error")
+        }
+
+        // Exchange code for tokens
+        let credential = try await exchangeCodeForTokens(
+            code: code,
+            codeVerifier: pkce.verifier,
+            state: state,
+            provider: provider
+        )
+
+        // Store credential
+        saveCredential(credential, for: provider)
+        logger.logInfo("OAuth sign-in complete for \(provider.providerName)")
+
+        return credential
+    }
+
+    /// Signs out by removing the stored credential.
+    func signOut(provider: some OAuthProvider) {
+        credentials.removeValue(forKey: provider.keychainKey)
+        KeychainService.shared.delete(forKey: provider.keychainKey, syncable: false)
+        logger.logInfo("Signed out from \(provider.providerName)")
+    }
+
+    /// Returns a valid access token, refreshing if needed.
+    func validAccessToken(for provider: some OAuthProvider) async throws -> (token: String, accountId: String?, projectId: String?) {
+        guard var credential = loadCredential(for: provider) else {
+            throw OAuthError.noCredential
+        }
+
+        if credential.isExpiringSoon {
+            logger.logInfo("Token expiring soon, refreshing for \(provider.providerName)")
+            credential = try await refreshToken(credential: credential, provider: provider)
+            saveCredential(credential, for: provider)
+        }
+
+        return (credential.accessToken, credential.accountId, credential.projectId)
+    }
+
+    // MARK: - Token Exchange
+
+    private func exchangeCodeForTokens(code: String, codeVerifier: String, state: String, provider: some OAuthProvider) async throws -> OAuthCredential {
+        var body = [
+            "grant_type": "authorization_code",
+            "client_id": provider.clientId,
+            "redirect_uri": provider.redirectURI,
+            "code": code,
+            "code_verifier": codeVerifier,
+            "state": state
+        ]
+
+        // Include client_secret when the provider requires it (e.g. Google)
+        if let secret = provider.clientSecret {
+            body["client_secret"] = secret
+        }
+
+        // OpenAI doesn't use state in token exchange
+        if !provider.tokenRequestUsesJSON {
+            body.removeValue(forKey: "state")
+        }
+
+        return try await tokenRequest(body: body, provider: provider)
+    }
+
+    // MARK: - Token Refresh
+
+    private func refreshToken(credential: OAuthCredential, provider: some OAuthProvider) async throws -> OAuthCredential {
+        var body = [
+            "grant_type": "refresh_token",
+            "client_id": provider.clientId,
+            "refresh_token": credential.refreshToken
+        ]
+
+        // Include client_secret when the provider requires it (e.g. Google)
+        if let secret = provider.clientSecret {
+            body["client_secret"] = secret
+        }
+
+        // Retry up to 3 times with exponential backoff
+        var lastError: Error?
+        let delays: [TimeInterval] = [0.25, 0.5, 1.0]
+
+        for (attempt, delay) in delays.enumerated() {
+            do {
+                var refreshed = try await tokenRequest(body: body, provider: provider)
+                // Preserve projectId from the original credential (project doesn't change on refresh)
+                if refreshed.projectId == nil, let existingProjectId = credential.projectId {
+                    refreshed = OAuthCredential(
+                        accessToken: refreshed.accessToken,
+                        refreshToken: refreshed.refreshToken,
+                        expiresAt: refreshed.expiresAt,
+                        accountId: refreshed.accountId ?? credential.accountId,
+                        accountEmail: refreshed.accountEmail ?? credential.accountEmail,
+                        projectId: existingProjectId
+                    )
+                }
+                return refreshed
+            } catch {
+                lastError = error
+                logger.logWarning("Token refresh attempt \(attempt + 1) failed: \(error.localizedDescription)")
+                if attempt < delays.count - 1 {
+                    try await Task.sleep(for: .seconds(delay))
+                }
+            }
+        }
+
+        throw OAuthError.tokenRefreshFailed(lastError?.localizedDescription ?? "Unknown error")
+    }
+
+    // MARK: - Shared Token Request
+
+    private func tokenRequest(body: [String: String], provider: some OAuthProvider) async throws -> OAuthCredential {
+        guard let url = URL(string: provider.tokenURL) else {
+            throw OAuthError.tokenExchangeFailed("Invalid token URL")
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+
+        if provider.tokenRequestUsesJSON {
+            request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+        } else {
+            request.addValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+            let formBody = body.map { "\($0.key)=\($0.value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? $0.value)" }
+                .joined(separator: "&")
+            request.httpBody = formBody.data(using: .utf8)
+        }
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw OAuthError.invalidResponse
+        }
+
+        guard httpResponse.statusCode == 200 else {
+            let errorBody = String(data: data, encoding: .utf8) ?? "Unknown error"
+            throw OAuthError.tokenExchangeFailed("HTTP \(httpResponse.statusCode): \(errorBody)")
+        }
+
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw OAuthError.tokenExchangeFailed("Invalid JSON response")
+        }
+
+        guard let accessToken = json["access_token"] as? String,
+              let refreshToken = json["refresh_token"] as? String else {
+            throw OAuthError.tokenExchangeFailed("Missing tokens in response")
+        }
+
+        let expiresIn = json["expires_in"] as? TimeInterval ?? 3600
+        let expiresAt = Date().addingTimeInterval(expiresIn)
+
+        // Extract account info
+        var accountId: String?
+        var email: String?
+
+        if let userinfoURL = provider.userinfoURL {
+            // Fetch account info from userinfo endpoint (e.g. Google)
+            let info = await fetchUserInfo(url: userinfoURL, accessToken: accessToken, provider: provider)
+            accountId = info.id
+            email = info.email
+        } else if let claims = OpenAIChatGPTOAuthProvider.decodeJWTPayload(accessToken) {
+            // Extract from JWT claims (OpenAI)
+            let info = provider.extractAccountInfo(from: claims)
+            accountId = info.id
+            email = info.email
+        }
+
+        // Run post-auth setup (e.g. Google Cloud project discovery)
+        let projectId = try? await provider.postAuthSetup(accessToken: accessToken)
+
+        return OAuthCredential(
+            accessToken: accessToken,
+            refreshToken: refreshToken,
+            expiresAt: expiresAt,
+            accountId: accountId,
+            accountEmail: email,
+            projectId: projectId
+        )
+    }
+
+    // MARK: - User Info
+
+    private func fetchUserInfo(url: String, accessToken: String, provider: some OAuthProvider) async -> (id: String?, email: String?) {
+        guard let userinfoURL = URL(string: url) else { return (nil, nil) }
+
+        var request = URLRequest(url: userinfoURL)
+        request.addValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 10
+
+        guard let (data, response) = try? await URLSession.shared.data(for: request),
+              let httpResponse = response as? HTTPURLResponse,
+              httpResponse.statusCode == 200,
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return (nil, nil)
+        }
+
+        return provider.extractAccountInfo(from: json)
+    }
+
+    // MARK: - Credential Storage
+
+    private func saveCredential(_ credential: OAuthCredential, for provider: some OAuthProvider) {
+        credentials[provider.keychainKey] = credential
+        if let data = try? JSONEncoder().encode(credential) {
+            KeychainService.shared.save(data: data, forKey: provider.keychainKey, syncable: false)
+        }
+    }
+
+    private func loadCredential(for provider: some OAuthProvider) -> OAuthCredential? {
+        // Check in-memory cache first
+        if let cached = credentials[provider.keychainKey] {
+            return cached
+        }
+
+        // Load from Keychain
+        guard let data = KeychainService.shared.getData(forKey: provider.keychainKey, syncable: false),
+              let credential = try? JSONDecoder().decode(OAuthCredential.self, from: data) else {
+            return nil
+        }
+
+        // Don't return expired credentials with no way to refresh
+        if credential.isExpired && credential.refreshToken.isEmpty {
+            KeychainService.shared.delete(forKey: provider.keychainKey, syncable: false)
+            return nil
+        }
+
+        credentials[provider.keychainKey] = credential
+        return credential
+    }
+}

--- a/VivaDicta/Services/OAuth/OAuthManager.swift
+++ b/VivaDicta/Services/OAuth/OAuthManager.swift
@@ -36,7 +36,9 @@ final class OAuthManager: Sendable {
         let state = PKCEGenerator.generateState()
 
         // Build authorization URL
-        var components = URLComponents(string: provider.authorizeURL)!
+        guard var components = URLComponents(string: provider.authorizeURL) else {
+            throw OAuthError.tokenExchangeFailed("Invalid authorization URL")
+        }
         var queryItems = [
             URLQueryItem(name: "response_type", value: "code"),
             URLQueryItem(name: "client_id", value: provider.clientId),

--- a/VivaDicta/Services/OAuth/OAuthProvider.swift
+++ b/VivaDicta/Services/OAuth/OAuthProvider.swift
@@ -1,0 +1,60 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+
+/// Protocol for OAuth provider configurations.
+protocol OAuthProvider: Sendable {
+    /// Human-readable provider name (e.g., "ChatGPT").
+    var providerName: String { get }
+
+    /// OAuth client ID.
+    var clientId: String { get }
+
+    /// Authorization endpoint URL.
+    var authorizeURL: String { get }
+
+    /// Token exchange/refresh endpoint URL.
+    var tokenURL: String { get }
+
+    /// Redirect URI for the OAuth callback.
+    var redirectURI: String { get }
+
+    /// OAuth scopes (space-separated).
+    var scopes: String { get }
+
+    /// Additional query parameters for the authorization request.
+    var extraAuthParams: [String: String] { get }
+
+    /// Keychain key used to store the credential.
+    var keychainKey: String { get }
+
+    /// Whether the token endpoint expects JSON (`true`) or form-urlencoded (`false`).
+    var tokenRequestUsesJSON: Bool { get }
+
+    /// OAuth client secret (required by some providers like Google, optional for public clients).
+    var clientSecret: String? { get }
+
+    /// Extract account info (id, email) from the JWT access token claims.
+    func extractAccountInfo(from claims: [String: Any]) -> (id: String?, email: String?)
+
+    /// Optional userinfo endpoint for providers whose access tokens aren't JWTs (e.g. Google).
+    var userinfoURL: String? { get }
+
+    /// Optional post-auth setup (e.g., project discovery). Called after token exchange.
+    /// Returns a project ID if applicable.
+    func postAuthSetup(accessToken: String) async throws -> String?
+}
+
+extension OAuthProvider {
+    /// Default: form-urlencoded (standard OAuth2).
+    var tokenRequestUsesJSON: Bool { false }
+
+    /// Default: no client secret (public PKCE client).
+    var clientSecret: String? { nil }
+
+    /// Default: no userinfo endpoint (use JWT claims).
+    var userinfoURL: String? { nil }
+
+    /// Default: no post-auth setup needed.
+    func postAuthSetup(accessToken: String) async throws -> String? { nil }
+}

--- a/VivaDicta/Services/OAuth/OpenAIChatGPTOAuthProvider.swift
+++ b/VivaDicta/Services/OAuth/OpenAIChatGPTOAuthProvider.swift
@@ -1,0 +1,82 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+
+/// OpenAI ChatGPT OAuth provider configuration.
+/// Uses the same client ID as the Codex CLI for OAuth PKCE flow.
+struct OpenAIChatGPTOAuthProvider: OAuthProvider {
+    let providerName = "ChatGPT"
+    let clientId = "app_EMoamEEZ73f0CkXaXp7hrann"
+    let authorizeURL = "https://auth.openai.com/oauth/authorize"
+    let tokenURL = "https://auth.openai.com/oauth/token"
+    let redirectURI = "http://localhost:1455/auth/callback"
+    let scopes = "openid profile email offline_access"
+    let keychainKey = "chatGPTOAuthCredential"
+
+    let extraAuthParams: [String: String] = [
+        "codex_cli_simplified_flow": "true",
+        "id_token_add_organizations": "true"
+    ]
+
+    /// ChatGPT backend API endpoint for AI completions.
+    static let completionsEndpoint = "https://chatgpt.com/backend-api/codex/responses"
+
+    /// ChatGPT backend API endpoint for listing available models.
+    static let modelsEndpoint = "https://chatgpt.com/backend-api/codex/models"
+
+    func extractAccountInfo(from claims: [String: Any]) -> (id: String?, email: String?) {
+        // Account ID: try multiple known claim paths
+        let accountId: String? = {
+            if let id = claims["chatgpt_account_id"] as? String {
+                return id
+            }
+            if let auth = claims["https://api.openai.com/auth"] as? [String: Any],
+               let id = auth["chatgpt_account_id"] as? String {
+                return id
+            }
+            if let orgs = claims["organizations"] as? [[String: Any]],
+               let first = orgs.first,
+               let id = first["id"] as? String {
+                return id
+            }
+            return nil
+        }()
+
+        // Email: try multiple known claim paths
+        let email: String? = {
+            if let email = claims["email"] as? String {
+                return email
+            }
+            if let profile = claims["https://api.openai.com/profile"] as? [String: Any],
+               let email = profile["email"] as? String {
+                return email
+            }
+            return nil
+        }()
+
+        return (accountId, email)
+    }
+
+    /// Decodes JWT payload without signature verification (trusted issuer).
+    static func decodeJWTPayload(_ jwt: String) -> [String: Any]? {
+        let segments = jwt.components(separatedBy: ".")
+        guard segments.count >= 2 else { return nil }
+
+        var base64 = segments[1]
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+
+        // Pad to multiple of 4
+        let remainder = base64.count % 4
+        if remainder > 0 {
+            base64 += String(repeating: "=", count: 4 - remainder)
+        }
+
+        guard let data = Data(base64Encoded: base64),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+
+        return json
+    }
+}

--- a/VivaDicta/Services/OAuth/PKCEGenerator.swift
+++ b/VivaDicta/Services/OAuth/PKCEGenerator.swift
@@ -1,0 +1,39 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import CryptoKit
+
+/// Generates PKCE (Proof Key for Code Exchange) parameters for OAuth flows.
+struct PKCEGenerator: Sendable {
+    let verifier: String
+    let challenge: String
+
+    /// Generates a new PKCE verifier/challenge pair.
+    static func generate() -> PKCEGenerator {
+        let verifierData = randomBytes(count: 32)
+        let verifier = base64URLEncode(verifierData)
+        let challengeData = Data(SHA256.hash(data: Data(verifier.utf8)))
+        let challenge = base64URLEncode(challengeData)
+        return PKCEGenerator(verifier: verifier, challenge: challenge)
+    }
+
+    /// Generates a random state string for CSRF protection.
+    static func generateState() -> String {
+        base64URLEncode(randomBytes(count: 32))
+    }
+
+    // MARK: - Helpers
+
+    static func base64URLEncode(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    private static func randomBytes(count: Int) -> Data {
+        var bytes = [UInt8](repeating: 0, count: count)
+        _ = SecRandomCopyBytes(kSecRandomDefault, count, &bytes)
+        return Data(bytes)
+    }
+}

--- a/VivaDicta/Utilities/LoggerExtension.swift
+++ b/VivaDicta/Utilities/LoggerExtension.swift
@@ -53,6 +53,8 @@ public enum LogCategory: String {
     case presetMigration = "PresetMigration"
     case presetSync = "PresetSync"
     case keychainService = "KeychainService"
+    case oauthManager = "OAuthManager"
+    case chatGPTAPI = "ChatGPTAPIClient"
 
     // MARK: - Keyboard Extension
     case keyboardExtension = "KeyboardExtension"

--- a/VivaDicta/Views/SettingsScreen/AIProvidersView.swift
+++ b/VivaDicta/Views/SettingsScreen/AIProvidersView.swift
@@ -103,11 +103,19 @@ struct AIProviders: View {
                                             .foregroundStyle(.secondary)
                                     }
                                 }
+                            } else if provider == .anthropic && ClaudeCLIServerClient.isEnabled && ClaudeCLIServerClient.isVerified {
+                                HStack(spacing: 4) {
+                                    Image(systemName: "checkmark.circle.fill")
+                                        .foregroundStyle(.green)
+                                    Text("CLI")
+                                        .font(.subheadline)
+                                        .foregroundStyle(.secondary)
+                                }
                             } else if provider == .openAI && appState.aiService.isChatGPTSignedIn {
                                 HStack(spacing: 4) {
                                     Image(systemName: "checkmark.circle.fill")
                                         .foregroundStyle(.green)
-                                    Text("ChatGPT")
+                                    Text("OAuth")
                                         .font(.subheadline)
                                         .foregroundStyle(.secondary)
                                 }

--- a/VivaDicta/Views/SettingsScreen/AIProvidersView.swift
+++ b/VivaDicta/Views/SettingsScreen/AIProvidersView.swift
@@ -103,6 +103,14 @@ struct AIProviders: View {
                                             .foregroundStyle(.secondary)
                                     }
                                 }
+                            } else if provider == .openAI && appState.aiService.isChatGPTSignedIn {
+                                HStack(spacing: 4) {
+                                    Image(systemName: "checkmark.circle.fill")
+                                        .foregroundStyle(.green)
+                                    Text("ChatGPT")
+                                        .font(.subheadline)
+                                        .foregroundStyle(.secondary)
+                                }
                             } else if !appState.aiService.connectedProviders.contains(provider) {
                                 HStack(spacing: 4) {
                                     Image(systemName: "exclamationmark.triangle.fill")
@@ -129,6 +137,8 @@ struct AIProviders: View {
                 CustomOpenAIConfigurationView(aiService: appState.aiService)
             } else if provider == .anthropic {
                 AnthropicConfigurationView(aiService: appState.aiService)
+            } else if provider == .openAI {
+                OpenAIConfigurationView(aiService: appState.aiService)
             } else {
                 AddAPIKeyView(
                     provider: provider,

--- a/VivaDicta/Views/SettingsScreen/ModeEditView.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditView.swift
@@ -463,6 +463,22 @@ struct ModeEditView: View {
                                         }
                                     }
                                     .alignmentGuide(.listRowSeparatorLeading) { _ in 0 }
+                                } else if provider == .openAI {
+                                    // OpenAI has dedicated config (OAuth + API key)
+                                    NavigationLink {
+                                        OpenAIConfigurationView(aiService: viewModel.aiService)
+                                    } label: {
+                                        HStack {
+                                            Image(systemName: "exclamationmark.triangle.fill")
+                                                .foregroundStyle(.orange)
+                                            Text("Configure OpenAI")
+                                            Spacer()
+                                            Text("Required")
+                                                .font(.caption)
+                                                .foregroundStyle(.secondary)
+                                        }
+                                    }
+                                    .alignmentGuide(.listRowSeparatorLeading) { _ in 0 }
                                 } else {
                                     // Cloud provider needs API key
                                     NavigationLink {

--- a/VivaDicta/Views/SettingsScreen/OpenAIConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/OpenAIConfigurationView.swift
@@ -66,12 +66,12 @@ struct OpenAIConfigurationView: View {
             Text(oauthErrorMessage)
         }
         .alert("Delete API Key", isPresented: $showDeleteConfirmation) {
+            Button("Cancel", role: .cancel) {}
             Button("Delete", role: .destructive) {
                 deleteAPIKey()
             }
-            Button("Cancel", role: .cancel) {}
         } message: {
-            Text("This will remove the stored API key.")
+            Text("Are you sure you want to delete the API key for OpenAI? This action cannot be undone.")
         }
     }
 
@@ -79,64 +79,80 @@ struct OpenAIConfigurationView: View {
 
     private var chatGPTSection: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Label("ChatGPT Account", systemImage: "person.badge.key")
+            Text("ChatGPT Account")
                 .font(.headline)
 
-            VStack(spacing: 12) {
-                if aiService.isChatGPTSignedIn {
-                    HStack {
-                        Image(systemName: "checkmark.circle.fill")
-                            .foregroundStyle(.green)
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("Signed in")
-                                .font(.callout)
-                            if let email = aiService.chatGPTEmail {
-                                Text(email)
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                            }
-                        }
-                        Spacer()
-                        Button("Sign Out", role: .destructive) {
-                            aiService.signOutFromChatGPT()
-                        }
-                        .controlSize(.small)
-                    }
+            Text("Use your ChatGPT Plus/Pro subscription — no API key needed.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
 
-                    Text("Using your ChatGPT subscription for AI processing.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                } else {
-                    Button {
-                        Task {
-                            do {
-                                try await aiService.signInWithChatGPT()
-                            } catch {
-                                oauthErrorMessage = error.localizedDescription
-                                showOAuthError = true
-                            }
+            if aiService.isChatGPTSignedIn {
+                HStack {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Signed in")
+                            .font(.callout)
+                        if let email = aiService.chatGPTEmail {
+                            Text(email)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
                         }
+                    }
+                    Spacer()
+                    Button("Sign Out", role: .destructive) {
+                        aiService.signOutFromChatGPT()
+                    }
+                    .controlSize(.small)
+                }
+            } else {
+                if #available(iOS 26.0, *) {
+                    Button {
+                        signInWithChatGPT()
                     } label: {
-                        HStack {
+                        HStack(spacing: 6) {
                             if aiService.isChatGPTSigningIn {
                                 ProgressView()
                                     .controlSize(.small)
                             }
-                            Image(systemName: "person.badge.key")
                             Text("Sign in with ChatGPT")
+                                .font(.headline.weight(.medium))
                         }
-                        .frame(maxWidth: .infinity)
                     }
-                    .buttonStyle(.borderedProminent)
                     .disabled(aiService.isChatGPTSigningIn)
-
-                    Text("Use your ChatGPT Plus/Pro subscription — no API key needed.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                    .padding(.vertical, 8)
+                    .padding(.horizontal, 16)
+                    .glassEffect(.regular.tint(.blue.opacity(0.3)).interactive())
+                    .buttonStyle(.plain)
+                } else {
+                    Button {
+                        signInWithChatGPT()
+                    } label: {
+                        HStack(spacing: 6) {
+                            if aiService.isChatGPTSigningIn {
+                                ProgressView()
+                                    .controlSize(.small)
+                            }
+                            Text("Sign in with ChatGPT")
+                                .font(.headline.weight(.medium))
+                                .foregroundStyle(.primary)
+                        }
+                        .padding(.vertical, 8)
+                        .padding(.horizontal, 16)
+                        .background {
+                            Capsule()
+                                .stroke(.blue, lineWidth: 2)
+                        }
+                    }
+                    .disabled(aiService.isChatGPTSigningIn)
+                    .buttonStyle(.plain)
                 }
             }
-            .padding()
-            .background(.ultraThinMaterial, in: .rect(cornerRadius: 12))
+        }
+        .padding()
+        .background {
+            RoundedRectangle(cornerRadius: 12)
+                .fill(.background.secondary)
         }
     }
 
@@ -144,82 +160,184 @@ struct OpenAIConfigurationView: View {
 
     private var apiKeySection: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Label("API Key", systemImage: "key")
+            Text("API Key")
                 .font(.headline)
 
-            VStack(spacing: 12) {
-                TextField("API Key", text: $apiKey)
-                    .privacySensitive()
-                    .textInputAutocapitalization(.never)
-                    .autocorrectionDisabled()
-                    .padding()
-                    .background {
-                        Capsule()
-                            .stroke(verificationError != nil ? .red : .gray, lineWidth: verificationError != nil ? 1.5 : 0.5)
-                    }
-                    .onChange(of: apiKey) { _, _ in
-                        verificationError = nil
-                    }
+            Text("Or use an OpenAI API key directly.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
 
-                if let error = verificationError {
-                    Text(error)
-                        .font(.caption)
-                        .foregroundStyle(.red)
+            TextField("API Key", text: $apiKey)
+                .privacySensitive()
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .padding()
+                .background {
+                    Capsule()
+                        .stroke(verificationError != nil ? .red : .gray, lineWidth: verificationError != nil ? 1.5 : 0.5)
+                }
+                .onChange(of: apiKey) { _, _ in
+                    verificationError = nil
                 }
 
+            if let error = verificationError {
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+
+            if #available(iOS 26.0, *) {
                 HStack {
                     Button {
-                        if let clipboardString = UIPasteboard.general.string {
-                            apiKey = clipboardString
-                        }
+                        saveAPIKey()
                     } label: {
-                        Label("Paste", systemImage: "doc.on.clipboard")
-                    }
-
-                    Spacer()
-
-                    if hasExistingKey {
-                        Button("Delete", role: .destructive) {
-                            showDeleteConfirmation = true
+                        HStack(spacing: 6) {
+                            if isVerifying {
+                                ProgressView()
+                                    .controlSize(.small)
+                            }
+                            Text("Save API Key")
+                                .font(.headline.weight(.medium))
                         }
                     }
+                    .disabled(apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isVerifying)
+                    .padding(.vertical, 8)
+                    .padding(.horizontal, 16)
+                    .glassEffect(.regular.tint(.blue.opacity(0.3)).interactive())
+                    .buttonStyle(.plain)
 
                     Button {
-                        Task {
-                            isVerifying = true
-                            verificationError = nil
-                            let success = await aiService.saveAPIKey(apiKey, for: .openAI)
-                            isVerifying = false
-                            if success {
-                                hasExistingKey = true
-                                HapticManager.success()
-                            } else {
-                                verificationError = "Invalid API key"
-                                HapticManager.error()
-                            }
-                        }
+                        pasteAndSave()
                     } label: {
-                        if isVerifying {
-                            ProgressView()
-                                .controlSize(.small)
-                        } else {
-                            Text("Save")
-                        }
+                        Text("Paste")
+                            .font(.headline.weight(.medium))
                     }
-                    .buttonStyle(.borderedProminent)
-                    .disabled(apiKey.isEmpty || isVerifying)
+                    .padding(.vertical, 8)
+                    .padding(.horizontal, 16)
+                    .glassEffect(.regular.tint(.gray.opacity(0.3)).interactive())
+                    .buttonStyle(.plain)
                 }
 
-                Text("Alternative: use an OpenAI API key for direct API access.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                if hasExistingKey {
+                    Button {
+                        showDeleteConfirmation = true
+                        HapticManager.warning()
+                    } label: {
+                        Text("Delete API Key")
+                            .font(.headline.weight(.semibold))
+                            .foregroundStyle(.red)
+                    }
+                    .padding(.vertical, 8)
+                    .padding(.horizontal, 16)
+                    .glassEffect(.regular.tint(.red.opacity(0.2)).interactive())
+                    .padding(.top, 4)
+                }
+            } else {
+                HStack {
+                    Button {
+                        saveAPIKey()
+                    } label: {
+                        HStack(spacing: 6) {
+                            if isVerifying {
+                                ProgressView()
+                                    .controlSize(.small)
+                            }
+                            Text("Save API Key")
+                                .font(.headline.weight(.medium))
+                                .foregroundStyle(.primary)
+                        }
+                        .padding(.vertical, 8)
+                        .padding(.horizontal, 16)
+                        .background {
+                            Capsule()
+                                .stroke(.blue, lineWidth: 2)
+                        }
+                    }
+                    .disabled(apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isVerifying)
+                    .buttonStyle(.plain)
+
+                    Button {
+                        pasteAndSave()
+                    } label: {
+                        Text("Paste")
+                            .font(.headline.weight(.medium))
+                            .foregroundStyle(.primary)
+                            .padding(.vertical, 8)
+                            .padding(.horizontal, 16)
+                            .background {
+                                Capsule()
+                                    .stroke(.gray, lineWidth: 2)
+                            }
+                    }
+                    .buttonStyle(.plain)
+                }
+
+                if hasExistingKey {
+                    Button {
+                        showDeleteConfirmation = true
+                        HapticManager.warning()
+                    } label: {
+                        Text("Delete API Key")
+                            .font(.headline.weight(.semibold))
+                            .foregroundStyle(.red)
+                    }
+                    .padding(.vertical, 8)
+                    .padding(.horizontal, 16)
+                    .overlay {
+                        Capsule()
+                            .stroke(Color.red, lineWidth: 1.5)
+                    }
+                    .padding(.top, 4)
+                }
             }
-            .padding()
-            .background(.ultraThinMaterial, in: .rect(cornerRadius: 12))
+        }
+        .padding()
+        .background {
+            RoundedRectangle(cornerRadius: 12)
+                .fill(.background.secondary)
         }
     }
 
-    // MARK: - Helpers
+    // MARK: - Actions
+
+    private func signInWithChatGPT() {
+        Task {
+            do {
+                try await aiService.signInWithChatGPT()
+            } catch {
+                oauthErrorMessage = error.localizedDescription
+                showOAuthError = true
+            }
+        }
+    }
+
+    private func saveAPIKey() {
+        Task {
+            isVerifying = true
+            verificationError = nil
+            HapticManager.mediumImpact()
+
+            let success = await aiService.saveAPIKey(apiKey, for: .openAI)
+            isVerifying = false
+            if success {
+                hasExistingKey = true
+                HapticManager.success()
+            } else {
+                verificationError = "Invalid API key"
+                HapticManager.error()
+            }
+        }
+    }
+
+    private func pasteAndSave() {
+        if let clipboardString = UIPasteboard.general.string {
+            let trimmed = clipboardString.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                apiKey = trimmed
+                saveAPIKey()
+            }
+        }
+    }
 
     private func deleteAPIKey() {
         KeychainService.shared.delete(forKey: AIProvider.openAI.keychainKey)

--- a/VivaDicta/Views/SettingsScreen/OpenAIConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/OpenAIConfigurationView.swift
@@ -1,0 +1,231 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import SwiftUI
+
+struct OpenAIConfigurationView: View {
+    @Environment(\.dismiss) private var dismiss
+    let aiService: AIService
+
+    // API Key state
+    @State private var apiKey: String = ""
+    @State private var isVerifying = false
+    @State private var verificationError: String?
+    @State private var hasExistingKey = false
+    @State private var showDeleteConfirmation = false
+
+    // OAuth error
+    @State private var showOAuthError = false
+    @State private var oauthErrorMessage = ""
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 24) {
+                // Header
+                VStack(spacing: 8) {
+                    if let iconName = AIProvider.openAI.iconName {
+                        Image(iconName)
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 64, height: 64)
+                    }
+
+                    Text("OpenAI")
+                        .font(.title2)
+
+                    if aiService.connectedProviders.contains(.openAI) {
+                        HStack(spacing: 4) {
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundStyle(.green)
+                            Text(aiService.isChatGPTSignedIn ? "ChatGPT Connected" : "API Key Configured")
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+                .padding(.top, 8)
+
+                // ChatGPT OAuth section
+                chatGPTSection
+
+                // API Key section
+                apiKeySection
+            }
+            .padding()
+        }
+        .scrollDismissesKeyboard(.interactively)
+        .navigationTitle("OpenAI")
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            let existingKey = AIProvider.openAI.apiKey
+            apiKey = existingKey ?? ""
+            hasExistingKey = existingKey != nil
+        }
+        .alert("Sign-In Error", isPresented: $showOAuthError) {
+            Button("OK") {}
+        } message: {
+            Text(oauthErrorMessage)
+        }
+        .alert("Delete API Key", isPresented: $showDeleteConfirmation) {
+            Button("Delete", role: .destructive) {
+                deleteAPIKey()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This will remove the stored API key.")
+        }
+    }
+
+    // MARK: - ChatGPT OAuth Section
+
+    private var chatGPTSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label("ChatGPT Account", systemImage: "person.badge.key")
+                .font(.headline)
+
+            VStack(spacing: 12) {
+                if aiService.isChatGPTSignedIn {
+                    HStack {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Signed in")
+                                .font(.callout)
+                            if let email = aiService.chatGPTEmail {
+                                Text(email)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        Spacer()
+                        Button("Sign Out", role: .destructive) {
+                            aiService.signOutFromChatGPT()
+                        }
+                        .controlSize(.small)
+                    }
+
+                    Text("Using your ChatGPT subscription for AI processing.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else {
+                    Button {
+                        Task {
+                            do {
+                                try await aiService.signInWithChatGPT()
+                            } catch {
+                                oauthErrorMessage = error.localizedDescription
+                                showOAuthError = true
+                            }
+                        }
+                    } label: {
+                        HStack {
+                            if aiService.isChatGPTSigningIn {
+                                ProgressView()
+                                    .controlSize(.small)
+                            }
+                            Image(systemName: "person.badge.key")
+                            Text("Sign in with ChatGPT")
+                        }
+                        .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(aiService.isChatGPTSigningIn)
+
+                    Text("Use your ChatGPT Plus/Pro subscription — no API key needed.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding()
+            .background(.ultraThinMaterial, in: .rect(cornerRadius: 12))
+        }
+    }
+
+    // MARK: - API Key Section
+
+    private var apiKeySection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label("API Key", systemImage: "key")
+                .font(.headline)
+
+            VStack(spacing: 12) {
+                TextField("API Key", text: $apiKey)
+                    .privacySensitive()
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .padding()
+                    .background {
+                        Capsule()
+                            .stroke(verificationError != nil ? .red : .gray, lineWidth: verificationError != nil ? 1.5 : 0.5)
+                    }
+                    .onChange(of: apiKey) { _, _ in
+                        verificationError = nil
+                    }
+
+                if let error = verificationError {
+                    Text(error)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
+
+                HStack {
+                    Button {
+                        if let clipboardString = UIPasteboard.general.string {
+                            apiKey = clipboardString
+                        }
+                    } label: {
+                        Label("Paste", systemImage: "doc.on.clipboard")
+                    }
+
+                    Spacer()
+
+                    if hasExistingKey {
+                        Button("Delete", role: .destructive) {
+                            showDeleteConfirmation = true
+                        }
+                    }
+
+                    Button {
+                        Task {
+                            isVerifying = true
+                            verificationError = nil
+                            let success = await aiService.saveAPIKey(apiKey, for: .openAI)
+                            isVerifying = false
+                            if success {
+                                hasExistingKey = true
+                                HapticManager.success()
+                            } else {
+                                verificationError = "Invalid API key"
+                                HapticManager.error()
+                            }
+                        }
+                    } label: {
+                        if isVerifying {
+                            ProgressView()
+                                .controlSize(.small)
+                        } else {
+                            Text("Save")
+                        }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(apiKey.isEmpty || isVerifying)
+                }
+
+                Text("Alternative: use an OpenAI API key for direct API access.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .padding()
+            .background(.ultraThinMaterial, in: .rect(cornerRadius: 12))
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func deleteAPIKey() {
+        KeychainService.shared.delete(forKey: AIProvider.openAI.keychainKey)
+        apiKey = ""
+        hasExistingKey = false
+        aiService.refreshConnectedProviders()
+        HapticManager.success()
+    }
+}

--- a/documentation/OAuth-Architecture.md
+++ b/documentation/OAuth-Architecture.md
@@ -1,0 +1,144 @@
+# OAuth Architecture
+
+## Overview
+
+VivaDicta supports OAuth sign-in for AI providers, allowing users to use their existing subscriptions (e.g., ChatGPT Plus/Pro) instead of separate API keys. The implementation uses PKCE (Proof Key for Code Exchange) OAuth 2.0 with a local callback server bridge pattern unique to iOS.
+
+## Supported Providers
+
+| Provider | Auth Flow | Status |
+|----------|-----------|--------|
+| ChatGPT (OpenAI) | PKCE OAuth + local server bridge | Implemented |
+| Gemini (Google) | PKCE OAuth + local server bridge | Planned |
+| GitHub Copilot | Device code flow (no server needed) | Planned |
+
+## iOS Authentication Flow
+
+### The Challenge
+
+OAuth providers like OpenAI register specific redirect URIs for their client IDs. The Codex CLI client ID (`app_EMoamEEZ73f0CkXaXp7hrann`) only accepts `http://localhost:*` redirects. However, `ASWebAuthenticationSession` on iOS can only intercept custom URL schemes (like `vivadicta://`), not localhost URLs.
+
+### The Solution: Local Server Bridge
+
+A temporary `NWListener` TCP server bridges the gap between the provider's localhost redirect and the app's custom URL scheme.
+
+```
+┌─────────┐    ┌──────────────┐    ┌────────────┐    ┌───────────────┐
+│  User    │───>│ ASWebAuth    │───>│  OpenAI    │───>│  localhost    │
+│  taps    │    │ Session      │    │  auth.     │    │  :1455        │
+│  Sign In │    │ (in-app      │    │  openai.   │    │  (NWListener) │
+│          │    │  browser)    │    │  com       │    │               │
+└─────────┘    └──────────────┘    └────────────┘    └───────┬───────┘
+                      ▲                                       │
+                      │                                       │
+                      │  vivadicta://auth/callback?code=xxx   │
+                      │◄──────────────────────────────────────┘
+                      │         HTTP 302 redirect
+                      │
+               Session intercepts
+               custom scheme, closes
+               browser, returns URL
+```
+
+### Step-by-Step
+
+1. **Start local server** — `OAuthCallbackServer` starts an `NWListener` on port 1455
+2. **Open in-app browser** — `ASWebAuthenticationSession` opens the provider's auth URL
+3. **User authenticates** — Logs in at the provider's website (e.g., auth.openai.com)
+4. **Provider redirects to localhost** — `http://localhost:1455/auth/callback?code=xxx&state=yyy`
+5. **Local server bridges** — Receives the request, responds with `302 → vivadicta://auth/callback?code=xxx&state=yyy`
+6. **Session intercepts** — `ASWebAuthenticationSession` sees the `vivadicta://` scheme, closes the browser, returns the callback URL
+7. **Server shuts down** — `defer { listener.cancel() }` stops the server immediately
+8. **Token exchange** — App exchanges the authorization code for access/refresh tokens
+9. **Credentials stored** — Tokens saved to Keychain (device-local, not synced)
+
+The local server exists only for a few seconds during sign-in. All subsequent API calls and token refreshes use standard HTTP requests.
+
+## File Structure
+
+```
+Services/OAuth/
+├── OAuthManager.swift              — @MainActor singleton managing sign-in, token refresh, credential storage
+├── OAuthProvider.swift             — Protocol for provider configurations
+├── OAuthCredential.swift           — Token + account info model (Codable)
+├── OAuthError.swift                — Error types
+├── PKCEGenerator.swift             — PKCE code verifier/challenge generation
+├── OAuthCallbackServer.swift       — NWListener localhost → custom scheme bridge
+├── ASWebAuthSessionContextProvider.swift — Presentation context for ASWebAuthenticationSession
+├── OpenAIChatGPTOAuthProvider.swift — OpenAI/ChatGPT provider configuration
+└── ChatGPTAPIClient.swift          — ChatGPT backend API client (SSE streaming)
+```
+
+## Token Lifecycle
+
+```
+Sign-in → access_token + refresh_token stored in Keychain (syncable: false)
+                │
+                ▼
+        On each API call:
+        ┌─────────────────────┐
+        │ isExpiringSoon?     │──No──> Use current token
+        │ (< 5 min remaining)│
+        └────────┬────────────┘
+                 Yes
+                  │
+                  ▼
+        Refresh token → new access_token
+        (retry up to 3x with backoff)
+                  │
+                  ▼
+        Save updated credential
+```
+
+- **Access tokens** — Short-lived (~1 hour), automatically refreshed
+- **Refresh tokens** — Long-lived, used to obtain new access tokens
+- **Storage** — Keychain with `syncable: false` (device-local, not iCloud synced)
+- **Why not sync** — OAuth tokens are device-specific; syncing causes race conditions where one device's refresh invalidates the other's
+
+## Request Routing & Fallback
+
+When an AI request is made with OpenAI as the provider:
+
+```
+1. ChatGPT OAuth signed in?
+   ├── Yes → Try ChatGPT backend API (chatgpt.com/backend-api/codex/responses)
+   │         ├── Success → Return result
+   │         └── OAuth error + API key exists → Fall through to step 2
+   └── No → Step 2
+
+2. API key exists?
+   ├── Yes → Use standard OpenAI API (api.openai.com)
+   └── No → Throw "not configured" error
+```
+
+## Model Lists
+
+OAuth and API key access expose different model sets:
+
+| Access Method | Models |
+|--------------|--------|
+| ChatGPT OAuth (Codex endpoint) | gpt-5.4, gpt-5.4-mini, gpt-5.2, gpt-5.1 |
+| OpenAI API key | gpt-5.4, gpt-5.4-mini, gpt-5.4-nano, gpt-5.2, gpt-5.1, o4-mini, o3, o3-mini, gpt-4.1, gpt-4.1-mini, gpt-4.1-nano, gpt-4o, gpt-4o-mini |
+
+The model picker (`getAvailableModels(for:)`) automatically switches lists based on `isChatGPTSignedIn`. If a mode has a model selected that isn't in the OAuth list, `ChatGPTAPIClient.resolveModel()` falls back to `gpt-5.4-mini`.
+
+## Adding a New OAuth Provider
+
+1. Create a struct conforming to `OAuthProvider` (see `OpenAIChatGPTOAuthProvider` as template)
+2. Set `redirectURI` to `http://localhost:<port>/auth/callback`
+3. Create an API client enum if the provider uses a non-standard API
+4. Add sign-in/sign-out/refresh methods to `AIService`
+5. Update `refreshConnectedProviders()` and `isProperlyConfigured()`
+6. Add UI in the provider's configuration view
+
+For **device code flow** providers (like GitHub Copilot), no local server is needed — the flow uses polling instead of redirects.
+
+## Comparison with macOS
+
+| Aspect | macOS | iOS |
+|--------|-------|-----|
+| Redirect capture | `NWListener` TCP server on localhost | `NWListener` + 302 redirect to custom scheme |
+| Browser | System browser via `NSWorkspace.shared.open()` | In-app browser via `ASWebAuthenticationSession` |
+| Redirect URI | `http://localhost:1455/auth/callback` | `http://localhost:1455/auth/callback` (same) |
+| OAuthManager | `actor` | `@MainActor final class` (Swift 6 strict concurrency) |
+| Codex CLI import | Imports from `~/.codex/auth.json` | Not applicable |

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -7,6 +7,7 @@
 | [Recording & Audio Pipeline](Recording-Audio-Pipeline-Architecture.md) | AVAudioRecorder setup, audio session management, file handling |
 | [Transcription System](Transcription-System-Architecture.md) | On-device (WhisperKit/Parakeet) and cloud transcription routing |
 | [AI Processing](AI-Processing-Architecture.md) | Multi-provider AI text processing, prompt building, mode/preset routing |
+| [OAuth](OAuth-Architecture.md) | OAuth PKCE sign-in for ChatGPT/Gemini, local callback server bridge, token lifecycle |
 | [Text Processing Pipeline](Text-Processing-Pipeline-Architecture.md) | Multi-stage pipeline: replacements, vocabulary, AI, output filters, formatting |
 | [Preset System](Preset-System-Architecture.md) | Built-in and custom presets, preset catalog, sync with CloudKit |
 | [Data Persistence & CloudKit Sync](Data-Persistence-CloudKit-Architecture.md) | SwiftData models, CloudKit container, cross-device sync |


### PR DESCRIPTION
## Summary
- Add OAuth PKCE flow for ChatGPT sign-in using ASWebAuthenticationSession + local callback server bridge
- New OpenAI configuration view with ChatGPT OAuth section and API key section
- Route OpenAI requests through ChatGPT backend API when signed in, with fallback to API key
- Show OAuth-specific model list in picker when ChatGPT is signed in
- Align OpenAI API key model list with macOS app

## Test plan
- [ ] Sign in with ChatGPT via OpenAI settings page
- [ ] Verify AI processing works with gpt-5.4-mini via OAuth
- [ ] Verify sign out clears credentials and switches back to API key mode
- [ ] Verify model picker shows OAuth models when signed in, full list otherwise
- [ ] Verify API key fallback still works when OAuth is not active