### PR TITLE
Reorder fallback chain to OAuth-first, move VivAgents to bottom, add preset haptics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ All skills live in `.claude/skills/`. Use `/create-skill` to create new ones whe
 ## Git Commit & PR Guidelines
 - NEVER commit and push without asking the user first - always ask "do we need to commit and push at the moment?" before executing git commit or git push commands
 - When user asks to commit/push, ALWAYS run `git status` first instead of relying on chat context — files may have been modified externally
-- When opening a PR, immediately post a comment with "@claude please review this PR" to request a review — do this by default. Skip only if the user explicitly says not to request a review. After requesting the review, start polling PR comments every 1 minute (using `/loop 1m`) to fetch Claude's review. Stop polling once the full review is received and show it to the user.
+- When opening a PR, immediately post a comment with "@claude please review this PR" to request a review — do this by default. Skip only if the user explicitly says not to request a review. After requesting the review, start polling PR comments every 2 minutes (using `/loop 2m`) to fetch Claude's review. Stop polling once the full review is received and show it to the user.
 
 ## Build Commands
 

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -852,54 +852,6 @@ class AIService {
         // Use pre-formatted text if provided (variation mode), otherwise format using selected mode's preset
         let formattedText = preFormattedUserMessage ?? formatTranscriptForLLM(text)
 
-        // Codex CLI via Mac server: route OpenAI requests through CLI server when enabled
-        if aiProvider == .openAI && VivAgentsClient.isEnabled && VivAgentsClient.isCodexCliActive,
-           let serverURL = VivAgentsClient.serverURL, !serverURL.isEmpty {
-            lastSystemMessageSent = resolvedSystemMessage
-            lastUserMessageSent = formattedText
-            logger.logDebug("AI Processing - Using Codex CLI Server at \(serverURL)")
-            do {
-                let result = try await VivAgentsClient.enhance(
-                    text: formattedText,
-                    systemPrompt: resolvedSystemMessage,
-                    model: selectedMode.aiModel,
-                    provider: "codex"
-                )
-                let filteredResult = AIEnhancementOutputFilter.filter(result.trimmingCharacters(in: .whitespacesAndNewlines))
-                return filteredResult
-            } catch {
-                if isChatGPTSignedIn || self.getAPIKey(for: aiProvider) != nil {
-                    logger.logWarning("Codex CLI Server failed, falling back: \(error.localizedDescription)")
-                } else {
-                    throw EnhancementError.customError(error.localizedDescription)
-                }
-            }
-        }
-
-        // Gemini CLI via Mac server: route Gemini requests through CLI server when enabled
-        if aiProvider == .gemini && VivAgentsClient.isEnabled && VivAgentsClient.isGeminiCliActive,
-           let serverURL = VivAgentsClient.serverURL, !serverURL.isEmpty {
-            lastSystemMessageSent = resolvedSystemMessage
-            lastUserMessageSent = formattedText
-            logger.logDebug("AI Processing - Using Gemini CLI Server at \(serverURL)")
-            do {
-                let result = try await VivAgentsClient.enhance(
-                    text: formattedText,
-                    systemPrompt: resolvedSystemMessage,
-                    model: selectedMode.aiModel,
-                    provider: "gemini"
-                )
-                let filteredResult = AIEnhancementOutputFilter.filter(result.trimmingCharacters(in: .whitespacesAndNewlines))
-                return filteredResult
-            } catch {
-                if isGeminiSignedIn || self.getAPIKey(for: aiProvider) != nil {
-                    logger.logWarning("Gemini CLI Server failed, falling back: \(error.localizedDescription)")
-                } else {
-                    throw EnhancementError.customError(error.localizedDescription)
-                }
-            }
-        }
-
         // ChatGPT OAuth: route OpenAI requests through ChatGPT backend API when signed in
         if aiProvider == .openAI && isChatGPTSignedIn {
             lastSystemMessageSent = resolvedSystemMessage
@@ -917,9 +869,9 @@ class AIService {
                 )
                 return AIEnhancementOutputFilter.filter(result)
             } catch let error as OAuthError {
-                // If OAuth fails and we have an API key, fall through to standard path
-                if self.getAPIKey(for: aiProvider) != nil {
-                    logger.logWarning("ChatGPT OAuth failed, falling back to API key: \(error.localizedDescription)")
+                // If OAuth fails, fall through to CLI or API key
+                if (VivAgentsClient.isEnabled && VivAgentsClient.isCodexCliActive) || self.getAPIKey(for: aiProvider) != nil {
+                    logger.logWarning("ChatGPT OAuth failed, falling back: \(error.localizedDescription)")
                 } else {
                     throw EnhancementError.customError(error.errorDescription ?? "ChatGPT OAuth error")
                 }
@@ -946,11 +898,59 @@ class AIService {
                 // Rate limit etc. — don't fall through, surface directly
                 throw error
             } catch let error as OAuthError {
-                // If OAuth fails and we have an API key, fall through to standard path
-                if self.getAPIKey(for: aiProvider) != nil {
-                    logger.logWarning("Gemini OAuth failed, falling back to API key: \(error.localizedDescription)")
+                // If OAuth fails, fall through to CLI or API key
+                if (VivAgentsClient.isEnabled && VivAgentsClient.isGeminiCliActive) || self.getAPIKey(for: aiProvider) != nil {
+                    logger.logWarning("Gemini OAuth failed, falling back: \(error.localizedDescription)")
                 } else {
                     throw EnhancementError.customError(error.errorDescription ?? "Gemini OAuth error")
+                }
+            }
+        }
+
+        // Codex CLI via Mac server: route OpenAI requests through CLI server when enabled
+        if aiProvider == .openAI && VivAgentsClient.isEnabled && VivAgentsClient.isCodexCliActive,
+           let serverURL = VivAgentsClient.serverURL, !serverURL.isEmpty {
+            lastSystemMessageSent = resolvedSystemMessage
+            lastUserMessageSent = formattedText
+            logger.logDebug("AI Processing - Using Codex CLI Server at \(serverURL)")
+            do {
+                let result = try await VivAgentsClient.enhance(
+                    text: formattedText,
+                    systemPrompt: resolvedSystemMessage,
+                    model: selectedMode.aiModel,
+                    provider: "codex"
+                )
+                let filteredResult = AIEnhancementOutputFilter.filter(result.trimmingCharacters(in: .whitespacesAndNewlines))
+                return filteredResult
+            } catch {
+                if self.getAPIKey(for: aiProvider) != nil {
+                    logger.logWarning("Codex CLI Server failed, falling back to API key: \(error.localizedDescription)")
+                } else {
+                    throw EnhancementError.customError(error.localizedDescription)
+                }
+            }
+        }
+
+        // Gemini CLI via Mac server: route Gemini requests through CLI server when enabled
+        if aiProvider == .gemini && VivAgentsClient.isEnabled && VivAgentsClient.isGeminiCliActive,
+           let serverURL = VivAgentsClient.serverURL, !serverURL.isEmpty {
+            lastSystemMessageSent = resolvedSystemMessage
+            lastUserMessageSent = formattedText
+            logger.logDebug("AI Processing - Using Gemini CLI Server at \(serverURL)")
+            do {
+                let result = try await VivAgentsClient.enhance(
+                    text: formattedText,
+                    systemPrompt: resolvedSystemMessage,
+                    model: selectedMode.aiModel,
+                    provider: "gemini"
+                )
+                let filteredResult = AIEnhancementOutputFilter.filter(result.trimmingCharacters(in: .whitespacesAndNewlines))
+                return filteredResult
+            } catch {
+                if self.getAPIKey(for: aiProvider) != nil {
+                    logger.logWarning("Gemini CLI Server failed, falling back to API key: \(error.localizedDescription)")
+                } else {
+                    throw EnhancementError.customError(error.localizedDescription)
                 }
             }
         }

--- a/VivaDicta/Views/Components/CategoryChipsView.swift
+++ b/VivaDicta/Views/Components/CategoryChipsView.swift
@@ -49,7 +49,10 @@ private struct CategoryChip: View {
     let action: () -> Void
 
     var body: some View {
-        Button(action: action) {
+        Button {
+            HapticManager.selectionChanged()
+            action()
+        } label: {
             HStack(spacing: 4) {
                 if let icon {
                     Image(systemName: icon)

--- a/VivaDicta/Views/SettingsScreen/AIProvidersView.swift
+++ b/VivaDicta/Views/SettingsScreen/AIProvidersView.swift
@@ -41,46 +41,6 @@ struct AIProviders: View {
                 }
             }
 
-            // VivAgents Server Section
-            Section {
-                NavigationLink {
-                    CLIServerConfigurationView(aiService: appState.aiService)
-                } label: {
-                    HStack(spacing: 12) {
-                        Image(systemName: "server.rack")
-                            .font(.title2)
-                            .foregroundStyle(.blue.gradient)
-                            .frame(width: 28, height: 28)
-
-                        Text("VivAgents Server")
-
-                        Spacer()
-
-                        if VivAgentsClient.isEnabled && VivAgentsClient.isVerified {
-                            HStack(spacing: 4) {
-                                Image(systemName: "checkmark.circle.fill")
-                                    .foregroundStyle(.green)
-                                Text("Connected")
-                                    .font(.subheadline)
-                                    .foregroundStyle(.secondary)
-                            }
-                        } else {
-                            HStack(spacing: 4) {
-                                Image(systemName: "gear")
-                                    .foregroundStyle(.orange)
-                                Text("Configure")
-                                    .font(.subheadline)
-                                    .foregroundStyle(.secondary)
-                            }
-                        }
-                    }
-                }
-            } header: {
-                Text("Server")
-            } footer: {
-                Text("Route AI processing through CLI agents (Claude, Codex, Gemini) running on your Mac or remote server. Uses your existing subscriptions — no API keys needed.")
-            }
-
             // Cloud Section
             Section("Cloud") {
                 ForEach(AIProvider.cloudProviders) { provider in
@@ -144,6 +104,22 @@ struct AIProviders: View {
                                             .foregroundStyle(.secondary)
                                     }
                                 }
+                            } else if provider == .openAI && appState.aiService.isChatGPTSignedIn {
+                                HStack(spacing: 4) {
+                                    Image(systemName: "checkmark.circle.fill")
+                                        .foregroundStyle(.green)
+                                    Text("ChatGPT")
+                                        .font(.subheadline)
+                                        .foregroundStyle(.secondary)
+                                }
+                            } else if provider == .gemini && appState.aiService.isGeminiSignedIn {
+                                HStack(spacing: 4) {
+                                    Image(systemName: "checkmark.circle.fill")
+                                        .foregroundStyle(.green)
+                                    Text("Google")
+                                        .font(.subheadline)
+                                        .foregroundStyle(.secondary)
+                                }
                             } else if provider == .anthropic && VivAgentsClient.isEnabled && VivAgentsClient.isClaudeCliActive {
                                 HStack(spacing: 4) {
                                     Image(systemName: "checkmark.circle.fill")
@@ -165,22 +141,6 @@ struct AIProviders: View {
                                     Image(systemName: "checkmark.circle.fill")
                                         .foregroundStyle(.green)
                                     Text("VivAgents")
-                                        .font(.subheadline)
-                                        .foregroundStyle(.secondary)
-                                }
-                            } else if provider == .openAI && appState.aiService.isChatGPTSignedIn {
-                                HStack(spacing: 4) {
-                                    Image(systemName: "checkmark.circle.fill")
-                                        .foregroundStyle(.green)
-                                    Text("OAuth")
-                                        .font(.subheadline)
-                                        .foregroundStyle(.secondary)
-                                }
-                            } else if provider == .gemini && appState.aiService.isGeminiSignedIn {
-                                HStack(spacing: 4) {
-                                    Image(systemName: "checkmark.circle.fill")
-                                        .foregroundStyle(.green)
-                                    Text("OAuth")
                                         .font(.subheadline)
                                         .foregroundStyle(.secondary)
                                 }
@@ -224,6 +184,46 @@ struct AIProviders: View {
                         }
                     }
                 }
+            }
+
+            // VivAgents Server Section
+            Section {
+                NavigationLink {
+                    CLIServerConfigurationView(aiService: appState.aiService)
+                } label: {
+                    HStack(spacing: 12) {
+                        Image(systemName: "server.rack")
+                            .font(.title2)
+                            .foregroundStyle(.blue.gradient)
+                            .frame(width: 28, height: 28)
+
+                        Text("VivAgents Server")
+
+                        Spacer()
+
+                        if VivAgentsClient.isEnabled && VivAgentsClient.isVerified {
+                            HStack(spacing: 4) {
+                                Image(systemName: "checkmark.circle.fill")
+                                    .foregroundStyle(.green)
+                                Text("Connected")
+                                    .font(.subheadline)
+                                    .foregroundStyle(.secondary)
+                            }
+                        } else {
+                            HStack(spacing: 4) {
+                                Image(systemName: "gear")
+                                    .foregroundStyle(.orange)
+                                Text("Configure")
+                                    .font(.subheadline)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                }
+            } header: {
+                Text("Server")
+            } footer: {
+                Text("Route AI processing through CLI agents (Claude, Codex, Gemini) running on your Mac or remote server. Uses your existing subscriptions — no API keys needed.")
             }
         }
         .id(refreshID)

--- a/VivaDicta/Views/SettingsScreen/GeminiConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/GeminiConfigurationView.swift
@@ -328,7 +328,7 @@ struct GeminiConfigurationView: View {
                     .font(.caption.bold())
                     .padding(.horizontal, 8)
                     .padding(.vertical, 4)
-                    .background(VivAgentsClient.isEnabled && VivAgentsClient.isVerified ? Color.green.opacity(0.15) : Color.secondary.opacity(0.1))
+                    .background(VivAgentsClient.isEnabled && VivAgentsClient.isGeminiCliActive ? Color.green.opacity(0.15) : Color.secondary.opacity(0.1))
                     .clipShape(.capsule)
                 Image(systemName: "chevron.right")
                     .font(.caption2)
@@ -359,7 +359,7 @@ struct GeminiConfigurationView: View {
     private var geminiConnectionLabel: String {
         if aiService.isGeminiSignedIn {
             return "Google Connected"
-        } else if VivAgentsClient.isEnabled && VivAgentsClient.isVerified {
+        } else if VivAgentsClient.isEnabled && VivAgentsClient.isGeminiCliActive {
             return "VivAgents Server Connected"
         } else {
             return "API Key Configured"

--- a/VivaDicta/Views/SettingsScreen/GeminiConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/GeminiConfigurationView.swift
@@ -45,11 +45,11 @@ struct GeminiConfigurationView: View {
                 }
                 .padding(.top, 8)
 
-                // CLI Server section
-                geminiCLIServerSection
-
                 // Google OAuth section
                 geminiOAuthSection
+
+                // CLI Server section
+                geminiCLIServerSection
 
                 // API Key section
                 apiKeySection
@@ -315,20 +315,20 @@ struct GeminiConfigurationView: View {
                 .foregroundStyle(.secondary)
 
             HStack(spacing: 6) {
-                Text("VivAgents")
-                    .font(.caption.bold())
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 4)
-                    .background(VivAgentsClient.isEnabled && VivAgentsClient.isVerified ? Color.green.opacity(0.15) : Color.secondary.opacity(0.1))
-                    .clipShape(.capsule)
-                Image(systemName: "chevron.right")
-                    .font(.caption2)
-                    .foregroundStyle(.tertiary)
                 Text("Google")
                     .font(.caption.bold())
                     .padding(.horizontal, 8)
                     .padding(.vertical, 4)
                     .background(aiService.isGeminiSignedIn ? Color.green.opacity(0.15) : Color.secondary.opacity(0.1))
+                    .clipShape(.capsule)
+                Image(systemName: "chevron.right")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                Text("VivAgents")
+                    .font(.caption.bold())
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(VivAgentsClient.isEnabled && VivAgentsClient.isVerified ? Color.green.opacity(0.15) : Color.secondary.opacity(0.1))
                     .clipShape(.capsule)
                 Image(systemName: "chevron.right")
                     .font(.caption2)
@@ -357,10 +357,10 @@ struct GeminiConfigurationView: View {
     // MARK: - CLI Server Section
 
     private var geminiConnectionLabel: String {
-        if VivAgentsClient.isEnabled && VivAgentsClient.isVerified {
-            return "VivAgents Server Connected"
-        } else if aiService.isGeminiSignedIn {
+        if aiService.isGeminiSignedIn {
             return "Google Connected"
+        } else if VivAgentsClient.isEnabled && VivAgentsClient.isVerified {
+            return "VivAgents Server Connected"
         } else {
             return "API Key Configured"
         }

--- a/VivaDicta/Views/SettingsScreen/OpenAIConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/OpenAIConfigurationView.swift
@@ -45,11 +45,11 @@ struct OpenAIConfigurationView: View {
                 }
                 .padding(.top, 8)
 
-                // CLI Server section
-                cliServerSection
-
                 // ChatGPT OAuth section
                 chatGPTSection
+
+                // CLI Server section
+                cliServerSection
 
                 // API Key section
                 apiKeySection
@@ -315,20 +315,20 @@ struct OpenAIConfigurationView: View {
                 .foregroundStyle(.secondary)
 
             HStack(spacing: 6) {
-                Text("VivAgents")
-                    .font(.caption.bold())
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 4)
-                    .background(VivAgentsClient.isEnabled && VivAgentsClient.isVerified ? Color.green.opacity(0.15) : Color.secondary.opacity(0.1))
-                    .clipShape(.capsule)
-                Image(systemName: "chevron.right")
-                    .font(.caption2)
-                    .foregroundStyle(.tertiary)
                 Text("ChatGPT")
                     .font(.caption.bold())
                     .padding(.horizontal, 8)
                     .padding(.vertical, 4)
                     .background(aiService.isChatGPTSignedIn ? Color.green.opacity(0.15) : Color.secondary.opacity(0.1))
+                    .clipShape(.capsule)
+                Image(systemName: "chevron.right")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                Text("VivAgents")
+                    .font(.caption.bold())
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(VivAgentsClient.isEnabled && VivAgentsClient.isVerified ? Color.green.opacity(0.15) : Color.secondary.opacity(0.1))
                     .clipShape(.capsule)
                 Image(systemName: "chevron.right")
                     .font(.caption2)
@@ -357,10 +357,10 @@ struct OpenAIConfigurationView: View {
     // MARK: - CLI Server Section
 
     private var openAIConnectionLabel: String {
-        if VivAgentsClient.isEnabled && VivAgentsClient.isVerified {
-            return "VivAgents Server Connected"
-        } else if aiService.isChatGPTSignedIn {
+        if aiService.isChatGPTSignedIn {
             return "ChatGPT Connected"
+        } else if VivAgentsClient.isEnabled && VivAgentsClient.isVerified {
+            return "VivAgents Server Connected"
         } else {
             return "API Key Configured"
         }

--- a/VivaDicta/Views/SettingsScreen/OpenAIConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/OpenAIConfigurationView.swift
@@ -328,7 +328,7 @@ struct OpenAIConfigurationView: View {
                     .font(.caption.bold())
                     .padding(.horizontal, 8)
                     .padding(.vertical, 4)
-                    .background(VivAgentsClient.isEnabled && VivAgentsClient.isVerified ? Color.green.opacity(0.15) : Color.secondary.opacity(0.1))
+                    .background(VivAgentsClient.isEnabled && VivAgentsClient.isCodexCliActive ? Color.green.opacity(0.15) : Color.secondary.opacity(0.1))
                     .clipShape(.capsule)
                 Image(systemName: "chevron.right")
                     .font(.caption2)
@@ -359,7 +359,7 @@ struct OpenAIConfigurationView: View {
     private var openAIConnectionLabel: String {
         if aiService.isChatGPTSignedIn {
             return "ChatGPT Connected"
-        } else if VivAgentsClient.isEnabled && VivAgentsClient.isVerified {
+        } else if VivAgentsClient.isEnabled && VivAgentsClient.isCodexCliActive {
             return "VivAgents Server Connected"
         } else {
             return "API Key Configured"

--- a/VivaDicta/Views/SettingsScreen/Presets/PresetFormView.swift
+++ b/VivaDicta/Views/SettingsScreen/Presets/PresetFormView.swift
@@ -156,6 +156,7 @@ struct PresetFormView: View {
             if !isCreateMode, let preset = existingPreset {
                 ToolbarItem(placement: .principal) {
                     Button {
+                        HapticManager.lightImpact()
                         presetManager.toggleFavorite(presetId: preset.id)
                     } label: {
                         Image(systemName: presetManager.preset(for: preset.id)?.isFavorite == true ? "heart.fill" : "heart")

--- a/VivaDicta/Views/SettingsScreen/Presets/PresetSettings.swift
+++ b/VivaDicta/Views/SettingsScreen/Presets/PresetSettings.swift
@@ -118,6 +118,7 @@ struct PresetSettings: View {
         }
         .searchable(text: $searchText, prompt: "Search presets")
         .onChange(of: filter) { _, _ in
+            HapticManager.selectionChanged()
             selectedCategory = nil
         }
         .onChange(of: presetManager.hasFavorites) {
@@ -130,6 +131,7 @@ struct PresetSettings: View {
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
                 Button("Add Preset", systemImage: "plus") {
+                    HapticManager.mediumImpact()
                     showCreatePreset = true
                 }
             }
@@ -194,6 +196,7 @@ private struct PresetRowView: View {
 
             if let onToggleFavorite {
                 Button {
+                    HapticManager.lightImpact()
                     onToggleFavorite()
                 } label: {
                     Image(systemName: preset.isFavorite ? "heart.fill" : "heart")


### PR DESCRIPTION
## Summary
- Reorder provider fallback chain from CLI → OAuth → API Key to **OAuth → CLI → API Key** for OpenAI and Gemini (both logic in `AIService.makeRequest()` and UI)
- Update fallback chain labels, section order, and connection label priority in OpenAI/Gemini configuration views
- Move VivAgents Server section to bottom of AI Providers list (less confusing for most users)
- Update provider status labels in list to show OAuth status (ChatGPT/Google) before VivAgents
- Add haptic feedback to AI Presets screen: segment control, category chips, heart/favorite buttons (list + detail), and add preset button

## Test plan
- [ ] Verify OAuth is attempted before CLI for OpenAI and Gemini providers
- [ ] Verify fallback chain UI shows correct order (ChatGPT > VivAgents > API Key, Google > VivAgents > API Key)
- [ ] Verify VivAgents Server section appears at bottom of AI Providers list
- [ ] Verify haptics fire on segment control change, chip selection, heart toggle, and + button in AI Presets