### PR TITLE
Convert control widget to configurable toggle for watchOS support

### DIFF
--- a/VivaDicta/AppIntents/ToggleRecordIntent.swift
+++ b/VivaDicta/AppIntents/ToggleRecordIntent.swift
@@ -20,12 +20,11 @@ struct ToggleRecordIntent: SetValueIntent {
     func perform() async throws -> some IntentResult {
         await MainActor.run {
             let coordinator = AppGroupCoordinator.shared
-            let isCurrentlyRecording = coordinator.isRecording
 
-            if isCurrentlyRecording {
-                coordinator.requestStopRecording()
-            } else {
+            if value {
                 coordinator.requestStartRecordingFromControl()
+            } else {
+                coordinator.requestStopRecording()
             }
         }
         return .result()

--- a/VivaDicta/AppIntents/ToggleRecordIntent.swift
+++ b/VivaDicta/AppIntents/ToggleRecordIntent.swift
@@ -8,15 +8,15 @@
 import AppIntents
 import SwiftUI
 
-struct ToggleRecordIntent: AppIntent {
-    static let title: LocalizedStringResource = "Start Recording"
-    static let description = IntentDescription("Start recording in VivaDicta")
+struct ToggleRecordIntent: SetValueIntent {
+    static let title: LocalizedStringResource = "Toggle Recording"
+    static let description = IntentDescription("Start or stop recording in VivaDicta")
 
     static let openAppWhenRun: Bool = true
 
-    @available(iOS 26.0, *)
-    static let supportedModes: IntentModes = .foreground(.immediate)
-    
+    @Parameter(title: "Recording")
+    var value: Bool
+
     func perform() async throws -> some IntentResult {
         await MainActor.run {
             let coordinator = AppGroupCoordinator.shared

--- a/VivaDictaWidget/VivaDictaWidgetControl.swift
+++ b/VivaDictaWidget/VivaDictaWidgetControl.swift
@@ -9,16 +9,41 @@ import AppIntents
 import SwiftUI
 import WidgetKit
 
+struct RecordingControlConfiguration: ControlConfigurationIntent {
+    static let title: LocalizedStringResource = "Recording Control"
+    static let description = IntentDescription("Configure the recording control.")
+
+    @Parameter(title: "Recording Name", default: "Recording")
+    var recordingName: String
+}
+
+struct RecordingControlValueProvider: AppIntentControlValueProvider {
+    func previewValue(configuration: RecordingControlConfiguration) -> Bool {
+        false
+    }
+
+    func currentValue(configuration: RecordingControlConfiguration) async throws -> Bool {
+        let coordinator = AppGroupCoordinator.shared
+        return coordinator.isRecording
+    }
+}
+
 struct VivaDictaWidgetControl: ControlWidget {
     var body: some ControlWidgetConfiguration {
-        
-        StaticControlConfiguration(kind: "VivaDictaControlWidget") {
-            ControlWidgetButton(action: ToggleRecordIntent()) {
-                Image(systemName: "microphone.circle")
+
+        AppIntentControlConfiguration(
+            kind: "VivaDictaControlWidget",
+            provider: RecordingControlValueProvider()
+        ) { isRecording in
+            ControlWidgetToggle(
+                "Recording in VivaDicta",
+                isOn: isRecording,
+                action: ToggleRecordIntent()
+            ) { isTurnedOn in
+                Label("Toggle Recording", systemImage: "microphone.circle")
             }
         }
-        
-        .displayName("Start Recording")
-        .description("Start Recording in VivaDicta")
+        .displayName("Toggle Recording")
+        .description("Toggle recording in VivaDicta")
     }
 }


### PR DESCRIPTION
## Summary
- Convert ControlWidget from `StaticControlConfiguration` + `ControlWidgetButton` to `AppIntentControlConfiguration` + `ControlWidgetToggle` so the control appears on watchOS under "From Your iPhone"
- Change `ToggleRecordIntent` from `AppIntent` to `SetValueIntent` with boolean value parameter
- Add `RecordingControlConfiguration` intent with configurable recording name
- Remove `supportedModes: .foreground(.immediate)` that blocked watchOS forwarding

## Test plan
- [ ] Verify control appears in watchOS Control Center under "From Your iPhone"
- [ ] Verify tapping control on watchOS opens VivaDicta on paired iPhone and starts recording
- [ ] Verify control still works from iOS Control Center
- [ ] Verify control works from iPhone Action Button
- [ ] Verify "Configure..." button appears in Action Button settings