### PR TITLE
Add Liquid Glass effects across app and keyboard on iOS 26+

### DIFF
--- a/VivaDicta/Shared/VivaModePicker.swift
+++ b/VivaDicta/Shared/VivaModePicker.swift
@@ -39,12 +39,32 @@ struct VivaModePicker: View {
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 6)
-            .background(.tertiary, in: .capsule)
+            .modePickerBackground()
         }
         .tint(.primary)
         .accessibilityLabel("Mode selector")
         .accessibilityValue(selectedModeName)
         .accessibilityHint("Double tap to choose a different mode")
+    }
+}
+
+// MARK: - Mode Picker Background
+
+private struct ModePickerBackgroundModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(iOS 26, *) {
+            content
+                .glassEffect(.regular.interactive(), in: .capsule)
+        } else {
+            content
+                .background(.tertiary, in: .capsule)
+        }
+    }
+}
+
+extension View {
+    fileprivate func modePickerBackground() -> some View {
+        modifier(ModePickerBackgroundModifier())
     }
 }
 

--- a/VivaDicta/Utils/Extensions/View+Ext.swift
+++ b/VivaDicta/Utils/Extensions/View+Ext.swift
@@ -237,6 +237,31 @@ extension View {
     }
 }
 
+// MARK: - Model Card Background
+struct ModelCardBackgroundModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(iOS 26, *) {
+            content
+                .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 20))
+        } else {
+            content
+                .background(.background.secondary)
+                .clipShape(.rect(cornerRadius: 20, style: .continuous))
+                .shadow(color: .primary.opacity(0.5), radius: 2, x: 2, y: 2)
+                .overlay {
+                    RoundedRectangle(cornerRadius: 20, style: .continuous)
+                        .stroke(.primary.opacity(0.3), lineWidth: 0.5)
+                }
+        }
+    }
+}
+
+extension View {
+    func modelCardBackground() -> some View {
+        modifier(ModelCardBackgroundModifier())
+    }
+}
+
 // MARK: - ButtonStyle
 // MARK: prominentButton
 struct ProminentButton: ViewModifier {

--- a/VivaDicta/Utils/Extensions/View+Ext.swift
+++ b/VivaDicta/Utils/Extensions/View+Ext.swift
@@ -237,6 +237,56 @@ extension View {
     }
 }
 
