### PR TITLE
Rebrand CLI Agents Server to VivAgents Server in UI

### DIFF
--- a/VivaDicta/Views/SettingsScreen/AIProvidersView.swift
+++ b/VivaDicta/Views/SettingsScreen/AIProvidersView.swift
@@ -147,7 +147,7 @@ struct AIProviders: View {
                                 HStack(spacing: 4) {
                                     Image(systemName: "checkmark.circle.fill")
                                         .foregroundStyle(.green)
-                                    Text("CLI")
+                                    Text("VivAgents")
                                         .font(.subheadline)
                                         .foregroundStyle(.secondary)
                                 }
@@ -155,7 +155,7 @@ struct AIProviders: View {
                                 HStack(spacing: 4) {
                                     Image(systemName: "checkmark.circle.fill")
                                         .foregroundStyle(.green)
-                                    Text("CLI")
+                                    Text("VivAgents")
                                         .font(.subheadline)
                                         .foregroundStyle(.secondary)
                                 }
@@ -163,7 +163,7 @@ struct AIProviders: View {
                                 HStack(spacing: 4) {
                                     Image(systemName: "checkmark.circle.fill")
                                         .foregroundStyle(.green)
-                                    Text("CLI")
+                                    Text("VivAgents")
                                         .font(.subheadline)
                                         .foregroundStyle(.secondary)
                                 }

--- a/VivaDicta/Views/SettingsScreen/AIProvidersView.swift
+++ b/VivaDicta/Views/SettingsScreen/AIProvidersView.swift
@@ -40,7 +40,7 @@ struct AIProviders: View {
                 }
             }
 
-            // CLI Agents Server Section
+            // VivAgents Server Section
             Section {
                 NavigationLink {
                     CLIServerConfigurationView(aiService: appState.aiService)
@@ -51,7 +51,7 @@ struct AIProviders: View {
                             .foregroundStyle(.blue.gradient)
                             .frame(width: 28, height: 28)
 
-                        Text("CLI Agents Server")
+                        Text("VivAgents Server")
 
                         Spacer()
 

--- a/VivaDicta/Views/SettingsScreen/AIProvidersView.swift
+++ b/VivaDicta/Views/SettingsScreen/AIProvidersView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct AIProviders: View {
     @Environment(AppState.self) private var appState
+    @State private var refreshID = UUID()
 
     var body: some View {
         List {
@@ -225,7 +226,9 @@ struct AIProviders: View {
                 }
             }
         }
+        .id(refreshID)
         .onAppear {
+            refreshID = UUID()
             appState.aiService.refreshConnectedProviders()
         }
         .navigationTitle("AI Providers")

--- a/VivaDicta/Views/SettingsScreen/AnthropicConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/AnthropicConfigurationView.swift
@@ -285,7 +285,7 @@ struct AnthropicConfigurationView: View {
                 .foregroundStyle(.secondary)
 
             HStack(spacing: 6) {
-                Text("VivAgents Server")
+                Text("VivAgents")
                     .font(.caption.bold())
                     .padding(.horizontal, 8)
                     .padding(.vertical, 4)

--- a/VivaDicta/Views/SettingsScreen/AnthropicConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/AnthropicConfigurationView.swift
@@ -39,7 +39,7 @@ struct AnthropicConfigurationView: View {
                         HStack(spacing: 4) {
                             Image(systemName: "checkmark.circle.fill")
                                 .foregroundStyle(.green)
-                            Text(VivAgentsClient.isEnabled && VivAgentsClient.isClaudeCliActive ? "CLI Server Connected" : "API Key Configured")
+                            Text(VivAgentsClient.isEnabled && VivAgentsClient.isClaudeCliActive ? "VivAgents Server Connected" : "API Key Configured")
                                 .font(.subheadline)
                                 .foregroundStyle(.secondary)
                         }
@@ -47,7 +47,7 @@ struct AnthropicConfigurationView: View {
                 }
                 .padding(.top, 8)
 
-                // CLI Server section
+                // VivAgents Server section
                 cliServerStatusSection
 
                 // API Key section
@@ -79,7 +79,7 @@ struct AnthropicConfigurationView: View {
         }
     }
 
-    // MARK: - CLI Server Status Section
+    // MARK: - VivAgents Server Status Section
 
     private var cliServerStatusSection: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -102,14 +102,14 @@ struct AnthropicConfigurationView: View {
                     }
                 }
             } else {
-                Text("Use your Claude subscription via the CLI Agents Server. No API key needed.")
+                Text("Use your Claude subscription via the VivAgents Server. No API key needed.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
 
                 NavigationLink {
                     CLIServerConfigurationView(aiService: aiService)
                 } label: {
-                    Text("Configure CLI Agents Server")
+                    Text("Configure VivAgents Server")
                         .font(.callout)
                 }
             }
@@ -285,7 +285,7 @@ struct AnthropicConfigurationView: View {
                 .foregroundStyle(.secondary)
 
             HStack(spacing: 6) {
-                Text("CLI Server")
+                Text("VivAgents Server")
                     .font(.caption.bold())
                     .padding(.horizontal, 8)
                     .padding(.vertical, 4)
@@ -342,7 +342,7 @@ struct AnthropicConfigurationView: View {
         apiKey = ""
         hasExistingKey = false
         aiService.refreshConnectedProviders()
-        // Only disable modes if CLI Server isn't keeping Anthropic connected
+        // Only disable modes if VivAgents Server isn't keeping Anthropic connected
         if !aiService.connectedProviders.contains(.anthropic) {
             aiService.disableAIEnhancementForModesUsingProvider(.anthropic)
         }

--- a/VivaDicta/Views/SettingsScreen/CLIServerConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/CLIServerConfigurationView.swift
@@ -294,6 +294,12 @@ struct CLIServerConfigurationView: View {
     // MARK: - Actions
 
     private func saveSettings() {
+        if isServerEnabled && !serverURL.isEmpty {
+            // When enabled with URL, test connection first (same as Test & Save)
+            saveAndTestConnection()
+            return
+        }
+
         UserDefaults.standard.set(isServerEnabled, forKey: VivAgentsClient.isEnabledKey)
 
         if !isServerEnabled {

--- a/VivaDicta/Views/SettingsScreen/CLIServerConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/CLIServerConfigurationView.swift
@@ -295,8 +295,10 @@ struct CLIServerConfigurationView: View {
     }
 
     private func saveAndTestConnection() {
+        UserDefaults.standard.set(isServerEnabled, forKey: VivAgentsClient.isEnabledKey)
         UserDefaults.standard.set(serverURL, forKey: VivAgentsClient.serverURLKey)
         KeychainService.shared.save(serverToken, forKey: VivAgentsClient.authTokenKeychainKey, syncable: false)
+        hasUnsavedChanges = false
 
         Task {
             isTestingConnection = true

--- a/VivaDicta/Views/SettingsScreen/CLIServerConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/CLIServerConfigurationView.swift
@@ -11,10 +11,10 @@ struct CLIServerConfigurationView: View {
     @Environment(\.dismiss) private var dismiss
     let aiService: AIService
 
-    // Server state
-    @State private var isServerEnabled = UserDefaults.standard.bool(forKey: VivAgentsClient.isEnabledKey)
-    @State private var serverURL = UserDefaults.standard.string(forKey: VivAgentsClient.serverURLKey) ?? ""
-    @State private var serverToken = KeychainService.shared.getString(forKey: VivAgentsClient.authTokenKeychainKey, syncable: false) ?? ""
+    // Server state — loaded in onAppear to always reflect current UserDefaults
+    @State private var isServerEnabled = false
+    @State private var serverURL = ""
+    @State private var serverToken = ""
     @State private var isTestingConnection = false
     @State private var connectionTestResult: Bool?
     @State private var showCLIWarning = false
@@ -74,6 +74,12 @@ struct CLIServerConfigurationView: View {
                 .disabled(!hasUnsavedChanges)
                 .bold()
             }
+        }
+        .onAppear {
+            isServerEnabled = UserDefaults.standard.bool(forKey: VivAgentsClient.isEnabledKey)
+            serverURL = UserDefaults.standard.string(forKey: VivAgentsClient.serverURLKey) ?? ""
+            serverToken = KeychainService.shared.getString(forKey: VivAgentsClient.authTokenKeychainKey, syncable: false) ?? ""
+            hasUnsavedChanges = false
         }
         .task {
             // Re-fetch health on appear if server is connected

--- a/VivaDicta/Views/SettingsScreen/CLIServerConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/CLIServerConfigurationView.swift
@@ -67,12 +67,20 @@ struct CLIServerConfigurationView: View {
         .navigationTitle("VivAgents Server")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
-            ToolbarItem(placement: .topBarTrailing) {
-                Button("Save") {
-                    saveSettings()
+            ToolbarItem(placement: .confirmationAction) {
+                if #available(iOS 26, *) {
+                    Button(role: .confirm) {
+                        saveSettings()
+                    }
+                    .disabled(!hasUnsavedChanges)
+                    .tint(hasUnsavedChanges ? .blue : .gray)
+                } else {
+                    Button("Save") {
+                        saveSettings()
+                    }
+                    .disabled(!hasUnsavedChanges)
+                    .foregroundStyle(hasUnsavedChanges ? .blue : .gray)
                 }
-                .disabled(!hasUnsavedChanges)
-                .bold()
             }
         }
         .onAppear {

--- a/VivaDicta/Views/SettingsScreen/CLIServerConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/CLIServerConfigurationView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct CLIServerConfigurationView: View {
+    @Environment(\.dismiss) private var dismiss
     let aiService: AIService
 
     // Server state
@@ -17,6 +18,7 @@ struct CLIServerConfigurationView: View {
     @State private var isTestingConnection = false
     @State private var connectionTestResult: Bool?
     @State private var showCLIWarning = false
+    @State private var hasUnsavedChanges = false
 
     // Health response for per-CLI availability
     @State private var healthResponse: VivAgentsClient.HealthResponse?
@@ -64,6 +66,15 @@ struct CLIServerConfigurationView: View {
         }
         .navigationTitle("VivAgents Server")
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button("Save") {
+                    saveSettings()
+                }
+                .disabled(!hasUnsavedChanges)
+                .bold()
+            }
+        }
         .task {
             // Re-fetch health on appear if server is connected
             if isServerEnabled && VivAgentsClient.isVerified && healthResponse == nil {
@@ -78,7 +89,7 @@ struct CLIServerConfigurationView: View {
             Button("Cancel", role: .cancel) { }
             Button("Enable") {
                 isServerEnabled = true
-                UserDefaults.standard.set(true, forKey: VivAgentsClient.isEnabledKey)
+                hasUnsavedChanges = true
             }
         } message: {
             Text("CLI agents (Claude, Codex, Gemini) are designed for software development use. Using them for general text processing may fall outside the intended use and could lead to account restrictions.\n\nBy enabling this feature you proceed at your own risk.")
@@ -103,12 +114,7 @@ struct CLIServerConfigurationView: View {
                         showCLIWarning = true
                     } else {
                         isServerEnabled = false
-                        UserDefaults.standard.set(false, forKey: VivAgentsClient.isEnabledKey)
-                        UserDefaults.standard.set(false, forKey: VivAgentsClient.isVerifiedKey)
-                        connectionTestResult = nil
-                        healthResponse = nil
-                        VivAgentsClient.clearAvailability()
-                        aiService.refreshConnectedProviders()
+                        hasUnsavedChanges = true
                     }
                 }
             ))
@@ -272,6 +278,21 @@ struct CLIServerConfigurationView: View {
     }
 
     // MARK: - Actions
+
+    private func saveSettings() {
+        UserDefaults.standard.set(isServerEnabled, forKey: VivAgentsClient.isEnabledKey)
+
+        if !isServerEnabled {
+            UserDefaults.standard.set(false, forKey: VivAgentsClient.isVerifiedKey)
+            connectionTestResult = nil
+            healthResponse = nil
+            VivAgentsClient.clearAvailability()
+        }
+
+        aiService.refreshConnectedProviders()
+        hasUnsavedChanges = false
+        HapticManager.success()
+    }
 
     private func saveAndTestConnection() {
         UserDefaults.standard.set(serverURL, forKey: VivAgentsClient.serverURLKey)

--- a/VivaDicta/Views/SettingsScreen/CLIServerConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/CLIServerConfigurationView.swift
@@ -30,7 +30,7 @@ struct CLIServerConfigurationView: View {
                         .font(.system(size: 48))
                         .foregroundStyle(.blue.gradient)
 
-                    Text("CLI Agents Server")
+                    Text("VivAgents Server")
                         .font(.title2)
 
                     if isServerEnabled && VivAgentsClient.isVerified {
@@ -62,7 +62,7 @@ struct CLIServerConfigurationView: View {
         .onTapGesture {
             UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
         }
-        .navigationTitle("CLI Agents Server")
+        .navigationTitle("VivAgents Server")
         .navigationBarTitleDisplayMode(.inline)
         .task {
             // Re-fetch health on appear if server is connected
@@ -96,7 +96,7 @@ struct CLIServerConfigurationView: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
-            Toggle("Enable CLI Server", isOn: Binding(
+            Toggle("Enable VivAgents Server", isOn: Binding(
                 get: { isServerEnabled },
                 set: { newValue in
                     if newValue {
@@ -259,7 +259,7 @@ struct CLIServerConfigurationView: View {
                 .font(.subheadline.bold())
                 .foregroundStyle(.secondary)
 
-            Text("The CLI Agents Server hosts CLI agents (Claude, Codex, Gemini) and exposes them over the network. Your iPhone or iPad connects to it and routes AI requests through the agents — using your existing subscriptions with no API keys needed.")
+            Text("The VivAgents Server hosts CLI agents (Claude, Codex, Gemini) and exposes them over the network. Your iPhone or iPad connects to it and routes AI requests through the agents — using your existing subscriptions with no API keys needed.")
                 .font(.caption)
                 .foregroundStyle(.tertiary)
         }

--- a/VivaDicta/Views/SettingsScreen/GeminiConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/GeminiConfigurationView.swift
@@ -315,7 +315,7 @@ struct GeminiConfigurationView: View {
                 .foregroundStyle(.secondary)
 
             HStack(spacing: 6) {
-                Text("CLI Server")
+                Text("VivAgents")
                     .font(.caption.bold())
                     .padding(.horizontal, 8)
                     .padding(.vertical, 4)
@@ -358,7 +358,7 @@ struct GeminiConfigurationView: View {
 
     private var geminiConnectionLabel: String {
         if VivAgentsClient.isEnabled && VivAgentsClient.isVerified {
-            return "CLI Server Connected"
+            return "VivAgents Server Connected"
         } else if aiService.isGeminiSignedIn {
             return "Google Connected"
         } else {
@@ -387,14 +387,14 @@ struct GeminiConfigurationView: View {
                     }
                 }
             } else {
-                Text("Use your Gemini CLI subscription via the CLI Agents Server. No API key needed.")
+                Text("Use your Gemini CLI subscription via the VivAgents Server. No API key needed.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
 
                 NavigationLink {
                     CLIServerConfigurationView(aiService: aiService)
                 } label: {
-                    Text("Configure CLI Agents Server")
+                    Text("Configure VivAgents Server")
                         .font(.callout)
                 }
             }

--- a/VivaDicta/Views/SettingsScreen/OpenAIConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/OpenAIConfigurationView.swift
@@ -315,7 +315,7 @@ struct OpenAIConfigurationView: View {
                 .foregroundStyle(.secondary)
 
             HStack(spacing: 6) {
-                Text("CLI Server")
+                Text("VivAgents")
                     .font(.caption.bold())
                     .padding(.horizontal, 8)
                     .padding(.vertical, 4)
@@ -358,7 +358,7 @@ struct OpenAIConfigurationView: View {
 
     private var openAIConnectionLabel: String {
         if VivAgentsClient.isEnabled && VivAgentsClient.isVerified {
-            return "CLI Server Connected"
+            return "VivAgents Server Connected"
         } else if aiService.isChatGPTSignedIn {
             return "ChatGPT Connected"
         } else {
@@ -387,14 +387,14 @@ struct OpenAIConfigurationView: View {
                     }
                 }
             } else {
-                Text("Use your OpenAI Codex CLI subscription via the CLI Agents Server. No API key needed.")
+                Text("Use your OpenAI Codex CLI subscription via the VivAgents Server. No API key needed.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
 
                 NavigationLink {
                     CLIServerConfigurationView(aiService: aiService)
                 } label: {
-                    Text("Configure CLI Agents Server")
+                    Text("Configure VivAgents Server")
                         .font(.callout)
                 }
             }


### PR DESCRIPTION
## Summary
- Rename all user-facing "CLI Agents Server" / "CLI Server" strings to "VivAgents Server"
- Applies to settings headers, fallback chain labels, toggle labels, status text, and descriptions
- Internal variable names and UserDefaults/keychain keys unchanged

## Test plan
- [ ] Verify settings screens show "VivAgents Server" everywhere
- [ ] Verify fallback chain labels say "VivAgents" not "CLI Server"
- [ ] Verify toggle says "Enable VivAgents Server"