### PR TITLE
Add auto-delete notes setting

### DIFF
--- a/VivaDicta/Services/NoteCleanupService.swift
+++ b/VivaDicta/Services/NoteCleanupService.swift
@@ -106,7 +106,7 @@ final class NoteCleanupService {
             for transcription in transcriptions {
                 // Delete audio file if exists
                 if let audioFileName = transcription.audioFileName {
-                    let audioURL = audioDirectory.appendingPathComponent(audioFileName)
+                    let audioURL = audioDirectory.appending(path: audioFileName)
                     if fileManager.fileExists(atPath: audioURL.path) {
                         do {
                             try fileManager.removeItem(at: audioURL)

--- a/VivaDicta/Services/NoteCleanupService.swift
+++ b/VivaDicta/Services/NoteCleanupService.swift
@@ -1,0 +1,145 @@
+//
+//  NoteCleanupService.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.07
+//
+
+import AppIntents
+import CoreSpotlight
+import Foundation
+import SwiftData
+import os
+
+/// Service responsible for auto-deleting old transcription notes based on user settings
+@MainActor
+final class NoteCleanupService {
+    static let shared = NoteCleanupService()
+
+    private static let lastCleanupKey = "lastNoteCleanupDate"
+    private static let cleanupIntervalSeconds: TimeInterval = 24 * 60 * 60 // 24 hours
+
+    private let logger = Logger(category: .app)
+    private let userDefaults: UserDefaults
+    private let audioDirectory: URL
+    private let fileManager: FileManager
+    private let minimumCleanupInterval: TimeInterval
+
+    init(
+        userDefaults: UserDefaults = UserDefaultsStorage.appPrivate,
+        audioDirectory: URL = FileManager.appDirectory(for: .audio),
+        fileManager: FileManager = .default,
+        minimumCleanupInterval: TimeInterval = cleanupIntervalSeconds
+    ) {
+        self.userDefaults = userDefaults
+        self.audioDirectory = audioDirectory
+        self.fileManager = fileManager
+        self.minimumCleanupInterval = minimumCleanupInterval
+    }
+
+    /// Performs note cleanup based on user settings
+    /// - Parameter modelContext: The SwiftData model context to use for queries
+    func performCleanupIfNeeded(modelContext: ModelContext) async {
+        let isEnabled = userDefaults.bool(forKey: UserDefaultsStorage.Keys.isAutoNoteCleanupEnabled)
+
+        guard isEnabled else {
+            logger.logInfo("Note cleanup: Disabled, skipping")
+            return
+        }
+
+        // Check if enough time has passed since last cleanup
+        let lastCleanup = userDefaults.object(forKey: Self.lastCleanupKey) as? Date
+        if let lastCleanup {
+            let timeSinceLastCleanup = Date().timeIntervalSince(lastCleanup)
+            if timeSinceLastCleanup < minimumCleanupInterval {
+                let hoursRemaining = (minimumCleanupInterval - timeSinceLastCleanup) / 3600
+                logger.logInfo("Note cleanup: Skipping, last cleanup was \(Int(timeSinceLastCleanup / 3600))h ago (next in \(Int(hoursRemaining))h)")
+                return
+            }
+        }
+
+        // Get retention days (default to 7 if not set)
+        let retentionDays = userDefaults.integer(forKey: UserDefaultsStorage.Keys.noteRetentionDays)
+        let effectiveRetentionDays = retentionDays > 0 ? retentionDays : 7
+
+        logger.logInfo("Note cleanup: Starting with \(effectiveRetentionDays) day retention")
+
+        guard let cutoffDate = Calendar.current.date(
+            byAdding: .day,
+            value: -effectiveRetentionDays,
+            to: Date()
+        ) else {
+            logger.logError("Note cleanup: Failed to calculate cutoff date, aborting")
+            return
+        }
+
+        let success = await deleteOldNotes(olderThan: cutoffDate, modelContext: modelContext)
+
+        if success {
+            userDefaults.set(Date(), forKey: Self.lastCleanupKey)
+        }
+    }
+
+    /// Deletes transcription notes older than the specified date
+    /// - Parameters:
+    ///   - cutoffDate: Delete notes before this date
+    ///   - modelContext: The SwiftData model context
+    /// Returns `true` when cleanup completes successfully (or there is nothing to clean).
+    private func deleteOldNotes(olderThan cutoffDate: Date, modelContext: ModelContext) async -> Bool {
+        do {
+            let predicate = #Predicate<Transcription> { transcription in
+                transcription.timestamp < cutoffDate
+            }
+            let descriptor = FetchDescriptor<Transcription>(predicate: predicate)
+            let transcriptions = try modelContext.fetch(descriptor)
+
+            guard !transcriptions.isEmpty else {
+                logger.logInfo("Note cleanup: No old notes to clean up")
+                return true
+            }
+
+            logger.logInfo("Note cleanup: Found \(transcriptions.count) old notes to delete")
+
+            var deletedAudioCount = 0
+            var spotlightIDs: [UUID] = []
+
+            for transcription in transcriptions {
+                // Delete audio file if exists
+                if let audioFileName = transcription.audioFileName {
+                    let audioURL = audioDirectory.appendingPathComponent(audioFileName)
+                    if fileManager.fileExists(atPath: audioURL.path) {
+                        do {
+                            try fileManager.removeItem(at: audioURL)
+                            deletedAudioCount += 1
+                        } catch {
+                            logger.logError("Note cleanup: Failed to delete audio \(audioFileName): \(error.localizedDescription)")
+                        }
+                    }
+                }
+
+                spotlightIDs.append(transcription.id)
+                modelContext.delete(transcription)
+            }
+
+            try modelContext.save()
+            RecentNotesCache.syncFromDatabase(modelContext: modelContext)
+
+            // Remove from Spotlight index
+            if CSSearchableIndex.isIndexingAvailable() && !spotlightIDs.isEmpty {
+                do {
+                    let index = CSSearchableIndex.default()
+                    try await index.deleteAppEntities(identifiedBy: spotlightIDs, ofType: TranscriptionEntity.self)
+                } catch {
+                    logger.logError("Note cleanup: Failed to remove from Spotlight: \(error.localizedDescription)")
+                }
+            }
+
+            logger.logInfo("Note cleanup: Deleted \(transcriptions.count) notes, \(deletedAudioCount) audio files")
+            return true
+
+        } catch {
+            logger.logError("Note cleanup: Failed to fetch transcriptions: \(error.localizedDescription)")
+            return false
+        }
+    }
+}

--- a/VivaDicta/Shared/UserDefaultsStorage.swift
+++ b/VivaDicta/Shared/UserDefaultsStorage.swift
@@ -44,6 +44,8 @@ enum UserDefaultsStorage {
         static let isSpellingCorrectionsEnabled = "isSpellingCorrectionsEnabled"
         static let isAutoAudioCleanupEnabled = "isAutoAudioCleanupEnabled"
         static let audioRetentionDays = "audioRetentionDays"
+        static let isAutoNoteCleanupEnabled = "isAutoNoteCleanupEnabled"
+        static let noteRetentionDays = "noteRetentionDays"
         static let openRouterModels = "openRouterModels"
         static let vercelAIGatewayModels = "vercelAIGatewayModels"
         static let huggingFaceModels = "huggingFaceModels"

--- a/VivaDicta/Views/MainView.swift
+++ b/VivaDicta/Views/MainView.swift
@@ -100,6 +100,7 @@ struct MainView: View {
         }
         .onAppear { handleOnAppear() }
         .task {
+            await NoteCleanupService.shared.performCleanupIfNeeded(modelContext: modelContext)
             await AudioCleanupService.shared.performCleanupIfNeeded(modelContext: modelContext)
         }
         .onChange(of: appState.transcriptionManager.hasAvailableTranscriptionModels) { _, newValue in

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -37,6 +37,11 @@ struct SettingsView: View {
     @AppStorage(UserDefaultsStorage.Keys.audioRetentionDays)
     private var audioRetentionDays = 7
 
+    @AppStorage(UserDefaultsStorage.Keys.isAutoNoteCleanupEnabled)
+    private var isAutoNoteCleanupEnabled = false
+    @AppStorage(UserDefaultsStorage.Keys.noteRetentionDays)
+    private var noteRetentionDays = 7
+
     @AppStorage(UserDefaultsStorage.Keys.isICloudSyncEnabled)
     private var isICloudSyncEnabled = true
     @State private var showRestartAlert = false
@@ -292,21 +297,24 @@ struct SettingsView: View {
 
                 Section("Storage") {
 
-                    Toggle(isOn: $isAutoAudioCleanupEnabled) {
+                    Toggle(isOn: $isAutoNoteCleanupEnabled) {
                         VStack(alignment: .leading, spacing: 4) {
-                            Text("Automatic Audio Cleanup")
+                            Text("Auto-delete Notes")
                                 .font(.body)
-                            Text("Automatically delete old audio files to save space")
+                            Text("Automatically delete old notes and their audio files")
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                         }
                     }
-                    .onChange(of: isAutoAudioCleanupEnabled) { _, _ in
+                    .onChange(of: isAutoNoteCleanupEnabled) { _, newValue in
                         HapticManager.selectionChanged()
+                        if newValue {
+                            isAutoAudioCleanupEnabled = false
+                        }
                     }
 
-                    if isAutoAudioCleanupEnabled {
-                        Picker("Keep Audio Files For", selection: $audioRetentionDays) {
+                    if isAutoNoteCleanupEnabled {
+                        Picker("Keep Notes For", selection: $noteRetentionDays) {
                             Text("1 day").tag(1)
                             Text("3 days").tag(3)
                             Text("7 days").tag(7)
@@ -316,8 +324,39 @@ struct SettingsView: View {
                         .pickerStyle(.menu)
                         .padding(.leading)
                         .tint(.primary)
-                        .onChange(of: audioRetentionDays) { _, _ in
+                        .onChange(of: noteRetentionDays) { _, _ in
                             HapticManager.selectionChanged()
+                        }
+                    }
+
+                    if !isAutoNoteCleanupEnabled {
+                        Toggle(isOn: $isAutoAudioCleanupEnabled) {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("Automatic Audio Cleanup")
+                                    .font(.body)
+                                Text("Automatically delete old audio files to save space")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        .onChange(of: isAutoAudioCleanupEnabled) { _, _ in
+                            HapticManager.selectionChanged()
+                        }
+
+                        if isAutoAudioCleanupEnabled {
+                            Picker("Keep Audio Files For", selection: $audioRetentionDays) {
+                                Text("1 day").tag(1)
+                                Text("3 days").tag(3)
+                                Text("7 days").tag(7)
+                                Text("14 days").tag(14)
+                                Text("30 days").tag(30)
+                            }
+                            .pickerStyle(.menu)
+                            .padding(.leading)
+                            .tint(.primary)
+                            .onChange(of: audioRetentionDays) { _, _ in
+                                HapticManager.selectionChanged()
+                            }
                         }
                     }
                 }

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -504,6 +504,7 @@ struct SettingsView: View {
 
         }
         .animation(.default, value: isAutoAudioCleanupEnabled)
+        .animation(.default, value: isAutoNoteCleanupEnabled)
         .onAppear {
             if appState.shouldNavigateToModels {
                 appState.shouldNavigateToModels = false

--- a/VivaDictaTests/NoteCleanupServiceTests.swift
+++ b/VivaDictaTests/NoteCleanupServiceTests.swift
@@ -1,0 +1,433 @@
+//
+//  NoteCleanupServiceTests.swift
+//  VivaDictaTests
+//
+//  Created by Anton Novoselov on 2026.04.07
+//
+
+import Foundation
+import Testing
+import SwiftData
+@testable import VivaDicta
+
+@MainActor
+struct NoteCleanupServiceTests {
+
+    private let testSuiteName = "NoteCleanupServiceTests"
+
+    private func makeTestDefaults() -> UserDefaults {
+        let defaults = UserDefaults(suiteName: testSuiteName)!
+        defaults.removePersistentDomain(forName: testSuiteName)
+        return defaults
+    }
+
+    private func makeTestDirectory() throws -> URL {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("NoteCleanupTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        return tempDir
+    }
+
+    private func makeModelContainer() throws -> ModelContainer {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        return try ModelContainer(for: Transcription.self, configurations: config)
+    }
+
+    private func createTranscription(
+        text: String = "Test transcription",
+        audioFileName: String? = nil,
+        daysAgo: Int = 0,
+        in context: ModelContext
+    ) -> Transcription {
+        let transcription = Transcription(
+            text: text,
+            audioDuration: 10.0,
+            audioFileName: audioFileName
+        )
+        if daysAgo > 0 {
+            transcription.timestamp = Calendar.current.date(
+                byAdding: .day,
+                value: -daysAgo,
+                to: Date()
+            ) ?? Date()
+        }
+        context.insert(transcription)
+        return transcription
+    }
+
+    private func createAudioFile(named fileName: String, in directory: URL) throws {
+        let fileURL = directory.appendingPathComponent(fileName)
+        let testData = "test audio data".data(using: .utf8)!
+        try testData.write(to: fileURL)
+    }
+
+    // MARK: - Cleanup Disabled Tests
+
+    @Test func cleanupSkippedWhenDisabled() async throws {
+        let defaults = makeTestDefaults()
+        let audioDir = try makeTestDirectory()
+        let container = try makeModelContainer()
+        let context = container.mainContext
+
+        defaults.set(false, forKey: UserDefaultsStorage.Keys.isAutoNoteCleanupEnabled)
+
+        let fileName = "old-audio.m4a"
+        try createAudioFile(named: fileName, in: audioDir)
+        let transcription = createTranscription(
+            audioFileName: fileName,
+            daysAgo: 30,
+            in: context
+        )
+        try context.save()
+
+        let service = NoteCleanupService(
+            userDefaults: defaults,
+            audioDirectory: audioDir,
+            minimumCleanupInterval: 0
+        )
+        await service.performCleanupIfNeeded(modelContext: context)
+
+        // Transcription and audio should still exist
+        #expect(FileManager.default.fileExists(atPath: audioDir.appendingPathComponent(fileName).path))
+        let fetchDescriptor = FetchDescriptor<Transcription>()
+        let remaining = try context.fetch(fetchDescriptor)
+        #expect(remaining.count == 1)
+        #expect(remaining.first?.audioFileName == fileName)
+
+        try? FileManager.default.removeItem(at: audioDir)
+    }
+
+    // MARK: - Retention Period Tests
+
+    @Test func cleanupWithDefaultRetentionDays() async throws {
+        let defaults = makeTestDefaults()
+        let audioDir = try makeTestDirectory()
+        let container = try makeModelContainer()
+        let context = container.mainContext
+
+        defaults.set(true, forKey: UserDefaultsStorage.Keys.isAutoNoteCleanupEnabled)
+
+        let oldFileName = "old-audio.m4a"
+        let recentFileName = "recent-audio.m4a"
+        try createAudioFile(named: oldFileName, in: audioDir)
+        try createAudioFile(named: recentFileName, in: audioDir)
+
+        _ = createTranscription(
+            text: "Old transcription",
+            audioFileName: oldFileName,
+            daysAgo: 10,
+            in: context
+        )
+        _ = createTranscription(
+            text: "Recent transcription",
+            audioFileName: recentFileName,
+            daysAgo: 3,
+            in: context
+        )
+        try context.save()
+
+        let service = NoteCleanupService(
+            userDefaults: defaults,
+            audioDirectory: audioDir,
+            minimumCleanupInterval: 0
+        )
+        await service.performCleanupIfNeeded(modelContext: context)
+
+        // Old note fully deleted, recent note kept
+        #expect(!FileManager.default.fileExists(atPath: audioDir.appendingPathComponent(oldFileName).path))
+        #expect(FileManager.default.fileExists(atPath: audioDir.appendingPathComponent(recentFileName).path))
+
+        let fetchDescriptor = FetchDescriptor<Transcription>()
+        let remaining = try context.fetch(fetchDescriptor)
+        #expect(remaining.count == 1)
+        #expect(remaining.first?.text == "Recent transcription")
+
+        try? FileManager.default.removeItem(at: audioDir)
+    }
+
+    @Test func cleanupWithCustomRetentionDays() async throws {
+        let defaults = makeTestDefaults()
+        let audioDir = try makeTestDirectory()
+        let container = try makeModelContainer()
+        let context = container.mainContext
+
+        defaults.set(true, forKey: UserDefaultsStorage.Keys.isAutoNoteCleanupEnabled)
+        defaults.set(3, forKey: UserDefaultsStorage.Keys.noteRetentionDays)
+
+        let fileName = "audio.m4a"
+        try createAudioFile(named: fileName, in: audioDir)
+        _ = createTranscription(
+            audioFileName: fileName,
+            daysAgo: 5,
+            in: context
+        )
+        try context.save()
+
+        let service = NoteCleanupService(
+            userDefaults: defaults,
+            audioDirectory: audioDir,
+            minimumCleanupInterval: 0
+        )
+        await service.performCleanupIfNeeded(modelContext: context)
+
+        #expect(!FileManager.default.fileExists(atPath: audioDir.appendingPathComponent(fileName).path))
+        let fetchDescriptor = FetchDescriptor<Transcription>()
+        let remaining = try context.fetch(fetchDescriptor)
+        #expect(remaining.isEmpty)
+
+        try? FileManager.default.removeItem(at: audioDir)
+    }
+
+    // MARK: - Full Deletion Tests
+
+    @Test func transcriptionFullyDeletedNotJustAudio() async throws {
+        let defaults = makeTestDefaults()
+        let audioDir = try makeTestDirectory()
+        let container = try makeModelContainer()
+        let context = container.mainContext
+
+        defaults.set(true, forKey: UserDefaultsStorage.Keys.isAutoNoteCleanupEnabled)
+        defaults.set(7, forKey: UserDefaultsStorage.Keys.noteRetentionDays)
+
+        let fileName = "test-audio.m4a"
+        try createAudioFile(named: fileName, in: audioDir)
+        let transcription = createTranscription(
+            text: "This should be fully deleted",
+            audioFileName: fileName,
+            daysAgo: 10,
+            in: context
+        )
+        transcription.enhancedText = "Enhanced version"
+        try context.save()
+
+        let service = NoteCleanupService(
+            userDefaults: defaults,
+            audioDirectory: audioDir,
+            minimumCleanupInterval: 0
+        )
+        await service.performCleanupIfNeeded(modelContext: context)
+
+        // Both audio file and transcription record should be gone
+        #expect(!FileManager.default.fileExists(atPath: audioDir.appendingPathComponent(fileName).path))
+        let fetchDescriptor = FetchDescriptor<Transcription>()
+        let remaining = try context.fetch(fetchDescriptor)
+        #expect(remaining.isEmpty)
+
+        try? FileManager.default.removeItem(at: audioDir)
+    }
+
+    @Test func noteWithoutAudioAlsoDeleted() async throws {
+        let defaults = makeTestDefaults()
+        let audioDir = try makeTestDirectory()
+        let container = try makeModelContainer()
+        let context = container.mainContext
+
+        defaults.set(true, forKey: UserDefaultsStorage.Keys.isAutoNoteCleanupEnabled)
+        defaults.set(7, forKey: UserDefaultsStorage.Keys.noteRetentionDays)
+
+        _ = createTranscription(
+            text: "Old note without audio",
+            audioFileName: nil,
+            daysAgo: 30,
+            in: context
+        )
+        try context.save()
+
+        let service = NoteCleanupService(
+            userDefaults: defaults,
+            audioDirectory: audioDir,
+            minimumCleanupInterval: 0
+        )
+        await service.performCleanupIfNeeded(modelContext: context)
+
+        let fetchDescriptor = FetchDescriptor<Transcription>()
+        let remaining = try context.fetch(fetchDescriptor)
+        #expect(remaining.isEmpty)
+
+        try? FileManager.default.removeItem(at: audioDir)
+    }
+
+    // MARK: - No Matching Notes Tests
+
+    @Test func cleanupWithNoOldNotes() async throws {
+        let defaults = makeTestDefaults()
+        let audioDir = try makeTestDirectory()
+        let container = try makeModelContainer()
+        let context = container.mainContext
+
+        defaults.set(true, forKey: UserDefaultsStorage.Keys.isAutoNoteCleanupEnabled)
+        defaults.set(7, forKey: UserDefaultsStorage.Keys.noteRetentionDays)
+
+        let fileName = "recent-audio.m4a"
+        try createAudioFile(named: fileName, in: audioDir)
+        _ = createTranscription(
+            audioFileName: fileName,
+            daysAgo: 1,
+            in: context
+        )
+        try context.save()
+
+        let service = NoteCleanupService(
+            userDefaults: defaults,
+            audioDirectory: audioDir,
+            minimumCleanupInterval: 0
+        )
+        await service.performCleanupIfNeeded(modelContext: context)
+
+        #expect(FileManager.default.fileExists(atPath: audioDir.appendingPathComponent(fileName).path))
+        let fetchDescriptor = FetchDescriptor<Transcription>()
+        let remaining = try context.fetch(fetchDescriptor)
+        #expect(remaining.count == 1)
+
+        try? FileManager.default.removeItem(at: audioDir)
+    }
+
+    // MARK: - Multiple Notes Tests
+
+    @Test func cleanupMultipleOldNotes() async throws {
+        let defaults = makeTestDefaults()
+        let audioDir = try makeTestDirectory()
+        let container = try makeModelContainer()
+        let context = container.mainContext
+
+        defaults.set(true, forKey: UserDefaultsStorage.Keys.isAutoNoteCleanupEnabled)
+        defaults.set(7, forKey: UserDefaultsStorage.Keys.noteRetentionDays)
+
+        for i in 1...5 {
+            let fileName = "audio-\(i).m4a"
+            try createAudioFile(named: fileName, in: audioDir)
+            _ = createTranscription(
+                text: "Transcription \(i)",
+                audioFileName: fileName,
+                daysAgo: 10 + i,
+                in: context
+            )
+        }
+        // One recent note that should survive
+        let recentFileName = "recent.m4a"
+        try createAudioFile(named: recentFileName, in: audioDir)
+        _ = createTranscription(
+            text: "Recent note",
+            audioFileName: recentFileName,
+            daysAgo: 1,
+            in: context
+        )
+        try context.save()
+
+        let service = NoteCleanupService(
+            userDefaults: defaults,
+            audioDirectory: audioDir,
+            minimumCleanupInterval: 0
+        )
+        await service.performCleanupIfNeeded(modelContext: context)
+
+        // 5 old notes deleted, 1 recent survives
+        let fetchDescriptor = FetchDescriptor<Transcription>()
+        let remaining = try context.fetch(fetchDescriptor)
+        #expect(remaining.count == 1)
+        #expect(remaining.first?.text == "Recent note")
+
+        for i in 1...5 {
+            #expect(!FileManager.default.fileExists(atPath: audioDir.appendingPathComponent("audio-\(i).m4a").path))
+        }
+        #expect(FileManager.default.fileExists(atPath: audioDir.appendingPathComponent(recentFileName).path))
+
+        try? FileManager.default.removeItem(at: audioDir)
+    }
+
+    // MARK: - Throttling Tests
+
+    @Test func cleanupSkippedWhenRunRecently() async throws {
+        let defaults = makeTestDefaults()
+        let audioDir = try makeTestDirectory()
+        let container = try makeModelContainer()
+        let context = container.mainContext
+
+        defaults.set(true, forKey: UserDefaultsStorage.Keys.isAutoNoteCleanupEnabled)
+        defaults.set(7, forKey: UserDefaultsStorage.Keys.noteRetentionDays)
+
+        let oneHourAgo = Date().addingTimeInterval(-3600)
+        defaults.set(oneHourAgo, forKey: "lastNoteCleanupDate")
+
+        _ = createTranscription(
+            text: "Old note",
+            daysAgo: 10,
+            in: context
+        )
+        try context.save()
+
+        let service = NoteCleanupService(
+            userDefaults: defaults,
+            audioDirectory: audioDir,
+            minimumCleanupInterval: 24 * 60 * 60
+        )
+        await service.performCleanupIfNeeded(modelContext: context)
+
+        // Note should NOT be deleted because cleanup ran recently
+        let fetchDescriptor = FetchDescriptor<Transcription>()
+        let remaining = try context.fetch(fetchDescriptor)
+        #expect(remaining.count == 1)
+
+        try? FileManager.default.removeItem(at: audioDir)
+    }
+
+    @Test func cleanupRunsOnFirstLaunch() async throws {
+        let defaults = makeTestDefaults()
+        let audioDir = try makeTestDirectory()
+        let container = try makeModelContainer()
+        let context = container.mainContext
+
+        defaults.set(true, forKey: UserDefaultsStorage.Keys.isAutoNoteCleanupEnabled)
+        defaults.set(7, forKey: UserDefaultsStorage.Keys.noteRetentionDays)
+
+        _ = createTranscription(
+            text: "Old note",
+            daysAgo: 10,
+            in: context
+        )
+        try context.save()
+
+        let service = NoteCleanupService(
+            userDefaults: defaults,
+            audioDirectory: audioDir,
+            minimumCleanupInterval: 24 * 60 * 60
+        )
+        await service.performCleanupIfNeeded(modelContext: context)
+
+        let fetchDescriptor = FetchDescriptor<Transcription>()
+        let remaining = try context.fetch(fetchDescriptor)
+        #expect(remaining.isEmpty)
+
+        try? FileManager.default.removeItem(at: audioDir)
+    }
+
+    @Test func cleanupUpdatesLastCleanupTimestamp() async throws {
+        let defaults = makeTestDefaults()
+        let audioDir = try makeTestDirectory()
+        let container = try makeModelContainer()
+        let context = container.mainContext
+
+        defaults.set(true, forKey: UserDefaultsStorage.Keys.isAutoNoteCleanupEnabled)
+        defaults.set(7, forKey: UserDefaultsStorage.Keys.noteRetentionDays)
+
+        #expect(defaults.object(forKey: "lastNoteCleanupDate") == nil)
+
+        _ = createTranscription(daysAgo: 10, in: context)
+        try context.save()
+
+        let beforeCleanup = Date()
+
+        let service = NoteCleanupService(
+            userDefaults: defaults,
+            audioDirectory: audioDir,
+            minimumCleanupInterval: 0
+        )
+        await service.performCleanupIfNeeded(modelContext: context)
+
+        let lastCleanup = defaults.object(forKey: "lastNoteCleanupDate") as? Date
+        #expect(lastCleanup != nil)
+        #expect(lastCleanup! >= beforeCleanup)
+
+        try? FileManager.default.removeItem(at: audioDir)
+    }
+}


### PR DESCRIPTION
## Summary
- Add "Auto-delete Notes" setting in Storage section with configurable retention (1/3/7/14/30 days)
- Full deletion: transcription record + audio file + Spotlight entry removed for notes older than retention period
- When note cleanup is enabled, audio-only cleanup is hidden and its flag is reset (redundant)
- Cleanup runs once per app launch with 24h throttling; timestamp only recorded on success to allow retry after failures

## Test plan
- [x] Build succeeds (0 errors)
- [x] 10 unit tests pass covering: disabled state, default/custom retention, full deletion, notes without audio, multiple notes, throttling, first launch, timestamp updates
- [ ] Manual: enable auto-delete notes, verify old notes are deleted on next launch
- [ ] Manual: verify audio cleanup toggle hides when note cleanup is on
- [ ] Manual: verify enabling note cleanup resets audio cleanup flag