### PR TITLE
Add streaming responses in note detail

### DIFF
--- a/VivaDicta/Services/AIEnhance/AIProvider.swift
+++ b/VivaDicta/Services/AIEnhance/AIProvider.swift
@@ -127,6 +127,16 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
         self == .apple || self == .customOpenAI
     }
 
+    /// Returns true when the selected model can stream text responses incrementally.
+    func supportsResponseStreaming(model: String) -> Bool {
+        switch self {
+        case .apple:
+            true
+        default:
+            false
+        }
+    }
+
     /// URL to obtain an API key for this provider.
     var apiKeyURL: URL? {
         switch self {

--- a/VivaDicta/Services/AIEnhance/AIProvider.swift
+++ b/VivaDicta/Services/AIEnhance/AIProvider.swift
@@ -130,7 +130,21 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
     /// Returns true when the selected model can stream text responses incrementally.
     func supportsResponseStreaming(model: String) -> Bool {
         switch self {
-        case .apple:
+        case .apple,
+             .anthropic,
+             .cerebras,
+             .groq,
+             .gemini,
+             .openAI,
+             .openRouter,
+             .grok,
+             .mistral,
+             .zai,
+             .kimi,
+             .vercelAIGateway,
+             .huggingFace,
+             .ollama,
+             .customOpenAI:
             true
         default:
             false

--- a/VivaDicta/Services/AIEnhance/AIProvider.swift
+++ b/VivaDicta/Services/AIEnhance/AIProvider.swift
@@ -133,6 +133,7 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
         case .apple,
              .anthropic,
              .cerebras,
+             .copilot,
              .groq,
              .gemini,
              .openAI,

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -1179,31 +1179,51 @@ class AIService {
             )
             return await finalizeStreamingResult(result, onPartialResponse: onPartialResponse)
         case .geminiOAuth:
-            let provider = GeminiOAuthProvider()
-            let (token, _, projectId) = try await OAuthManager.shared.validAccessToken(for: provider)
-            let model = selectedMode.aiModel.isEmpty ? GeminiAPIClient.defaultModel : selectedMode.aiModel
-            let result = try await GeminiAPIClient.enhanceStreaming(
-                text: userMsg,
-                systemPrompt: sysMsg,
-                model: model,
-                accessToken: token,
-                projectId: projectId,
-                onPartialResult: onPartialResponse
-            )
-            return await finalizeStreamingResult(result, onPartialResponse: onPartialResponse)
+            do {
+                let provider = GeminiOAuthProvider()
+                let (token, _, projectId) = try await OAuthManager.shared.validAccessToken(for: provider)
+                let model = selectedMode.aiModel.isEmpty ? GeminiAPIClient.defaultModel : selectedMode.aiModel
+                let result = try await GeminiAPIClient.enhanceStreaming(
+                    text: userMsg,
+                    systemPrompt: sysMsg,
+                    model: model,
+                    accessToken: token,
+                    projectId: projectId,
+                    onPartialResult: onPartialResponse
+                )
+                return await finalizeStreamingResult(result, onPartialResponse: onPartialResponse)
+            } catch let error as EnhancementError {
+                throw error
+            } catch let error as OAuthError {
+                if (VivAgentsClient.isEnabled && VivAgentsClient.isGeminiCliActive) || self.getAPIKey(for: aiProvider) != nil {
+                    logger.logWarning("Gemini OAuth streaming failed, falling back: \(error.localizedDescription)")
+                    break
+                } else {
+                    throw EnhancementError.customError(error.errorDescription ?? "Gemini OAuth error")
+                }
+            }
         case .openAIOAuth:
-            let provider = OpenAIOAuthProvider()
-            let (token, accountId, _) = try await OAuthManager.shared.validAccessToken(for: provider)
-            let model = selectedMode.aiModel.isEmpty ? OpenAIOAuthClient.defaultModel : selectedMode.aiModel
-            let result = try await OpenAIOAuthClient.enhance(
-                text: userMsg,
-                systemPrompt: sysMsg,
-                model: model,
-                accessToken: token,
-                accountId: accountId,
-                onPartialResult: onPartialResponse
-            )
-            return await finalizeStreamingResult(result, onPartialResponse: onPartialResponse)
+            do {
+                let provider = OpenAIOAuthProvider()
+                let (token, accountId, _) = try await OAuthManager.shared.validAccessToken(for: provider)
+                let model = selectedMode.aiModel.isEmpty ? OpenAIOAuthClient.defaultModel : selectedMode.aiModel
+                let result = try await OpenAIOAuthClient.enhance(
+                    text: userMsg,
+                    systemPrompt: sysMsg,
+                    model: model,
+                    accessToken: token,
+                    accountId: accountId,
+                    onPartialResult: onPartialResponse
+                )
+                return await finalizeStreamingResult(result, onPartialResponse: onPartialResponse)
+            } catch let error as OAuthError {
+                if (VivAgentsClient.isEnabled && VivAgentsClient.isCodexCliActive) || self.getAPIKey(for: aiProvider) != nil {
+                    logger.logWarning("OpenAI OAuth streaming failed, falling back: \(error.localizedDescription)")
+                    break
+                } else {
+                    throw EnhancementError.customError(error.errorDescription ?? "OpenAI OAuth error")
+                }
+            }
         case .openAICompatibleCloud:
             guard let apiKey = self.getAPIKey(for: aiProvider) else {
                 throw EnhancementError.notConfigured

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -43,6 +43,15 @@ import os
 class AIService {
     private let logger = Logger(category: .aiService)
 
+    private enum StreamingRoute {
+        case apple
+        case anthropic
+        case openAIOAuth
+        case openAICompatibleCloud
+        case ollama
+        case customOpenAI
+    }
+
     /// List of AI providers that have valid API keys or are otherwise available.
     public var connectedProviders: [AIProvider] = []
 
@@ -687,7 +696,7 @@ class AIService {
             return false
         }
 
-        return aiProvider.supportsResponseStreaming(model: selectedMode.aiModel)
+        return resolvedStreamingRoute(for: aiProvider) != nil
     }
 
     // MARK: - Enhance methods
@@ -823,6 +832,287 @@ class AIService {
         return (systemMessage, userMessage)
     }
 
+    private func resolvedStreamingRoute(for aiProvider: AIProvider) -> StreamingRoute? {
+        switch aiProvider {
+        case .apple:
+            return .apple
+        case .openAI:
+            if isOpenAISignedIn {
+                return .openAIOAuth
+            }
+            if VivAgentsClient.isEnabled && VivAgentsClient.isCodexCliActive,
+               let serverURL = VivAgentsClient.serverURL, !serverURL.isEmpty {
+                return nil
+            }
+            return aiProvider.supportsResponseStreaming(model: selectedMode.aiModel) ? .openAICompatibleCloud : nil
+        case .gemini:
+            if isGeminiSignedIn {
+                return nil
+            }
+            if VivAgentsClient.isEnabled && VivAgentsClient.isGeminiCliActive,
+               let serverURL = VivAgentsClient.serverURL, !serverURL.isEmpty {
+                return nil
+            }
+            return aiProvider.supportsResponseStreaming(model: selectedMode.aiModel) ? .openAICompatibleCloud : nil
+        case .anthropic:
+            if VivAgentsClient.isEnabled && VivAgentsClient.isAnthropicCliActive,
+               let serverURL = VivAgentsClient.serverURL, !serverURL.isEmpty {
+                return nil
+            }
+            return .anthropic
+        case .ollama:
+            return .ollama
+        case .customOpenAI:
+            return .customOpenAI
+        default:
+            return aiProvider.supportsResponseStreaming(model: selectedMode.aiModel) ? .openAICompatibleCloud : nil
+        }
+    }
+
+    private func buildOpenAICompatibleRequestBody(
+        modelName: String,
+        systemMessage: String,
+        userMessage: String,
+        stream: Bool
+    ) -> [String: Any] {
+        let messages: [[String: Any]] = [
+            ["role": "system", "content": systemMessage],
+            ["role": "user", "content": userMessage]
+        ]
+
+        var requestBody: [String: Any] = [
+            "model": modelName,
+            "messages": messages,
+            "stream": stream
+        ]
+
+        if modelName.lowercased().hasPrefix("gpt-5") == false {
+            requestBody["temperature"] = 0.3
+        }
+
+        if let reasoningEffort = ReasoningConfig.getReasoningParameter(for: modelName) {
+            requestBody["reasoning_effort"] = reasoningEffort
+        }
+
+        if let extraBody = ReasoningConfig.getExtraBodyParameters(for: modelName) {
+            for (key, value) in extraBody {
+                requestBody[key] = value
+            }
+        }
+
+        return requestBody
+    }
+
+    private func makeOpenAICompatibleStreamingRequest(
+        url: URL,
+        modelName: String,
+        systemMessage: String,
+        userMessage: String,
+        headers: [String: String],
+        timeout: TimeInterval,
+        errorPrefix: String,
+        notFoundMessage: String? = nil,
+        unauthorizedMessage: String? = nil,
+        onPartialResponse: @escaping @MainActor (String) -> Void
+    ) async throws -> String {
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addValue("text/event-stream", forHTTPHeaderField: "Accept")
+        request.timeoutInterval = timeout
+
+        for (key, value) in headers {
+            request.addValue(value, forHTTPHeaderField: key)
+        }
+
+        let requestBody = buildOpenAICompatibleRequestBody(
+            modelName: modelName,
+            systemMessage: systemMessage,
+            userMessage: userMessage,
+            stream: true
+        )
+        request.httpBody = try? JSONSerialization.data(withJSONObject: requestBody)
+
+        try Task.checkCancellation()
+
+        let (bytes, response) = try await URLSession.shared.bytes(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw EnhancementError.invalidResponse
+        }
+
+        guard httpResponse.statusCode == 200 else {
+            var errorData = Data()
+            for try await byte in bytes {
+                errorData.append(byte)
+            }
+            let errorString = String(data: errorData, encoding: .utf8) ?? "Unknown error"
+
+            switch httpResponse.statusCode {
+            case 401 where unauthorizedMessage != nil:
+                throw EnhancementError.customError(unauthorizedMessage ?? errorString)
+            case 404 where notFoundMessage != nil:
+                throw EnhancementError.customError(notFoundMessage ?? errorString)
+            case 429:
+                throw EnhancementError.rateLimitExceeded
+            case 500...599:
+                throw EnhancementError.serverError
+            default:
+                throw EnhancementError.customError("\(errorPrefix) (HTTP \(httpResponse.statusCode)): \(errorString)")
+            }
+        }
+
+        var aggregatedText = ""
+        for try await line in bytes.lines {
+            try Task.checkCancellation()
+
+            if let delta = Self.openAICompatibleStreamingDelta(from: line) {
+                aggregatedText += delta
+                await onPartialResponse(aggregatedText)
+            }
+        }
+
+        guard !aggregatedText.isEmpty else {
+            throw EnhancementError.enhancementFailed
+        }
+
+        let filteredText = AIEnhancementOutputFilter.filter(aggregatedText.trimmingCharacters(in: .whitespacesAndNewlines))
+        if filteredText != aggregatedText {
+            await onPartialResponse(filteredText)
+        }
+
+        return filteredText
+    }
+
+    static func openAICompatibleStreamingDelta(from line: String) -> String? {
+        guard line.hasPrefix("data:") else {
+            return nil
+        }
+
+        let payload = String(line.dropFirst(5)).trimmingCharacters(in: .whitespaces)
+        guard payload.isEmpty == false, payload != "[DONE]",
+              let data = payload.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let choices = json["choices"] as? [[String: Any]],
+              let firstChoice = choices.first else {
+            return nil
+        }
+
+        if let delta = firstChoice["delta"] as? [String: Any] {
+            if let content = delta["content"] as? String, content.isEmpty == false {
+                return content
+            }
+
+            if let contentItems = delta["content"] as? [[String: Any]] {
+                let text = contentItems.compactMap { $0["text"] as? String }.joined()
+                return text.isEmpty ? nil : text
+            }
+        }
+
+        if let text = firstChoice["text"] as? String, text.isEmpty == false {
+            return text
+        }
+
+        return nil
+    }
+
+    private func makeAnthropicStreamingRequest(
+        systemMessage: String,
+        userMessage: String,
+        apiKey: String,
+        onPartialResponse: @escaping @MainActor (String) -> Void
+    ) async throws -> String {
+        var request = URLRequest(url: URL(string: AIProvider.anthropic.baseURL)!)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addValue("text/event-stream", forHTTPHeaderField: "Accept")
+        request.addValue(apiKey, forHTTPHeaderField: "x-api-key")
+        request.addValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+        request.timeoutInterval = baseTimeout
+
+        let requestBody: [String: Any] = [
+            "model": selectedMode.aiModel,
+            "max_tokens": 8192,
+            "system": systemMessage,
+            "messages": [
+                ["role": "user", "content": userMessage]
+            ],
+            "stream": true
+        ]
+
+        request.httpBody = try? JSONSerialization.data(withJSONObject: requestBody)
+
+        try Task.checkCancellation()
+
+        let (bytes, response) = try await URLSession.shared.bytes(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw EnhancementError.invalidResponse
+        }
+
+        guard httpResponse.statusCode == 200 else {
+            var errorData = Data()
+            for try await byte in bytes {
+                errorData.append(byte)
+            }
+            let errorString = String(data: errorData, encoding: .utf8) ?? "Could not decode error response."
+
+            if httpResponse.statusCode == 429 {
+                throw EnhancementError.rateLimitExceeded
+            } else if (500...599).contains(httpResponse.statusCode) {
+                throw EnhancementError.serverError
+            } else {
+                throw EnhancementError.customError("HTTP \(httpResponse.statusCode): \(errorString)")
+            }
+        }
+
+        var aggregatedText = ""
+        for try await line in bytes.lines {
+            try Task.checkCancellation()
+
+            guard line.hasPrefix("data: ") else { continue }
+            let payload = String(line.dropFirst(6))
+            guard payload.isEmpty == false,
+                  let data = payload.data(using: .utf8),
+                  let event = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let type = event["type"] as? String else {
+                continue
+            }
+
+            if type == "content_block_delta",
+               let delta = event["delta"] as? [String: Any],
+               let deltaType = delta["type"] as? String,
+               deltaType == "text_delta",
+               let text = delta["text"] as? String,
+               text.isEmpty == false {
+                aggregatedText += text
+                await onPartialResponse(aggregatedText)
+                continue
+            }
+
+            if type == "error",
+               let error = event["error"] as? [String: Any] {
+                let message = (error["message"] as? String) ?? "Anthropic streaming error"
+                let errorType = error["type"] as? String
+                if errorType == "overloaded_error" {
+                    throw EnhancementError.serverError
+                }
+                throw EnhancementError.customError(message)
+            }
+        }
+
+        guard !aggregatedText.isEmpty else {
+            throw EnhancementError.enhancementFailed
+        }
+
+        let filteredText = AIEnhancementOutputFilter.filter(aggregatedText.trimmingCharacters(in: .whitespacesAndNewlines))
+        if filteredText != aggregatedText {
+            await onPartialResponse(filteredText)
+        }
+
+        return filteredText
+    }
+
     private func makeStreamingRequest(
         text: String,
         systemMessage: String? = nil,
@@ -838,15 +1128,17 @@ class AIService {
             return ""
         }
 
-        if aiProvider == .apple {
+        let sysMsg = systemMessage ?? getSystemMessage()
+        let userMsg = preFormattedUserMessage ?? formatTranscriptForLLM(text)
+        lastSystemMessageSent = sysMsg
+        lastUserMessageSent = userMsg
+
+        switch resolvedStreamingRoute(for: aiProvider) {
+        case .apple:
             if #available(iOS 26, *) {
-                let sysMsg = systemMessage ?? getSystemMessage()
-                let userMsg = preFormattedUserMessage ?? formatTranscriptForLLM(text)
                 logger.logDebug("AI Processing - Using Apple Foundation Model streaming")
                 logger.logDebug("AI Processing - System Message: \(sysMsg)")
                 logger.logDebug("AI Processing - User Message: \(userMsg)")
-                lastSystemMessageSent = sysMsg
-                lastUserMessageSent = userMsg
                 return try await appleFoundationModelService.enhanceStreaming(
                     systemMessage: sysMsg,
                     userMessage: userMsg,
@@ -855,6 +1147,109 @@ class AIService {
             } else {
                 throw EnhancementError.notConfigured
             }
+        case .anthropic:
+            guard let apiKey = self.getAPIKey(for: aiProvider) else {
+                throw EnhancementError.notConfigured
+            }
+
+            logger.logDebug("AI Processing - Using Anthropic streaming")
+            logger.logDebug("AI Processing - Model: \(self.selectedMode.aiModel)")
+
+            return try await makeAnthropicStreamingRequest(
+                systemMessage: sysMsg,
+                userMessage: userMsg,
+                apiKey: apiKey,
+                onPartialResponse: onPartialResponse
+            )
+        case .openAIOAuth:
+            let provider = OpenAIOAuthProvider()
+            let (token, accountId, _) = try await OAuthManager.shared.validAccessToken(for: provider)
+            let model = selectedMode.aiModel.isEmpty ? OpenAIOAuthClient.defaultModel : selectedMode.aiModel
+            let result = try await OpenAIOAuthClient.enhance(
+                text: userMsg,
+                systemPrompt: sysMsg,
+                model: model,
+                accessToken: token,
+                accountId: accountId,
+                onPartialResult: onPartialResponse
+            )
+            return AIEnhancementOutputFilter.filter(result)
+        case .openAICompatibleCloud:
+            guard let apiKey = self.getAPIKey(for: aiProvider) else {
+                throw EnhancementError.notConfigured
+            }
+
+            logger.logDebug("AI Processing - Using \(aiProvider.displayName) streaming")
+            logger.logDebug("AI Processing - Model: \(self.selectedMode.aiModel)")
+
+            return try await makeOpenAICompatibleStreamingRequest(
+                url: URL(string: aiProvider.baseURL)!,
+                modelName: selectedMode.aiModel,
+                systemMessage: sysMsg,
+                userMessage: userMsg,
+                headers: ["Authorization": "Bearer \(apiKey)"],
+                timeout: baseTimeout,
+                errorPrefix: "\(aiProvider.displayName) error",
+                onPartialResponse: onPartialResponse
+            )
+        case .ollama:
+            let serverURL = ollamaServerURL
+            guard let url = URL(string: "\(serverURL)/v1/chat/completions") else {
+                throw EnhancementError.customError("Invalid Ollama server URL: \(serverURL)")
+            }
+
+            logger.logDebug("AI Processing - Using Ollama streaming at \(serverURL)")
+            logger.logDebug("AI Processing - Model: \(self.selectedMode.aiModel)")
+
+            return try await makeOpenAICompatibleStreamingRequest(
+                url: url,
+                modelName: selectedMode.aiModel,
+                systemMessage: sysMsg,
+                userMessage: userMsg,
+                headers: [:],
+                timeout: 120,
+                errorPrefix: "Ollama error",
+                notFoundMessage: "Model '\(self.selectedMode.aiModel)' not found. Run 'ollama pull \(self.selectedMode.aiModel)' on your Mac/server to download it.",
+                onPartialResponse: onPartialResponse
+            )
+        case .customOpenAI:
+            let endpointURL = customOpenAIEndpointURL
+            let modelName = customOpenAIModelName
+
+            guard !endpointURL.isEmpty else {
+                throw EnhancementError.customError("Custom AI endpoint URL is not configured")
+            }
+
+            guard !modelName.isEmpty else {
+                throw EnhancementError.customError("Custom AI model name is not configured")
+            }
+
+            guard let url = URL(string: endpointURL) else {
+                throw EnhancementError.customError("Invalid Custom AI endpoint URL: \(endpointURL)")
+            }
+
+            var headers: [String: String] = [:]
+            if let apiKey = getAPIKey(for: .customOpenAI), !apiKey.isEmpty {
+                headers["Authorization"] = "Bearer \(apiKey)"
+            }
+
+            logger.logDebug("AI Processing - Using Custom OpenAI streaming at \(endpointURL)")
+            logger.logDebug("AI Processing - Model: \(modelName)")
+
+            return try await makeOpenAICompatibleStreamingRequest(
+                url: url,
+                modelName: modelName,
+                systemMessage: sysMsg,
+                userMessage: userMsg,
+                headers: headers,
+                timeout: 120,
+                errorPrefix: "Custom AI provider error",
+                notFoundMessage: "Model '\(modelName)' not found on the server.",
+                unauthorizedMessage: "Authentication failed. Check your API key.",
+                onPartialResponse: onPartialResponse
+            )
+        case nil:
+            break
         }
 
         let result = try await makeRequest(
@@ -1138,29 +1533,12 @@ class AIService {
             request.addValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
             request.timeoutInterval = baseTimeout
 
-            let messages: [[String: Any]] = [
-                ["role": "system", "content": resolvedSystemMessage],
-                ["role": "user", "content": formattedText]
-            ]
-
-            var requestBody: [String: Any] = [
-                "model": selectedMode.aiModel,
-                "messages": messages,
-                "temperature": selectedMode.aiModel.lowercased().hasPrefix("gpt-5") ? 1.0 : 0.3,
-                "stream": false
-            ]
-            
-            // Add reasoning_effort parameter if the model supports it
-            if let reasoningEffort = ReasoningConfig.getReasoningParameter(for: selectedMode.aiModel) {
-                requestBody["reasoning_effort"] = reasoningEffort
-            }
-
-            // Add extra body parameters for models that need custom config
-            if let extraBody = ReasoningConfig.getExtraBodyParameters(for: selectedMode.aiModel) {
-                for (key, value) in extraBody {
-                    requestBody[key] = value
-                }
-            }
+            let requestBody = buildOpenAICompatibleRequestBody(
+                modelName: selectedMode.aiModel,
+                systemMessage: resolvedSystemMessage,
+                userMessage: formattedText,
+                stream: false
+            )
 
             request.httpBody = try? JSONSerialization.data(withJSONObject: requestBody)
 
@@ -1273,17 +1651,14 @@ class AIService {
         // No Authorization header needed for Ollama
         request.timeoutInterval = 120 // Longer timeout for local inference
 
-        let requestBody: [String: Any] = [
-            "model": selectedMode.aiModel,
-            "messages": [
-                ["role": "system", "content": systemMessage],
-                ["role": "user", "content": formattedText]
-            ],
-            "temperature": 0.3,
-            "stream": false
-        ]
+        let finalRequestBody = buildOpenAICompatibleRequestBody(
+            modelName: selectedMode.aiModel,
+            systemMessage: systemMessage,
+            userMessage: formattedText,
+            stream: false
+        )
 
-        request.httpBody = try? JSONSerialization.data(withJSONObject: requestBody)
+        request.httpBody = try? JSONSerialization.data(withJSONObject: finalRequestBody)
 
         do {
             try Task.checkCancellation()
@@ -1505,15 +1880,12 @@ class AIService {
 
         request.timeoutInterval = 120 // Longer timeout for potentially slow endpoints
 
-        let requestBody: [String: Any] = [
-            "model": modelName,
-            "messages": [
-                ["role": "system", "content": systemMessage],
-                ["role": "user", "content": formattedText]
-            ],
-            "temperature": 0.3,
-            "stream": false
-        ]
+        let requestBody = buildOpenAICompatibleRequestBody(
+            modelName: modelName,
+            systemMessage: systemMessage,
+            userMessage: formattedText,
+            stream: false
+        )
 
         request.httpBody = try? JSONSerialization.data(withJSONObject: requestBody)
 

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -46,6 +46,8 @@ class AIService {
     private enum StreamingRoute {
         case apple
         case anthropic
+        case copilot
+        case geminiOAuth
         case openAIOAuth
         case openAICompatibleCloud
         case ollama
@@ -847,7 +849,7 @@ class AIService {
             return aiProvider.supportsResponseStreaming(model: selectedMode.aiModel) ? .openAICompatibleCloud : nil
         case .gemini:
             if isGeminiSignedIn {
-                return nil
+                return .geminiOAuth
             }
             if VivAgentsClient.isEnabled && VivAgentsClient.isGeminiCliActive,
                let serverURL = VivAgentsClient.serverURL, !serverURL.isEmpty {
@@ -860,6 +862,8 @@ class AIService {
                 return nil
             }
             return .anthropic
+        case .copilot:
+            return isCopilotSignedIn ? .copilot : nil
         case .ollama:
             return .ollama
         case .customOpenAI:
@@ -867,6 +871,18 @@ class AIService {
         default:
             return aiProvider.supportsResponseStreaming(model: selectedMode.aiModel) ? .openAICompatibleCloud : nil
         }
+    }
+
+    private func finalizeStreamingResult(
+        _ text: String,
+        onPartialResponse: @escaping @MainActor (String) -> Void
+    ) async -> String {
+        let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let filteredText = AIEnhancementOutputFilter.filter(trimmedText)
+        if filteredText != text {
+            await onPartialResponse(filteredText)
+        }
+        return filteredText
     }
 
     private func buildOpenAICompatibleRequestBody(
@@ -976,12 +992,7 @@ class AIService {
             throw EnhancementError.enhancementFailed
         }
 
-        let filteredText = AIEnhancementOutputFilter.filter(aggregatedText.trimmingCharacters(in: .whitespacesAndNewlines))
-        if filteredText != aggregatedText {
-            await onPartialResponse(filteredText)
-        }
-
-        return filteredText
+        return await finalizeStreamingResult(aggregatedText, onPartialResponse: onPartialResponse)
     }
 
     static func openAICompatibleStreamingDelta(from line: String) -> String? {
@@ -1105,12 +1116,7 @@ class AIService {
             throw EnhancementError.enhancementFailed
         }
 
-        let filteredText = AIEnhancementOutputFilter.filter(aggregatedText.trimmingCharacters(in: .whitespacesAndNewlines))
-        if filteredText != aggregatedText {
-            await onPartialResponse(filteredText)
-        }
-
-        return filteredText
+        return await finalizeStreamingResult(aggregatedText, onPartialResponse: onPartialResponse)
     }
 
     private func makeStreamingRequest(
@@ -1161,6 +1167,30 @@ class AIService {
                 apiKey: apiKey,
                 onPartialResponse: onPartialResponse
             )
+        case .copilot:
+            let token = try await CopilotOAuthManager.shared.validCopilotToken()
+            let model = selectedMode.aiModel.isEmpty ? CopilotAPIClient.defaultModel : selectedMode.aiModel
+            let result = try await CopilotAPIClient.enhanceStreaming(
+                text: userMsg,
+                systemPrompt: sysMsg,
+                model: model,
+                copilotToken: token,
+                onPartialResult: onPartialResponse
+            )
+            return await finalizeStreamingResult(result, onPartialResponse: onPartialResponse)
+        case .geminiOAuth:
+            let provider = GeminiOAuthProvider()
+            let (token, _, projectId) = try await OAuthManager.shared.validAccessToken(for: provider)
+            let model = selectedMode.aiModel.isEmpty ? GeminiAPIClient.defaultModel : selectedMode.aiModel
+            let result = try await GeminiAPIClient.enhanceStreaming(
+                text: userMsg,
+                systemPrompt: sysMsg,
+                model: model,
+                accessToken: token,
+                projectId: projectId,
+                onPartialResult: onPartialResponse
+            )
+            return await finalizeStreamingResult(result, onPartialResponse: onPartialResponse)
         case .openAIOAuth:
             let provider = OpenAIOAuthProvider()
             let (token, accountId, _) = try await OAuthManager.shared.validAccessToken(for: provider)
@@ -1173,7 +1203,7 @@ class AIService {
                 accountId: accountId,
                 onPartialResult: onPartialResponse
             )
-            return AIEnhancementOutputFilter.filter(result)
+            return await finalizeStreamingResult(result, onPartialResponse: onPartialResponse)
         case .openAICompatibleCloud:
             guard let apiKey = self.getAPIKey(for: aiProvider) else {
                 throw EnhancementError.notConfigured

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -679,6 +679,17 @@ class AIService {
         lastCapturedClipboard = nil
     }
 
+    /// Returns true when the current mode can produce incremental text updates.
+    public var currentModeSupportsResponseStreaming: Bool {
+        guard selectedMode.aiEnhanceEnabled,
+              let aiProvider = selectedMode.aiProvider,
+              !selectedMode.aiModel.isEmpty else {
+            return false
+        }
+
+        return aiProvider.supportsResponseStreaming(model: selectedMode.aiModel)
+    }
+
     // MARK: - Enhance methods
 
     /// Enhances transcribed text using the configured AI provider.
@@ -727,36 +738,35 @@ class AIService {
     ///   - text: The original transcription text to process.
     ///   - preset: The preset containing the prompt instructions.
     /// - Returns: A tuple of the generated text and processing duration.
-    public func generateVariation(text: String, preset: Preset) async throws -> (String, TimeInterval) {
+    public func generateVariation(
+        text: String,
+        preset: Preset,
+        onPartialResult: (@MainActor (String) -> Void)? = nil
+    ) async throws -> (String, TimeInterval) {
         let startTime = Date()
 
-        // Build system message respecting useSystemTemplate (same logic as enhance flow)
-        var customVocabularySection = ""
-        let customVocabularyWords = CustomVocabulary.getTerms()
-        if !customVocabularyWords.isEmpty {
-            let vocabularyString = customVocabularyWords.joined(separator: ", ")
-            customVocabularySection = "\n\n<CUSTOM_VOCABULARY>Important Vocabulary: \(vocabularyString)\n</CUSTOM_VOCABULARY>"
-        }
-
-        let systemMessage: String
-        if preset.useSystemTemplate {
-            systemMessage = PromptsTemplates.systemPrompt(with: preset.promptInstructions) + customVocabularySection
-        } else {
-            systemMessage = preset.promptInstructions + customVocabularySection
-        }
-
-        // Format user text respecting the variation preset's wrapInTranscriptTags
-        let formattedText: String
-        if preset.wrapInTranscriptTags {
-            formattedText = "\n<TRANSCRIPT>\n\(text)\n</TRANSCRIPT>"
-        } else {
-            formattedText = text
-        }
+        let (systemMessage, formattedText) = buildVariationMessages(text: text, preset: preset)
 
         lastSystemMessageSent = systemMessage
         lastUserMessageSent = formattedText
 
-        var result = try await makeRequest(text: text, systemMessage: systemMessage, preFormattedUserMessage: formattedText)
+        let requestResult: String
+        if let onPartialResult, currentModeSupportsResponseStreaming {
+            requestResult = try await makeStreamingRequest(
+                text: text,
+                systemMessage: systemMessage,
+                preFormattedUserMessage: formattedText,
+                onPartialResponse: onPartialResult
+            )
+        } else {
+            requestResult = try await makeRequest(
+                text: text,
+                systemMessage: systemMessage,
+                preFormattedUserMessage: formattedText
+            )
+        }
+
+        var result = requestResult
         if preset.id == "assistant", selectedMode.isAutoTextFormattingEnabled {
             result = TextFormatter.format(result)
         }
@@ -786,6 +796,74 @@ class AIService {
         } else {
             return text
         }
+    }
+
+    private func buildVariationMessages(text: String, preset: Preset) -> (systemMessage: String, userMessage: String) {
+        var customVocabularySection = ""
+        let customVocabularyWords = CustomVocabulary.getTerms()
+        if !customVocabularyWords.isEmpty {
+            let vocabularyString = customVocabularyWords.joined(separator: ", ")
+            customVocabularySection = "\n\n<CUSTOM_VOCABULARY>Important Vocabulary: \(vocabularyString)\n</CUSTOM_VOCABULARY>"
+        }
+
+        let systemMessage: String
+        if preset.useSystemTemplate {
+            systemMessage = PromptsTemplates.systemPrompt(with: preset.promptInstructions) + customVocabularySection
+        } else {
+            systemMessage = preset.promptInstructions + customVocabularySection
+        }
+
+        let userMessage: String
+        if preset.wrapInTranscriptTags {
+            userMessage = "\n<TRANSCRIPT>\n\(text)\n</TRANSCRIPT>"
+        } else {
+            userMessage = text
+        }
+
+        return (systemMessage, userMessage)
+    }
+
+    private func makeStreamingRequest(
+        text: String,
+        systemMessage: String? = nil,
+        preFormattedUserMessage: String? = nil,
+        onPartialResponse: @escaping @MainActor (String) -> Void
+    ) async throws -> String {
+        guard let aiProvider = self.selectedMode.aiProvider else {
+            throw EnhancementError.notConfigured
+        }
+
+        guard !text.isEmpty else {
+            await onPartialResponse("")
+            return ""
+        }
+
+        if aiProvider == .apple {
+            if #available(iOS 26, *) {
+                let sysMsg = systemMessage ?? getSystemMessage()
+                let userMsg = preFormattedUserMessage ?? formatTranscriptForLLM(text)
+                logger.logDebug("AI Processing - Using Apple Foundation Model streaming")
+                logger.logDebug("AI Processing - System Message: \(sysMsg)")
+                logger.logDebug("AI Processing - User Message: \(userMsg)")
+                lastSystemMessageSent = sysMsg
+                lastUserMessageSent = userMsg
+                return try await appleFoundationModelService.enhanceStreaming(
+                    systemMessage: sysMsg,
+                    userMessage: userMsg,
+                    onPartialResponse: onPartialResponse
+                )
+            } else {
+                throw EnhancementError.notConfigured
+            }
+        }
+
+        let result = try await makeRequest(
+            text: text,
+            systemMessage: systemMessage,
+            preFormattedUserMessage: preFormattedUserMessage
+        )
+        await onPartialResponse(result)
+        return result
     }
 
     private func makeRequest(text: String, systemMessage: String? = nil, preFormattedUserMessage: String? = nil) async throws -> String {

--- a/VivaDicta/Services/AIEnhance/AppleFoundationModelService.swift
+++ b/VivaDicta/Services/AIEnhance/AppleFoundationModelService.swift
@@ -80,6 +80,77 @@ final class AppleFoundationModelService {
         }
     }
 
+    /// Enhance text using Apple's on-device Foundation Model while streaming partial updates.
+    /// - Parameters:
+    ///   - systemMessage: The system message (same as cloud providers)
+    ///   - userMessage: The formatted user message (transcript, optionally wrapped in tags)
+    ///   - onPartialResponse: Called with the latest partial response snapshot.
+    /// - Returns: The final enhanced text
+    func enhanceStreaming(
+        systemMessage: String,
+        userMessage: String,
+        onPartialResponse: @escaping @MainActor (String) -> Void
+    ) async throws -> String {
+        guard AppleFoundationModelAvailability.isAvailable else {
+            throw AppleFoundationModelError.notAvailable
+        }
+
+        guard !userMessage.isEmpty else {
+            onPartialResponse("")
+            return ""
+        }
+
+        logger.logNotice("Apple Foundation Model - Starting streaming enhancement")
+
+        let model = SystemLanguageModel(guardrails: .permissiveContentTransformations)
+        let session = LanguageModelSession(model: model, instructions: systemMessage)
+        let prompt = Prompt { userMessage }
+
+        do {
+            let options = GenerationOptions(sampling: .greedy)
+            let stream = session.streamResponse(to: prompt, options: options)
+
+            for try await partialResponse in stream {
+                onPartialResponse(partialResponse.content)
+            }
+
+            let response = try await stream.collect()
+            let enhancedText = response.content.trimmingCharacters(in: .whitespacesAndNewlines)
+            let filteredText = AIEnhancementOutputFilter.filter(enhancedText)
+            onPartialResponse(filteredText)
+            logger.logNotice("Apple Foundation Model - Streaming enhancement completed")
+
+            #if DEBUG
+            logTranscript(session)
+            #endif
+
+            return filteredText
+        } catch is CancellationError {
+            logger.logInfo("Apple Foundation Model - Streaming enhancement cancelled")
+            throw CancellationError()
+        } catch let error as LanguageModelSession.GenerationError {
+            logger.logError("Apple Foundation Model streaming generation error: \(error.localizedDescription)")
+
+            #if DEBUG
+            logTranscript(session)
+            #endif
+
+            switch error {
+            case .guardrailViolation(let context):
+                logger.logWarning("Safety guardrail triggered: \(context.debugDescription)")
+                throw AppleFoundationModelError.guardrailViolation
+            case .exceededContextWindowSize:
+                logger.logWarning("Context window size exceeded")
+                throw AppleFoundationModelError.generationFailed("Context window size exceeded")
+            default:
+                throw AppleFoundationModelError.generationFailed(error.localizedDescription)
+            }
+        } catch {
+            logger.logError("Apple Foundation Model streaming unexpected error: \(error.localizedDescription)")
+            throw AppleFoundationModelError.generationFailed(error.localizedDescription)
+        }
+    }
+
     // MARK: - Debug
 
     #if DEBUG

--- a/VivaDicta/Services/OAuth/CopilotAPIClient.swift
+++ b/VivaDicta/Services/OAuth/CopilotAPIClient.swift
@@ -39,6 +39,34 @@ enum CopilotAPIClient {
         }
     }
 
+    static func enhanceStreaming(
+        text: String,
+        systemPrompt: String,
+        model: String,
+        copilotToken: String,
+        onPartialResult: @escaping @MainActor (String) -> Void
+    ) async throws -> String {
+        let effectiveModel = model.isEmpty ? defaultModel : model
+
+        if isClaudeModel(effectiveModel) {
+            return try await enhanceWithAnthropicStreaming(
+                text: text,
+                systemPrompt: systemPrompt,
+                model: effectiveModel,
+                token: copilotToken,
+                onPartialResult: onPartialResult
+            )
+        } else {
+            return try await enhanceWithOpenAIStreaming(
+                text: text,
+                systemPrompt: systemPrompt,
+                model: effectiveModel,
+                token: copilotToken,
+                onPartialResult: onPartialResult
+            )
+        }
+    }
+
     private static func isClaudeModel(_ model: String) -> Bool {
         model.hasPrefix("claude-")
     }
@@ -80,6 +108,44 @@ enum CopilotAPIClient {
         return try await executeRequest(request)
     }
 
+    private static func enhanceWithAnthropicStreaming(
+        text: String,
+        systemPrompt: String,
+        model: String,
+        token: String,
+        onPartialResult: @escaping @MainActor (String) -> Void
+    ) async throws -> String {
+        guard let url = URL(string: "\(baseURL)/chat/completions") else {
+            throw CopilotOAuthError.tokenExchangeFailed("Invalid URL")
+        }
+
+        logger.logInfo("Copilot streaming: using Claude model '\(model)'")
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addValue("text/event-stream", forHTTPHeaderField: "Accept")
+        request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 60
+
+        for (key, value) in staticHeaders {
+            request.addValue(value, forHTTPHeaderField: key)
+        }
+
+        let requestBody: [String: Any] = [
+            "model": model,
+            "messages": [
+                ["role": "system", "content": systemPrompt],
+                ["role": "user", "content": text]
+            ],
+            "max_tokens": 8192,
+            "stream": true
+        ]
+        request.httpBody = try? JSONSerialization.data(withJSONObject: requestBody)
+
+        return try await executeStreamingRequest(request, onPartialResult: onPartialResult)
+    }
+
     // MARK: - OpenAI API (for GPT, Gemini, Grok models)
 
     private static func enhanceWithOpenAI(
@@ -116,6 +182,43 @@ enum CopilotAPIClient {
         return try await executeRequest(request)
     }
 
+    private static func enhanceWithOpenAIStreaming(
+        text: String,
+        systemPrompt: String,
+        model: String,
+        token: String,
+        onPartialResult: @escaping @MainActor (String) -> Void
+    ) async throws -> String {
+        guard let url = URL(string: "\(baseURL)/chat/completions") else {
+            throw CopilotOAuthError.tokenExchangeFailed("Invalid URL")
+        }
+
+        logger.logInfo("Copilot streaming: using model '\(model)'")
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addValue("text/event-stream", forHTTPHeaderField: "Accept")
+        request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 60
+
+        for (key, value) in staticHeaders {
+            request.addValue(value, forHTTPHeaderField: key)
+        }
+
+        let requestBody: [String: Any] = [
+            "model": model,
+            "messages": [
+                ["role": "system", "content": systemPrompt],
+                ["role": "user", "content": text]
+            ],
+            "stream": true
+        ]
+        request.httpBody = try? JSONSerialization.data(withJSONObject: requestBody)
+
+        return try await executeStreamingRequest(request, onPartialResult: onPartialResult)
+    }
+
     // MARK: - Shared Response Handling
 
     private static func executeRequest(_ request: URLRequest) async throws -> String {
@@ -144,6 +247,84 @@ enum CopilotAPIClient {
         }
 
         return content.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func executeStreamingRequest(
+        _ request: URLRequest,
+        onPartialResult: @escaping @MainActor (String) -> Void
+    ) async throws -> String {
+        try Task.checkCancellation()
+
+        let (bytes, response) = try await URLSession.shared.bytes(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw CopilotOAuthError.tokenExchangeFailed("Invalid response")
+        }
+
+        guard httpResponse.statusCode == 200 else {
+            var errorData = Data()
+            for try await byte in bytes {
+                errorData.append(byte)
+            }
+
+            let errorBody = String(data: errorData, encoding: .utf8) ?? "Unknown error"
+            logger.logError("Copilot streaming error: HTTP \(httpResponse.statusCode) - \(errorBody)")
+            if httpResponse.statusCode == 429 {
+                throw EnhancementError.customError("Copilot rate limit reached. Please wait and try again.")
+            }
+            throw CopilotOAuthError.tokenExchangeFailed("HTTP \(httpResponse.statusCode): \(errorBody)")
+        }
+
+        var aggregatedText = ""
+        for try await line in bytes.lines {
+            try Task.checkCancellation()
+
+            if let delta = streamingDelta(from: line) {
+                aggregatedText += delta
+                await onPartialResult(aggregatedText)
+            }
+        }
+
+        guard !aggregatedText.isEmpty else {
+            throw CopilotOAuthError.tokenExchangeFailed("Invalid response format")
+        }
+
+        let finalResult = aggregatedText.trimmingCharacters(in: .whitespacesAndNewlines)
+        await onPartialResult(finalResult)
+        return finalResult
+    }
+
+    static func streamingDelta(from line: String) -> String? {
+        guard line.hasPrefix("data:") else {
+            return nil
+        }
+
+        let payload = String(line.dropFirst(5)).trimmingCharacters(in: .whitespaces)
+        guard payload.isEmpty == false,
+              payload != "[DONE]",
+              let data = payload.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let choices = json["choices"] as? [[String: Any]],
+              let firstChoice = choices.first else {
+            return nil
+        }
+
+        if let delta = firstChoice["delta"] as? [String: Any] {
+            if let content = delta["content"] as? String, content.isEmpty == false {
+                return content
+            }
+
+            if let contentItems = delta["content"] as? [[String: Any]] {
+                let text = contentItems.compactMap { $0["text"] as? String }.joined()
+                return text.isEmpty ? nil : text
+            }
+        }
+
+        if let text = firstChoice["text"] as? String, text.isEmpty == false {
+            return text
+        }
+
+        return nil
     }
 
     // MARK: - Fetch Available Models

--- a/VivaDicta/Services/OAuth/GeminiAPIClient.swift
+++ b/VivaDicta/Services/OAuth/GeminiAPIClient.swift
@@ -23,6 +23,7 @@ enum GeminiAPIClient {
 
     /// Cloud Code Assist endpoint (non-streaming).
     private static let endpoint = "https://cloudcode-pa.googleapis.com/v1internal:generateContent"
+    private static let streamingEndpoint = "https://cloudcode-pa.googleapis.com/v1internal:streamGenerateContent?alt=sse"
 
     /// Returns the model to use. Falls back to default if empty.
     static func resolveModel(_ requestedModel: String) -> String {
@@ -126,5 +127,174 @@ enum GeminiAPIClient {
         }
 
         return resultText.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    static func enhanceStreaming(
+        text: String,
+        systemPrompt: String,
+        model: String,
+        accessToken: String,
+        projectId: String?,
+        onPartialResult: @escaping @MainActor (String) -> Void
+    ) async throws -> String {
+        guard let url = URL(string: streamingEndpoint) else {
+            throw OAuthError.invalidResponse
+        }
+
+        let effectiveModel = resolveModel(model)
+        logger.logInfo("Gemini OAuth streaming: model '\(effectiveModel)', projectId: \(projectId ?? "none")")
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addValue("text/event-stream", forHTTPHeaderField: "Accept")
+        request.addValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.addValue("google-cloud-sdk vscode_cloudshelleditor/0.1", forHTTPHeaderField: "User-Agent")
+        request.addValue("gl-node/22.17.0", forHTTPHeaderField: "X-Goog-Api-Client")
+        request.timeoutInterval = 60
+
+        var requestBody: [String: Any] = [
+            "model": effectiveModel,
+            "userAgent": "vivadicta",
+            "request": [
+                "contents": [
+                    [
+                        "role": "user",
+                        "parts": [["text": text]]
+                    ]
+                ],
+                "systemInstruction": [
+                    "parts": [["text": systemPrompt]]
+                ],
+                "generationConfig": [
+                    "maxOutputTokens": 8192
+                ]
+            ]
+        ]
+
+        if let projectId {
+            requestBody["project"] = projectId
+        }
+
+        request.httpBody = try? JSONSerialization.data(withJSONObject: requestBody)
+
+        try Task.checkCancellation()
+
+        let (bytes, response) = try await URLSession.shared.bytes(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw OAuthError.invalidResponse
+        }
+
+        guard httpResponse.statusCode == 200 else {
+            var errorData = Data()
+            for try await byte in bytes {
+                errorData.append(byte)
+            }
+            let errorBody = String(data: errorData, encoding: .utf8) ?? "Unknown error"
+            logger.logError("Gemini OAuth streaming error: HTTP \(httpResponse.statusCode) - \(errorBody)")
+
+            if httpResponse.statusCode == 429 {
+                if let errorData = errorBody.data(using: .utf8),
+                   let errorJson = try? JSONSerialization.jsonObject(with: errorData) as? [String: Any],
+                   let error = errorJson["error"] as? [String: Any],
+                   let message = error["message"] as? String {
+                    throw EnhancementError.customError("Gemini rate limit reached. \(message)")
+                }
+                throw EnhancementError.rateLimitExceeded
+            }
+
+            throw OAuthError.tokenExchangeFailed("HTTP \(httpResponse.statusCode): \(errorBody)")
+        }
+
+        var aggregatedText = ""
+        var bufferedDataLines: [String] = []
+
+        for try await line in bytes.lines {
+            try Task.checkCancellation()
+
+            if line.hasPrefix("data: ") {
+                bufferedDataLines.append(String(line.dropFirst(6)))
+                continue
+            }
+
+            guard line.isEmpty else {
+                continue
+            }
+
+            aggregatedText = try await processStreamChunk(
+                bufferedDataLines,
+                currentAggregatedText: aggregatedText,
+                onPartialResult: onPartialResult
+            )
+            bufferedDataLines.removeAll(keepingCapacity: true)
+        }
+
+        aggregatedText = try await processStreamChunk(
+            bufferedDataLines,
+            currentAggregatedText: aggregatedText,
+            onPartialResult: onPartialResult
+        )
+
+        guard !aggregatedText.isEmpty else {
+            throw OAuthError.invalidResponse
+        }
+
+        let finalResult = aggregatedText.trimmingCharacters(in: .whitespacesAndNewlines)
+        await onPartialResult(finalResult)
+        return finalResult
+    }
+
+    private static func processStreamChunk(
+        _ bufferedDataLines: [String],
+        currentAggregatedText: String,
+        onPartialResult: @escaping @MainActor (String) -> Void
+    ) async throws -> String {
+        guard !bufferedDataLines.isEmpty else {
+            return currentAggregatedText
+        }
+
+        let payload = bufferedDataLines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard payload.isEmpty == false,
+              let data = payload.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return currentAggregatedText
+        }
+
+        if let error = json["error"] as? [String: Any],
+           let message = error["message"] as? String {
+            throw EnhancementError.customError(message)
+        }
+
+        var aggregatedText = currentAggregatedText
+        if let chunkText = streamingText(from: json) {
+            if chunkText.hasPrefix(aggregatedText) {
+                aggregatedText = chunkText
+            } else {
+                aggregatedText += chunkText
+            }
+            await onPartialResult(aggregatedText)
+        }
+
+        return aggregatedText
+    }
+
+    static func streamingText(from event: [String: Any]) -> String? {
+        let geminiResponse: [String: Any]
+        if let wrapped = event["response"] as? [String: Any] {
+            geminiResponse = wrapped
+        } else {
+            geminiResponse = event
+        }
+
+        guard let candidates = geminiResponse["candidates"] as? [[String: Any]],
+              let firstCandidate = candidates.first,
+              let content = firstCandidate["content"] as? [String: Any],
+              let parts = content["parts"] as? [[String: Any]] else {
+            return nil
+        }
+
+        let text = parts.compactMap { $0["text"] as? String }.joined()
+        return text.isEmpty ? nil : text
     }
 }

--- a/VivaDicta/Services/OAuth/OpenAIOAuthClient.swift
+++ b/VivaDicta/Services/OAuth/OpenAIOAuthClient.swift
@@ -39,7 +39,8 @@ enum OpenAIOAuthClient {
         systemPrompt: String,
         model: String,
         accessToken: String,
-        accountId: String?
+        accountId: String?,
+        onPartialResult: (@MainActor (String) -> Void)? = nil
     ) async throws -> String {
         guard let url = URL(string: OpenAIOAuthProvider.completionsEndpoint) else {
             throw OAuthError.invalidResponse
@@ -101,6 +102,9 @@ enum OpenAIOAuthClient {
             if type == "response.output_text.delta",
                let delta = event["delta"] as? String {
                 result += delta
+                if let onPartialResult {
+                    await onPartialResult(result)
+                }
             }
         }
 
@@ -109,7 +113,12 @@ enum OpenAIOAuthClient {
             throw OAuthError.invalidResponse
         }
 
-        return result.trimmingCharacters(in: .whitespacesAndNewlines)
+        let finalResult = result.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let onPartialResult {
+            await onPartialResult(finalResult)
+        }
+
+        return finalResult
     }
 
     /// Fetches available models from OpenAI's backend.

--- a/VivaDicta/Utils/HapticManager.swift
+++ b/VivaDicta/Utils/HapticManager.swift
@@ -17,6 +17,7 @@ enum HapticManager {
     private static let impactLight = UIImpactFeedbackGenerator(style: .light)
     private static let impactMedium = UIImpactFeedbackGenerator(style: .medium)
     private static let impactHeavy = UIImpactFeedbackGenerator(style: .heavy)
+    private static let impactSoft = UIImpactFeedbackGenerator(style: .soft)
     private static let selection = UISelectionFeedbackGenerator()
     private static let notification = UINotificationFeedbackGenerator()
 
@@ -26,6 +27,10 @@ enum HapticManager {
     private static var engineNeedsStart = true
 
     // MARK: - Settings
+
+    /// Throttle interval for incremental streaming pulses.
+    private static let streamingPulseMinimumInterval: TimeInterval = 0.14
+    private static var lastStreamingPulseAt: TimeInterval = 0
 
     /// Check if haptics are enabled in app settings (defaults to true if not set)
     private static var isEnabled: Bool {
@@ -184,6 +189,18 @@ enum HapticManager {
         impactHeavy.impactOccurred()
     }
 
+    /// Soft pulse - for incremental streaming text updates.
+    static func streamingPulse() {
+        guard isEnabled else { return }
+
+        let now = CACurrentMediaTime()
+        guard now - lastStreamingPulseAt >= streamingPulseMinimumInterval else { return }
+
+        lastStreamingPulseAt = now
+        impactSoft.impactOccurred(intensity: 0.45)
+        impactSoft.prepare()
+    }
+
     // MARK: - Selection Feedback
 
     /// Selection changed - for pickers, toggles, select all/deselect all, item selection
@@ -217,5 +234,11 @@ enum HapticManager {
         impactMedium.prepare()
         notification.prepare()
         ensureEngineRunning()
+    }
+
+    /// Prepare the softer generator used for streaming updates.
+    static func prepareStreaming() {
+        guard isEnabled else { return }
+        impactSoft.prepare()
     }
 }

--- a/VivaDicta/Utils/HapticManager.swift
+++ b/VivaDicta/Utils/HapticManager.swift
@@ -17,7 +17,6 @@ enum HapticManager {
     private static let impactLight = UIImpactFeedbackGenerator(style: .light)
     private static let impactMedium = UIImpactFeedbackGenerator(style: .medium)
     private static let impactHeavy = UIImpactFeedbackGenerator(style: .heavy)
-    private static let impactSoft = UIImpactFeedbackGenerator(style: .soft)
     private static let selection = UISelectionFeedbackGenerator()
     private static let notification = UINotificationFeedbackGenerator()
 
@@ -29,7 +28,7 @@ enum HapticManager {
     // MARK: - Settings
 
     /// Throttle interval for incremental streaming pulses.
-    private static let streamingPulseMinimumInterval: TimeInterval = 0.14
+    private static let streamingPulseMinimumInterval: TimeInterval = 0.1
     private static var lastStreamingPulseAt: TimeInterval = 0
 
     /// Check if haptics are enabled in app settings (defaults to true if not set)
@@ -189,7 +188,15 @@ enum HapticManager {
         impactHeavy.impactOccurred()
     }
 
-    /// Soft pulse - for incremental streaming text updates.
+    /// Stronger pulse when streaming visibly begins.
+    static func streamingStart() {
+        guard isEnabled else { return }
+        lastStreamingPulseAt = CACurrentMediaTime()
+        impactMedium.impactOccurred(intensity: 0.75)
+        impactLight.prepare()
+    }
+
+    /// Chatty pulse - for incremental streaming text updates.
     static func streamingPulse() {
         guard isEnabled else { return }
 
@@ -197,8 +204,8 @@ enum HapticManager {
         guard now - lastStreamingPulseAt >= streamingPulseMinimumInterval else { return }
 
         lastStreamingPulseAt = now
-        impactSoft.impactOccurred(intensity: 0.45)
-        impactSoft.prepare()
+        impactLight.impactOccurred(intensity: 0.65)
+        impactLight.prepare()
     }
 
     // MARK: - Selection Feedback
@@ -239,6 +246,7 @@ enum HapticManager {
     /// Prepare the softer generator used for streaming updates.
     static func prepareStreaming() {
         guard isEnabled else { return }
-        impactSoft.prepare()
+        impactMedium.prepare()
+        impactLight.prepare()
     }
 }

--- a/VivaDicta/Views/TranscriptionDetailView.swift
+++ b/VivaDicta/Views/TranscriptionDetailView.swift
@@ -107,6 +107,10 @@ struct TranscriptionDetailView: View {
         processingState == .transcribing || (processingState == .enhancing && activeStreamingText == nil)
     }
 
+    private var shouldShowStreamingCancelButton: Bool {
+        processingState == .enhancing && streamingVariationPresetId != nil
+    }
+
     private var temporaryGeneratingPreset: Preset? {
         guard let generatingPresetId,
               sortedVariations.contains(where: { $0.presetId == generatingPresetId }) == false else {
@@ -291,6 +295,15 @@ struct TranscriptionDetailView: View {
                         cancelProcessing()
                     }
                 )
+            }
+        }
+        .overlay(alignment: .bottom) {
+            if shouldShowStreamingCancelButton {
+                StreamingCancelButton {
+                    cancelProcessing()
+                }
+                .padding(.bottom, 104)
+                .transition(.move(edge: .bottom).combined(with: .opacity))
             }
         }
         .animation(.default, value: processingState)
@@ -801,6 +814,28 @@ struct TranscriptionDetailView: View {
 }
 
 // MARK: - Configure AI Sheet
+
+private struct StreamingCancelButton: View {
+    let onCancel: () -> Void
+
+    var body: some View {
+        Button("Cancel", systemImage: "xmark.circle.fill") {
+            HapticManager.lightImpact()
+            onCancel()
+        }
+        .font(.subheadline.weight(.medium))
+        .buttonStyle(.plain)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(.thinMaterial)
+        .clipShape(.capsule)
+        .overlay {
+            Capsule()
+                .strokeBorder(.white.opacity(0.18), lineWidth: 1)
+        }
+        .shadow(color: .black.opacity(0.12), radius: 10, y: 4)
+    }
+}
 
 private struct ConfigureAISheet: View {
     let onOpenSettings: () -> Void

--- a/VivaDicta/Views/TranscriptionDetailView.swift
+++ b/VivaDicta/Views/TranscriptionDetailView.swift
@@ -99,6 +99,10 @@ struct TranscriptionDetailView: View {
         return streamingVariationText
     }
 
+    private var shouldShowProcessingGlowOverlay: Bool {
+        processingState == .transcribing || processingState == .enhancing
+    }
+
     private var shouldShowProcessingHUD: Bool {
         processingState == .transcribing || (processingState == .enhancing && activeStreamingText == nil)
     }
@@ -252,13 +256,13 @@ struct TranscriptionDetailView: View {
         .animation(.easeInOut, value: processingState)
         .allowsHitTesting(processingState == .idle)
         .overlay {
-            if shouldShowProcessingHUD {
+            if shouldShowProcessingGlowOverlay {
                 GeometryReader { geometry in
                     AnimatedMeshGradient()
                         .onAppear {
                             rippleEffectTimer = Timer.scheduledTimer(withTimeInterval: 2, repeats: true, block: { _ in
                                 Task { @MainActor in
-                                    if shouldShowProcessingHUD {
+                                    if shouldShowProcessingGlowOverlay {
                                         rippleEffectTrigger.toggle()
                                     }
                                 }

--- a/VivaDicta/Views/TranscriptionDetailView.swift
+++ b/VivaDicta/Views/TranscriptionDetailView.swift
@@ -29,6 +29,8 @@ struct TranscriptionDetailView: View {
     @State private var showMetaInfo: Bool = false
     @State private var showConfigureAI: Bool = false
     @State private var generatingPresetId: String?
+    @State private var streamingVariationPresetId: String?
+    @State private var streamingVariationText: String = ""
     @State private var showTextEditor: Bool = false
     @State private var showTagPicker: Bool = false
 
@@ -42,6 +44,10 @@ struct TranscriptionDetailView: View {
 
     private var hasVariations: Bool {
         !(transcription.variations ?? []).isEmpty
+    }
+
+    private var showsVariationChipBar: Bool {
+        hasVariations || temporaryGeneratingPreset != nil
     }
 
     private var displayedText: String {
@@ -60,6 +66,10 @@ struct TranscriptionDetailView: View {
 
     private var selectedLabel: String {
         if selectedChipId == "original" { return "Original" }
+        if generatingPresetId == selectedChipId,
+           let preset = appState.presetManager.preset(for: selectedChipId) {
+            return preset.name
+        }
         if let variation = sortedVariations.first(where: { $0.presetId == selectedChipId }) {
             return PresetCatalog.displayName(for: variation.presetId, fallback: variation.presetDisplayName)
         }
@@ -78,6 +88,28 @@ struct TranscriptionDetailView: View {
 
     private var canRetranscribe: Bool {
         audioURL != nil && processingState == .idle
+    }
+
+    private var activeStreamingText: String? {
+        guard processingState == .enhancing,
+              streamingVariationPresetId == selectedChipId else {
+            return nil
+        }
+
+        return streamingVariationText
+    }
+
+    private var shouldShowProcessingHUD: Bool {
+        processingState == .transcribing || (processingState == .enhancing && activeStreamingText == nil)
+    }
+
+    private var temporaryGeneratingPreset: Preset? {
+        guard let generatingPresetId,
+              sortedVariations.contains(where: { $0.presetId == generatingPresetId }) == false else {
+            return nil
+        }
+
+        return appState.presetManager.preset(for: generatingPresetId)
     }
 
     var body: some View {
@@ -105,7 +137,7 @@ struct TranscriptionDetailView: View {
                 }
 
                 // Chip bar for text variations
-                if hasVariations {
+                if showsVariationChipBar {
                     variationChipBar
                         .padding(.top, 4)
                         .padding(.bottom, 12)
@@ -220,13 +252,13 @@ struct TranscriptionDetailView: View {
         .animation(.easeInOut, value: processingState)
         .allowsHitTesting(processingState == .idle)
         .overlay {
-            if processingState == .transcribing || processingState == .enhancing {
+            if shouldShowProcessingHUD {
                 GeometryReader { geometry in
                     AnimatedMeshGradient()
                         .onAppear {
                             rippleEffectTimer = Timer.scheduledTimer(withTimeInterval: 2, repeats: true, block: { _ in
                                 Task { @MainActor in
-                                    if processingState == .transcribing || processingState == .enhancing {
+                                    if shouldShowProcessingHUD {
                                         rippleEffectTrigger.toggle()
                                     }
                                 }
@@ -248,7 +280,7 @@ struct TranscriptionDetailView: View {
             }
         }
         .overlay {
-            if processingState == .transcribing || processingState == .enhancing {
+            if shouldShowProcessingHUD {
                 HudView(
                     state: processingState,
                     onCancel: {
@@ -278,7 +310,21 @@ struct TranscriptionDetailView: View {
 
     private var textContentView: some View {
         VStack(alignment: .leading, spacing: 0) {
-            if processingState != .idle {
+            if let activeStreamingText {
+                if activeStreamingText.isEmpty {
+                    VStack(alignment: .leading, spacing: 12) {
+                        ProgressView()
+                        Text("Generating variation...")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                } else {
+                    Text(activeStreamingText)
+                        .font(.system(size: 16, weight: .regular, design: .default))
+                        .lineSpacing(2)
+                        .textSelection(.enabled)
+                }
+            } else if processingState != .idle {
                 // Lightweight placeholder to avoid expensive CoreText layout on large text
                 Text("The art of writing is the art of discovering what you believe. Every word you speak is a seed, and every thought refined becomes a garden of clarity and understanding.")
                     .font(.system(size: 16, weight: .regular, design: .default))
@@ -476,6 +522,7 @@ struct TranscriptionDetailView: View {
     private func cancelProcessing() {
         processingTask?.cancel()
         processingTask = nil
+        resetStreamingState()
         processingState = .idle
     }
 
@@ -552,6 +599,15 @@ struct TranscriptionDetailView: View {
                         label: PresetCatalog.displayName(for: variation.presetId, fallback: variation.presetDisplayName),
                         icon: PresetCatalog.icon(for: variation.presetId),
                         isLoading: generatingPresetId == variation.presetId
+                    )
+                }
+
+                if let temporaryGeneratingPreset {
+                    variationChip(
+                        id: temporaryGeneratingPreset.id,
+                        label: temporaryGeneratingPreset.name,
+                        icon: PresetCatalog.icon(for: temporaryGeneratingPreset.id),
+                        isLoading: true
                     )
                 }
 
@@ -634,7 +690,10 @@ struct TranscriptionDetailView: View {
     }
 
     private func generateVariation(preset: Preset) {
+        let shouldStreamResponse = appState.aiService.currentModeSupportsResponseStreaming
         generatingPresetId = preset.id
+        streamingVariationPresetId = shouldStreamResponse ? preset.id : nil
+        streamingVariationText = ""
         HapticManager.lightImpact()
 
         withAnimation(.easeInOut(duration: 0.15)) {
@@ -645,10 +704,21 @@ struct TranscriptionDetailView: View {
             processingState = .enhancing
 
             do {
-                let (resultText, duration) = try await appState.aiService.generateVariation(
-                    text: transcription.text,
-                    preset: preset
-                )
+                let (resultText, duration): (String, TimeInterval)
+                if shouldStreamResponse {
+                    (resultText, duration) = try await appState.aiService.generateVariation(
+                        text: transcription.text,
+                        preset: preset,
+                        onPartialResult: { partialText in
+                            streamingVariationText = partialText
+                        }
+                    )
+                } else {
+                    (resultText, duration) = try await appState.aiService.generateVariation(
+                        text: transcription.text,
+                        preset: preset
+                    )
+                }
 
                 // Check if a variation with this presetId already exists (regeneration)
                 if let existing = sortedVariations.first(where: { $0.presetId == preset.id }) {
@@ -682,6 +752,7 @@ struct TranscriptionDetailView: View {
                     await appState.updateTranscriptionEntityInSpotlight(entity)
                 }
 
+                resetStreamingState()
                 generatingPresetId = nil
 
                 withAnimation(.easeInOut(duration: 0.15)) {
@@ -691,8 +762,15 @@ struct TranscriptionDetailView: View {
                 HapticManager.heartbeat()
                 RateAppManager.requestReviewIfAppropriate()
             } catch is CancellationError {
+                resetStreamingState()
                 generatingPresetId = nil
+            } catch AppleFoundationModelError.guardrailViolation {
+                resetStreamingState()
+                generatingPresetId = nil
+                showGuardrailAlert = true
+                HapticManager.error()
             } catch {
+                resetStreamingState()
                 generatingPresetId = nil
                 enhancementErrorMessage = error.localizedDescription
                 showEnhancementErrorAlert = true
@@ -701,6 +779,11 @@ struct TranscriptionDetailView: View {
 
             processingState = .idle
         }
+    }
+
+    private func resetStreamingState() {
+        streamingVariationPresetId = nil
+        streamingVariationText = ""
     }
 }
 

--- a/VivaDicta/Views/TranscriptionDetailView.swift
+++ b/VivaDicta/Views/TranscriptionDetailView.swift
@@ -717,7 +717,10 @@ struct TranscriptionDetailView: View {
                         text: transcription.text,
                         preset: preset,
                         onPartialResult: { partialText in
-                            if partialText.count > streamingVariationText.count {
+                            let previousText = streamingVariationText
+                            if previousText.isEmpty, partialText.isEmpty == false {
+                                HapticManager.streamingStart()
+                            } else if partialText.count > previousText.count {
                                 HapticManager.streamingPulse()
                             }
                             streamingVariationText = partialText

--- a/VivaDicta/Views/TranscriptionDetailView.swift
+++ b/VivaDicta/Views/TranscriptionDetailView.swift
@@ -699,6 +699,9 @@ struct TranscriptionDetailView: View {
         streamingVariationPresetId = shouldStreamResponse ? preset.id : nil
         streamingVariationText = ""
         HapticManager.lightImpact()
+        if shouldStreamResponse {
+            HapticManager.prepareStreaming()
+        }
 
         withAnimation(.easeInOut(duration: 0.15)) {
             selectedChipId = preset.id
@@ -714,6 +717,9 @@ struct TranscriptionDetailView: View {
                         text: transcription.text,
                         preset: preset,
                         onPartialResult: { partialText in
+                            if partialText.count > streamingVariationText.count {
+                                HapticManager.streamingPulse()
+                            }
                             streamingVariationText = partialText
                         }
                     )

--- a/VivaDictaTests/AIServiceConfigurationTests.swift
+++ b/VivaDictaTests/AIServiceConfigurationTests.swift
@@ -150,12 +150,54 @@ struct AIServiceConfigurationTests {
         #expect(service.currentModeSupportsResponseStreaming == true)
     }
 
-    @Test func currentModeSupportsResponseStreaming_cloudMode_returnsFalse() {
+    @Test func currentModeSupportsResponseStreaming_openAIAPIKeyMode_returnsTrue() {
         let mode = makeMode(aiProvider: .openAI, aiModel: "gpt-5-mini")
         let service = makeService(withModes: [mode])
         service.selectedModeName = mode.name
 
+        #expect(service.currentModeSupportsResponseStreaming == true)
+    }
+
+    @Test func currentModeSupportsResponseStreaming_openAIOAuth_returnsTrue() {
+        let mode = makeMode(aiProvider: .openAI, aiModel: "gpt-5.4-mini")
+        let service = makeService(withModes: [mode])
+        service.selectedModeName = mode.name
+        service.isOpenAISignedIn = true
+
+        #expect(service.currentModeSupportsResponseStreaming == true)
+    }
+
+    @Test func currentModeSupportsResponseStreaming_geminiOAuth_returnsFalse() {
+        let mode = makeMode(aiProvider: .gemini, aiModel: "gemini-3-flash-preview")
+        let service = makeService(withModes: [mode])
+        service.selectedModeName = mode.name
+        service.isGeminiSignedIn = true
+
         #expect(service.currentModeSupportsResponseStreaming == false)
+    }
+
+    @Test func openAICompatibleStreamingDelta_extractsContentDelta() {
+        let line = #"data: {"choices":[{"delta":{"content":"Hello"}}]}"#
+
+        let delta = AIService.openAICompatibleStreamingDelta(from: line)
+
+        #expect(delta == "Hello")
+    }
+
+    @Test func openAICompatibleStreamingDelta_ignoresDoneSentinel() {
+        let line = "data: [DONE]"
+
+        let delta = AIService.openAICompatibleStreamingDelta(from: line)
+
+        #expect(delta == nil)
+    }
+
+    @Test func currentModeSupportsResponseStreaming_anthropicReturnsTrue() {
+        let mode = makeMode(aiProvider: .anthropic, aiModel: "claude-sonnet-4-6")
+        let service = makeService(withModes: [mode])
+        service.selectedModeName = mode.name
+
+        #expect(service.currentModeSupportsResponseStreaming == true)
     }
 
     // MARK: - Disable Modes by Provider Tests

--- a/VivaDictaTests/AIServiceConfigurationTests.swift
+++ b/VivaDictaTests/AIServiceConfigurationTests.swift
@@ -167,13 +167,22 @@ struct AIServiceConfigurationTests {
         #expect(service.currentModeSupportsResponseStreaming == true)
     }
 
-    @Test func currentModeSupportsResponseStreaming_geminiOAuth_returnsFalse() {
+    @Test func currentModeSupportsResponseStreaming_geminiOAuth_returnsTrue() {
         let mode = makeMode(aiProvider: .gemini, aiModel: "gemini-3-flash-preview")
         let service = makeService(withModes: [mode])
         service.selectedModeName = mode.name
         service.isGeminiSignedIn = true
 
-        #expect(service.currentModeSupportsResponseStreaming == false)
+        #expect(service.currentModeSupportsResponseStreaming == true)
+    }
+
+    @Test func currentModeSupportsResponseStreaming_copilotOAuth_returnsTrue() {
+        let mode = makeMode(aiProvider: .copilot, aiModel: "gpt-4o")
+        let service = makeService(withModes: [mode])
+        service.selectedModeName = mode.name
+        service.isCopilotSignedIn = true
+
+        #expect(service.currentModeSupportsResponseStreaming == true)
     }
 
     @Test func openAICompatibleStreamingDelta_extractsContentDelta() {
@@ -190,6 +199,35 @@ struct AIServiceConfigurationTests {
         let delta = AIService.openAICompatibleStreamingDelta(from: line)
 
         #expect(delta == nil)
+    }
+
+    @Test func copilotStreamingDelta_extractsContentDelta() {
+        let line = #"data: {"choices":[{"delta":{"content":"Hello"}}]}"#
+
+        let delta = CopilotAPIClient.streamingDelta(from: line)
+
+        #expect(delta == "Hello")
+    }
+
+    @Test func geminiStreamingText_extractsCandidateText() {
+        let event: [String: Any] = [
+            "response": [
+                "candidates": [
+                    [
+                        "content": [
+                            "parts": [
+                                ["text": "Hello"],
+                                ["text": " world"]
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ]
+
+        let text = GeminiAPIClient.streamingText(from: event)
+
+        #expect(text == "Hello world")
     }
 
     @Test func currentModeSupportsResponseStreaming_anthropicReturnsTrue() {

--- a/VivaDictaTests/AIServiceConfigurationTests.swift
+++ b/VivaDictaTests/AIServiceConfigurationTests.swift
@@ -140,6 +140,24 @@ struct AIServiceConfigurationTests {
         #expect(service.isProperlyConfigured() == false)
     }
 
+    // MARK: - Streaming Capability Tests
+
+    @Test func currentModeSupportsResponseStreaming_appleMode_returnsTrue() {
+        let mode = makeMode(aiProvider: .apple, aiModel: "foundation-model")
+        let service = makeService(withModes: [mode])
+        service.selectedModeName = mode.name
+
+        #expect(service.currentModeSupportsResponseStreaming == true)
+    }
+
+    @Test func currentModeSupportsResponseStreaming_cloudMode_returnsFalse() {
+        let mode = makeMode(aiProvider: .openAI, aiModel: "gpt-5-mini")
+        let service = makeService(withModes: [mode])
+        service.selectedModeName = mode.name
+
+        #expect(service.currentModeSupportsResponseStreaming == false)
+    }
+
     // MARK: - Disable Modes by Provider Tests
 
     @Test func disableAIForModesUsingProvider_onlyAffectsMatchingModes() {


### PR DESCRIPTION
## Summary
- add note-detail streaming for Apple Foundation Models, OpenAI-compatible providers, OpenAI OAuth, Anthropic, Gemini OAuth, Copilot, Ollama, and Custom OpenAI
- keep the edge glow visible during streaming and add streaming haptics for live responses
- add provider capability gates, shared streaming helpers, and focused parser/capability tests

## Testing
- xcodebuild -scheme VivaDicta -configuration Debug -workspace ./VivaDicta.xcodeproj/project.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max,OS=26.4' test -only-testing:VivaDictaTests/AIServiceConfigurationTests 2>&1 | xcsift
- AIServiceConfigurationTests: 25 passed, 0 failed

## Notes
- VivAgents CLI-backed routes are still non-streaming in this branch
- PR intentionally opened without automated review-request comments