### PR TITLE
Replace Timer-based mesh gradient animation with TimelineView

### DIFF
--- a/VivaDicta/Shared/AnimatedMeshGradient.swift
+++ b/VivaDicta/Shared/AnimatedMeshGradient.swift
@@ -8,30 +8,25 @@
 import SwiftUI
 
 struct AnimatedMeshGradient: View {
-    @State var t: Float = 0.0
-    @State var timer: Timer?
+    @State private var startDate = Date.now
 
     var body: some View {
-        MeshGradient(width: 3, height: 3, points: [
-            .init(0, 0), .init(0.5, 0), .init(1, 0),
-            
-            [sinInRange(-0.8...(-0.2), offset: 0.439, timeScale: 0.342, t: t), sinInRange(0.3...0.7, offset: 3.42, timeScale: 0.984, t: t)],
-            [sinInRange(0.1...0.8, offset: 0.239, timeScale: 0.084, t: t), sinInRange(0.2...0.8, offset: 5.21, timeScale: 0.242, t: t)],
-            [sinInRange(1.0...1.5, offset: 0.939, timeScale: 0.084, t: t), sinInRange(0.4...0.8, offset: 0.25, timeScale: 0.642, t: t)],
-            [sinInRange(-0.8...0.0, offset: 1.439, timeScale: 0.442, t: t), sinInRange(1.4...1.9, offset: 3.42, timeScale: 0.984, t: t)],
-            [sinInRange(0.3...0.6, offset: 0.339, timeScale: 0.784, t: t), sinInRange(1.0...1.2, offset: 1.22, timeScale: 0.772, t: t)],
-            [sinInRange(1.0...1.5, offset: 0.939, timeScale: 0.056, t: t), sinInRange(1.3...1.7, offset: 0.47, timeScale: 0.342, t: t)]
-        ], colors: [
-            .red, .purple, .indigo,
-            .orange, .white, .blue,
-            .yellow, .black, .mint
-        ])
-        .onAppear {
-            timer = Timer.scheduledTimer(withTimeInterval: 0.016, repeats: true) { _ in
-                Task { @MainActor in
-                    t += 0.16
-                }
-            }
+        TimelineView(.animation) { timeline in
+            let t = Float(timeline.date.timeIntervalSince(startDate)) * 10
+            MeshGradient(width: 3, height: 3, points: [
+                .init(0, 0), .init(0.5, 0), .init(1, 0),
+
+                [sinInRange(-0.8...(-0.2), offset: 0.439, timeScale: 0.342, t: t), sinInRange(0.3...0.7, offset: 3.42, timeScale: 0.984, t: t)],
+                [sinInRange(0.1...0.8, offset: 0.239, timeScale: 0.084, t: t), sinInRange(0.2...0.8, offset: 5.21, timeScale: 0.242, t: t)],
+                [sinInRange(1.0...1.5, offset: 0.939, timeScale: 0.084, t: t), sinInRange(0.4...0.8, offset: 0.25, timeScale: 0.642, t: t)],
+                [sinInRange(-0.8...0.0, offset: 1.439, timeScale: 0.442, t: t), sinInRange(1.4...1.9, offset: 3.42, timeScale: 0.984, t: t)],
+                [sinInRange(0.3...0.6, offset: 0.339, timeScale: 0.784, t: t), sinInRange(1.0...1.2, offset: 1.22, timeScale: 0.772, t: t)],
+                [sinInRange(1.0...1.5, offset: 0.939, timeScale: 0.056, t: t), sinInRange(1.3...1.7, offset: 0.47, timeScale: 0.342, t: t)]
+            ], colors: [
+                .red, .purple, .indigo,
+                .orange, .white, .blue,
+                .yellow, .black, .mint
+            ])
         }
         .background(
             LinearGradient(
@@ -42,12 +37,6 @@ struct AnimatedMeshGradient: View {
         )
         .ignoresSafeArea()
     }
-
-    func sinInRange(_ range: ClosedRange<Float>, offset: Float, timeScale: Float, t: Float) -> Float {
-        let amplitude = (range.upperBound - range.lowerBound) / 2
-        let midPoint = (range.upperBound + range.lowerBound) / 2
-        return midPoint + amplitude * sin(timeScale * t + offset)
-    }
 }
 
 #Preview("AnimatedMeshGradient") {
@@ -55,30 +44,25 @@ struct AnimatedMeshGradient: View {
 }
 
 struct AnimatedMeshGradient2: View {
-    @State var t: Float = 0.0
-    @State var timer: Timer?
+    @State private var startDate = Date.now
 
     var body: some View {
-        MeshGradient(width: 3, height: 3, points: [
-            .init(0, 0), .init(0.5, 0), .init(1, 0),
+        TimelineView(.animation) { timeline in
+            let t = Float(timeline.date.timeIntervalSince(startDate)) * 10
+            MeshGradient(width: 3, height: 3, points: [
+                .init(0, 0), .init(0.5, 0), .init(1, 0),
 
-            [sinInRange(-0.8...(-0.2), offset: 0.439, timeScale: 0.342, t: t), sinInRange(0.3...0.7, offset: 3.42, timeScale: 0.984, t: t)],
-            [sinInRange(0.1...0.8, offset: 0.239, timeScale: 0.084, t: t), sinInRange(0.2...0.8, offset: 5.21, timeScale: 0.242, t: t)],
-            [sinInRange(1.0...1.5, offset: 0.939, timeScale: 0.084, t: t), sinInRange(0.4...0.8, offset: 0.25, timeScale: 0.642, t: t)],
-            [sinInRange(-0.8...0.0, offset: 1.439, timeScale: 0.442, t: t), sinInRange(1.4...1.9, offset: 3.42, timeScale: 0.984, t: t)],
-            [sinInRange(0.3...0.6, offset: 0.339, timeScale: 0.784, t: t), sinInRange(1.0...1.2, offset: 1.22, timeScale: 0.772, t: t)],
-            [sinInRange(1.0...1.5, offset: 0.939, timeScale: 0.056, t: t), sinInRange(1.3...1.7, offset: 0.47, timeScale: 0.342, t: t)]
-        ], colors: [
-            .blue, .red, .orange,
-            .orange, .indigo, .red,
-            .cyan, .purple, .mint
-        ])
-        .onAppear {
-            timer = Timer.scheduledTimer(withTimeInterval: 0.016, repeats: true) { _ in
-                Task { @MainActor in
-                    t += 0.16
-                }
-            }
+                [sinInRange(-0.8...(-0.2), offset: 0.439, timeScale: 0.342, t: t), sinInRange(0.3...0.7, offset: 3.42, timeScale: 0.984, t: t)],
+                [sinInRange(0.1...0.8, offset: 0.239, timeScale: 0.084, t: t), sinInRange(0.2...0.8, offset: 5.21, timeScale: 0.242, t: t)],
+                [sinInRange(1.0...1.5, offset: 0.939, timeScale: 0.084, t: t), sinInRange(0.4...0.8, offset: 0.25, timeScale: 0.642, t: t)],
+                [sinInRange(-0.8...0.0, offset: 1.439, timeScale: 0.442, t: t), sinInRange(1.4...1.9, offset: 3.42, timeScale: 0.984, t: t)],
+                [sinInRange(0.3...0.6, offset: 0.339, timeScale: 0.784, t: t), sinInRange(1.0...1.2, offset: 1.22, timeScale: 0.772, t: t)],
+                [sinInRange(1.0...1.5, offset: 0.939, timeScale: 0.056, t: t), sinInRange(1.3...1.7, offset: 0.47, timeScale: 0.342, t: t)]
+            ], colors: [
+                .blue, .red, .orange,
+                .orange, .indigo, .red,
+                .cyan, .purple, .mint
+            ])
         }
         .background(
             LinearGradient(
@@ -89,14 +73,14 @@ struct AnimatedMeshGradient2: View {
         )
         .ignoresSafeArea()
     }
-    
-    func sinInRange(_ range: ClosedRange<Float>, offset: Float, timeScale: Float, t: Float) -> Float {
-        let amplitude = (range.upperBound - range.lowerBound) / 2
-        let midPoint = (range.upperBound + range.lowerBound) / 2
-        return midPoint + amplitude * sin(timeScale * t + offset)
-    }
 }
 
 #Preview("AnimatedMeshGradient2") {
     AnimatedMeshGradient2()
+}
+
+private func sinInRange(_ range: ClosedRange<Float>, offset: Float, timeScale: Float, t: Float) -> Float {
+    let amplitude = (range.upperBound - range.lowerBound) / 2
+    let midPoint = (range.upperBound + range.lowerBound) / 2
+    return midPoint + amplitude * sin(timeScale * t + offset)
 }


### PR DESCRIPTION
## Summary
- Replace `Timer.scheduledTimer(withTimeInterval: 0.016)` with `TimelineView(.animation)` in both `AnimatedMeshGradient` and `AnimatedMeshGradient2`
- Fix timer leak — timers were created in `onAppear` but never invalidated in `onDisappear`, leaking across all ~15 usage sites
- Use relative `startDate` for time computation to avoid `Float` precision loss (absolute `timeIntervalSinceReferenceDate` is ~7.9e8 in 2026, exceeding Float's precision)
- Extract shared `sinInRange` as a single private file-level function (was duplicated in both structs)

## Test plan
- [ ] Verify mesh gradient animations are smooth in MainView, HudView, TranscriptionDetailView, TranscriptionRowView
- [ ] Verify keyboard extension ProcessingStateView gradient animates correctly
- [ ] Confirm no visible difference in animation speed or appearance vs. previous behavior