### PR TITLE
Add background task protection for transcription

### DIFF
--- a/VivaDicta/AppDelegate.swift
+++ b/VivaDicta/AppDelegate.swift
@@ -17,6 +17,7 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         logger.logInfo("🚀 didFinishLaunchingWithOptions - state: \(application.applicationState.debugDescription)")
         FirebaseApp.configure()
+        BackgroundTaskService.registerBGTaskHandler()
         return true
     }
 

--- a/VivaDicta/AppState.swift
+++ b/VivaDicta/AppState.swift
@@ -74,6 +74,9 @@ class AppState {
     /// Service for receiving audio files from Apple Watch.
     var watchConnectivityService: PhoneWatchConnectivityService!
 
+    /// Service for managing background task protection.
+    var backgroundTaskService: BackgroundTaskService!
+
 
     // MARK: - Navigation State
 
@@ -152,15 +155,24 @@ class AppState {
             aiService: aiService,
             modelContainer: modelContainer
         )
+
+        // Set up background task service
+        backgroundTaskService = BackgroundTaskService(modelContainer: modelContainer)
+        backgroundTaskService.configure(watchAudioProcessor: watchProcessor)
+
         watchConnectivityService = PhoneWatchConnectivityService()
-        watchConnectivityService.configure(audioProcessor: watchProcessor)
+        watchConnectivityService.configure(audioProcessor: watchProcessor, backgroundTaskService: backgroundTaskService)
 
         // Sync current modes to watch
         watchConnectivityService.syncModesToWatch(modes: aiService.modes)
 
-        // Process any orphaned watch audio files from interrupted background sessions
+        // Startup recovery: drain queued items first (they have richer metadata),
+        // then orphan recovery as catch-all fallback. Sequential to prevent duplicates.
+        // Orphan recovery excludes files still in the queue (failed items awaiting retry).
         Task {
-            await watchProcessor.processOrphanedFiles()
+            await backgroundTaskService.processQueue()
+            let queuedFiles = backgroundTaskService.queuedFileNames()
+            await watchProcessor.processOrphanedFiles(excludedFileNames: queuedFiles)
         }
     }
 

--- a/VivaDicta/Info.plist
+++ b/VivaDicta/Info.plist
@@ -127,6 +127,11 @@
 	<array>
 		<string>audio</string>
 		<string>remote-notification</string>
+		<string>processing</string>
+	</array>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>com.antonnovoselov.VivaDicta.transcription-processing</string>
 	</array>
 </dict>
 </plist>

