### PR TITLE
Switch Watch recording to M4A and use dynamic MIME types

### DIFF
--- a/VivaDicta.xcodeproj/project.pbxproj
+++ b/VivaDicta.xcodeproj/project.pbxproj
@@ -264,6 +264,13 @@
 			);
 			target = 18BA23FE2F7ED0D700C4F68B /* VivaDictaWatch Watch AppTests */;
 		};
+		18BA4BF82F8250C000C4F68B /* Exceptions for "VivaDictaWatch Watch App" folder in "VivaDictaWatch Watch App" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				"VivaDictaWatch-Watch-App-Info.plist",
+			);
+			target = 18BA23F22F7ED0D500C4F68B /* VivaDictaWatch Watch App */;
+		};
 		18E1B4A62E8C6FF400BE8A11 /* Exceptions for "VivaDictaKeyboard" folder in "VivaDictaKeyboard" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
@@ -382,6 +389,7 @@
 		18BA23F42F7ED0D500C4F68B /* VivaDictaWatch Watch App */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
+				18BA4BF82F8250C000C4F68B /* Exceptions for "VivaDictaWatch Watch App" folder in "VivaDictaWatch Watch App" target */,
 				18BA452C2F81907E00C4F68B /* Exceptions for "VivaDictaWatch Watch App" folder in "VivaDictaWatch Watch AppTests" target */,
 			);
 			path = "VivaDictaWatch Watch App";
@@ -1764,6 +1772,7 @@
 				DEVELOPMENT_TEAM = 358V8FBM3U;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "VivaDictaWatch-Watch-App-Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = VivaDicta;
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "VivaDicta records audio on your Apple Watch and sends it to your iPhone for transcription.";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
@@ -1799,6 +1808,7 @@
 				DEVELOPMENT_TEAM = 358V8FBM3U;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "VivaDictaWatch-Watch-App-Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = VivaDicta;
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "VivaDicta records audio on your Apple Watch and sends it to your iPhone for transcription.";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
@@ -1833,6 +1843,7 @@
 				DEVELOPMENT_TEAM = 358V8FBM3U;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "VivaDictaWatch-Watch-App-Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = VivaDicta;
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "VivaDicta records audio on your Apple Watch and sends it to your iPhone for transcription.";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";

--- a/VivaDicta/Extensions/URL+AudioMIMEType.swift
+++ b/VivaDicta/Extensions/URL+AudioMIMEType.swift
@@ -1,0 +1,21 @@
+//
+//  URL+AudioMIMEType.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.05
+//
+
+import Foundation
+
+extension URL {
+    var audioMIMEType: String {
+        switch pathExtension.lowercased() {
+        case "m4a": "audio/mp4"
+        case "mp3": "audio/mpeg"
+        case "flac": "audio/flac"
+        case "ogg": "audio/ogg"
+        case "webm": "audio/webm"
+        default: "audio/wav"
+        }
+    }
+}

--- a/VivaDicta/Services/AudioPrewarmManager.swift
+++ b/VivaDicta/Services/AudioPrewarmManager.swift
@@ -93,7 +93,7 @@ final class AudioPrewarmManager {
             options: [.mixWithOthers, .allowBluetoothHFP, .defaultToSpeaker]
         )
         try audioSession.setAllowHapticsAndSystemSoundsDuringRecording(true)
-        try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
+        try audioSession.setActive(true)
         #endif
 
         // Start continuous dummy recorder and wait for it to complete

