### PR TITLE
Keyboard AI processing: preset picker with VivaMode selector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,5 @@ internal/
 
 settings.local.json
 skills-lock.json
+
+.trees/

--- a/VivaDicta.xcodeproj/project.pbxproj
+++ b/VivaDicta.xcodeproj/project.pbxproj
@@ -225,6 +225,7 @@
 		18E1C8232E8EE47200BE8A11 /* Exceptions for "VivaDicta" folder in "VivaDictaKeyboard" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
+				Assets.xcassets,
 				"Extensions/FileManager+Directories.swift",
 				"GoogleService-Info.plist",
 				Models/CloudModel.swift,
@@ -815,8 +816,8 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				EAGER_LINKING = YES;
 				DEVELOPMENT_TEAM = TDX2FNZ56U;
+				EAGER_LINKING = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;

--- a/VivaDicta/Models/PresetCatalog.swift
+++ b/VivaDicta/Models/PresetCatalog.swift
@@ -943,7 +943,7 @@ enum PresetCatalog {
             return builtIn.name
         }
         // Look up custom preset name from shared UserDefaults
-        if let data = UserDefaultsStorage.shared.data(forKey: "Presets_v1"),
+        if let data = UserDefaultsStorage.shared.data(forKey: UserDefaultsStorage.SharedKeys.presets),
            let presets = try? JSONDecoder().decode([Preset].self, from: data),
            let preset = presets.first(where: { $0.id == presetId }) {
             return preset.name

--- a/VivaDicta/Services/PresetManager.swift
+++ b/VivaDicta/Services/PresetManager.swift
@@ -31,7 +31,7 @@ class PresetManager {
     var syncService: PresetSyncService?
 
     init(userDefaults: UserDefaults = UserDefaultsStorage.shared,
-         storageKey: String = "Presets_v1") {
+         storageKey: String = UserDefaultsStorage.SharedKeys.presets) {
         self.userDefaults = userDefaults
         self.storageKey = storageKey
         loadPresets()

--- a/VivaDicta/Shared/AppGroupCoordinator.swift
+++ b/VivaDicta/Shared/AppGroupCoordinator.swift
@@ -88,6 +88,7 @@ public final class AppGroupCoordinator {
         // Text processing (keyboard rewrite feature)
         static let textProcessingInput = "textProcessingInput"
         static let textProcessingModeName = "textProcessingModeName"
+        static let textProcessingPresetId = "textProcessingPresetId"
         static let textProcessingResult = "textProcessingResult"
         static let textProcessingErrorMessage = "textProcessingErrorMessage"
     }
@@ -188,6 +189,7 @@ public final class AppGroupCoordinator {
         // Clear stale text processing state
         sharedDefaults?.removeObject(forKey: UserDefaultsKeys.textProcessingInput)
         sharedDefaults?.removeObject(forKey: UserDefaultsKeys.textProcessingModeName)
+        sharedDefaults?.removeObject(forKey: UserDefaultsKeys.textProcessingPresetId)
         sharedDefaults?.removeObject(forKey: UserDefaultsKeys.textProcessingResult)
         sharedDefaults?.removeObject(forKey: UserDefaultsKeys.textProcessingErrorMessage)
 
@@ -337,26 +339,33 @@ public final class AppGroupCoordinator {
 
     // MARK: - Text Processing (Keyboard Rewrite)
 
-    /// Sends text and mode name from the keyboard extension to the main app for AI processing.
-    public func requestTextProcessing(text: String, modeName: String) {
+    /// Sends text, mode name, and optional preset ID from the keyboard extension to the main app for AI processing.
+    public func requestTextProcessing(text: String, modeName: String, presetId: String? = nil) {
         sharedDefaults?.set(text, forKey: UserDefaultsKeys.textProcessingInput)
         sharedDefaults?.set(modeName, forKey: UserDefaultsKeys.textProcessingModeName)
+        if let presetId {
+            sharedDefaults?.set(presetId, forKey: UserDefaultsKeys.textProcessingPresetId)
+        } else {
+            sharedDefaults?.removeObject(forKey: UserDefaultsKeys.textProcessingPresetId)
+        }
         sharedDefaults?.synchronize()
         postDarwinNotification(NotificationNames.requestTextProcessing)
-        logger.logError("📝 Keyboard requested text processing with mode: \(modeName), text length: \(text.count)")
+        logger.logError("📝 Keyboard requested text processing with mode: \(modeName), preset: \(presetId ?? "nil"), text length: \(text.count)")
     }
 
     /// Retrieves and clears the pending text processing request (called by main app).
-    func getAndConsumePendingTextProcessing() -> (text: String, modeName: String)? {
+    func getAndConsumePendingTextProcessing() -> (text: String, modeName: String, presetId: String?)? {
         guard let defaults = sharedDefaults,
               let text = defaults.string(forKey: UserDefaultsKeys.textProcessingInput),
               let modeName = defaults.string(forKey: UserDefaultsKeys.textProcessingModeName),
               !text.isEmpty else {
             return nil
         }
+        let presetId = defaults.string(forKey: UserDefaultsKeys.textProcessingPresetId)
         defaults.removeObject(forKey: UserDefaultsKeys.textProcessingInput)
         defaults.removeObject(forKey: UserDefaultsKeys.textProcessingModeName)
-        return (text, modeName)
+        defaults.removeObject(forKey: UserDefaultsKeys.textProcessingPresetId)
+        return (text, modeName, presetId)
     }
 
     /// Shares the AI-processed text result back to the keyboard extension (called by main app).

--- a/VivaDicta/Shared/AppGroupCoordinator.swift
+++ b/VivaDicta/Shared/AppGroupCoordinator.swift
@@ -1049,15 +1049,19 @@ public final class AppGroupCoordinator {
 
     nonisolated private func handleTextProcessingCompletedNotification() {
         Task { @MainActor in
+            // Only consume the result if a callback is set — prevents the main app
+            // from racing with the keyboard extension and deleting the result first.
+            guard let callback = onTextProcessingCompleted else { return }
             let text = await getAndConsumeTextProcessingResult() ?? ""
-            await onTextProcessingCompleted?(text)
+            callback(text)
         }
     }
 
     nonisolated private func handleTextProcessingErrorNotification() {
         Task { @MainActor in
+            guard let callback = onTextProcessingError else { return }
             let message = await getAndConsumeTextProcessingError() ?? "Text processing failed"
-            await onTextProcessingError?(message)
+            callback(message)
         }
     }
 }

--- a/VivaDicta/Shared/UserDefaultsStorage.swift
+++ b/VivaDicta/Shared/UserDefaultsStorage.swift
@@ -21,6 +21,12 @@ enum UserDefaultsStorage {
         UserDefaults.standard
     }
 
+    // MARK: - Shared Keys (used by main app + extensions)
+
+    enum SharedKeys {
+        static let presets = "Presets_v1"
+    }
+
     // MARK: - App-Private Keys
 
     enum Keys {

--- a/VivaDicta/Views/RecordViewModel.swift
+++ b/VivaDicta/Views/RecordViewModel.swift
@@ -897,7 +897,7 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
             return
         }
 
-        logger.logInfo("📝 Processing text from keyboard with mode: \(pending.modeName), text length: \(pending.text.count)")
+        logger.logInfo("📝 Processing text from keyboard with mode: \(pending.modeName), preset: \(pending.presetId ?? "nil"), text length: \(pending.text.count)")
 
         // Extend session while processing (same pattern as recording flow)
         let timeoutSeconds = AudioPrewarmManager.shared.audioSessionTimeout
@@ -911,7 +911,16 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
         Task {
             defer { appState.aiService.selectedMode = previousMode }
             do {
-                let (result, _, _) = try await appState.aiService.enhance(pending.text)
+                let result: String
+                // If a preset ID is specified, use generateVariation with that preset
+                if let presetId = pending.presetId,
+                   let preset = appState.aiService.presetManager?.preset(for: presetId) {
+                    let (text, _) = try await appState.aiService.generateVariation(text: pending.text, preset: preset)
+                    result = text
+                } else {
+                    let (text, _, _) = try await appState.aiService.enhance(pending.text)
+                    result = text
+                }
                 logger.logInfo("📝 Text processing completed, result length: \(result.count)")
                 if result.isEmpty {
                     logger.logError("📝 Text processing returned empty result")

--- a/VivaDictaKeyboard/KeyboardCustomView.swift
+++ b/VivaDictaKeyboard/KeyboardCustomView.swift
@@ -60,11 +60,12 @@ struct KeyboardCustomView: View {
                     )
                 } else if dictationState.activeTab == .textProcessing {
                     RewriteModesView(
-                        onModeSelected: { mode in
+                        onPresetSelected: { mode, presetId in
                             guard let vc = keyboardVC else { return }
                             vc.textProcessor.processText(
                                 proxy: vc.textDocumentProxy,
                                 mode: mode,
+                                presetId: presetId,
                                 dictationState: dictationState
                             )
                         },

--- a/VivaDictaKeyboard/Models/KeyboardPresetLoader.swift
+++ b/VivaDictaKeyboard/Models/KeyboardPresetLoader.swift
@@ -1,0 +1,25 @@
+//
+//  KeyboardPresetLoader.swift
+//  VivaDictaKeyboard
+//
+//  Created by Anton Novoselov on 2026.03.29
+//
+
+import Foundation
+
+/// Loads presets from shared App Group UserDefaults for display in the keyboard extension.
+///
+/// The keyboard doesn't have access to `PresetManager`, but `Preset` and `PresetCatalog`
+/// are available via target membership. This loader reads the persisted preset array directly.
+enum KeyboardPresetLoader {
+    private static let storageKey = "Presets_v1"
+
+    /// Loads all presets from shared UserDefaults.
+    static func loadPresets() -> [Preset] {
+        guard let defaults = UserDefaults(suiteName: AppGroupCoordinator.shared.appGroupId),
+              let data = defaults.data(forKey: storageKey) else {
+            return []
+        }
+        return (try? JSONDecoder().decode([Preset].self, from: data)) ?? []
+    }
+}

--- a/VivaDictaKeyboard/Models/KeyboardPresetLoader.swift
+++ b/VivaDictaKeyboard/Models/KeyboardPresetLoader.swift
@@ -12,7 +12,7 @@ import Foundation
 /// The keyboard doesn't have access to `PresetManager`, but `Preset` and `PresetCatalog`
 /// are available via target membership. This loader reads the persisted preset array directly.
 enum KeyboardPresetLoader {
-    private static let storageKey = "Presets_v1"
+    private static let storageKey = UserDefaultsStorage.SharedKeys.presets
 
     /// Loads all presets from shared UserDefaults.
     static func loadPresets() -> [Preset] {

--- a/VivaDictaKeyboard/Services/KeyboardTextProcessor.swift
+++ b/VivaDictaKeyboard/Services/KeyboardTextProcessor.swift
@@ -22,13 +22,14 @@ final class KeyboardTextProcessor {
     private var resultContinuation: CheckedContinuation<String, Error>?
     private var isProcessing = false
 
-    /// Processes text in the host text field using the specified mode.
+    /// Processes text in the host text field using the specified mode and optional preset.
     ///
     /// If text is selected, processes the selection. Otherwise, processes
     /// `documentContextBeforeInput` (text before cursor).
     func processText(
         proxy: UITextDocumentProxy,
         mode: VivaMode,
+        presetId: String? = nil,
         dictationState: KeyboardDictationState
     ) {
         // Prevent double invocation
@@ -44,7 +45,7 @@ final class KeyboardTextProcessor {
         currentTask = Task {
             defer { isProcessing = false }
             do {
-                try await performProcessing(proxy: proxy, mode: mode, dictationState: dictationState)
+                try await performProcessing(proxy: proxy, mode: mode, presetId: presetId, dictationState: dictationState)
             } catch is CancellationError {
                 dictationState.textProcessingPhase = .idle
             } catch {
@@ -67,6 +68,7 @@ final class KeyboardTextProcessor {
     private func performProcessing(
         proxy: UITextDocumentProxy,
         mode: VivaMode,
+        presetId: String? = nil,
         dictationState: KeyboardDictationState
     ) async throws {
         // Phase 1: Read text
@@ -94,7 +96,7 @@ final class KeyboardTextProcessor {
 
         // Phase 2: Send to main app
         dictationState.textProcessingPhase = .sendingToApp
-        logger.logInfo("📝 [TextProcessor] Sending to AI with mode: \(mode.name), text (\(text.count) chars): \(text)")
+        logger.logInfo("📝 [TextProcessor] Sending to AI with mode: \(mode.name), preset: \(presetId ?? "nil"), text (\(text.count) chars): \(text)")
 
         let processedText: String = try await withCheckedThrowingContinuation { continuation in
             self.resultContinuation = continuation
@@ -121,7 +123,7 @@ final class KeyboardTextProcessor {
                 self?.resultContinuation = nil
             }
 
-            AppGroupCoordinator.shared.requestTextProcessing(text: text, modeName: mode.name)
+            AppGroupCoordinator.shared.requestTextProcessing(text: text, modeName: mode.name, presetId: presetId)
             dictationState.textProcessingPhase = .waitingForResult(modeName: mode.name)
         }
 

--- a/VivaDictaKeyboard/Views/RewriteModesView.swift
+++ b/VivaDictaKeyboard/Views/RewriteModesView.swift
@@ -335,28 +335,53 @@ private struct KeyboardCategoryChipsView: View {
                 }
             }
             .padding(.horizontal, 16)
+            .padding(.vertical, 4)
             .contentShape(.rect)
         }
         .scrollIndicators(.hidden)
     }
 
+    @ViewBuilder
     private func chip(title: String, icon: String? = nil, isSelected: Bool, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            HStack(spacing: 4) {
-                if let icon {
-                    Image(systemName: icon)
-                        .font(.system(size: 10))
+        if #available(iOS 26.0, *) {
+            Button(action: action) {
+                HStack(spacing: 4) {
+                    if let icon {
+                        Image(systemName: icon)
+                            .font(.system(size: 10))
+                    }
+                    Text(title)
                 }
-                Text(title)
+                .font(.system(size: 13))
+                .fontWeight(isSelected ? .semibold : .regular)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .foregroundStyle(isSelected ? .white : .primary)
             }
-            .font(.system(size: 13))
-            .fontWeight(isSelected ? .semibold : .regular)
-            .padding(.horizontal, 12)
-            .padding(.vertical, 6)
-            .foregroundStyle(isSelected ? .white : .primary)
-            .background(isSelected ? Color.accentColor : Color(.systemGray5))
-            .clipShape(.capsule)
+            .buttonStyle(.plain)
+            .glassEffect(
+                isSelected
+                ? .regular.tint(Color.pink.opacity(0.6))
+                : .regular.interactive()
+            )
+        } else {
+            Button(action: action) {
+                HStack(spacing: 4) {
+                    if let icon {
+                        Image(systemName: icon)
+                            .font(.system(size: 10))
+                    }
+                    Text(title)
+                }
+                .font(.system(size: 13))
+                .fontWeight(isSelected ? .semibold : .regular)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .foregroundStyle(isSelected ? .white : .primary)
+                .background(isSelected ? Color.accentColor : Color(.systemGray5))
+                .clipShape(.capsule)
+            }
+            .buttonStyle(.plain)
         }
-        .buttonStyle(.plain)
     }
 }

--- a/VivaDictaKeyboard/Views/RewriteModesView.swift
+++ b/VivaDictaKeyboard/Views/RewriteModesView.swift
@@ -170,6 +170,7 @@ struct RewriteModesView: View {
                 .textCase(.uppercase)
                 .padding(.horizontal, 4)
                 .padding(.top, 10)
+                .frame(maxWidth: .infinity, alignment: .leading)
 
             LazyVGrid(columns: gridColumns, spacing: 6) {
                 ForEach(presets) { preset in
@@ -177,6 +178,7 @@ struct RewriteModesView: View {
                 }
             }
         }
+        .background(Color.white.opacity(0.001))
     }
 
     private func presetCell(_ preset: Preset) -> some View {
@@ -333,6 +335,7 @@ private struct KeyboardCategoryChipsView: View {
                 }
             }
             .padding(.horizontal, 16)
+            .contentShape(.rect)
         }
         .scrollIndicators(.hidden)
     }

--- a/VivaDictaKeyboard/Views/RewriteModesView.swift
+++ b/VivaDictaKeyboard/Views/RewriteModesView.swift
@@ -344,7 +344,7 @@ private struct KeyboardCategoryChipsView: View {
     @ViewBuilder
     private func chip(title: String, icon: String? = nil, isSelected: Bool, action: @escaping () -> Void) -> some View {
         if #available(iOS 26.0, *) {
-            Button(action: action) {
+            Button { HapticManager.selectionChanged(); action() } label: {
                 HStack(spacing: 4) {
                     if let icon {
                         Image(systemName: icon)
@@ -365,7 +365,7 @@ private struct KeyboardCategoryChipsView: View {
                 : .regular.interactive()
             )
         } else {
-            Button(action: action) {
+            Button { HapticManager.selectionChanged(); action() } label: {
                 HStack(spacing: 4) {
                     if let icon {
                         Image(systemName: icon)

--- a/VivaDictaKeyboard/Views/RewriteModesView.swift
+++ b/VivaDictaKeyboard/Views/RewriteModesView.swift
@@ -134,7 +134,7 @@ struct RewriteModesView: View {
             .padding(.bottom, 6)
 
             ScrollView {
-                LazyVStack(spacing: 0) {
+                LazyVStack(alignment: .leading, spacing: 0) {
                     // Favorites section when no category filter is active
                     if selectedCategory == nil {
                         let favorites = presets.filter(\.isFavorite)
@@ -150,70 +150,76 @@ struct RewriteModesView: View {
                         )
                     }
                 }
-                .padding(.horizontal, 16)
+                .padding(.horizontal, 12)
                 .padding(.bottom, 8)
             }
             .scrollIndicators(.hidden)
         }
     }
 
+    private let gridColumns = [
+        GridItem(.flexible(), spacing: 6),
+        GridItem(.flexible(), spacing: 6)
+    ]
+
     private func presetSection(title: String, presets: [Preset]) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
+        VStack(alignment: .leading, spacing: 6) {
             Text(title)
                 .font(.system(size: 12, weight: .semibold))
                 .foregroundStyle(.secondary)
                 .textCase(.uppercase)
-                .padding(.horizontal, 12)
+                .padding(.horizontal, 4)
                 .padding(.top, 10)
 
-            ForEach(presets) { preset in
-                presetRow(preset)
+            LazyVGrid(columns: gridColumns, spacing: 6) {
+                ForEach(presets) { preset in
+                    presetCell(preset)
+                }
             }
         }
     }
 
-    private func presetRow(_ preset: Preset) -> some View {
+    private func presetCell(_ preset: Preset) -> some View {
         Button {
             HapticManager.mediumImpact()
             onPresetSelected(dictationState.vivaModeManager.selectedVivaMode, preset.id)
         } label: {
-            HStack(spacing: 10) {
+            HStack(spacing: 6) {
                 if !preset.isBuiltIn {
                     Capsule()
                         .fill(.orange)
-                        .frame(width: 4, height: 20)
+                        .frame(width: 3, height: 18)
                 }
 
                 PresetIconView(icon: preset.icon)
-                    .frame(width: 20)
+                    .frame(width: 18)
                     .foregroundStyle(.secondary)
 
                 VStack(alignment: .leading, spacing: 1) {
                     Text(preset.name)
-                        .font(.system(size: 15, weight: .medium))
+                        .font(.system(size: 13, weight: .medium))
                         .foregroundStyle(.primary)
                         .lineLimit(1)
                     if !preset.presetDescription.isEmpty {
                         Text(preset.presetDescription)
-                            .font(.system(size: 12))
+                            .font(.system(size: 10))
                             .foregroundStyle(.secondary)
                             .lineLimit(1)
                     }
                 }
-
-                Spacer()
+                .frame(maxWidth: .infinity, alignment: .leading)
 
                 if preset.isFavorite {
                     Image(systemName: "heart.fill")
-                        .font(.system(size: 12))
+                        .font(.system(size: 10))
                         .foregroundStyle(.red.opacity(0.6))
                 }
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 7)
             .background(
                 colorScheme == .dark ? Color(.quaternarySystemFill).opacity(0.5) : Color.white,
-                in: .rect(cornerRadius: 10)
+                in: .rect(cornerRadius: 8)
             )
         }
         .buttonStyle(.plain)

--- a/VivaDictaKeyboard/Views/RewriteModesView.swift
+++ b/VivaDictaKeyboard/Views/RewriteModesView.swift
@@ -7,91 +7,216 @@
 
 import SwiftUI
 
-/// Displays available VivaModes in the keyboard for text processing.
+/// Displays a VivaMode picker and categorized preset list for AI text processing in the keyboard.
 ///
-/// Shows a scrollable list of modes. Tapping a mode triggers the text processing
-/// pipeline that reads text from the host app, sends it to the main app for AI
-/// processing using that mode, and replaces it with the result.
+/// The VivaMode picker selects which AI provider/model to use. Tapping a preset triggers
+/// the text processing pipeline using the selected mode's provider with the chosen preset's prompt.
 ///
 /// When the main app session is not active, shows a prompt to open the main app.
 struct RewriteModesView: View {
     @Environment(KeyboardDictationState.self) var dictationState
     @Environment(\.colorScheme) private var colorScheme
 
-    let onModeSelected: (VivaMode) -> Void
+    let onPresetSelected: (VivaMode, String) -> Void
     let onOpenApp: () -> Void
     let onBackspace: () -> Void
     let onDeleteWord: () -> Void
     let onNewline: () -> Void
     let onSpace: () -> Void
 
+    @State private var presets: [Preset] = []
+    @State private var selectedCategory: String?
+
     private var modes: [VivaMode] {
         dictationState.vivaModeManager.availableVivaModes
     }
 
+    private var hasFavorites: Bool {
+        presets.contains(where: \.isFavorite)
+    }
+
+    private var filteredPresets: [Preset] {
+        if selectedCategory == KeyboardCategoryChipsView.favoritesFilter {
+            return presets.filter(\.isFavorite)
+        }
+        guard let selectedCategory else { return presets }
+        return presets.filter { $0.category == selectedCategory }
+    }
+
+    private var orderedCategories: [String] {
+        let activePresets = filteredPresets
+        var seen = Set<String>()
+        var cats: [String] = []
+        for preset in activePresets {
+            if seen.insert(preset.category).inserted {
+                cats.append(preset.category)
+            }
+        }
+        return cats.sorted {
+            PresetCatalog.categoryOrder.firstIndex(of: $0) ?? PresetCatalog.categoryOrder.count
+            < PresetCatalog.categoryOrder.firstIndex(of: $1) ?? PresetCatalog.categoryOrder.count
+        }
+    }
+
+    private var allCategories: [String] {
+        var seen = Set<String>()
+        var cats: [String] = []
+        for preset in presets {
+            if seen.insert(preset.category).inserted {
+                cats.append(preset.category)
+            }
+        }
+        return cats.sorted {
+            PresetCatalog.categoryOrder.firstIndex(of: $0) ?? PresetCatalog.categoryOrder.count
+            < PresetCatalog.categoryOrder.firstIndex(of: $1) ?? PresetCatalog.categoryOrder.count
+        }
+    }
+
     var body: some View {
         VStack(spacing: 0) {
-            // Header: switcher on left, utility buttons on right
-            HStack {
-                KeyboardTabToggle(dictationState: dictationState)
+            headerView
+                .padding(.horizontal, 16)
+                .padding(.vertical, 12)
 
-                Spacer()
-
-                // Utility buttons: space, return, backspace
-                HStack(spacing: 4) {
-                    
-                    utilityButton(icon: "space", color: .blue, action: onSpace)
-                        .shadow(color: .black.opacity(0.2), radius: 6)
-                    utilityButton(icon: "return", color: .blue, action: onNewline)
-                        .shadow(color: .black.opacity(0.2), radius: 6)
-                    utilityButton(icon: "delete.backward", color: .red, action: onBackspace, longHoldAction: onDeleteWord)
-                        .shadow(color: .black.opacity(0.2), radius: 6)
-                }
-            }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 16)
-            
-            // Content: modes list or "open app" prompt
             if dictationState.isSessionActive {
-                modesListView
-                    .padding(.horizontal, 24)
+                presetListView
             } else {
                 openAppPromptView
             }
         }
+        .frame(height: 260)
+        .onAppear {
+            presets = KeyboardPresetLoader.loadPresets()
+        }
     }
 
-    // MARK: - Modes List
+    // MARK: - Header
 
-    private var modesListView: some View {
-        VStack {
-            Text("Select Mode")
-                .font(.system(size: 18, weight: .semibold))
-            ScrollView {
-                LazyVStack(spacing: 6) {
-                    ForEach(modes) { mode in
-                        Button {
-                            HapticManager.mediumImpact()
-                            onModeSelected(mode)
-                        } label: {
-                            Text(mode.name)
-                                .font(.system(size: 16, weight: .medium))
-                                .foregroundStyle(.primary)
-                                .lineLimit(1)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(.horizontal, 16)
-                            .padding(.vertical, 12)
-                            .background(colorScheme == .dark ? Color(.quaternarySystemFill).opacity(0.5) : Color.white, in: .rect(cornerRadius: 10))
+    private var headerView: some View {
+        HStack {
+            KeyboardTabToggle(dictationState: dictationState)
 
+            VivaModePicker(
+                modes: modes,
+                selectedModeName: Binding(
+                    get: { dictationState.vivaModeManager.selectedVivaMode.name },
+                    set: { newName in
+                        HapticManager.selectionChanged()
+                        if let mode = modes.first(where: { $0.name == newName }) {
+                            dictationState.vivaModeManager.selectedVivaMode = mode
                         }
-                        .buttonStyle(.plain)
+                    }
+                )
+            )
+
+            Spacer()
+
+            HStack(spacing: 4) {
+                utilityButton(icon: "space", color: .blue, action: onSpace)
+                    .shadow(color: .black.opacity(0.2), radius: 6)
+                utilityButton(icon: "return", color: .blue, action: onNewline)
+                    .shadow(color: .black.opacity(0.2), radius: 6)
+                utilityButton(icon: "delete.backward", color: .red, action: onBackspace, longHoldAction: onDeleteWord)
+                    .shadow(color: .black.opacity(0.2), radius: 6)
+            }
+        }
+    }
+
+    // MARK: - Preset List
+
+    private var presetListView: some View {
+        VStack(spacing: 0) {
+            KeyboardCategoryChipsView(
+                categories: allCategories,
+                selectedCategory: $selectedCategory,
+                showFavorites: hasFavorites
+            )
+            .padding(.bottom, 6)
+
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    // Favorites section when no category filter is active
+                    if selectedCategory == nil {
+                        let favorites = presets.filter(\.isFavorite)
+                        if !favorites.isEmpty {
+                            presetSection(title: "Favorites", presets: favorites)
+                        }
+                    }
+
+                    ForEach(orderedCategories, id: \.self) { category in
+                        presetSection(
+                            title: category,
+                            presets: filteredPresets.filter { $0.category == category }
+                        )
                     }
                 }
-                .padding(.horizontal, 12)
-                .padding(.vertical, 8)
+                .padding(.horizontal, 16)
+                .padding(.bottom, 8)
             }
             .scrollIndicators(.hidden)
         }
+    }
+
+    private func presetSection(title: String, presets: [Preset]) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .textCase(.uppercase)
+                .padding(.horizontal, 12)
+                .padding(.top, 10)
+
+            ForEach(presets) { preset in
+                presetRow(preset)
+            }
+        }
+    }
+
+    private func presetRow(_ preset: Preset) -> some View {
+        Button {
+            HapticManager.mediumImpact()
+            onPresetSelected(dictationState.vivaModeManager.selectedVivaMode, preset.id)
+        } label: {
+            HStack(spacing: 10) {
+                if !preset.isBuiltIn {
+                    Capsule()
+                        .fill(.orange)
+                        .frame(width: 4, height: 20)
+                }
+
+                PresetIconView(icon: preset.icon)
+                    .frame(width: 20)
+                    .foregroundStyle(.secondary)
+
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(preset.name)
+                        .font(.system(size: 15, weight: .medium))
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+                    if !preset.presetDescription.isEmpty {
+                        Text(preset.presetDescription)
+                            .font(.system(size: 12))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+
+                Spacer()
+
+                if preset.isFavorite {
+                    Image(systemName: "heart.fill")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.red.opacity(0.6))
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(
+                colorScheme == .dark ? Color(.quaternarySystemFill).opacity(0.5) : Color.white,
+                in: .rect(cornerRadius: 10)
+            )
+        }
+        .buttonStyle(.plain)
     }
 
     // MARK: - Open App Prompt
@@ -128,7 +253,6 @@ struct RewriteModesView: View {
 
     // MARK: - Utility Button
 
-    
     enum UtilityButtonPlacement {
         case first
         case mid
@@ -169,5 +293,61 @@ struct RewriteModesView: View {
             .font(.system(size: 16, weight: .medium))
             .foregroundStyle(.primary)
             .contentShape(.rect)
+    }
+}
+
+// MARK: - Category Chips (Keyboard-local)
+
+/// Horizontal scrollable category filter chips for the keyboard preset list.
+///
+/// Self-contained version for the keyboard extension since `CategoryChipsView`
+/// from the main app is not in the keyboard target.
+private struct KeyboardCategoryChipsView: View {
+    static let favoritesFilter = "__favorites__"
+
+    let categories: [String]
+    @Binding var selectedCategory: String?
+    var showFavorites: Bool = false
+
+    var body: some View {
+        ScrollView(.horizontal) {
+            HStack(spacing: 6) {
+                chip(title: "All", isSelected: selectedCategory == nil) {
+                    selectedCategory = nil
+                }
+                if showFavorites {
+                    chip(title: "Favorites", icon: "heart.fill", isSelected: selectedCategory == Self.favoritesFilter) {
+                        selectedCategory = Self.favoritesFilter
+                    }
+                }
+                ForEach(categories, id: \.self) { category in
+                    chip(title: category, isSelected: selectedCategory == category) {
+                        selectedCategory = category
+                    }
+                }
+            }
+            .padding(.horizontal, 16)
+        }
+        .scrollIndicators(.hidden)
+    }
+
+    private func chip(title: String, icon: String? = nil, isSelected: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(spacing: 4) {
+                if let icon {
+                    Image(systemName: icon)
+                        .font(.system(size: 10))
+                }
+                Text(title)
+            }
+            .font(.system(size: 13))
+            .fontWeight(isSelected ? .semibold : .regular)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .foregroundStyle(isSelected ? .white : .primary)
+            .background(isSelected ? Color.accentColor : Color(.systemGray5))
+            .clipShape(.capsule)
+        }
+        .buttonStyle(.plain)
     }
 }


### PR DESCRIPTION
## Summary
- Replace the keyboard's mode-based AI processing with independent VivaMode picker (provider/model) and categorized preset grid
- Add presetId to the IPC layer so the keyboard can request a specific AI preset independently from the VivaMode
- Fix race condition where the main app consumed its own text processing result from UserDefaults before the keyboard extension could read it
- Use liquid glass for category filter chips on iOS 26+
- Fix scroll touch handling in grid gaps using hit-testable backgrounds

## Test plan
- [ ] Open keyboard in any host app, switch to AI processing tab
- [ ] Verify VivaMode picker appears at top and preset grid below with category chips
- [ ] Select a VivaMode, then tap a preset — verify AI processing works
- [ ] Try different presets (built-in and custom) across different VivaModes
- [ ] Verify scrolling works from empty spaces between grid cells
- [ ] Verify category chip filtering works with haptic feedback
- [ ] Verify the feature works with both selected text and text before cursor