+// MARK: - Glass Dismiss Circle
+/// Dismiss/cancel button background: clear interactive glass on iOS 26+, gray circle on older.
+struct GlassDismissCircleModifier: ViewModifier {
+    var fallback: AnyShapeStyle
+
+    func body(content: Content) -> some View {
+        if #available(iOS 26, *) {
+            content
+                .glassEffect(.clear.interactive(), in: .circle)
+        } else {
+            content
+                .background(fallback, in: .circle)
+        }
+    }
+}
+
+extension View {
+    func glassDismissCircle(fallback: some ShapeStyle = Color.gray.opacity(0.1)) -> some View {
+        modifier(GlassDismissCircleModifier(fallback: AnyShapeStyle(fallback)))
+    }
+}
+
+// MARK: - Glass Capsule
+/// Capsule background: interactive glass with optional tint on iOS 26+, solid fallback on older.
+struct GlassCapsuleModifier: ViewModifier {
+    var tint: Color?
+    var fallback: AnyShapeStyle
+
+    func body(content: Content) -> some View {
+        if #available(iOS 26, *) {
+            if let tint {
+                content
+                    .glassEffect(.regular.tint(tint).interactive(), in: .capsule)
+            } else {
+                content
+                    .glassEffect(.regular.interactive(), in: .capsule)
+            }
+        } else {
+            content
+                .background(fallback, in: .capsule)
+        }
+    }
+}
+
+extension View {
+    func glassCapsule(tint: Color? = nil, fallback: some ShapeStyle = Color(.systemGray5)) -> some View {
+        modifier(GlassCapsuleModifier(tint: tint, fallback: AnyShapeStyle(fallback)))
+    }
+}
+
 // MARK: - Model Card Background
 struct ModelCardBackgroundModifier: ViewModifier {
     func body(content: Content) -> some View {

--- a/VivaDicta/Views/Chat/ChatBubbleView.swift
+++ b/VivaDicta/Views/Chat/ChatBubbleView.swift
@@ -101,7 +101,7 @@ private struct BubbleBackgroundModifier: ViewModifier {
 }
 
 extension View {
-    fileprivate func bubbleBackground(isUser: Bool, isError: Bool) -> some View {
+    func bubbleBackground(isUser: Bool, isError: Bool) -> some View {
         modifier(BubbleBackgroundModifier(isUser: isUser, isError: isError))
     }
 }

--- a/VivaDicta/Views/Chat/ChatBubbleView.swift
+++ b/VivaDicta/Views/Chat/ChatBubbleView.swift
@@ -49,9 +49,8 @@ struct ChatBubbleView: View {
                 .textSelection(.enabled)
                 .padding(.horizontal, 14)
                 .padding(.vertical, 10)
-                .background(bubbleBackground(isUser: isUser, isError: isError))
                 .foregroundStyle(isUser ? .white : (isError ? .red : .primary))
-                .clipShape(.rect(cornerRadius: 18))
+                .bubbleBackground(isUser: isUser, isError: isError)
 
                 if !isUser, let modelName = message.aiModelName {
                     Text(modelName)
@@ -65,13 +64,44 @@ struct ChatBubbleView: View {
         .padding(.horizontal)
     }
 
-    private func bubbleBackground(isUser: Bool, isError: Bool) -> some ShapeStyle {
-        if isError {
-            return AnyShapeStyle(Color.red.opacity(0.15))
+}
+
+// MARK: - Bubble Background Modifier
+
+private struct BubbleBackgroundModifier: ViewModifier {
+    let isUser: Bool
+    let isError: Bool
+
+    func body(content: Content) -> some View {
+        if #available(iOS 26, *) {
+            content
+                .glassEffect(
+                    .regular.tint(glassTint).interactive(),
+                    in: .rect(cornerRadius: 18)
+                )
+        } else {
+            content
+                .background(legacyBackground)
+                .clipShape(.rect(cornerRadius: 18))
         }
-        if isUser {
-            return AnyShapeStyle(Color.accentColor)
-        }
+    }
+
+    @available(iOS 26, *)
+    private var glassTint: Color {
+        if isError { return .red.opacity(0.3) }
+        if isUser { return .accentColor }
+        return .gray.opacity(0.3)
+    }
+
+    private var legacyBackground: AnyShapeStyle {
+        if isError { return AnyShapeStyle(Color.red.opacity(0.15)) }
+        if isUser { return AnyShapeStyle(Color.accentColor) }
         return AnyShapeStyle(Color(.systemGray5))
+    }
+}
+
+extension View {
+    fileprivate func bubbleBackground(isUser: Bool, isError: Bool) -> some View {
+        modifier(BubbleBackgroundModifier(isUser: isUser, isError: isError))
     }
 }

--- a/VivaDicta/Views/Chat/ChatInputBar.swift
+++ b/VivaDicta/Views/Chat/ChatInputBar.swift
@@ -88,10 +88,9 @@ struct ChatInputBar: View {
                     onSend()
                 }
             } label: {
-                Image(systemName: isStreaming ? "stop.circle" : "arrow.up.circle")
+                Image(systemName: isStreaming ? "stop.circle.fill" : "arrow.up.circle.fill")
                     .font(.system(size: 30))
-                    .foregroundStyle(canSend || isStreaming ? .white : Color.gray)
-                    .glassEffectColor(isInteractive: true, color: canSend || isStreaming ? Color.accentColor : .secondary, opacity: 0.8)
+                    .foregroundStyle(canSend || isStreaming ? Color.accentColor : .secondary)
             }
             .buttonStyle(.plain)
             .disabled(!canSend && !isStreaming)

--- a/VivaDicta/Views/Chat/ChatView.swift
+++ b/VivaDicta/Views/Chat/ChatView.swift
@@ -145,6 +145,8 @@ struct ChatView: View {
                 .padding(.vertical, 12)
             }
             .scrollIndicators(.hidden)
+            .scrollDismissesKeyboard(.interactively)
+            .defaultScrollAnchor(.bottom)
             .onAppear {
                 scrollToBottom(proxy: proxy)
             }
@@ -158,6 +160,9 @@ struct ChatView: View {
                 scrollToBottom(proxy: proxy)
             }
             .onChange(of: viewModel.isCompacting) {
+                scrollToBottom(proxy: proxy)
+            }
+            .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { _ in
                 scrollToBottom(proxy: proxy)
             }
         }

--- a/VivaDicta/Views/Chat/ChatView.swift
+++ b/VivaDicta/Views/Chat/ChatView.swift
@@ -202,8 +202,7 @@ struct ChatView: View {
                     .textSelection(.enabled)
                     .padding(.horizontal, 14)
                     .padding(.vertical, 10)
-                    .background(Color(.systemGray5))
-                    .clipShape(.rect(cornerRadius: 18))
+                    .bubbleBackground(isUser: false, isError: false)
 
                 if let model = viewModel.selectedModel {
                     Text(model)

--- a/VivaDicta/Views/Components/CategoryChipsView.swift
+++ b/VivaDicta/Views/Components/CategoryChipsView.swift
@@ -43,6 +43,8 @@ struct CategoryChipsView: View {
 }
 
 private struct CategoryChip: View {
+    @Environment(\.colorScheme) private var colorScheme
+
     let title: String
     var icon: String?
     let isSelected: Bool
@@ -65,9 +67,37 @@ private struct CategoryChip: View {
             .padding(.horizontal, 14)
             .padding(.vertical, 7)
             .foregroundStyle(isSelected ? .white : .primary)
-            .background(isSelected ? Color.accentColor : Color(.systemGray5))
-            .clipShape(.capsule)
+            .chipBackground(isSelected: isSelected, color: Color.accentColor.opacity(colorScheme == .dark ? 0.6 : 1.0))
         }
         .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Chip Background Modifier
+
+private struct ChipBackgroundModifier: ViewModifier {
+    let isSelected: Bool
+    let color: Color
+
+    func body(content: Content) -> some View {
+        if #available(iOS 26, *) {
+            content
+                .glassEffect(
+                    isSelected
+                        ? .regular.tint(color).interactive()
+                        : .regular.interactive(),
+                    in: .capsule
+                )
+        } else {
+            content
+                .background(isSelected ? color.opacity(0.2) : Color(.systemGray5))
+                .clipShape(.capsule)
+        }
+    }
+}
+
+extension View {
+    fileprivate func chipBackground(isSelected: Bool, color: Color) -> some View {
+        modifier(ChipBackgroundModifier(isSelected: isSelected, color: color))
     }
 }

--- a/VivaDicta/Views/ModelsScreen/CloudModelCard.swift
+++ b/VivaDicta/Views/ModelsScreen/CloudModelCard.swift
@@ -151,13 +151,7 @@ struct CloudModelCard: View {
                 .foregroundStyle(.secondary)
         }
         .padding(20)
-        .background(.background.secondary)
-        .clipShape(.rect(cornerRadius: 20, style: .continuous))
-        .shadow(color: .primary.opacity(0.5), radius: 2, x: 2, y: 2)
-        .overlay {
-            RoundedRectangle(cornerRadius: 20, style: .continuous)
-                .stroke(.primary.opacity(0.3), lineWidth: 0.5)
-        }
+        .modelCardBackground()
         .contentShape(.rect)
         .onTapGesture {
             guard !isAPIConfigured else { return }

--- a/VivaDicta/Views/ModelsScreen/LocalModelCard.swift
+++ b/VivaDicta/Views/ModelsScreen/LocalModelCard.swift
@@ -204,13 +204,7 @@ struct LocalModelCard: View {
                 .foregroundStyle(.secondary)
         }
         .padding(20)
-        .background(.background.secondary)
-        .clipShape(.rect(cornerRadius: 20, style: .continuous))
-        .shadow(color: .primary.opacity(0.5), radius: 2, x: 2, y: 2)
-        .overlay {
-            RoundedRectangle(cornerRadius: 20, style: .continuous)
-                .stroke(.primary.opacity(0.3), lineWidth: 0.5)
-        }
+        .modelCardBackground()
         .contextMenu {
             if isDownloaded {
                 Button(role: .destructive) {

--- a/VivaDicta/Views/MultiNoteChat/MultiNoteChatView.swift
+++ b/VivaDicta/Views/MultiNoteChat/MultiNoteChatView.swift
@@ -181,8 +181,7 @@ struct MultiNoteChatView: View {
                     .textSelection(.enabled)
                     .padding(.horizontal, 14)
                     .padding(.vertical, 10)
-                    .background(Color(.systemGray5))
-                    .clipShape(.rect(cornerRadius: 18))
+                    .bubbleBackground(isUser: false, isError: false)
 
                 if let model = viewModel.selectedModel {
                     Text(model)

--- a/VivaDicta/Views/MultiNoteChat/MultiNoteChatView.swift
+++ b/VivaDicta/Views/MultiNoteChat/MultiNoteChatView.swift
@@ -124,6 +124,8 @@ struct MultiNoteChatView: View {
                 .padding(.vertical, 12)
             }
             .scrollIndicators(.hidden)
+            .scrollDismissesKeyboard(.interactively)
+            .defaultScrollAnchor(.bottom)
             .onAppear {
                 scrollToBottom(proxy: proxy)
             }
@@ -137,6 +139,9 @@ struct MultiNoteChatView: View {
                 scrollToBottom(proxy: proxy)
             }
             .onChange(of: viewModel.isCompacting) {
+                scrollToBottom(proxy: proxy)
+            }
+            .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { _ in
                 scrollToBottom(proxy: proxy)
             }
         }

--- a/VivaDicta/Views/MultiNoteChat/MultiNoteChatsListView.swift
+++ b/VivaDicta/Views/MultiNoteChat/MultiNoteChatsListView.swift
@@ -26,9 +26,27 @@ struct MultiNoteChatsListView: View {
         case singleNote = "Single-Note"
     }
 
+    private var isAIConfigured: Bool {
+        appState.aiService.isProperlyConfigured()
+    }
+
     var body: some View {
         NavigationStack(path: $navigationPath) {
             VStack(spacing: 0) {
+                if !isAIConfigured {
+                    HStack(spacing: 8) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.orange)
+                        Text("Set up an AI provider in mode settings to start new chats.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(.horizontal)
+                    .padding(.vertical, 10)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color(.systemGray6))
+                }
+
                 Picker("Chat Type", selection: $selectedTab) {
                     ForEach(ChatTab.allCases, id: \.self) { tab in
                         Text(tab.rawValue).tag(tab)
@@ -58,6 +76,7 @@ struct MultiNoteChatsListView: View {
                         Button("New Chat", systemImage: "plus") {
                             navigationPath.append(NavigationTarget.creation)
                         }
+                        .disabled(!isAIConfigured)
                     }
                 }
             }

--- a/VivaDicta/Views/MultiNoteChat/MultiNoteCreationView.swift
+++ b/VivaDicta/Views/MultiNoteChat/MultiNoteCreationView.swift
@@ -78,7 +78,6 @@ struct MultiNoteCreationView: View {
                     selectedSourceTags: $selectedSourceTags,
                     selectedUserTagIds: $selectedUserTagIds
                 )
-                .padding(.vertical, 8)
             }
 
             // Selection header

--- a/VivaDicta/Views/RecordingSheetView.swift
+++ b/VivaDicta/Views/RecordingSheetView.swift
@@ -53,8 +53,8 @@ struct RecordingSheetView: View {
                             .font(.system(size: 18, weight: .semibold))
                             .foregroundStyle(Color.secondary)
                             .frame(width: 44, height: 44)
-                            .background(.gray.opacity(0.1), in: .circle)
-                            .contentShape(.rect)
+                            .recordingSheetButtonBackground(color: nil)
+                            .contentShape(.circle)
                     }
                     .accessibilityLabel("Cancel Recording")
                     .padding(.vertical, 16)
@@ -67,9 +67,11 @@ struct RecordingSheetView: View {
                 Button {
                     stopRecordingAndDismiss()
                 } label: {
-                    Image(systemName: "stop.circle.fill")
-                        .font(.system(size: 56))
-                        .foregroundStyle(.red)
+                    Image(systemName: "stop.fill")
+                        .font(.system(size: 24, weight: .semibold))
+                        .foregroundStyle(.white)
+                        .frame(width: 56, height: 56)
+                        .recordingSheetButtonBackground(color: .red)
                 }
                 .accessibilityLabel("Stop Recording")
                 .disabled(vm.recordingState != .recording)
@@ -100,6 +102,41 @@ struct RecordingSheetView: View {
         vm.stopCaptureAudio(modelContext: modelContext)
         // Sheet will automatically dismiss when recordingState changes from .recording
         // This happens via the onChange modifier in MainView
+    }
+}
+
+// MARK: - Recording Sheet Button Background
+
+private struct RecordingSheetButtonBackgroundModifier: ViewModifier {
+    let color: Color?
+
+    func body(content: Content) -> some View {
+        if #available(iOS 26, *) {
+            if let color {
+                content
+                    .glassEffect(
+                        .regular.tint(color).interactive(),
+                        in: .circle
+                    )
+            } else {
+                content
+                    .glassEffect(.clear.interactive(), in: .circle)
+            }
+        } else {
+            if let color {
+                content
+                    .background(color, in: .circle)
+            } else {
+                content
+                    .background(.gray.opacity(0.1), in: .circle)
+            }
+        }
+    }
+}
+
+extension View {
+    fileprivate func recordingSheetButtonBackground(color: Color?) -> some View {
+        modifier(RecordingSheetButtonBackgroundModifier(color: color))
     }
 }
 

--- a/VivaDicta/Views/RecordingSheetView.swift
+++ b/VivaDicta/Views/RecordingSheetView.swift
@@ -120,7 +120,7 @@ private struct RecordingSheetButtonBackgroundModifier: ViewModifier {
                     )
             } else {
                 content
-                    .glassEffect(.clear.interactive(), in: .circle)
+                    .glassEffect(.regular.interactive(), in: .circle)
             }
         } else {
             if let color {

--- a/VivaDicta/Views/ScrollToTopButton.swift
+++ b/VivaDicta/Views/ScrollToTopButton.swift
@@ -18,13 +18,40 @@ struct ScrollToTopButton: View {
         } label: {
             Image(systemName: "arrow.up")
                 .font(.system(size: 20, weight: .semibold))
-                .foregroundStyle(Color(.systemBackground))
+                .foregroundStyle(.white)
                 .frame(width: 44, height: 44)
-                .background(backgroundColor)
+                .contentShape(.circle)
+                .scrollToTopBackground(color: backgroundColor)
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Background Modifier
+
+private struct ScrollToTopBackgroundModifier: ViewModifier {
+    let color: Color
+
+    func body(content: Content) -> some View {
+        if #available(iOS 26, *) {
+            content
+                .glassEffect(
+                    .regular.tint(color).interactive(true),
+                    in: .circle
+                )
+                .shadow(color: .black.opacity(0.3), radius: 8, x: 0, y: 4)
+        } else {
+            content
+                .background(color)
                 .clipShape(.circle)
                 .shadow(color: .black.opacity(1), radius: 10, x: 0, y: 5)
         }
-        .buttonStyle(.plain)
+    }
+}
+
+extension View {
+    fileprivate func scrollToTopBackground(color: Color) -> some View {
+        modifier(ScrollToTopBackgroundModifier(color: color))
     }
 }
 

--- a/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
@@ -99,7 +99,7 @@ class ModeEditViewModel {
         }
         if !isProviderReady(provider) {
             if provider == .apple {
-                return "Apple Intelligence is not available on this device\(Self.disableHint)"
+                return "\(appleFoundationModelStatusMessage)\(Self.disableHint)"
             }
             if provider == .ollama {
                 return "Configure Ollama server in AI Providers settings\(Self.disableHint)"
@@ -531,10 +531,16 @@ class ModeEditViewModel {
         return aiService.connectedProviders.contains(provider)
     }
 
-    /// Check if Apple Foundation Model is available on this device
+    /// Whether Apple FM should appear in the provider picker.
+    /// Shows when available or when the user can take action (enable AI, wait for download).
     @MainActor
     var isAppleFoundationModelAvailable: Bool {
-        AppleFoundationModelAvailability.isAvailable
+        switch AppleFoundationModelAvailability.currentStatus {
+        case .available, .appleIntelligenceNotEnabled, .modelNotReady:
+            return true
+        case .deviceNotEligible, .unavailable:
+            return false
+        }
     }
 
     /// Get availability status message for Apple Foundation Model

--- a/VivaDicta/Views/SettingsScreen/Tags/TagFilterBar.swift
+++ b/VivaDicta/Views/SettingsScreen/Tags/TagFilterBar.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 /// Horizontal scrollable filter bar with source tags and user tags.
 struct TagFilterBar: View {
+    @Environment(\.colorScheme) private var colorScheme
+
     let sourceTags: [String]
     let userTags: [TranscriptionTag]
     @Binding var selectedSourceTags: Set<String>
@@ -19,6 +21,7 @@ struct TagFilterBar: View {
     }
 
     var body: some View {
+        
         ScrollView(.horizontal) {
             HStack(spacing: 6) {
                 // "All" chip
@@ -30,7 +33,7 @@ struct TagFilterBar: View {
                     selectedSourceTags.removeAll()
                     selectedUserTagIds.removeAll()
                 }
-
+                
                 // Source tag chips
                 ForEach(sourceTags, id: \.self) { tag in
                     chipButton(
@@ -46,12 +49,12 @@ struct TagFilterBar: View {
                         }
                     }
                 }
-
+                
                 if !sourceTags.isEmpty && !userTags.isEmpty {
                     Divider()
                         .frame(height: 20)
                 }
-
+                
                 // User tag chips
                 ForEach(userTags) { tag in
                     chipButton(
@@ -68,9 +71,14 @@ struct TagFilterBar: View {
                     }
                 }
             }
+            .padding(.vertical, 8)
             .padding(.horizontal)
         }
         .scrollIndicators(.hidden)
+//        .glassEffectOrMaterial()
+        
+        
+        
     }
 
     private func chipButton(label: String, icon: String?, isSelected: Bool, color: Color = .blue, action: @escaping () -> Void) -> some View {
@@ -83,12 +91,40 @@ struct TagFilterBar: View {
                 Text(label)
                     .font(.caption)
             }
-            .padding(.horizontal, 10)
+            .padding(.horizontal, 12)
             .padding(.vertical, 6)
-            .background(isSelected ? color.opacity(0.2) : Color(.systemGray6))
-            .foregroundStyle(isSelected ? color : .secondary)
-            .clipShape(.capsule)
+            .foregroundStyle(isSelected ? .white : .primary)
+            .chipBackground(isSelected: isSelected, color: color.opacity(colorScheme == .dark ? 0.6 : 1.0))
         }
         .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Chip Background Modifier
+
+private struct ChipBackgroundModifier: ViewModifier {
+    let isSelected: Bool
+    let color: Color
+
+    func body(content: Content) -> some View {
+        if #available(iOS 26, *) {
+            content
+                .glassEffect(
+                    isSelected
+                    ? .regular.tint(color).interactive()
+                    : .regular.interactive(),
+                    in: .capsule
+                )
+        } else {
+            content
+                .background(isSelected ? color.opacity(0.2) : Color(.systemGray6))
+                .clipShape(.capsule)
+        }
+    }
+}
+
+extension View {
+    fileprivate func chipBackground(isSelected: Bool, color: Color) -> some View {
+        modifier(ChipBackgroundModifier(isSelected: isSelected, color: color))
     }
 }

--- a/VivaDicta/Views/TranscriptionDetailView.swift
+++ b/VivaDicta/Views/TranscriptionDetailView.swift
@@ -28,6 +28,7 @@ struct TranscriptionDetailView: View {
     @State private var showPresetPicker: Bool = false
     @State private var showMetaInfo: Bool = false
     @State private var showConfigureAI: Bool = false
+    @State private var showConfigureChat: Bool = false
     @State private var generatingPresetId: String?
     @State private var streamingVariationPresetId: String?
     @State private var streamingVariationText: String = ""
@@ -260,6 +261,13 @@ struct TranscriptionDetailView: View {
         .sheet(isPresented: $showConfigureAI) {
             ConfigureAISheet {
                 showConfigureAI = false
+                appState.shouldNavigateToModeSettings = true
+            }
+            .presentationDetents([.height(240)])
+        }
+        .sheet(isPresented: $showConfigureChat) {
+            ConfigureChatSheet {
+                showConfigureChat = false
                 appState.shouldNavigateToModeSettings = true
             }
             .presentationDetents([.height(240)])
@@ -537,21 +545,24 @@ struct TranscriptionDetailView: View {
                 // Button 3: Chat with Note
                 Button {
                     HapticManager.lightImpact()
-                    if chatViewModel == nil {
-                        let conversation = findOrCreateConversation(for: transcription)
-                        chatViewModel = ChatViewModel(
-                            conversation: conversation,
-                            transcription: transcription,
-                            aiService: appState.aiService,
-                            modelContext: modelContext
-                        )
+                    if isAIConfigured {
+                        if chatViewModel == nil {
+                            let conversation = findOrCreateConversation(for: transcription)
+                            chatViewModel = ChatViewModel(
+                                conversation: conversation,
+                                transcription: transcription,
+                                aiService: appState.aiService,
+                                modelContext: modelContext
+                            )
+                        }
+                        showChat = true
+                    } else {
+                        showConfigureChat = true
                     }
-                    showChat = true
                 } label: {
                     chatButtonLabel
                 }
                 .buttonStyle(.plain)
-                .disabled(!isAIConfigured)
                 
                 Spacer()
 
@@ -961,6 +972,38 @@ private struct ConfigureAISheet: View {
                 .font(.title3.bold())
 
             Text("Set up an AI provider in your mode settings to use AI text processing.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal)
+
+            Button {
+                onOpenSettings()
+            } label: {
+                Text("Open Mode Settings")
+                    .font(.headline)
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .padding(.horizontal, 40)
+        }
+    }
+}
+
+private struct ConfigureChatSheet: View {
+    let onOpenSettings: () -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "bubble.left.and.text.bubble.right")
+                .font(.system(size: 40))
+                .foregroundStyle(.secondary)
+
+            Text("Chat Not Available")
+                .font(.title3.bold())
+
+            Text("Set up an AI provider in your mode settings to chat with your notes.")
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)

--- a/VivaDicta/Views/TranscriptionDetailView.swift
+++ b/VivaDicta/Views/TranscriptionDetailView.swift
@@ -109,9 +109,9 @@ struct TranscriptionDetailView: View {
                                 .mask {
                                     Capsule()
                                         .strokeBorder(lineWidth: 3)
-                                        .blur(radius: 1)
                                 }
                                 .glassEffect(.regular.tint(.blue.opacity(0.75)).interactive())
+                                .blur(radius: 1)
                         }
                         
                     } else {

--- a/VivaDicta/Views/TranscriptionDetailView.swift
+++ b/VivaDicta/Views/TranscriptionDetailView.swift
@@ -82,21 +82,17 @@ struct TranscriptionDetailView: View {
         appState.aiService.isProperlyConfigured()
     }
 
-    private var isChatAvailable: Bool {
-        !appState.aiService.connectedProviders.isEmpty
-    }
-
     @ViewBuilder
     private var chatButtonLabel: some View {
         if #available(iOS 26.0, *) {
             
             Image(systemName: "bubble.left.and.text.bubble.right")
                 .font(.system(size: 16, weight: .bold))
-                .foregroundStyle(isChatAvailable ? Color.white : .secondary)
+                .foregroundStyle(isAIConfigured ? Color.white : .secondary)
                 .padding(.horizontal, 12)
                 .padding(.vertical, 8)
                 .background {
-                    if isChatAvailable {
+                    if isAIConfigured {
                         
                         if colorScheme == .dark {
                             AnimatedMeshGradient2()
@@ -126,12 +122,12 @@ struct TranscriptionDetailView: View {
         } else {
             Image(systemName: "bubble.left.and.text.bubble.right")
                 .font(.system(size: 16, weight: .bold))
-                .foregroundStyle(isChatAvailable ? .primary : .secondary)
+                .foregroundStyle(isAIConfigured ? .primary : .secondary)
                 .padding(.horizontal, 20)
                 .padding(.vertical, 10)
                 .background {
                     Capsule()
-                        .fill(isChatAvailable ? .blue : Color(.systemGray5))
+                        .fill(isAIConfigured ? .blue : Color(.systemGray5))
                 }
         }
         
@@ -555,7 +551,7 @@ struct TranscriptionDetailView: View {
                     chatButtonLabel
                 }
                 .buttonStyle(.plain)
-                .disabled(!isChatAvailable)
+                .disabled(!isAIConfigured)
                 
                 Spacer()
 

--- a/VivaDicta/Views/TranscriptionDetailView.swift
+++ b/VivaDicta/Views/TranscriptionDetailView.swift
@@ -82,6 +82,126 @@ struct TranscriptionDetailView: View {
     private var isAIConfigured: Bool {
         appState.aiService.isProperlyConfigured()
     }
+    
+    
+    @ViewBuilder
+    private var aiRewriteButtonLabel: some View {
+        if #available(iOS 26.0, *) {
+            HStack(spacing: 4) {
+                Image(systemName: "sparkles")
+                Text("AI")
+            }
+            .font(.system(size: 16, weight: .bold))
+            .foregroundStyle(isAIConfigured ? .white : .secondary)
+            .padding(.horizontal, 20)
+            .padding(.vertical, 10)
+            .background {
+                if isAIConfigured {
+                    if colorScheme == .dark {
+                        // Dark mode: edge-glow HUD style
+                        AnimatedMeshGradient()
+                            .mask(
+                                Capsule()
+                                    .stroke(lineWidth: 14)
+                                    .blur(radius: 6)
+                            )
+                            .blendMode(.lighten)
+                            .overlay(
+                                Capsule()
+                                    .stroke(lineWidth: 2)
+                                    .fill(Color.white)
+                                    .blur(radius: 1.5)
+                                    .blendMode(.overlay)
+                            )
+                            .overlay(
+                                Capsule()
+                                    .stroke(lineWidth: 0.5)
+                                    .fill(Color.white)
+                                    .blur(radius: 0.5)
+                                    .blendMode(.overlay)
+                            )
+                            .background(.black)
+                            .clipShape(.capsule)
+                            .glassEffect(.clear.interactive(), in: .capsule)
+                    } else {
+                        // Light mode: full gradient fill
+                        AnimatedMeshGradient2()
+                            .overlay(
+                                Capsule()
+                                    .stroke(lineWidth: 1)
+                                    .fill(Color.white)
+                                    .blur(radius: 1)
+                                    .blendMode(.overlay)
+                            )
+                            .clipShape(.capsule)
+                            .glassEffect(.clear.interactive(), in: .capsule)
+                            .shadow(color: .black.opacity(0.15), radius: 8, x: 0, y: 4)
+                    }
+                } else {
+                    Color(.systemGray5)
+                        .glassEffect(.clear, in: .capsule)
+//                    Capsule()
+//                        .fill(Color(.systemGray5))
+                }
+            }
+
+        } else {
+            HStack(spacing: 4) {
+                Image(systemName: "sparkles")
+                Text("AI")
+            }
+            .font(.system(size: 16, weight: .bold))
+            .foregroundStyle(isAIConfigured ? .white : .secondary)
+            .padding(.horizontal, 20)
+            .padding(.vertical, 10)
+            .background {
+                if isAIConfigured {
+                    if colorScheme == .dark {
+                        // Dark mode: edge-glow HUD style
+                        AnimatedMeshGradient()
+                            .mask(
+                                Capsule()
+                                    .stroke(lineWidth: 14)
+                                    .blur(radius: 6)
+                            )
+                            .blendMode(.lighten)
+                            .overlay(
+                                Capsule()
+                                    .stroke(lineWidth: 2)
+                                    .fill(Color.white)
+                                    .blur(radius: 1.5)
+                                    .blendMode(.overlay)
+                            )
+                            .overlay(
+                                Capsule()
+                                    .stroke(lineWidth: 0.5)
+                                    .fill(Color.white)
+                                    .blur(radius: 0.5)
+                                    .blendMode(.overlay)
+                            )
+                            .background(.black)
+                            .clipShape(.capsule)
+                    } else {
+                        // Light mode: full gradient fill
+                        AnimatedMeshGradient2()
+                            .overlay(
+                                Capsule()
+                                    .stroke(lineWidth: 1)
+                                    .fill(Color.white)
+                                    .blur(radius: 1)
+                                    .blendMode(.overlay)
+                            )
+                            .clipShape(.capsule)
+                            .shadow(color: .black.opacity(0.15), radius: 8, x: 0, y: 4)
+                    }
+                } else {
+                    Capsule()
+                        .fill(Color(.systemGray5))
+                }
+            }
+
+        }
+    }
 
     @ViewBuilder
     private var chatButtonLabel: some View {
@@ -483,59 +603,7 @@ struct TranscriptionDetailView: View {
                         showConfigureAI = true
                     }
                 } label: {
-                    HStack(spacing: 4) {
-                        Image(systemName: "sparkles")
-                        Text("AI")
-                    }
-                    .font(.system(size: 16, weight: .bold))
-                    .foregroundStyle(isAIConfigured ? .white : .secondary)
-                    .padding(.horizontal, 20)
-                    .padding(.vertical, 10)
-                    .background {
-                        if isAIConfigured {
-                            if colorScheme == .dark {
-                                // Dark mode: edge-glow HUD style
-                                AnimatedMeshGradient()
-                                    .mask(
-                                        Capsule()
-                                            .stroke(lineWidth: 14)
-                                            .blur(radius: 6)
-                                    )
-                                    .blendMode(.lighten)
-                                    .overlay(
-                                        Capsule()
-                                            .stroke(lineWidth: 2)
-                                            .fill(Color.white)
-                                            .blur(radius: 1.5)
-                                            .blendMode(.overlay)
-                                    )
-                                    .overlay(
-                                        Capsule()
-                                            .stroke(lineWidth: 0.5)
-                                            .fill(Color.white)
-                                            .blur(radius: 0.5)
-                                            .blendMode(.overlay)
-                                    )
-                                    .background(.black)
-                                    .clipShape(.capsule)
-                            } else {
-                                // Light mode: full gradient fill
-                                AnimatedMeshGradient2()
-                                    .overlay(
-                                        Capsule()
-                                            .stroke(lineWidth: 1)
-                                            .fill(Color.white)
-                                            .blur(radius: 1)
-                                            .blendMode(.overlay)
-                                    )
-                                    .clipShape(.capsule)
-                                    .shadow(color: .black.opacity(0.15), radius: 8, x: 0, y: 4)
-                            }
-                        } else {
-                            Capsule()
-                                .fill(Color(.systemGray5))
-                        }
-                    }
+                    aiRewriteButtonLabel
                 }
                 .buttonStyle(.plain)
                 .disabled(generatingPresetId != nil)

--- a/VivaDicta/Views/TranscriptionsContentView.swift
+++ b/VivaDicta/Views/TranscriptionsContentView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 
 struct TranscriptionsContentView: View {
     @Environment(\.modelContext) private var modelContext
+    @Environment(\.colorScheme) var colorScheme
     @Query(sort: \Transcription.timestamp, order: .reverse) private var allTranscriptions: [Transcription]
     @Query(sort: \TranscriptionTag.sortOrder) private var allTags: [TranscriptionTag]
 
@@ -129,7 +130,7 @@ struct TranscriptionsContentView: View {
                     .overlay(alignment: .bottom) {
                         if showGoToTopButton {
                             
-                            ScrollToTopButton(backgroundColor: .indigo) {
+                            ScrollToTopButton(backgroundColor: .indigo.opacity(colorScheme == .dark ? 0.4 : 0.7)) {
                                 withAnimation {
                                     proxy.scrollTo(topAnchorID, anchor: .top)
                                 }

--- a/VivaDicta/Views/TranscriptionsContentView.swift
+++ b/VivaDicta/Views/TranscriptionsContentView.swift
@@ -48,7 +48,7 @@ struct TranscriptionsContentView: View {
                     selectedSourceTags: $selectedSourceTags,
                     selectedUserTagIds: $selectedUserTagIds
                 )
-                .padding(.vertical, 8)
+//                .padding(.vertical, 8)
             }
 
             if allTranscriptions.isEmpty {

--- a/VivaDictaKeyboard/KeyboardViewController.swift
+++ b/VivaDictaKeyboard/KeyboardViewController.swift
@@ -189,7 +189,7 @@ struct ModeCycleSelector: View {
         }
         .padding(.horizontal, 4)
         .padding(.vertical, 6)
-        .background(.quaternary, in: .capsule)
+        .glassCapsule(fallback: .quaternary)
         .gesture(
             DragGesture(minimumDistance: 20)
                 .onEnded { value in

--- a/VivaDictaKeyboard/Views/FullAccessPromptView.swift
+++ b/VivaDictaKeyboard/Views/FullAccessPromptView.swift
@@ -24,7 +24,7 @@ struct FullAccessPromptView: View {
                         .font(.system(size: 16, weight: .semibold))
                         .foregroundStyle(.primary)
                         .frame(width: 36, height: 36)
-                        .background(.quinary, in: .circle)
+                        .glassDismissCircle(fallback: .quinary)
                 }
                 .buttonStyle(.plain)
 

--- a/VivaDictaKeyboard/Views/ProcessingStateView.swift
+++ b/VivaDictaKeyboard/Views/ProcessingStateView.swift
@@ -67,8 +67,8 @@ struct ProcessingStateView: View {
                         .font(.system(size: 18, weight: .medium))
                         .foregroundStyle(Color.secondary)
                         .frame(width: 44, height: 44)
-                        .background(.gray.opacity(0.1), in: .circle)
-                        .contentShape(.rect)
+                        .glassDismissCircle()
+                        .contentShape(.circle)
                 }
                 .padding(.trailing, 16)
             }

--- a/VivaDictaKeyboard/Views/RecordingStateView.swift
+++ b/VivaDictaKeyboard/Views/RecordingStateView.swift
@@ -41,8 +41,8 @@ struct RecordingStateView: View {
                         .font(.system(size: 18, weight: .semibold))
                         .foregroundStyle(Color.secondary)
                         .frame(width: 44, height: 44)
-                        .background(.gray.opacity(0.1), in: .circle)
-                        .contentShape(.rect)
+                        .glassDismissCircle()
+                        .contentShape(.circle)
                 }
                 .padding(.trailing, 16)
             }
@@ -68,7 +68,7 @@ struct RecordingStateView: View {
                 }
                 .padding(.horizontal, 40)
                 .padding(.vertical, 12)
-                .background(.red, in: .capsule)
+                .glassCapsule(tint: .red, fallback: Color.red)
             }
         }
         .onAppear {

--- a/VivaDictaKeyboard/Views/RewriteModesView.swift
+++ b/VivaDictaKeyboard/Views/RewriteModesView.swift
@@ -219,10 +219,7 @@ struct RewriteModesView: View {
             }
             .padding(.horizontal, 8)
             .padding(.vertical, 7)
-            .background(
-                colorScheme == .dark ? Color(.quaternarySystemFill).opacity(0.5) : Color.white,
-                in: .rect(cornerRadius: 8)
-            )
+            .presetCardBackground(colorScheme: colorScheme)
         }
         .buttonStyle(.plain)
     }
@@ -383,5 +380,30 @@ private struct KeyboardCategoryChipsView: View {
             }
             .buttonStyle(.plain)
         }
+    }
+}
+
+// MARK: - Preset Card Background
+
+private struct PresetCardBackgroundModifier: ViewModifier {
+    let colorScheme: ColorScheme
+
+    func body(content: Content) -> some View {
+        if #available(iOS 26, *) {
+            content
+                .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 8))
+        } else {
+            content
+                .background(
+                    colorScheme == .dark ? Color(.quaternarySystemFill).opacity(0.5) : Color.white,
+                    in: .rect(cornerRadius: 8)
+                )
+        }
+    }
+}
+
+extension View {
+    fileprivate func presetCardBackground(colorScheme: ColorScheme) -> some View {
+        modifier(PresetCardBackgroundModifier(colorScheme: colorScheme))
     }
 }

--- a/VivaDictaKeyboard/Views/RewriteModesView.swift
+++ b/VivaDictaKeyboard/Views/RewriteModesView.swift
@@ -361,7 +361,7 @@ private struct KeyboardCategoryChipsView: View {
             .buttonStyle(.plain)
             .glassEffect(
                 isSelected
-                ? .regular.tint(Color.pink.opacity(0.6))
+                ? .regular.tint(Color.pink.opacity(0.6)).interactive()
                 : .regular.interactive()
             )
         } else {

--- a/VivaDictaKeyboard/Views/TextProcessingStateView.swift
+++ b/VivaDictaKeyboard/Views/TextProcessingStateView.swift
@@ -29,8 +29,8 @@ struct TextProcessingStateView: View {
                         .font(.system(size: 18, weight: .medium))
                         .foregroundStyle(.secondary)
                         .frame(width: 44, height: 44)
-                        .background(.gray.opacity(0.1), in: .circle)
-                        .contentShape(.rect)
+                        .glassDismissCircle()
+                        .contentShape(.circle)
                 }
                 .buttonStyle(.plain)
                 .padding(.trailing, 16)


### PR DESCRIPTION
## Summary
- Apply iOS 26+ Liquid Glass effects throughout the main app and keyboard extension
- Glass effects on chat bubbles, chat input bar, tag/category filter chips, mode picker, scroll-to-top button, recording sheet buttons, and model cards
- Add reusable glass modifiers (`glassDismissCircle`, `glassCapsule`, `modelCardBackground`) in View+Ext for shared usage
- Glassify keyboard extension: dismiss buttons, stop recording, mode cycle selector, and preset cards
- Sync chat button disabled state with AI configuration status
- All changes include pre-iOS 26 fallbacks preserving existing appearance

## Test plan
- [ ] Verify glass effects render correctly on iOS 26 simulator/device
- [ ] Verify pre-iOS 26 fallback styling is unchanged
- [ ] Test chat input bar send/stop button in both states
- [ ] Test chat bubbles (user, assistant, error) appearance
- [ ] Test tag filter and category chip selection/deselection
- [ ] Test scroll-to-top button visibility and tap reliability
- [ ] Test mode picker in main screen and recording sheet
- [ ] Test recording sheet cancel and stop buttons
- [ ] Test model cards in local and cloud model screens
- [ ] Test keyboard extension: recording, processing, rewrite views
- [ ] Verify chat button disables when AI is not configured