--- a/VivaDicta/Services/BackgroundTaskQueue.swift
+++ b/VivaDicta/Services/BackgroundTaskQueue.swift
@@ -1,0 +1,115 @@
+//
+//  BackgroundTaskQueue.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.04
+//
+
+import Foundation
+
+/// A work item representing audio that needs background transcription processing.
+nonisolated struct BackgroundWorkItem: Codable, Sendable {
+    let id: UUID
+    let audioFileURL: URL
+    let sourceTag: String
+    let modeId: String?
+    let recordingTimestamp: Date
+    let createdAt: Date
+    var retryCount: Int
+
+    init(audioFileURL: URL, sourceTag: String, modeId: String?, recordingTimestamp: Date = Date()) {
+        self.id = UUID()
+        self.audioFileURL = audioFileURL
+        self.sourceTag = sourceTag
+        self.modeId = modeId
+        self.recordingTimestamp = recordingTimestamp
+        self.createdAt = Date()
+        self.retryCount = 0
+    }
+}
+
+/// Persistent queue for background transcription work items.
+///
+/// Stores items in UserDefaults so they survive app termination.
+/// Thread-safe: all persistence goes through UserDefaults which is thread-safe.
+/// This allows expiration handlers (called on arbitrary threads) to enqueue
+/// items synchronously without a MainActor hop.
+nonisolated final class BackgroundTaskQueue {
+    private static let storageKey = "BackgroundTaskQueue.items"
+    private static let maxRetryCount = 3
+    private static let maxAgeInterval: TimeInterval = 24 * 60 * 60 // 24 hours
+
+    private let defaults: UserDefaults
+
+    var isEmpty: Bool { loadItems().isEmpty }
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    func enqueue(_ item: BackgroundWorkItem) {
+        var items = loadItems()
+        items.append(item)
+        saveItems(items)
+    }
+
+    /// Returns all pending items after pruning aged-out and over-retried entries.
+    func allPending() -> [BackgroundWorkItem] {
+        var items = loadItems()
+        let countBefore = items.count
+        items.removeAll { item in
+            item.retryCount >= Self.maxRetryCount ||
+            Date().timeIntervalSince(item.createdAt) > Self.maxAgeInterval
+        }
+        if items.count != countBefore {
+            saveItems(items)
+        }
+        return items
+    }
+
+    func markFailed(id: UUID) {
+        var items = loadItems()
+        if let index = items.firstIndex(where: { $0.id == id }) {
+            items[index].retryCount += 1
+            if items[index].retryCount >= Self.maxRetryCount {
+                items.remove(at: index)
+            }
+        }
+        saveItems(items)
+    }
+
+    func remove(id: UUID) {
+        var items = loadItems()
+        items.removeAll { $0.id == id }
+        saveItems(items)
+    }
+
+    /// Removes all items matching the given audio filename.
+    func removeByFileName(_ fileName: String) {
+        var items = loadItems()
+        items.removeAll { $0.audioFileURL.lastPathComponent == fileName }
+        saveItems(items)
+    }
+
+    /// Checks if a file URL is already in the queue.
+    func contains(audioFileURL: URL) -> Bool {
+        loadItems().contains { $0.audioFileURL == audioFileURL }
+    }
+
+    /// Returns all queued audio filenames (for orphan recovery exclusion).
+    func queuedFileNames() -> Set<String> {
+        Set(loadItems().map { $0.audioFileURL.lastPathComponent })
+    }
+
+    // MARK: - Persistence
+
+    private func loadItems() -> [BackgroundWorkItem] {
+        guard let data = defaults.data(forKey: Self.storageKey) else { return [] }
+        return (try? JSONDecoder().decode([BackgroundWorkItem].self, from: data)) ?? []
+    }
+
+    private func saveItems(_ items: [BackgroundWorkItem]) {
+        let data = try? JSONEncoder().encode(items)
+        defaults.set(data, forKey: Self.storageKey)
+    }
+}

