### PR TITLE
Add Gemini OAuth sign-in for Google account

### DIFF
--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -51,6 +51,11 @@ class AIService {
     public var chatGPTEmail: String?
     public var isChatGPTSigningIn: Bool = false
 
+    // MARK: - Gemini OAuth
+    public var isGeminiSignedIn: Bool = false
+    public var geminiEmail: String?
+    public var isGeminiSigningIn: Bool = false
+
     public var openRouterModels: [String] = []
     public var vercelAIGatewayModels: [String] = []
     public var huggingFaceModels: [String] = []
@@ -162,6 +167,7 @@ class AIService {
         // Refresh connected providers on main actor (needed for Apple availability check)
         Task { @MainActor in
             refreshChatGPTOAuthState()
+            refreshGeminiOAuthState()
             refreshConnectedProviders()
             await dismissTranscriptionTipsIfModelConfigured()
             await autoAssignCloudTranscriptionIfAvailable()
@@ -613,6 +619,8 @@ class AIService {
             // Anthropic is connected (via API key or CLI Server)
         } else if aiProvider == .openAI && connectedProviders.contains(.openAI) {
             // OpenAI is connected (via ChatGPT OAuth or API key)
+        } else if aiProvider == .gemini && connectedProviders.contains(.gemini) {
+            // Gemini is connected (via Gemini OAuth or API key)
         } else {
             // Check if API key exists for the selected cloud provider
             guard getAPIKey(for: aiProvider) != nil else {
@@ -858,6 +866,35 @@ class AIService {
                     logger.logWarning("ChatGPT OAuth failed, falling back to API key: \(error.localizedDescription)")
                 } else {
                     throw EnhancementError.customError(error.errorDescription ?? "ChatGPT OAuth error")
+                }
+            }
+        }
+
+        // Gemini OAuth: route Gemini requests through OAuth when signed in
+        if aiProvider == .gemini && isGeminiSignedIn {
+            lastSystemMessageSent = resolvedSystemMessage
+            lastUserMessageSent = formattedText
+            do {
+                let provider = GeminiOAuthProvider()
+                let (token, _, projectId) = try await OAuthManager.shared.validAccessToken(for: provider)
+                let model = selectedMode.aiModel.isEmpty ? GeminiAPIClient.defaultModel : selectedMode.aiModel
+                let result = try await GeminiAPIClient.enhance(
+                    text: formattedText,
+                    systemPrompt: resolvedSystemMessage,
+                    model: model,
+                    accessToken: token,
+                    projectId: projectId
+                )
+                return AIEnhancementOutputFilter.filter(result)
+            } catch let error as EnhancementError {
+                // Rate limit etc. — don't fall through, surface directly
+                throw error
+            } catch let error as OAuthError {
+                // If OAuth fails and we have an API key, fall through to standard path
+                if self.getAPIKey(for: aiProvider) != nil {
+                    logger.logWarning("Gemini OAuth failed, falling back to API key: \(error.localizedDescription)")
+                } else {
+                    throw EnhancementError.customError(error.errorDescription ?? "Gemini OAuth error")
                 }
             }
         }
@@ -1561,6 +1598,9 @@ class AIService {
             if provider == .openAI {
                 return isChatGPTSignedIn || provider.apiKey != nil
             }
+            if provider == .gemini {
+                return isGeminiSignedIn || provider.apiKey != nil
+            }
             return provider.requiresAPIKey && provider.apiKey != nil
         }
 
@@ -1946,6 +1986,10 @@ class AIService {
         if provider == .openAI && isChatGPTSignedIn {
             return ChatGPTAPIClient.supportedModels
         }
+        // Gemini OAuth: show only Cloud Code Assist-supported models when signed in
+        if provider == .gemini && isGeminiSignedIn {
+            return GeminiAPIClient.supportedModels
+        }
         return provider.availableModels
     }
     
@@ -2180,5 +2224,39 @@ extension AIService {
         chatGPTEmail = nil
         refreshConnectedProviders()
     }
+}
 
+// MARK: - Gemini OAuth
+
+extension AIService {
+    /// Refreshes the Gemini OAuth state from stored credentials.
+    @MainActor
+    func refreshGeminiOAuthState() {
+        let provider = GeminiOAuthProvider()
+        isGeminiSignedIn = OAuthManager.shared.isSignedIn(provider: provider)
+        geminiEmail = OAuthManager.shared.accountEmail(for: provider)
+    }
+
+    /// Signs in to Gemini via OAuth.
+    @MainActor
+    func signInWithGemini() async throws {
+        isGeminiSigningIn = true
+        defer { isGeminiSigningIn = false }
+
+        let provider = GeminiOAuthProvider()
+        let credential = try await OAuthManager.shared.signIn(provider: provider)
+        isGeminiSignedIn = true
+        geminiEmail = credential.accountEmail
+        refreshConnectedProviders()
+    }
+
+    /// Signs out from Gemini OAuth.
+    @MainActor
+    func signOutFromGemini() {
+        let provider = GeminiOAuthProvider()
+        OAuthManager.shared.signOut(provider: provider)
+        isGeminiSignedIn = false
+        geminiEmail = nil
+        refreshConnectedProviders()
+    }
 }

--- a/VivaDicta/Services/OAuth/GeminiAPIClient.swift
+++ b/VivaDicta/Services/OAuth/GeminiAPIClient.swift
@@ -1,0 +1,132 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import os
+
+/// Client for Gemini API using OAuth tokens.
+/// Uses the Cloud Code Assist endpoint (same as Gemini CLI / VS Code extension),
+/// NOT the standard generativelanguage.googleapis.com endpoint.
+enum GeminiAPIClient {
+    private static let logger = Logger(category: .geminiOAuthAPI)
+
+    /// Default model for Gemini OAuth requests.
+    static let defaultModel = "gemini-2.5-flash"
+
+    /// Models available via Gemini OAuth.
+    static let supportedModels: [String] = [
+        "gemini-2.5-pro",
+        "gemini-2.5-flash",
+        "gemini-2.5-flash-lite",
+        "gemini-3-pro-preview",
+        "gemini-3-flash-preview",
+        "gemini-3.1-pro-preview",
+        "gemini-3.1-flash-lite-preview"
+    ]
+
+    /// Cloud Code Assist endpoint (non-streaming).
+    private static let endpoint = "https://cloudcode-pa.googleapis.com/v1internal:generateContent"
+
+    /// Returns the model to use. Falls back to default if empty.
+    static func resolveModel(_ requestedModel: String) -> String {
+        if requestedModel.isEmpty { return defaultModel }
+        return requestedModel
+    }
+
+    /// Sends an AI enhancement request via Cloud Code Assist API using OAuth token.
+    static func enhance(
+        text: String,
+        systemPrompt: String,
+        model: String,
+        accessToken: String,
+        projectId: String?
+    ) async throws -> String {
+        guard let url = URL(string: endpoint) else {
+            throw OAuthError.invalidResponse
+        }
+
+        let effectiveModel = resolveModel(model)
+        logger.logInfo("Gemini OAuth: model '\(effectiveModel)', projectId: \(projectId ?? "none")")
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.addValue("google-cloud-sdk vscode_cloudshelleditor/0.1", forHTTPHeaderField: "User-Agent")
+        request.addValue("gl-node/22.17.0", forHTTPHeaderField: "X-Goog-Api-Client")
+        request.timeoutInterval = 60
+
+        // Cloud Code Assist request format — projectId in the body
+        var requestBody: [String: Any] = [
+            "model": effectiveModel,
+            "userAgent": "vivadicta",
+            "request": [
+                "contents": [
+                    [
+                        "role": "user",
+                        "parts": [["text": text]]
+                    ]
+                ],
+                "systemInstruction": [
+                    "parts": [["text": systemPrompt]]
+                ],
+                "generationConfig": [
+                    "maxOutputTokens": 8192
+                ]
+            ]
+        ]
+
+        if let projectId {
+            requestBody["project"] = projectId
+        }
+
+        request.httpBody = try? JSONSerialization.data(withJSONObject: requestBody)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw OAuthError.invalidResponse
+        }
+
+        guard httpResponse.statusCode == 200 else {
+            let errorBody = String(data: data, encoding: .utf8) ?? "Unknown error"
+            logger.logError("Gemini API error: HTTP \(httpResponse.statusCode) — \(errorBody)")
+            if httpResponse.statusCode == 429 {
+                if let errorData = errorBody.data(using: .utf8),
+                   let errorJson = try? JSONSerialization.jsonObject(with: errorData) as? [String: Any],
+                   let error = errorJson["error"] as? [String: Any],
+                   let message = error["message"] as? String {
+                    throw EnhancementError.customError("Gemini rate limit reached. \(message)")
+                }
+                throw EnhancementError.rateLimitExceeded
+            }
+            throw OAuthError.tokenExchangeFailed("HTTP \(httpResponse.statusCode): \(errorBody)")
+        }
+
+        // Parse Cloud Code Assist response — wraps standard Gemini response under .response
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            logger.logError("Gemini OAuth: failed to parse JSON response")
+            throw OAuthError.invalidResponse
+        }
+
+        // Try Cloud Code Assist wrapper format first
+        let geminiResponse: [String: Any]
+        if let wrapped = json["response"] as? [String: Any] {
+            geminiResponse = wrapped
+        } else {
+            geminiResponse = json
+        }
+
+        guard let candidates = geminiResponse["candidates"] as? [[String: Any]],
+              let firstCandidate = candidates.first,
+              let content = firstCandidate["content"] as? [String: Any],
+              let parts = content["parts"] as? [[String: Any]],
+              let firstPart = parts.first,
+              let resultText = firstPart["text"] as? String else {
+            let responseStr = String(data: data, encoding: .utf8) ?? "empty"
+            logger.logError("Gemini OAuth: unexpected response format: \(responseStr)")
+            throw OAuthError.invalidResponse
+        }
+
+        return resultText.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/VivaDicta/Services/OAuth/GeminiOAuthProvider.swift
+++ b/VivaDicta/Services/OAuth/GeminiOAuthProvider.swift
@@ -1,0 +1,143 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import os
+
+/// Google Gemini OAuth provider configuration.
+/// Uses the same client ID as the Gemini CLI for OAuth PKCE flow.
+/// After authentication, discovers a Google Cloud project via Code Assist API.
+struct GeminiOAuthProvider: OAuthProvider {
+    let providerName = "Gemini"
+    let clientId = "681255809395-oo8ft2oprdrnp9e3aqf6av3hmdib135j.apps.googleusercontent.com"
+    let clientSecret: String? = "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"
+    let authorizeURL = "https://accounts.google.com/o/oauth2/v2/auth"
+    let tokenURL = "https://oauth2.googleapis.com/token"
+    let redirectURI = "http://localhost:8085/oauth2callback"
+    let scopes = "https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile"
+    let keychainKey = "geminiOAuthCredential"
+    let userinfoURL: String? = "https://www.googleapis.com/oauth2/v3/userinfo"
+
+    let extraAuthParams: [String: String] = [
+        "access_type": "offline",
+        "prompt": "consent"
+    ]
+
+    func extractAccountInfo(from claims: [String: Any]) -> (id: String?, email: String?) {
+        let id = claims["sub"] as? String
+        let email = claims["email"] as? String
+        return (id, email)
+    }
+
+    // MARK: - Code Assist Project Discovery
+
+    private static let logger = Logger(category: .oauthManager)
+    private static let codeAssistEndpoint = "https://cloudcode-pa.googleapis.com"
+
+    func postAuthSetup(accessToken: String) async throws -> String? {
+        // Step 1: Try to load existing Code Assist project
+        if let projectId = try? await loadCodeAssist(accessToken: accessToken) {
+            Self.logger.logInfo("Gemini: found existing project \(projectId)")
+            return projectId
+        }
+
+        // Step 2: Onboard user if no project exists
+        Self.logger.logInfo("Gemini: no project found, onboarding user")
+        if let projectId = try? await onboardUser(accessToken: accessToken) {
+            Self.logger.logInfo("Gemini: onboarded, project \(projectId)")
+            return projectId
+        }
+
+        Self.logger.logWarning("Gemini: project discovery failed, continuing without projectId")
+        return nil
+    }
+
+    private func loadCodeAssist(accessToken: String) async throws -> String? {
+        guard let url = URL(string: "\(Self.codeAssistEndpoint)/v1internal:loadCodeAssist") else { return nil }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 15
+
+        let body: [String: Any] = [
+            "metadata": [
+                "ideType": "IDE_UNSPECIFIED",
+                "platform": "PLATFORM_UNSPECIFIED",
+                "pluginType": "GEMINI"
+            ]
+        ]
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            return nil
+        }
+
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let projectId = json["cloudaicompanionProject"] as? String else {
+            return nil
+        }
+
+        return projectId
+    }
+
+    private func onboardUser(accessToken: String) async throws -> String? {
+        guard let url = URL(string: "\(Self.codeAssistEndpoint)/v1internal:onboardUser") else { return nil }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 30
+
+        let body: [String: Any] = ["tierId": "free-tier"]
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            return nil
+        }
+
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+
+        // Check if it's a long-running operation
+        if let operationName = json["name"] as? String {
+            return try? await pollOperation(name: operationName, accessToken: accessToken)
+        }
+
+        return json["cloudaicompanionProject"] as? String
+    }
+
+    private func pollOperation(name: String, accessToken: String) async throws -> String? {
+        guard let url = URL(string: "\(Self.codeAssistEndpoint)/v1internal/\(name)") else { return nil }
+
+        // Poll up to 10 times with 2s intervals
+        for _ in 0..<10 {
+            try await Task.sleep(for: .seconds(2))
+
+            var request = URLRequest(url: url)
+            request.addValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+            request.timeoutInterval = 10
+
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200,
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                continue
+            }
+
+            if let done = json["done"] as? Bool, done,
+               let result = json["response"] as? [String: Any],
+               let projectId = result["cloudaicompanionProject"] as? String {
+                return projectId
+            }
+        }
+
+        return nil
+    }
+}