--- a/VivaDicta/Services/PhoneWatchConnectivityService.swift
+++ b/VivaDicta/Services/PhoneWatchConnectivityService.swift
@@ -163,7 +163,8 @@ extension PhoneWatchConnectivityService: WCSessionDelegate {
 
         do {
             try FileManager.default.createDirectory(at: audioDir, withIntermediateDirectories: true)
-            let destURL = audioDir.appending(path: "watch-\(UUID().uuidString).wav")
+            let ext = sourceURL.pathExtension.isEmpty ? "m4a" : sourceURL.pathExtension
+            let destURL = audioDir.appending(path: "watch-\(UUID().uuidString).\(ext)")
             try FileManager.default.moveItem(at: sourceURL, to: destURL)
             logger.logInfo("Received watch audio: \(destURL.lastPathComponent)")
 

--- a/VivaDicta/Services/Transcription/CloudTranscription/CohereTranscriptionService.swift
+++ b/VivaDicta/Services/Transcription/CloudTranscription/CohereTranscriptionService.swift
@@ -98,7 +98,7 @@ struct CohereTranscriptionService {
         // File (must be last)
         body.append("--\(boundary)\(crlf)".data(using: .utf8)!)
         body.append("Content-Disposition: form-data; name=\"file\"; filename=\"\(audioURL.lastPathComponent)\"\(crlf)".data(using: .utf8)!)
-        body.append("Content-Type: audio/wav\(crlf)\(crlf)".data(using: .utf8)!)
+        body.append("Content-Type: \(audioURL.audioMIMEType)\(crlf)\(crlf)".data(using: .utf8)!)
         body.append(audioData)
         body.append(crlf.data(using: .utf8)!)
         body.append("--\(boundary)--\(crlf)".data(using: .utf8)!)

--- a/VivaDicta/Services/Transcription/CloudTranscription/DeepgramTranscriptionService.swift
+++ b/VivaDicta/Services/Transcription/CloudTranscription/DeepgramTranscriptionService.swift
@@ -23,7 +23,7 @@ class DeepgramTranscriptionService {
         var request = URLRequest(url: config.url)
         request.httpMethod = "POST"
         request.setValue("Token \(config.apiKey)", forHTTPHeaderField: "Authorization")
-        request.setValue("audio/wav", forHTTPHeaderField: "Content-Type")
+        request.setValue(audioURL.audioMIMEType, forHTTPHeaderField: "Content-Type")
         request.timeoutInterval = NetworkRetry.defaultTimeout
 
         guard let audioData = try? Data(contentsOf: audioURL) else {

--- a/VivaDicta/Services/Transcription/CloudTranscription/ElevenLabsTranscriptionService.swift
+++ b/VivaDicta/Services/Transcription/CloudTranscription/ElevenLabsTranscriptionService.swift
@@ -77,7 +77,7 @@ class ElevenLabsTranscriptionService {
     private func createRequestBody(audioURL: URL, modelName: String, boundary: String) throws -> Data {
         var body = Data()
         
-        body.append(formField: "file", fileName: audioURL.lastPathComponent, fileData: try Data(contentsOf: audioURL), mimeType: "audio/wav", boundary: boundary)
+        body.append(formField: "file", fileName: audioURL.lastPathComponent, fileData: try Data(contentsOf: audioURL), mimeType: audioURL.audioMIMEType, boundary: boundary)
         body.append(formField: "model_id", value: modelName, boundary: boundary)
         body.append(formField: "temperature", value: "0.0", boundary: boundary)
         body.append(formField: "tag_audio_events", value: "false", boundary: boundary)

--- a/VivaDicta/Services/Transcription/CloudTranscription/GeminiTranscriptionService.swift
+++ b/VivaDicta/Services/Transcription/CloudTranscription/GeminiTranscriptionService.swift
@@ -43,7 +43,7 @@ class GeminiTranscriptionService {
                         .text(GeminiTextPart(text: "Please transcribe this audio file. Provide only the transcribed text.")),
                         .audio(GeminiAudioPart(
                             inlineData: GeminiInlineData(
-                                mimeType: "audio/wav",
+                                mimeType: audioURL.audioMIMEType,
                                 data: base64AudioData
                             )
                         ))

--- a/VivaDicta/Services/Transcription/CloudTranscription/GroqTranscriptionService.swift
+++ b/VivaDicta/Services/Transcription/CloudTranscription/GroqTranscriptionService.swift
@@ -74,7 +74,7 @@ struct GroqTranscriptionService {
 
         body.append("--\(boundary)\(crlf)".data(using: .utf8)!)
         body.append("Content-Disposition: form-data; name=\"file\"; filename=\"\(audioURL.lastPathComponent)\"\(crlf)".data(using: .utf8)!)
-        body.append("Content-Type: audio/wav\(crlf)\(crlf)".data(using: .utf8)!)
+        body.append("Content-Type: \(audioURL.audioMIMEType)\(crlf)\(crlf)".data(using: .utf8)!)
         body.append(audioData)
         body.append(crlf.data(using: .utf8)!)
 

--- a/VivaDicta/Services/Transcription/CloudTranscription/MistralTranscriptionService.swift
+++ b/VivaDicta/Services/Transcription/CloudTranscription/MistralTranscriptionService.swift
@@ -78,7 +78,7 @@ struct MistralTranscriptionService {
         // Add file data
         body.append("--\(boundary)\(crlf)".data(using: .utf8)!)
         body.append("Content-Disposition: form-data; name=\"file\"; filename=\"\(audioURL.lastPathComponent)\"\(crlf)".data(using: .utf8)!)
-        body.append("Content-Type: audio/wav\(crlf)\(crlf)".data(using: .utf8)!)
+        body.append("Content-Type: \(audioURL.audioMIMEType)\(crlf)\(crlf)".data(using: .utf8)!)
         body.append(audioData)
         body.append(crlf.data(using: .utf8)!)
 

--- a/VivaDicta/Services/Transcription/CloudTranscription/OpenAITranscriptionService.swift
+++ b/VivaDicta/Services/Transcription/CloudTranscription/OpenAITranscriptionService.swift
@@ -73,7 +73,7 @@ struct OpenAITranscriptionService {
         
         body.append("--\(boundary)\(crlf)".data(using: .utf8)!)
         body.append("Content-Disposition: form-data; name=\"file\"; filename=\"\(audioURL.lastPathComponent)\"\(crlf)".data(using: .utf8)!)
-        body.append("Content-Type: audio/wav\(crlf)\(crlf)".data(using: .utf8)!)
+        body.append("Content-Type: \(audioURL.audioMIMEType)\(crlf)\(crlf)".data(using: .utf8)!)
         body.append(audioData)
         body.append(crlf.data(using: .utf8)!)
 

--- a/VivaDicta/Services/Transcription/CloudTranscription/SonioxTranscriptionService.swift
+++ b/VivaDicta/Services/Transcription/CloudTranscription/SonioxTranscriptionService.swift
@@ -218,7 +218,7 @@ struct SonioxTranscriptionService {
 
         body.append("--\(boundary)\(crlf)".data(using: .utf8)!)
         body.append("Content-Disposition: form-data; name=\"file\"; filename=\"\(fileURL.lastPathComponent)\"\(crlf)".data(using: .utf8)!)
-        body.append("Content-Type: audio/wav\(crlf)\(crlf)".data(using: .utf8)!)
+        body.append("Content-Type: \(fileURL.audioMIMEType)\(crlf)\(crlf)".data(using: .utf8)!)
         body.append(audioData)
         body.append(crlf.data(using: .utf8)!)
         body.append("--\(boundary)--\(crlf)".data(using: .utf8)!)

--- a/VivaDicta/Services/Transcription/CustomTranscription/CustomTranscriptionService.swift
+++ b/VivaDicta/Services/Transcription/CustomTranscription/CustomTranscriptionService.swift
@@ -73,7 +73,7 @@ struct CustomTranscriptionService {
         // Audio file
         body.append("--\(boundary)\(crlf)".data(using: .utf8)!)
         body.append("Content-Disposition: form-data; name=\"file\"; filename=\"\(audioURL.lastPathComponent)\"\(crlf)".data(using: .utf8)!)
-        body.append("Content-Type: audio/wav\(crlf)\(crlf)".data(using: .utf8)!)
+        body.append("Content-Type: \(audioURL.audioMIMEType)\(crlf)\(crlf)".data(using: .utf8)!)
         body.append(audioData)
         body.append(crlf.data(using: .utf8)!)
 

--- a/VivaDicta/Services/WatchAudioProcessor.swift
+++ b/VivaDicta/Services/WatchAudioProcessor.swift
@@ -151,7 +151,7 @@ final class WatchAudioProcessor {
         guard fm.fileExists(atPath: audioDir.path) else { return }
 
         guard let files = try? fm.contentsOfDirectory(at: audioDir, includingPropertiesForKeys: nil)
-            .filter({ $0.lastPathComponent.hasPrefix("watch-") && $0.pathExtension == "wav" }) else { return }
+            .filter({ $0.lastPathComponent.hasPrefix("watch-") && ["wav", "m4a"].contains($0.pathExtension) }) else { return }
 
         guard !files.isEmpty else { return }
 

--- a/VivaDictaWatch Watch App/Services/WatchAudioRecorder.swift
+++ b/VivaDictaWatch Watch App/Services/WatchAudioRecorder.swift
@@ -32,19 +32,17 @@ final class WatchAudioRecorder: NSObject, WatchAudioRecorderProtocol {
 
     func startRecording() throws -> URL {
         let session = AVAudioSession.sharedInstance()
-        try session.setCategory(.record)
+        try session.setCategory(.playAndRecord)
         try session.setActive(true)
 
         let fileURL = FileManager.default.temporaryDirectory
-            .appending(path: "\(UUID().uuidString).wav")
+            .appending(path: "\(UUID().uuidString).m4a")
 
         let settings: [String: Any] = [
-            AVFormatIDKey: kAudioFormatLinearPCM,
+            AVFormatIDKey: kAudioFormatMPEG4AAC,
             AVSampleRateKey: 16_000.0,
             AVNumberOfChannelsKey: 1,
-            AVLinearPCMBitDepthKey: 16,
-            AVLinearPCMIsBigEndianKey: false,
-            AVLinearPCMIsFloatKey: false
+            AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue
         ]
 
         let recorder = try AVAudioRecorder(url: fileURL, settings: settings)
@@ -67,7 +65,7 @@ final class WatchAudioRecorder: NSObject, WatchAudioRecorderProtocol {
         currentFileURL = nil
 
         do {
-            try AVAudioSession.sharedInstance().setActive(false)
+            try AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
         } catch {
             logger.warning("Failed to deactivate audio session: \(error.localizedDescription)")
         }

--- a/VivaDictaWatch-Watch-App-Info.plist
+++ b/VivaDictaWatch-Watch-App-Info.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- Watch now records M4A (AAC) instead of WAV - ~10x smaller files, faster Bluetooth transfer, less battery drain
- All cloud transcription services derive MIME type from file extension instead of hardcoding `audio/wav`
- Added Background Audio mode support (`.playAndRecord` session category) for recording when wrist is lowered
- Fixed `.notifyOthersOnDeactivation` being incorrectly passed on audio session activation (Watch recorder + AudioPrewarmManager)

## Test plan
- [ ] Record on Watch, verify M4A file transfers to iPhone and transcribes correctly
- [ ] Verify iOS app still records WAV and all transcription providers work unchanged
- [ ] Test Watch recording continues when wrist is lowered (Background Audio mode enabled in Xcode)
- [ ] Verify orphan recovery picks up both legacy `.wav` and new `.m4a` watch files