--- a/VivaDicta/Services/BackgroundTaskService.swift
+++ b/VivaDicta/Services/BackgroundTaskService.swift
@@ -1,0 +1,265 @@
+//
+//  BackgroundTaskService.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.04
+//
+
+import UIKit
+import BackgroundTasks
+import SwiftData
+import os
+
+/// Manages background task protection for transcription and AI processing.
+///
+/// Provides two mechanisms:
+/// 1. `UIApplication.beginBackgroundTask` for immediate background time (~30s)
+/// 2. `BGProcessingTask` via `BGTaskScheduler` for longer deferred processing
+///
+/// The primary use case is protecting Watch audio processing, which happens
+/// entirely in background when the iPhone receives files via WatchConnectivity.
+@MainActor
+final class BackgroundTaskService {
+    nonisolated static let bgTaskIdentifier = "com.antonnovoselov.VivaDicta.transcription-processing"
+
+    /// Live instance reference for the BGTask handler to dispatch to.
+    static nonisolated(unsafe) weak var shared: BackgroundTaskService?
+
+    private let logger = Logger(category: .backgroundTask)
+    private nonisolated(unsafe) let queue: BackgroundTaskQueue
+    private let modelContainer: ModelContainer
+    private var watchAudioProcessor: WatchAudioProcessor?
+    private var isProcessingQueue = false
+    private var bgProcessingDrainTask: Task<Void, Never>?
+
+    init(modelContainer: ModelContainer) {
+        self.queue = BackgroundTaskQueue()
+        self.modelContainer = modelContainer
+        Self.shared = self
+    }
+
+    func configure(watchAudioProcessor: WatchAudioProcessor) {
+        self.watchAudioProcessor = watchAudioProcessor
+    }
+
+    // MARK: - UIApplication Background Task
+
+    /// Begins a UIKit background task and returns its identifier.
+    ///
+    /// Each caller gets its own background task ID, supporting concurrent
+    /// Watch file processing. The expiration handler ends the task automatically;
+    /// `endBackgroundTask` is safe to call afterward (it checks for double-end).
+    func beginBackgroundTask(
+        name: String,
+        onExpiration: @escaping @Sendable () -> Void
+    ) -> UIBackgroundTaskIdentifier {
+        let lock = NSLock()
+        var taskID: UIBackgroundTaskIdentifier = .invalid
+        var ended = false
+        taskID = UIApplication.shared.beginBackgroundTask(withName: name) { [weak self] in
+            onExpiration()
+            // iOS expects the task to be ended inside the expiration handler
+            lock.lock()
+            if !ended {
+                ended = true
+                UIApplication.shared.endBackgroundTask(taskID)
+                lock.unlock()
+                self?.logger.logInfo("Background task ended by expiration (id: \(taskID.rawValue))")
+            } else {
+                lock.unlock()
+            }
+        }
+        if taskID == .invalid {
+            logger.logWarning("Failed to begin background task: \(name)")
+        } else {
+            logger.logInfo("Began background task: \(name) (id: \(taskID.rawValue))")
+            // Store the lock+ended flag for endBackgroundTask to use
+            backgroundTaskLocks[taskID] = (lock, { ended }, { ended = true })
+        }
+        return taskID
+    }
+
+    /// Tracks lock and ended state for each active background task to prevent double-end.
+    private var backgroundTaskLocks: [UIBackgroundTaskIdentifier: (NSLock, () -> Bool, () -> Void)] = [:]
+
+    func endBackgroundTask(_ identifier: UIBackgroundTaskIdentifier) {
+        guard identifier != .invalid else { return }
+        if let (lock, isEnded, markEnded) = backgroundTaskLocks[identifier] {
+            lock.lock()
+            if !isEnded() {
+                markEnded()
+                UIApplication.shared.endBackgroundTask(identifier)
+                lock.unlock()
+                logger.logInfo("Ended background task (id: \(identifier.rawValue))")
+            } else {
+                lock.unlock()
+                logger.logInfo("Background task already ended (id: \(identifier.rawValue))")
+            }
+            backgroundTaskLocks.removeValue(forKey: identifier)
+        } else {
+            UIApplication.shared.endBackgroundTask(identifier)
+            logger.logInfo("Ended background task (id: \(identifier.rawValue))")
+        }
+    }
+
+    // MARK: - BGProcessingTask
+
+    /// Registers the BGProcessingTask handler. Must be called during `didFinishLaunching`.
+    ///
+    /// The handler dispatches to the live `shared` instance. By the time iOS delivers
+    /// a BGProcessingTask, AppState (and thus BackgroundTaskService) is always initialized
+    /// because the task is scheduled from within the running app.
+    static func registerBGTaskHandler() {
+        BGTaskScheduler.shared.register(
+            forTaskWithIdentifier: bgTaskIdentifier,
+            using: nil
+        ) { task in
+            guard let bgTask = task as? BGProcessingTask else { return }
+            Task { @MainActor in
+                guard let service = shared else {
+                    bgTask.setTaskCompleted(success: false)
+                    return
+                }
+                service.handleBGProcessingTask(bgTask)
+            }
+        }
+    }
+
+    private var bgTaskExpired = false
+
+    private func handleBGProcessingTask(_ task: BGProcessingTask) {
+        logger.logInfo("Handling BGProcessingTask")
+        bgTaskExpired = false
+
+        bgProcessingDrainTask = Task {
+            await processQueue()
+            guard !bgTaskExpired else { return } // Expiration handler already completed the task
+            scheduleIfNeeded()
+            task.setTaskCompleted(success: queue.isEmpty)
+            logger.logInfo("BGProcessingTask completed, queue empty: \(queue.isEmpty)")
+        }
+
+        task.expirationHandler = { [weak self] in
+            self?.bgTaskExpired = true
+            self?.bgProcessingDrainTask?.cancel()
+            self?.scheduleIfNeeded()
+            task.setTaskCompleted(success: false)
+        }
+    }
+
+    /// Schedules a BGProcessingTask. Thread-safe - can be called from expiration handlers.
+    nonisolated func scheduleBGProcessingTask() {
+        let request = BGProcessingTaskRequest(identifier: Self.bgTaskIdentifier)
+        request.requiresNetworkConnectivity = false
+        request.requiresExternalPower = false
+        request.earliestBeginDate = Date(timeIntervalSinceNow: 1)
+        do {
+            try BGTaskScheduler.shared.submit(request)
+        } catch {
+            let logger = Logger(category: .backgroundTask)
+            logger.logError("Failed to schedule BGProcessingTask: \(error.localizedDescription)")
+        }
+    }
+
+    /// Schedules a BGProcessingTask if the queue has pending items. Thread-safe.
+    nonisolated func scheduleIfNeeded() {
+        guard !queue.isEmpty else { return }
+        scheduleBGProcessingTask()
+    }
+
+    // MARK: - Queue Management
+
+    /// Enqueues a work item for later processing. Thread-safe - can be called from
+    /// expiration handlers without a MainActor hop.
+    nonisolated func enqueueForLaterProcessing(audioURL: URL, sourceTag: String, modeId: String?, recordingTimestamp: Date = Date()) {
+        let item = BackgroundWorkItem(
+            audioFileURL: audioURL,
+            sourceTag: sourceTag,
+            modeId: modeId,
+            recordingTimestamp: recordingTimestamp
+        )
+        queue.enqueue(item)
+        scheduleBGProcessingTask()
+    }
+
+    /// Returns filenames currently in the queue (for orphan recovery exclusion).
+    func queuedFileNames() -> Set<String> {
+        queue.queuedFileNames()
+    }
+
+    /// Removes a queued item if the audio file was successfully processed.
+    /// Cancels the pending BGProcessingTask if the queue is now empty.
+    func removeFromQueueIfProcessed(audioFileName: String) {
+        if transcriptionExists(for: audioFileName) {
+            queue.removeByFileName(audioFileName)
+            if queue.isEmpty {
+                BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: Self.bgTaskIdentifier)
+                logger.logInfo("Queue empty after success, cancelled pending BGProcessingTask")
+            }
+        }
+    }
+
+    func processQueue() async {
+        guard !isProcessingQueue else { return }
+        guard let watchAudioProcessor else {
+            logger.logError("WatchAudioProcessor not configured, cannot process queue")
+            return
+        }
+        isProcessingQueue = true
+        defer { isProcessingQueue = false }
+
+        for item in queue.allPending() {
+            // Stop if cancelled (e.g. BGProcessingTask expired)
+            guard !Task.isCancelled else {
+                logger.logInfo("Queue processing cancelled")
+                break
+            }
+
+            let fileName = item.audioFileURL.lastPathComponent
+
+            // Skip if audio file no longer exists
+            guard FileManager.default.fileExists(atPath: item.audioFileURL.path) else {
+                logger.logWarning("Queued audio file missing, removing: \(fileName)")
+                queue.remove(id: item.id)
+                continue
+            }
+
+            // Skip if a Transcription already exists for this file (prevents duplicates)
+            if transcriptionExists(for: fileName) {
+                logger.logInfo("Transcription already exists for \(fileName), removing from queue")
+                queue.remove(id: item.id)
+                continue
+            }
+
+            // Skip if the file is currently being processed by a live Watch transfer
+            if watchAudioProcessor.inFlightFiles.contains(fileName) {
+                logger.logInfo("File in-flight, skipping: \(fileName)")
+                continue
+            }
+
+            logger.logInfo("Processing queued item: \(fileName)")
+            await watchAudioProcessor.processAudioFile(
+                at: item.audioFileURL,
+                sourceTag: item.sourceTag,
+                recordingTimestamp: item.recordingTimestamp,
+                modeId: item.modeId
+            )
+
+            // Check if processing actually created a Transcription
+            if transcriptionExists(for: fileName) {
+                queue.remove(id: item.id)
+            } else {
+                logger.logWarning("Processing did not create Transcription for \(fileName), marking failed")
+                queue.markFailed(id: item.id)
+            }
+        }
+    }
+
+    /// Checks if a Transcription record already exists for the given audio filename.
+    private func transcriptionExists(for audioFileName: String) -> Bool {
+        let context = ModelContext(modelContainer)
+        let descriptor = FetchDescriptor<Transcription>()
+        guard let transcriptions = try? context.fetch(descriptor) else { return false }
+        return transcriptions.contains { $0.audioFileName == audioFileName }
+    }
+}