--- a/VivaDicta/Services/OAuth/OAuthManager.swift
+++ b/VivaDicta/Services/OAuth/OAuthManager.swift
@@ -58,7 +58,14 @@ final class OAuthManager: Sendable {
         }
 
         // Start local callback server that bridges localhost redirect → custom scheme
-        let callbackServer = OAuthCallbackServer(port: 1455, customSchemeRedirectBase: "vivadicta://auth/callback")
+        let callbackPort: UInt16 = {
+            if let urlComponents = URLComponents(string: provider.redirectURI),
+               let port = urlComponents.port {
+                return UInt16(port)
+            }
+            return 1455
+        }()
+        let callbackServer = OAuthCallbackServer(port: callbackPort, customSchemeRedirectBase: "vivadicta://auth/callback")
         let listener = try await callbackServer.start()
         defer { listener.cancel() }
 

--- a/VivaDicta/Services/OAuth/OAuthManager.swift
+++ b/VivaDicta/Services/OAuth/OAuthManager.swift
@@ -187,7 +187,7 @@ final class OAuthManager: Sendable {
 
         for (attempt, delay) in delays.enumerated() {
             do {
-                var refreshed = try await tokenRequest(body: body, provider: provider)
+                var refreshed = try await tokenRequest(body: body, provider: provider, existingRefreshToken: credential.refreshToken)
                 // Preserve projectId from the original credential (project doesn't change on refresh)
                 if refreshed.projectId == nil, let existingProjectId = credential.projectId {
                     refreshed = OAuthCredential(
@@ -214,7 +214,7 @@ final class OAuthManager: Sendable {
 
     // MARK: - Shared Token Request
 
-    private func tokenRequest(body: [String: String], provider: some OAuthProvider) async throws -> OAuthCredential {
+    private func tokenRequest(body: [String: String], provider: some OAuthProvider, existingRefreshToken: String? = nil) async throws -> OAuthCredential {
         guard let url = URL(string: provider.tokenURL) else {
             throw OAuthError.tokenExchangeFailed("Invalid token URL")
         }
@@ -247,10 +247,11 @@ final class OAuthManager: Sendable {
             throw OAuthError.tokenExchangeFailed("Invalid JSON response")
         }
 
-        guard let accessToken = json["access_token"] as? String,
-              let refreshToken = json["refresh_token"] as? String else {
-            throw OAuthError.tokenExchangeFailed("Missing tokens in response")
+        guard let accessToken = json["access_token"] as? String else {
+            throw OAuthError.tokenExchangeFailed("Missing access token in response")
         }
+        // Google's refresh endpoint omits refresh_token — fall back to existing one
+        let refreshToken = json["refresh_token"] as? String ?? existingRefreshToken ?? ""
 
         let expiresIn = json["expires_in"] as? TimeInterval ?? 3600
         let expiresAt = Date().addingTimeInterval(expiresIn)

--- a/VivaDicta/Utilities/LoggerExtension.swift
+++ b/VivaDicta/Utilities/LoggerExtension.swift
@@ -55,6 +55,7 @@ public enum LogCategory: String {
     case keychainService = "KeychainService"
     case oauthManager = "OAuthManager"
     case chatGPTAPI = "ChatGPTAPIClient"
+    case geminiOAuthAPI = "GeminiAPIClient"
 
     // MARK: - Keyboard Extension
     case keyboardExtension = "KeyboardExtension"

--- a/VivaDicta/Views/SettingsScreen/AIProvidersView.swift
+++ b/VivaDicta/Views/SettingsScreen/AIProvidersView.swift
@@ -119,6 +119,14 @@ struct AIProviders: View {
                                         .font(.subheadline)
                                         .foregroundStyle(.secondary)
                                 }
+                            } else if provider == .gemini && appState.aiService.isGeminiSignedIn {
+                                HStack(spacing: 4) {
+                                    Image(systemName: "checkmark.circle.fill")
+                                        .foregroundStyle(.green)
+                                    Text("OAuth")
+                                        .font(.subheadline)
+                                        .foregroundStyle(.secondary)
+                                }
                             } else if !appState.aiService.connectedProviders.contains(provider) {
                                 HStack(spacing: 4) {
                                     Image(systemName: "exclamationmark.triangle.fill")
@@ -147,6 +155,8 @@ struct AIProviders: View {
                 AnthropicConfigurationView(aiService: appState.aiService)
             } else if provider == .openAI {
                 OpenAIConfigurationView(aiService: appState.aiService)
+            } else if provider == .gemini {
+                GeminiConfigurationView(aiService: appState.aiService)
             } else {
                 AddAPIKeyView(
                     provider: provider,

--- a/VivaDicta/Views/SettingsScreen/GeminiConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/GeminiConfigurationView.swift
@@ -2,7 +2,7 @@
 
 import SwiftUI
 
-struct OpenAIConfigurationView: View {
+struct GeminiConfigurationView: View {
     @Environment(\.dismiss) private var dismiss
     let aiService: AIService
 
@@ -22,21 +22,21 @@ struct OpenAIConfigurationView: View {
             VStack(spacing: 24) {
                 // Header
                 VStack(spacing: 8) {
-                    if let iconName = AIProvider.openAI.iconName {
+                    if let iconName = AIProvider.gemini.iconName {
                         Image(iconName)
                             .resizable()
                             .scaledToFit()
                             .frame(width: 64, height: 64)
                     }
 
-                    Text("OpenAI")
+                    Text("Gemini")
                         .font(.title2)
 
-                    if aiService.connectedProviders.contains(.openAI) {
+                    if aiService.connectedProviders.contains(.gemini) {
                         HStack(spacing: 4) {
                             Image(systemName: "checkmark.circle.fill")
                                 .foregroundStyle(.green)
-                            Text(aiService.isChatGPTSignedIn ? "ChatGPT Connected" : "API Key Configured")
+                            Text(aiService.isGeminiSignedIn ? "Google Connected" : "API Key Configured")
                                 .font(.subheadline)
                                 .foregroundStyle(.secondary)
                         }
@@ -44,8 +44,8 @@ struct OpenAIConfigurationView: View {
                 }
                 .padding(.top, 8)
 
-                // ChatGPT OAuth section
-                chatGPTSection
+                // Google OAuth section
+                geminiOAuthSection
 
                 // API Key section
                 apiKeySection
@@ -53,10 +53,10 @@ struct OpenAIConfigurationView: View {
             .padding()
         }
         .scrollDismissesKeyboard(.interactively)
-        .navigationTitle("OpenAI")
+        .navigationTitle("Gemini")
         .navigationBarTitleDisplayMode(.inline)
         .onAppear {
-            let existingKey = AIProvider.openAI.apiKey
+            let existingKey = AIProvider.gemini.apiKey
             apiKey = existingKey ?? ""
             hasExistingKey = existingKey != nil
         }
@@ -71,29 +71,29 @@ struct OpenAIConfigurationView: View {
                 deleteAPIKey()
             }
         } message: {
-            Text("Are you sure you want to delete the API key for OpenAI? This action cannot be undone.")
+            Text("Are you sure you want to delete the API key for Gemini? This action cannot be undone.")
         }
     }
 
-    // MARK: - ChatGPT OAuth Section
+    // MARK: - Google OAuth Section
 
-    private var chatGPTSection: some View {
+    private var geminiOAuthSection: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text("ChatGPT Account")
+            Text("Google Account")
                 .font(.headline)
 
-            Text("Use your ChatGPT Plus/Pro subscription — no API key needed.")
+            Text("Use your Google account with Gemini — no API key needed.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
-            if aiService.isChatGPTSignedIn {
+            if aiService.isGeminiSignedIn {
                 HStack {
                     Image(systemName: "checkmark.circle.fill")
                         .foregroundStyle(.green)
                     VStack(alignment: .leading, spacing: 2) {
                         Text("Signed in")
                             .font(.callout)
-                        if let email = aiService.chatGPTEmail {
+                        if let email = aiService.geminiEmail {
                             Text(email)
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
@@ -101,39 +101,39 @@ struct OpenAIConfigurationView: View {
                     }
                     Spacer()
                     Button("Sign Out", role: .destructive) {
-                        aiService.signOutFromChatGPT()
+                        aiService.signOutFromGemini()
                     }
                     .controlSize(.small)
                 }
             } else {
                 if #available(iOS 26.0, *) {
                     Button {
-                        signInWithChatGPT()
+                        signInWithGemini()
                     } label: {
                         HStack(spacing: 6) {
-                            if aiService.isChatGPTSigningIn {
+                            if aiService.isGeminiSigningIn {
                                 ProgressView()
                                     .controlSize(.small)
                             }
-                            Text("Sign in with ChatGPT")
+                            Text("Sign in with Google")
                                 .font(.headline.weight(.medium))
                         }
                     }
-                    .disabled(aiService.isChatGPTSigningIn)
+                    .disabled(aiService.isGeminiSigningIn)
                     .padding(.vertical, 8)
                     .padding(.horizontal, 16)
                     .glassEffect(.regular.tint(.blue.opacity(0.3)).interactive())
                     .buttonStyle(.plain)
                 } else {
                     Button {
-                        signInWithChatGPT()
+                        signInWithGemini()
                     } label: {
                         HStack(spacing: 6) {
-                            if aiService.isChatGPTSigningIn {
+                            if aiService.isGeminiSigningIn {
                                 ProgressView()
                                     .controlSize(.small)
                             }
-                            Text("Sign in with ChatGPT")
+                            Text("Sign in with Google")
                                 .font(.headline.weight(.medium))
                                 .foregroundStyle(.primary)
                         }
@@ -144,7 +144,7 @@ struct OpenAIConfigurationView: View {
                                 .stroke(.blue, lineWidth: 2)
                         }
                     }
-                    .disabled(aiService.isChatGPTSigningIn)
+                    .disabled(aiService.isGeminiSigningIn)
                     .buttonStyle(.plain)
                 }
             }
@@ -164,7 +164,7 @@ struct OpenAIConfigurationView: View {
             Text("API Key")
                 .font(.headline)
 
-            Text("Or use an OpenAI API key directly.")
+            Text("Or use a Gemini API key directly.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
@@ -301,10 +301,10 @@ struct OpenAIConfigurationView: View {
 
     // MARK: - Actions
 
-    private func signInWithChatGPT() {
+    private func signInWithGemini() {
         Task {
             do {
-                try await aiService.signInWithChatGPT()
+                try await aiService.signInWithGemini()
             } catch {
                 oauthErrorMessage = error.localizedDescription
                 showOAuthError = true
@@ -318,7 +318,7 @@ struct OpenAIConfigurationView: View {
             verificationError = nil
             HapticManager.mediumImpact()
 
-            let success = await aiService.saveAPIKey(apiKey, for: .openAI)
+            let success = await aiService.saveAPIKey(apiKey, for: .gemini)
             isVerifying = false
             if success {
                 hasExistingKey = true
@@ -341,7 +341,7 @@ struct OpenAIConfigurationView: View {
     }
 
     private func deleteAPIKey() {
-        KeychainService.shared.delete(forKey: AIProvider.openAI.keychainKey)
+        KeychainService.shared.delete(forKey: AIProvider.gemini.keychainKey)
         apiKey = ""
         hasExistingKey = false
         aiService.refreshConnectedProviders()

--- a/VivaDicta/Views/SettingsScreen/ModeEditView.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditView.swift
@@ -479,6 +479,22 @@ struct ModeEditView: View {
                                         }
                                     }
                                     .alignmentGuide(.listRowSeparatorLeading) { _ in 0 }
+                                } else if provider == .gemini {
+                                    // Gemini has dedicated config (OAuth + API key)
+                                    NavigationLink {
+                                        GeminiConfigurationView(aiService: viewModel.aiService)
+                                    } label: {
+                                        HStack {
+                                            Image(systemName: "exclamationmark.triangle.fill")
+                                                .foregroundStyle(.orange)
+                                            Text("Configure Gemini")
+                                            Spacer()
+                                            Text("Required")
+                                                .font(.caption)
+                                                .foregroundStyle(.secondary)
+                                        }
+                                    }
+                                    .alignmentGuide(.listRowSeparatorLeading) { _ in 0 }
                                 } else {
                                     // Cloud provider needs API key
                                     NavigationLink {


### PR DESCRIPTION
## Summary
- Add Gemini OAuth via Google Cloud Code Assist API — sign in with Google account, no API key needed
- Automatic Google Cloud project discovery on first sign-in (loadCodeAssist → onboardUser)
- Dedicated Gemini configuration view with OAuth + API key sections
- OAuth-specific model list when signed in (gemini-2.5-pro, gemini-2.5-flash, etc.)
- Fallback chain: OAuth first, then API key
- Dynamic callback port extraction from redirect URI (OpenAI:1455, Gemini:8085)

Builds on top of #169 (OpenAI OAuth)

## Test plan
- [ ] Sign in with Google via Gemini settings page
- [ ] Verify AI processing works with gemini-2.5-flash via OAuth
- [ ] Verify sign out clears credentials
- [ ] Verify model picker shows OAuth models when signed in
- [ ] Verify API key fallback still works