### PR TITLE
Rename ClaudeCLIServerClient to VivAgentsClient

### DIFF
--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -825,14 +825,14 @@ class AIService {
         let resolvedSystemMessage = systemMessage ?? getSystemMessage()
 
         // Claude CLI Server: route Anthropic requests through remote server when enabled
-        if aiProvider == .anthropic && ClaudeCLIServerClient.isEnabled && ClaudeCLIServerClient.isClaudeCliActive,
-           let serverURL = ClaudeCLIServerClient.serverURL, !serverURL.isEmpty {
+        if aiProvider == .anthropic && VivAgentsClient.isEnabled && VivAgentsClient.isClaudeCliActive,
+           let serverURL = VivAgentsClient.serverURL, !serverURL.isEmpty {
             let formattedText = preFormattedUserMessage ?? formatTranscriptForLLM(text)
             lastSystemMessageSent = resolvedSystemMessage
             lastUserMessageSent = formattedText
             logger.logDebug("AI Processing - Using Claude CLI Server at \(serverURL)")
             do {
-                let result = try await ClaudeCLIServerClient.enhance(
+                let result = try await VivAgentsClient.enhance(
                     text: formattedText,
                     systemPrompt: resolvedSystemMessage,
                     model: selectedMode.aiModel
@@ -853,13 +853,13 @@ class AIService {
         let formattedText = preFormattedUserMessage ?? formatTranscriptForLLM(text)
 
         // Codex CLI via Mac server: route OpenAI requests through CLI server when enabled
-        if aiProvider == .openAI && ClaudeCLIServerClient.isEnabled && ClaudeCLIServerClient.isCodexCliActive,
-           let serverURL = ClaudeCLIServerClient.serverURL, !serverURL.isEmpty {
+        if aiProvider == .openAI && VivAgentsClient.isEnabled && VivAgentsClient.isCodexCliActive,
+           let serverURL = VivAgentsClient.serverURL, !serverURL.isEmpty {
             lastSystemMessageSent = resolvedSystemMessage
             lastUserMessageSent = formattedText
             logger.logDebug("AI Processing - Using Codex CLI Server at \(serverURL)")
             do {
-                let result = try await ClaudeCLIServerClient.enhance(
+                let result = try await VivAgentsClient.enhance(
                     text: formattedText,
                     systemPrompt: resolvedSystemMessage,
                     model: selectedMode.aiModel,
@@ -877,13 +877,13 @@ class AIService {
         }
 
         // Gemini CLI via Mac server: route Gemini requests through CLI server when enabled
-        if aiProvider == .gemini && ClaudeCLIServerClient.isEnabled && ClaudeCLIServerClient.isGeminiCliActive,
-           let serverURL = ClaudeCLIServerClient.serverURL, !serverURL.isEmpty {
+        if aiProvider == .gemini && VivAgentsClient.isEnabled && VivAgentsClient.isGeminiCliActive,
+           let serverURL = VivAgentsClient.serverURL, !serverURL.isEmpty {
             lastSystemMessageSent = resolvedSystemMessage
             lastUserMessageSent = formattedText
             logger.logDebug("AI Processing - Using Gemini CLI Server at \(serverURL)")
             do {
-                let result = try await ClaudeCLIServerClient.enhance(
+                let result = try await VivAgentsClient.enhance(
                     text: formattedText,
                     systemPrompt: resolvedSystemMessage,
                     model: selectedMode.aiModel,
@@ -1664,21 +1664,21 @@ class AIService {
         providers += AIProvider.allCases.filter { provider in
             if provider == .anthropic {
                 // Anthropic is connected if it has an API key OR Claude CLI is available
-                let cliAvailable = ClaudeCLIServerClient.isEnabled
-                    && ClaudeCLIServerClient.isVerified
-                    && ClaudeCLIServerClient.isClaudeCliAvailable
+                let cliAvailable = VivAgentsClient.isEnabled
+                    && VivAgentsClient.isVerified
+                    && VivAgentsClient.isClaudeCliAvailable
                 return cliAvailable || provider.apiKey != nil
             }
             if provider == .openAI {
-                let cliAvailable = ClaudeCLIServerClient.isEnabled
-                    && ClaudeCLIServerClient.isVerified
-                    && ClaudeCLIServerClient.isCodexCliActive
+                let cliAvailable = VivAgentsClient.isEnabled
+                    && VivAgentsClient.isVerified
+                    && VivAgentsClient.isCodexCliActive
                 return cliAvailable || isChatGPTSignedIn || provider.apiKey != nil
             }
             if provider == .gemini {
-                let cliAvailable = ClaudeCLIServerClient.isEnabled
-                    && ClaudeCLIServerClient.isVerified
-                    && ClaudeCLIServerClient.isGeminiCliActive
+                let cliAvailable = VivAgentsClient.isEnabled
+                    && VivAgentsClient.isVerified
+                    && VivAgentsClient.isGeminiCliActive
                 return cliAvailable || isGeminiSignedIn || provider.apiKey != nil
             }
             if provider == .copilot {
@@ -2088,11 +2088,11 @@ class AIService {
             return customOpenAIModelName.isEmpty ? [] : [customOpenAIModelName]
         }
         // OpenAI: show OAuth model list when connected via ChatGPT or CLI server
-        if provider == .openAI && (isChatGPTSignedIn || (ClaudeCLIServerClient.isEnabled && ClaudeCLIServerClient.isVerified)) {
+        if provider == .openAI && (isChatGPTSignedIn || (VivAgentsClient.isEnabled && VivAgentsClient.isVerified)) {
             return ChatGPTAPIClient.supportedModels
         }
         // Gemini: show OAuth model list when connected via Google or CLI server
-        if provider == .gemini && (isGeminiSignedIn || (ClaudeCLIServerClient.isEnabled && ClaudeCLIServerClient.isVerified)) {
+        if provider == .gemini && (isGeminiSignedIn || (VivAgentsClient.isEnabled && VivAgentsClient.isVerified)) {
             return GeminiAPIClient.supportedModels
         }
         // Copilot: show dynamically fetched models

--- a/VivaDicta/Services/AIEnhance/VivAgentsClient.swift
+++ b/VivaDicta/Services/AIEnhance/VivAgentsClient.swift
@@ -54,9 +54,9 @@ enum VivAgentsClient {
 
     // MARK: - UserDefaults Keys
 
-    static let isEnabledKey = "isVivAgentsClientEnabled"
+    static let isEnabledKey = "isClaudeCLIServerClientEnabled"
     static let serverURLKey = "claudeCLIServerClientURL"
-    static let isVerifiedKey = "isVivAgentsClientVerified"
+    static let isVerifiedKey = "isClaudeCLIServerClientVerified"
 
     // MARK: - Per-CLI Availability Keys
 

--- a/VivaDicta/Services/AIEnhance/VivAgentsClient.swift
+++ b/VivaDicta/Services/AIEnhance/VivAgentsClient.swift
@@ -1,5 +1,5 @@
 //
-//  ClaudeCLIServerClient.swift
+//  VivAgentsClient.swift
 //  VivaDicta
 //
 //  Created by Anton Novoselov on 2026.03.25
@@ -8,9 +8,9 @@
 import Foundation
 import os
 
-enum ClaudeCLIServerClient {
+enum VivAgentsClient {
 
-    private static let logger = Logger(category: .cliServerClient)
+    private static let logger = Logger(category: .vivAgentsClient)
 
     struct EnhanceRequest: Encodable {
         let text: String
@@ -54,9 +54,9 @@ enum ClaudeCLIServerClient {
 
     // MARK: - UserDefaults Keys
 
-    static let isEnabledKey = "isClaudeCLIServerClientEnabled"
+    static let isEnabledKey = "isVivAgentsClientEnabled"
     static let serverURLKey = "claudeCLIServerClientURL"
-    static let isVerifiedKey = "isClaudeCLIServerClientVerified"
+    static let isVerifiedKey = "isVivAgentsClientVerified"
 
     // MARK: - Per-CLI Availability Keys
 
@@ -143,12 +143,12 @@ enum ClaudeCLIServerClient {
         provider: String = "claude"
     ) async throws -> String {
         guard let baseURL = serverURL, !baseURL.isEmpty else {
-            throw ClaudeCLIServerError.invalidURL
+            throw VivAgentsClientError.invalidURL
         }
 
-        let urlString = baseURL.trimmingCharacters(in: CharacterSet(charactersIn: "/")) + "/enhance"
+        let urlString = baseURL.trimmingCharacters(in: CharacterSet(charactersIn: "/")) + "/process"
         guard let url = URL(string: urlString) else {
-            throw ClaudeCLIServerError.invalidURL
+            throw VivAgentsClientError.invalidURL
         }
 
         var request = URLRequest(url: url)
@@ -163,30 +163,30 @@ enum ClaudeCLIServerClient {
         let body = EnhanceRequest(text: text, systemPrompt: systemPrompt, model: model, provider: provider)
         request.httpBody = try JSONEncoder().encode(body)
 
-        logger.logInfo("CLI Server request: provider=\(provider), model=\(model), textLength=\(text.count)")
+        logger.logInfo("VivAgents request: provider=\(provider), model=\(model), textLength=\(text.count)")
 
         let (data, response) = try await URLSession.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
-            logger.logError("CLI Server: invalid response (not HTTP)")
-            throw ClaudeCLIServerError.invalidResponse
+            logger.logError("VivAgents: invalid response (not HTTP)")
+            throw VivAgentsClientError.invalidResponse
         }
 
-        logger.logInfo("CLI Server response: HTTP \(httpResponse.statusCode)")
+        logger.logInfo("VivAgents response: HTTP \(httpResponse.statusCode)")
 
         if httpResponse.statusCode == 200 {
             let result = try JSONDecoder().decode(EnhanceResponse.self, from: data)
-            logger.logInfo("CLI Server success: resultLength=\(result.result.count), duration=\(result.duration ?? 0)s")
+            logger.logInfo("VivAgents success: resultLength=\(result.result.count), duration=\(result.duration ?? 0)s")
             return result.result
         } else {
             let rawBody = String(data: data, encoding: .utf8) ?? "(non-UTF8 body)"
-            logger.logError("CLI Server error: HTTP \(httpResponse.statusCode), body=\(rawBody)")
+            logger.logError("VivAgents error: HTTP \(httpResponse.statusCode), body=\(rawBody)")
 
             if let errorResponse = try? JSONDecoder().decode(ErrorResponse.self, from: data) {
                 let message = Self.humanReadableError(errorResponse.error, code: errorResponse.code, httpStatus: httpResponse.statusCode, provider: provider)
-                throw ClaudeCLIServerError.serverError(message)
+                throw VivAgentsClientError.serverError(message)
             }
-            throw ClaudeCLIServerError.httpError(httpResponse.statusCode)
+            throw VivAgentsClientError.httpError(httpResponse.statusCode)
         }
     }
 
@@ -282,7 +282,7 @@ enum ClaudeCLIServerClient {
 
 }
 
-enum ClaudeCLIServerError: LocalizedError {
+enum VivAgentsClientError: LocalizedError {
     case invalidURL
     case invalidResponse
     case serverError(String)
@@ -291,13 +291,13 @@ enum ClaudeCLIServerError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .invalidURL:
-            "Invalid Claude CLI Server URL."
+            "Invalid VivAgents server URL."
         case .invalidResponse:
-            "Invalid response from Claude CLI server."
+            "Invalid response from VivAgents server."
         case .serverError(let message):
             message
         case .httpError(let code):
-            "Claude CLI server returned HTTP \(code)."
+            "VivAgents server returned HTTP \(code)."
         }
     }
 }

--- a/VivaDicta/Utilities/LoggerExtension.swift
+++ b/VivaDicta/Utilities/LoggerExtension.swift
@@ -59,7 +59,7 @@ public enum LogCategory: String {
     case geminiOAuthAPI = "GeminiAPIClient"
     case copilotOAuth = "CopilotOAuth"
     case copilotAPI = "CopilotAPIClient"
-    case cliServerClient = "CLIServerClient"
+    case vivAgentsClient = "VivAgentsClient"
 
     // MARK: - Keyboard Extension
     case keyboardExtension = "KeyboardExtension"

--- a/VivaDicta/Views/SettingsScreen/AIProvidersView.swift
+++ b/VivaDicta/Views/SettingsScreen/AIProvidersView.swift
@@ -55,7 +55,7 @@ struct AIProviders: View {
 
                         Spacer()
 
-                        if ClaudeCLIServerClient.isEnabled && ClaudeCLIServerClient.isVerified {
+                        if VivAgentsClient.isEnabled && VivAgentsClient.isVerified {
                             HStack(spacing: 4) {
                                 Image(systemName: "checkmark.circle.fill")
                                     .foregroundStyle(.green)
@@ -143,7 +143,7 @@ struct AIProviders: View {
                                             .foregroundStyle(.secondary)
                                     }
                                 }
-                            } else if provider == .anthropic && ClaudeCLIServerClient.isEnabled && ClaudeCLIServerClient.isClaudeCliActive {
+                            } else if provider == .anthropic && VivAgentsClient.isEnabled && VivAgentsClient.isClaudeCliActive {
                                 HStack(spacing: 4) {
                                     Image(systemName: "checkmark.circle.fill")
                                         .foregroundStyle(.green)
@@ -151,7 +151,7 @@ struct AIProviders: View {
                                         .font(.subheadline)
                                         .foregroundStyle(.secondary)
                                 }
-                            } else if provider == .openAI && ClaudeCLIServerClient.isEnabled && ClaudeCLIServerClient.isCodexCliActive {
+                            } else if provider == .openAI && VivAgentsClient.isEnabled && VivAgentsClient.isCodexCliActive {
                                 HStack(spacing: 4) {
                                     Image(systemName: "checkmark.circle.fill")
                                         .foregroundStyle(.green)
@@ -159,7 +159,7 @@ struct AIProviders: View {
                                         .font(.subheadline)
                                         .foregroundStyle(.secondary)
                                 }
-                            } else if provider == .gemini && ClaudeCLIServerClient.isEnabled && ClaudeCLIServerClient.isGeminiCliActive {
+                            } else if provider == .gemini && VivAgentsClient.isEnabled && VivAgentsClient.isGeminiCliActive {
                                 HStack(spacing: 4) {
                                     Image(systemName: "checkmark.circle.fill")
                                         .foregroundStyle(.green)

--- a/VivaDicta/Views/SettingsScreen/AnthropicConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/AnthropicConfigurationView.swift
@@ -17,7 +17,7 @@ struct AnthropicConfigurationView: View {
     @State private var verificationError: String?
     @State private var hasExistingKey = false
     @State private var showDeleteConfirmation = false
-    @State private var isClaudeCliEnabled = ClaudeCLIServerClient.isClaudeCliEnabled
+    @State private var isClaudeCliEnabled = VivAgentsClient.isClaudeCliEnabled
 
 
     var body: some View {
@@ -39,7 +39,7 @@ struct AnthropicConfigurationView: View {
                         HStack(spacing: 4) {
                             Image(systemName: "checkmark.circle.fill")
                                 .foregroundStyle(.green)
-                            Text(ClaudeCLIServerClient.isEnabled && ClaudeCLIServerClient.isClaudeCliActive ? "CLI Server Connected" : "API Key Configured")
+                            Text(VivAgentsClient.isEnabled && VivAgentsClient.isClaudeCliActive ? "CLI Server Connected" : "API Key Configured")
                                 .font(.subheadline)
                                 .foregroundStyle(.secondary)
                         }
@@ -86,10 +86,10 @@ struct AnthropicConfigurationView: View {
             Text("Claude CLI Agent")
                 .font(.headline)
 
-            if ClaudeCLIServerClient.isEnabled && ClaudeCLIServerClient.isClaudeCliAvailable {
+            if VivAgentsClient.isEnabled && VivAgentsClient.isClaudeCliAvailable {
                 Toggle("Use Claude CLI Agent", isOn: $isClaudeCliEnabled)
                     .onChange(of: isClaudeCliEnabled) { _, newValue in
-                        UserDefaults.standard.set(newValue, forKey: ClaudeCLIServerClient.claudeCliEnabledKey)
+                        UserDefaults.standard.set(newValue, forKey: VivAgentsClient.claudeCliEnabledKey)
                         aiService.refreshConnectedProviders()
                     }
 
@@ -289,7 +289,7 @@ struct AnthropicConfigurationView: View {
                     .font(.caption.bold())
                     .padding(.horizontal, 8)
                     .padding(.vertical, 4)
-                    .background(ClaudeCLIServerClient.isEnabled && ClaudeCLIServerClient.isVerified ? Color.green.opacity(0.15) : Color.secondary.opacity(0.1))
+                    .background(VivAgentsClient.isEnabled && VivAgentsClient.isVerified ? Color.green.opacity(0.15) : Color.secondary.opacity(0.1))
                     .clipShape(.capsule)
                 Image(systemName: "chevron.right")
                     .font(.caption2)

--- a/VivaDicta/Views/SettingsScreen/CLIServerConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/CLIServerConfigurationView.swift
@@ -11,15 +11,15 @@ struct CLIServerConfigurationView: View {
     let aiService: AIService
 
     // Server state
-    @State private var isServerEnabled = UserDefaults.standard.bool(forKey: ClaudeCLIServerClient.isEnabledKey)
-    @State private var serverURL = UserDefaults.standard.string(forKey: ClaudeCLIServerClient.serverURLKey) ?? ""
-    @State private var serverToken = KeychainService.shared.getString(forKey: ClaudeCLIServerClient.authTokenKeychainKey, syncable: false) ?? ""
+    @State private var isServerEnabled = UserDefaults.standard.bool(forKey: VivAgentsClient.isEnabledKey)
+    @State private var serverURL = UserDefaults.standard.string(forKey: VivAgentsClient.serverURLKey) ?? ""
+    @State private var serverToken = KeychainService.shared.getString(forKey: VivAgentsClient.authTokenKeychainKey, syncable: false) ?? ""
     @State private var isTestingConnection = false
     @State private var connectionTestResult: Bool?
     @State private var showCLIWarning = false
 
     // Health response for per-CLI availability
-    @State private var healthResponse: ClaudeCLIServerClient.HealthResponse?
+    @State private var healthResponse: VivAgentsClient.HealthResponse?
 
     var body: some View {
         ScrollView {
@@ -33,7 +33,7 @@ struct CLIServerConfigurationView: View {
                     Text("CLI Agents Server")
                         .font(.title2)
 
-                    if isServerEnabled && ClaudeCLIServerClient.isVerified {
+                    if isServerEnabled && VivAgentsClient.isVerified {
                         HStack(spacing: 4) {
                             Image(systemName: "checkmark.circle.fill")
                                 .foregroundStyle(.green)
@@ -49,7 +49,7 @@ struct CLIServerConfigurationView: View {
                 connectionSection
 
                 // CLI availability
-                if isServerEnabled && ClaudeCLIServerClient.isVerified {
+                if isServerEnabled && VivAgentsClient.isVerified {
                     availabilitySection
                 }
 
@@ -66,10 +66,10 @@ struct CLIServerConfigurationView: View {
         .navigationBarTitleDisplayMode(.inline)
         .task {
             // Re-fetch health on appear if server is connected
-            if isServerEnabled && ClaudeCLIServerClient.isVerified && healthResponse == nil {
-                healthResponse = await ClaudeCLIServerClient.fetchHealth()
+            if isServerEnabled && VivAgentsClient.isVerified && healthResponse == nil {
+                healthResponse = await VivAgentsClient.fetchHealth()
                 if let health = healthResponse {
-                    ClaudeCLIServerClient.saveAvailability(from: health)
+                    VivAgentsClient.saveAvailability(from: health)
                     aiService.refreshConnectedProviders()
                 }
             }
@@ -78,7 +78,7 @@ struct CLIServerConfigurationView: View {
             Button("Cancel", role: .cancel) { }
             Button("Enable") {
                 isServerEnabled = true
-                UserDefaults.standard.set(true, forKey: ClaudeCLIServerClient.isEnabledKey)
+                UserDefaults.standard.set(true, forKey: VivAgentsClient.isEnabledKey)
             }
         } message: {
             Text("CLI agents (Claude, Codex, Gemini) are designed for software development use. Using them for general text processing may fall outside the intended use and could lead to account restrictions.\n\nBy enabling this feature you proceed at your own risk.")
@@ -103,11 +103,11 @@ struct CLIServerConfigurationView: View {
                         showCLIWarning = true
                     } else {
                         isServerEnabled = false
-                        UserDefaults.standard.set(false, forKey: ClaudeCLIServerClient.isEnabledKey)
-                        UserDefaults.standard.set(false, forKey: ClaudeCLIServerClient.isVerifiedKey)
+                        UserDefaults.standard.set(false, forKey: VivAgentsClient.isEnabledKey)
+                        UserDefaults.standard.set(false, forKey: VivAgentsClient.isVerifiedKey)
                         connectionTestResult = nil
                         healthResponse = nil
-                        ClaudeCLIServerClient.clearAvailability()
+                        VivAgentsClient.clearAvailability()
                         aiService.refreshConnectedProviders()
                     }
                 }
@@ -274,28 +274,28 @@ struct CLIServerConfigurationView: View {
     // MARK: - Actions
 
     private func saveAndTestConnection() {
-        UserDefaults.standard.set(serverURL, forKey: ClaudeCLIServerClient.serverURLKey)
-        KeychainService.shared.save(serverToken, forKey: ClaudeCLIServerClient.authTokenKeychainKey, syncable: false)
+        UserDefaults.standard.set(serverURL, forKey: VivAgentsClient.serverURLKey)
+        KeychainService.shared.save(serverToken, forKey: VivAgentsClient.authTokenKeychainKey, syncable: false)
 
         Task {
             isTestingConnection = true
-            let success = await ClaudeCLIServerClient.testConnection(provider: "any")
+            let success = await VivAgentsClient.testConnection(provider: "any")
             connectionTestResult = success
-            UserDefaults.standard.set(success, forKey: ClaudeCLIServerClient.isVerifiedKey)
+            UserDefaults.standard.set(success, forKey: VivAgentsClient.isVerifiedKey)
             isTestingConnection = false
             aiService.refreshConnectedProviders()
 
             // Fetch health details for CLI availability
             if success {
-                let health = await ClaudeCLIServerClient.fetchHealth()
+                let health = await VivAgentsClient.fetchHealth()
                 healthResponse = health
                 if let health {
-                    ClaudeCLIServerClient.saveAvailability(from: health)
+                    VivAgentsClient.saveAvailability(from: health)
                 }
                 HapticManager.success()
             } else {
                 healthResponse = nil
-                ClaudeCLIServerClient.clearAvailability()
+                VivAgentsClient.clearAvailability()
                 HapticManager.error()
             }
         }

--- a/VivaDicta/Views/SettingsScreen/GeminiConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/GeminiConfigurationView.swift
@@ -12,7 +12,7 @@ struct GeminiConfigurationView: View {
     @State private var verificationError: String?
     @State private var hasExistingKey = false
     @State private var showDeleteConfirmation = false
-    @State private var isGeminiCliEnabled = ClaudeCLIServerClient.isGeminiCliEnabled
+    @State private var isGeminiCliEnabled = VivAgentsClient.isGeminiCliEnabled
 
     // OAuth error
     @State private var showOAuthError = false
@@ -319,7 +319,7 @@ struct GeminiConfigurationView: View {
                     .font(.caption.bold())
                     .padding(.horizontal, 8)
                     .padding(.vertical, 4)
-                    .background(ClaudeCLIServerClient.isEnabled && ClaudeCLIServerClient.isVerified ? Color.green.opacity(0.15) : Color.secondary.opacity(0.1))
+                    .background(VivAgentsClient.isEnabled && VivAgentsClient.isVerified ? Color.green.opacity(0.15) : Color.secondary.opacity(0.1))
                     .clipShape(.capsule)
                 Image(systemName: "chevron.right")
                     .font(.caption2)
@@ -357,7 +357,7 @@ struct GeminiConfigurationView: View {
     // MARK: - CLI Server Section
 
     private var geminiConnectionLabel: String {
-        if ClaudeCLIServerClient.isEnabled && ClaudeCLIServerClient.isVerified {
+        if VivAgentsClient.isEnabled && VivAgentsClient.isVerified {
             return "CLI Server Connected"
         } else if aiService.isGeminiSignedIn {
             return "Google Connected"
@@ -371,10 +371,10 @@ struct GeminiConfigurationView: View {
             Text("Gemini CLI Agent")
                 .font(.headline)
 
-            if ClaudeCLIServerClient.isEnabled && ClaudeCLIServerClient.isGeminiCliAvailable {
+            if VivAgentsClient.isEnabled && VivAgentsClient.isGeminiCliAvailable {
                 Toggle("Use Gemini CLI Agent", isOn: $isGeminiCliEnabled)
                     .onChange(of: isGeminiCliEnabled) { _, newValue in
-                        UserDefaults.standard.set(newValue, forKey: ClaudeCLIServerClient.geminiCliEnabledKey)
+                        UserDefaults.standard.set(newValue, forKey: VivAgentsClient.geminiCliEnabledKey)
                         aiService.refreshConnectedProviders()
                     }
 

--- a/VivaDicta/Views/SettingsScreen/OpenAIConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/OpenAIConfigurationView.swift
@@ -12,7 +12,7 @@ struct OpenAIConfigurationView: View {
     @State private var verificationError: String?
     @State private var hasExistingKey = false
     @State private var showDeleteConfirmation = false
-    @State private var isCodexCliEnabled = ClaudeCLIServerClient.isCodexCliEnabled
+    @State private var isCodexCliEnabled = VivAgentsClient.isCodexCliEnabled
 
     // OAuth error
     @State private var showOAuthError = false
@@ -319,7 +319,7 @@ struct OpenAIConfigurationView: View {
                     .font(.caption.bold())
                     .padding(.horizontal, 8)
                     .padding(.vertical, 4)
-                    .background(ClaudeCLIServerClient.isEnabled && ClaudeCLIServerClient.isVerified ? Color.green.opacity(0.15) : Color.secondary.opacity(0.1))
+                    .background(VivAgentsClient.isEnabled && VivAgentsClient.isVerified ? Color.green.opacity(0.15) : Color.secondary.opacity(0.1))
                     .clipShape(.capsule)
                 Image(systemName: "chevron.right")
                     .font(.caption2)
@@ -357,7 +357,7 @@ struct OpenAIConfigurationView: View {
     // MARK: - CLI Server Section
 
     private var openAIConnectionLabel: String {
-        if ClaudeCLIServerClient.isEnabled && ClaudeCLIServerClient.isVerified {
+        if VivAgentsClient.isEnabled && VivAgentsClient.isVerified {
             return "CLI Server Connected"
         } else if aiService.isChatGPTSignedIn {
             return "ChatGPT Connected"
@@ -371,10 +371,10 @@ struct OpenAIConfigurationView: View {
             Text("Codex CLI Agent")
                 .font(.headline)
 
-            if ClaudeCLIServerClient.isEnabled && ClaudeCLIServerClient.isCodexCliAvailable {
+            if VivAgentsClient.isEnabled && VivAgentsClient.isCodexCliAvailable {
                 Toggle("Use Codex CLI Agent", isOn: $isCodexCliEnabled)
                     .onChange(of: isCodexCliEnabled) { _, newValue in
-                        UserDefaults.standard.set(newValue, forKey: ClaudeCLIServerClient.codexCliEnabledKey)
+                        UserDefaults.standard.set(newValue, forKey: VivAgentsClient.codexCliEnabledKey)
                         aiService.refreshConnectedProviders()
                     }
 


### PR DESCRIPTION
## Summary
- Rename `ClaudeCLIServerClient` → `VivAgentsClient` and `ClaudeCLIServerError` → `VivAgentsClientError`
- Change endpoint from `/enhance` to `/process` to match macOS app and standalone VivAgents server
- Update logger category from `cliServerClient` to `vivAgentsClient`
- UserDefaults and keychain keys unchanged for backward compatibility

## Test plan
- [ ] Verify CLI Agents Server connection still works (test connection from settings)
- [ ] Verify AI processing via CLI server succeeds with all providers (Claude, Codex, Gemini)
- [ ] Verify settings/toggles persist correctly (keys unchanged)