--- a/VivaDicta/Services/BackgroundTaskService.swift
+++ b/VivaDicta/Services/BackgroundTaskService.swift
@@ -258,8 +258,10 @@ final class BackgroundTaskService {
     /// Checks if a Transcription record already exists for the given audio filename.
     private func transcriptionExists(for audioFileName: String) -> Bool {
         let context = ModelContext(modelContainer)
-        let descriptor = FetchDescriptor<Transcription>()
-        guard let transcriptions = try? context.fetch(descriptor) else { return false }
-        return transcriptions.contains { $0.audioFileName == audioFileName }
+        var descriptor = FetchDescriptor<Transcription>(
+            predicate: #Predicate { $0.audioFileName == audioFileName }
+        )
+        descriptor.fetchLimit = 1
+        return (try? context.fetchCount(descriptor)) ?? 0 > 0
     }
 }

--- a/VivaDicta/Services/PhoneWatchConnectivityService.swift
+++ b/VivaDicta/Services/PhoneWatchConnectivityService.swift
@@ -5,6 +5,7 @@
 //  Created by Anton Novoselov on 2026.04.02
 //
 
+import UIKit
 import WatchConnectivity
 import os
 
@@ -15,11 +16,15 @@ final class PhoneWatchConnectivityService: NSObject {
     /// Processor for transcribing watch audio in the background.
     private var audioProcessor: WatchAudioProcessor?
 
+    /// Service for background task protection.
+    private var backgroundTaskService: BackgroundTaskService?
+
     /// Modes to sync to watch once session activates.
     private var pendingModes: [VivaMode]?
 
-    func configure(audioProcessor: WatchAudioProcessor) {
+    func configure(audioProcessor: WatchAudioProcessor, backgroundTaskService: BackgroundTaskService) {
         self.audioProcessor = audioProcessor
+        self.backgroundTaskService = backgroundTaskService
     }
 
     override init() {
@@ -72,6 +77,26 @@ final class PhoneWatchConnectivityService: NSObject {
             return
         }
 
+        let fileName = audioURL.lastPathComponent
+
+        // Proactively enqueue and schedule BGProcessingTask before starting work.
+        // This guarantees the fallback is in the system before any time pressure.
+        // If processing succeeds, we remove from queue and cancel the BGTask.
+        backgroundTaskService?.enqueueForLaterProcessing(
+            audioURL: audioURL,
+            sourceTag: sourceTag,
+            modeId: modeId,
+            recordingTimestamp: recordingTimestamp
+        )
+
+        // Begin background task to prevent iOS from suspending during processing
+        let bgTaskID = backgroundTaskService?.beginBackgroundTask(
+            name: "watch-audio-\(fileName)",
+            onExpiration: {
+                // No need to enqueue here - already done above
+            }
+        ) ?? .invalid
+
         Task {
             await audioProcessor.processAudioFile(
                 at: audioURL,
@@ -79,6 +104,9 @@ final class PhoneWatchConnectivityService: NSObject {
                 recordingTimestamp: recordingTimestamp,
                 modeId: modeId
             )
+            // On success, remove from queue and cancel the BGProcessingTask
+            backgroundTaskService?.removeFromQueueIfProcessed(audioFileName: fileName)
+            backgroundTaskService?.endBackgroundTask(bgTaskID)
         }
     }
 }

--- a/VivaDicta/Services/WatchAudioProcessor.swift
+++ b/VivaDicta/Services/WatchAudioProcessor.swift
@@ -25,7 +25,7 @@ final class WatchAudioProcessor {
     private let modelContainer: ModelContainer
 
     /// Tracks filenames currently being processed to avoid duplicates.
-    private var inFlightFiles: Set<String> = []
+    private(set) var inFlightFiles: Set<String> = []
 
 
     init(transcriptionManager: TranscriptionManager,
@@ -143,7 +143,8 @@ final class WatchAudioProcessor {
 
     /// Checks for orphaned watch audio files that were never transcribed
     /// (e.g. if iOS killed the app during background processing).
-    func processOrphanedFiles() async {
+    /// - Parameter excludedFileNames: Filenames to skip (e.g. files still in the background task queue).
+    func processOrphanedFiles(excludedFileNames: Set<String> = []) async {
         let audioDir = FileManager.appDirectory(for: .audio)
 
         let fm = FileManager.default
@@ -163,7 +164,9 @@ final class WatchAudioProcessor {
         }()
 
         let orphaned = files.filter {
-            !existingFileNames.contains($0.lastPathComponent) && !inFlightFiles.contains($0.lastPathComponent)
+            !existingFileNames.contains($0.lastPathComponent) &&
+            !inFlightFiles.contains($0.lastPathComponent) &&
+            !excludedFileNames.contains($0.lastPathComponent)
         }
 
         guard !orphaned.isEmpty else {

--- a/VivaDicta/Utilities/LoggerExtension.swift
+++ b/VivaDicta/Utilities/LoggerExtension.swift
@@ -64,6 +64,9 @@ public enum LogCategory: String {
     // MARK: - Watch Connectivity
     case watchConnectivity = "WatchConnectivity"
 
+    // MARK: - Background Tasks
+    case backgroundTask = "BackgroundTask"
+
     // MARK: - Keyboard Extension
     case keyboardExtension = "KeyboardExtension"
     case vivaModeManager = "VivaModeManager"

--- a/VivaDicta/Views/RecordViewModel.swift
+++ b/VivaDicta/Views/RecordViewModel.swift
@@ -373,6 +373,16 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
 
     func transcribeSpeechTask(recordURL: URL, modelContext: ModelContext, sourceTag: String? = nil) -> Task<Void, Never> {
         Task { @MainActor in
+            // Begin background task to allow transcription to complete if user switches apps
+            let bgTaskID = appState?.backgroundTaskService.beginBackgroundTask(
+                name: "transcription",
+                onExpiration: {
+                    // Background time expired - transcription will be interrupted
+                    // The audio file remains on disk for orphan recovery on next launch
+                }
+            ) ?? .invalid
+            defer { appState?.backgroundTaskService.endBackgroundTask(bgTaskID) }
+
             do {
                 self.recordingState = .transcribing
 

--- a/VivaDictaWatch Watch App/Views/WatchRecordView.swift
+++ b/VivaDictaWatch Watch App/Views/WatchRecordView.swift
@@ -35,15 +35,9 @@ struct WatchRecordView: View {
             .frame(maxWidth: .infinity)
         }
         .toolbar {
-            if !viewModel.availableModes.isEmpty {
-                if viewModel.state == .idle {
-                    ToolbarItem(placement: .topBarLeading) {
-                        modePicker
-                    }
-                } else {
-                    ToolbarItem(placement: .topBarLeading) {
-                        modePicker.hidden()
-                    }
+            if viewModel.state == .idle {
+                ToolbarItem(placement: .topBarLeading) {
+                    modePicker
                 }
             }
         }
@@ -127,14 +121,9 @@ struct WatchRecordView: View {
             }
             .navigationTitle("Mode")
         } label: {
-            Text(String(selectedName.prefix(7)))
-                .font(.system(size: 11, weight: .semibold))
-                .lineLimit(1)
+            Image(systemName: "list.bullet")
+                .font(.system(size: 16, weight: .semibold))
         }
-        .buttonStyle(.plain)
-        .padding(.horizontal, 10)
-        .padding(.vertical, 8)
-        .glassEffectClear(isInteractive: true)
     }
 
     private var formattedDuration: String {

--- a/documentation/Background-Task-Architecture.md
+++ b/documentation/Background-Task-Architecture.md
@@ -1,0 +1,192 @@
+# Background Task Architecture
+
+## Overview
+
+VivaDicta uses iOS background task APIs to protect transcription and AI processing from being killed when the app moves to background. This is critical for two scenarios:
+
+1. **Watch audio processing (primary)** - When Apple Watch sends audio files via WatchConnectivity, the iPhone app processes them entirely in background
+2. **Main app transcription** - When the user switches apps during an active transcription
+
+## iOS Background Task APIs
+
+| API | What it does | SwiftUI modifier? |
+|-----|-------------|-------------------|
+| `UIApplication.beginBackgroundTask` | Immediate ~30s execution time | No |
+| `BGProcessingTask` | Longer deferred work (minutes) | No |
+| `BGAppRefreshTask` | Periodic data refresh | Yes (`.appRefresh`) |
+| Background `URLSession` | Background downloads | Yes (`.urlSession`) |
+
+We use `beginBackgroundTask` and `BGProcessingTask`. SwiftUI's `.backgroundTask` modifier does not support `BGProcessingTask` - only `.appRefresh` and `.urlSession`.
+
+## Two-Layer Protection
+
+### Layer 1: `UIApplication.beginBackgroundTask` (Immediate)
+
+Requests ~30 seconds of continued execution when the app enters background. Each processing task gets its own background task identifier, supporting concurrent Watch file processing.
+
+- **Watch path**: Each `didReceive(file:)` call creates its own background task via `BackgroundTaskService.beginBackgroundTask(name:onExpiration:)`
+- **Main app path**: `RecordViewModel.transcribeSpeechTask()` wraps itself in a background task
+
+The expiration handler ends the UIKit background task immediately (iOS requirement) and enqueues the work for Layer 2.
+
+### Layer 2: `BGProcessingTask` via `BGTaskScheduler` (Deferred Fallback)
+
+If Layer 1's time expires before Watch audio processing finishes, the expiration handler:
+1. Saves the unfinished work to a persistent `BackgroundTaskQueue` (UserDefaults-backed)
+2. Schedules a `BGProcessingTask` with `earliestBeginDate` of 1 second ("as soon as possible")
+
+iOS will wake the app later (when device is idle) to drain the queue.
+
+**Note**: The main app transcription path does not use the queue fallback because RecordViewModel has UI dependencies (state updates, haptics, Spotlight indexing) that can't run headlessly.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                   BackgroundTaskService                  │
+│                                                         │
+│  beginBackgroundTask(name:onExpiration:)                 │
+│    -> Returns UIBackgroundTaskIdentifier per caller      │
+│    -> Expiration handler ends task + calls callback      │
+│                                                         │
+│  endBackgroundTask(_ identifier:)                        │
+│    -> Ends a specific background task                    │
+│                                                         │
+│  scheduleBGProcessingTask()                              │
+│    -> Submits BGProcessingTaskRequest to iOS             │
+│                                                         │
+│  enqueueForLaterProcessing(audioURL:sourceTag:modeId:)   │
+│    -> Saves work item to BackgroundTaskQueue             │
+│                                                         │
+│  processQueue()                                          │
+│    -> Peeks items, checks for duplicates, processes,     │
+│       removes only after success                         │
+├─────────────────────────────────────────────────────────┤
+│                   BackgroundTaskQueue                    │
+│                                                         │
+│  Persistent queue of BackgroundWorkItem (Codable)        │
+│  Stored in UserDefaults, survives app termination        │
+│  peek() -> does not remove (safe against crashes)        │
+│  remove(id:) -> only after successful processing         │
+│  Max 3 retries per item, 24-hour age limit               │
+│  Duplicate check: skips files with existing Transcription│
+└─────────────────────────────────────────────────────────┘
+```
+
+## Watch Audio Flow
+
+```
+Watch                              iPhone
+  |                                  |
+  | transferFile(audio, metadata)    |
+  | -------------------------------->|
+  |                                  |
+  | sendMessage(["wake": true])      |
+  | -------------------------------->|  Wakes app
+  |                                  |
+  |                                  |  didReceive(file:)
+  |                                  |    |
+  |                                  |    +-- Move file to Documents/Audio/
+  |                                  |    +-- beginBackgroundTask ----------+
+  |                                  |    |                                |
+  |                                  |    +-- WatchAudioProcessor          |
+  |                                  |    |   .processAudioFile()          |
+  |                                  |    |   (transcribe + enhance        |
+  |                                  |    |    + save to SwiftData)        |
+  |                                  |    |                                |
+  |                                  |    +-- Success?                     |
+  |                                  |    |   +-- YES -> endBGTask --------+
+  |                                  |    |   |
+  |                                  |    |   +-- TIME EXPIRED ->
+  |                                  |    |       +-- endBGTask (required by iOS)
+  |                                  |    |       +-- Enqueue to BackgroundTaskQueue
+  |                                  |    |       +-- Schedule BGProcessingTask
+  |                                  |    |
+  |                                  |    |  ... later, iOS wakes app ...
+  |                                  |    |
+  |                                  |    +-- handleBGProcessingTask()
+  |                                  |        +-- processQueue()
+  |                                  |            +-- Check for existing Transcription
+  |                                  |            +-- WatchAudioProcessor (if no dupe)
+```
+
+## Main App Transcription Flow
+
+```
+RecordViewModel.transcribeSpeechTask()
+  |
+  +-- beginBackgroundTask("transcription")
+  |   (no queue fallback - UI-dependent code)
+  |
+  +-- Transcribe audio
+  +-- AI enhance text
+  +-- Save to SwiftData
+  +-- Spotlight indexing
+  +-- Clipboard, haptics, etc.
+  |
+  +-- endBackgroundTask (via defer)
+```
+
+If the 30-second background time expires for the main app path, the transcription is interrupted. The audio file remains on disk and can be manually retranscribed by the user.
+
+## Startup Recovery
+
+On every app launch, `AppState.init()` runs recovery sequentially in a single Task (order matters to prevent duplicates):
+
+1. **Queued items first** - `BackgroundTaskService.processQueue()` drains items with full metadata (modeId, timestamp). Uses peek-then-remove: items stay in queue until processing succeeds. Checks for existing Transcription records to prevent duplicates.
+2. **Orphaned files second** - `WatchAudioProcessor.processOrphanedFiles()` scans `Documents/Audio/` for `watch-*.wav` files without matching Transcription records. This is the catch-all fallback for files that weren't in the queue.
+
+## Registration
+
+`BGTaskScheduler.register()` must be called during `application(_:didFinishLaunchingWithOptions:)` (Apple requirement).
+
+1. `AppDelegate` calls `BackgroundTaskService.registerBGTaskHandler()`
+2. The handler dispatches to `BackgroundTaskService.shared` (weak reference to the live instance)
+3. By the time iOS delivers a `BGProcessingTask`, `AppState` is always initialized because the task is only scheduled from within the running app
+
+## Configuration
+
+### Info.plist
+
+```xml
+<key>UIBackgroundModes</key>
+<array>
+    <string>audio</string>
+    <string>remote-notification</string>
+    <string>processing</string>
+</array>
+<key>BGTaskSchedulerPermittedIdentifiers</key>
+<array>
+    <string>com.antonnovoselov.VivaDicta.transcription-processing</string>
+</array>
+```
+
+- `processing` background mode is required for `BGProcessingTask`
+- `BGTaskSchedulerPermittedIdentifiers` lists allowed task identifiers
+- `UIApplication.beginBackgroundTask` requires no Info.plist entry
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `Services/BackgroundTaskService.swift` | Manages both background task mechanisms |
+| `Services/BackgroundTaskQueue.swift` | Persistent work item queue (peek-then-remove) |
+| `Services/PhoneWatchConnectivityService.swift` | Wraps Watch audio processing with background protection |
+| `Services/WatchAudioProcessor.swift` | Headless transcription processor (used by queue) |
+| `Views/RecordViewModel.swift` | Main app transcription with background protection |
+| `AppDelegate.swift` | BGProcessingTask handler registration |
+| `AppState.swift` | Service initialization and startup recovery |
+
+## Debugging
+
+Simulate BGProcessingTask in lldb:
+
+```
+# Launch the task
+e -l objc -- (void)[[BGTaskScheduler sharedScheduler] _simulateLaunchForTaskWithIdentifier:@"com.antonnovoselov.VivaDicta.transcription-processing"]
+
+# Simulate expiration
+e -l objc -- (void)[[BGTaskScheduler sharedScheduler] _simulateExpirationForTaskWithIdentifier:@"com.antonnovoselov.VivaDicta.transcription-processing"]
+```
+
+**Note**: `BGProcessingTask` does not work in iOS Simulator - test on a physical device.

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -25,6 +25,7 @@
 | [App Intents & Shortcuts](App-Intents-Shortcuts-Architecture.md) | Siri/Shortcuts integration, TranscriptionEntity, Spotlight indexing |
 | [Deep Linking & URL Routing](Deep-Linking-URL-Routing-Architecture.md) | URL scheme handling, navigation routing |
 | [Hot Mic / Audio Prewarm](Hot-Mic-Audio-Prewarm-Architecture.md) | Audio session pre-warming for instant recording start |
+| [Background Tasks](Background-Task-Architecture.md) | Background task protection for Watch audio and main app transcription |
 
 ## Guides & References
 


### PR DESCRIPTION
## Summary

- Add `beginBackgroundTask` protection for Watch audio processing and main app transcription so they can finish when the app goes to background
- Add persistent `BackgroundTaskQueue` + `BGProcessingTask` as deferred fallback for Watch audio that doesn't finish in time
- Proactive scheduling: BGProcessingTask is submitted upfront when Watch audio arrives, cancelled on success
- Startup recovery: drain queue first, then orphan recovery (with exclusion of queued files)
- Add `processing` background mode and `BGTaskSchedulerPermittedIdentifiers` to Info.plist
- Add architecture documentation

## Key files
- `BackgroundTaskService.swift` - manages both background task mechanisms
- `BackgroundTaskQueue.swift` - persistent work item queue (peek-then-remove, retry limits)
- `PhoneWatchConnectivityService.swift` - wraps Watch audio with background protection
- `RecordViewModel.swift` - wraps main app transcription with background protection

## Test plan
- [ ] Record on Watch, send to iPhone while app is suspended - verify transcription completes
- [ ] Record long audio on Watch, send while app is backgrounded - verify BGProcessingTask fallback works
- [ ] Kill app during Watch audio processing, relaunch - verify queued items are processed
- [ ] Test main app: start transcription, switch to another app - verify it completes
- [ ] Verify no duplicate Transcription records after recovery paths