### PR TITLE
Add review prompts for chat and Smart Search

### DIFF
--- a/VivaDicta/Views/Chat/ChatViewModel.swift
+++ b/VivaDicta/Views/Chat/ChatViewModel.swift
@@ -23,6 +23,7 @@ import os
 @MainActor
 final class ChatViewModel {
     private let logger = Logger(category: .chatViewModel)
+    private let reviewReplyThreshold = 3
 
     // MARK: - State
 
@@ -120,6 +121,8 @@ final class ChatViewModel {
     private let modelContext: ModelContext
     private var streamingTask: Task<Void, Never>?
     private var pendingUserMessage: ChatMessage?
+    private var successfulReplyCount = 0
+    private var hasRequestedReviewForSession = false
 
     /// The note text for this conversation.
     var assembledNoteText: String {
@@ -229,6 +232,9 @@ final class ChatViewModel {
                 modelContext.insert(assistantMessage)
                 messages.append(assistantMessage)
 
+                successfulReplyCount += 1
+                requestReviewIfNeededForSession()
+
                 HapticManager.heartbeat()
 
             } catch is CancellationError {
@@ -281,6 +287,8 @@ final class ChatViewModel {
             modelContext.delete(message)
         }
         messages.removeAll()
+        successfulReplyCount = 0
+        hasRequestedReviewForSession = false
 
         conversation.appleFMTranscriptData = nil
         trySave()
@@ -290,6 +298,12 @@ final class ChatViewModel {
         }
 
         updateContextFillRatio()
+    }
+
+    private func requestReviewIfNeededForSession() {
+        guard !hasRequestedReviewForSession, successfulReplyCount >= reviewReplyThreshold else { return }
+        hasRequestedReviewForSession = true
+        RateAppManager.requestReviewIfAppropriate()
     }
 
     // MARK: - Compact Chat

--- a/VivaDicta/Views/MultiNoteChat/MultiNoteChatViewModel.swift
+++ b/VivaDicta/Views/MultiNoteChat/MultiNoteChatViewModel.swift
@@ -19,6 +19,7 @@ import os
 @MainActor
 final class MultiNoteChatViewModel {
     private let logger = Logger(category: .multiNoteChat)
+    private let reviewReplyThreshold = 2
 
     // MARK: - State
 
@@ -113,6 +114,8 @@ final class MultiNoteChatViewModel {
     private var streamingTask: Task<Void, Never>?
     /// User message not yet persisted to SwiftData. Re-appended after loadMessages() during send flow.
     private var pendingUserMessage: ChatMessage?
+    private var successfulReplyCount = 0
+    private var hasRequestedReviewForSession = false
 
     var assembledNoteText: String {
         conversation.noteContext
@@ -219,6 +222,9 @@ final class MultiNoteChatViewModel {
                 modelContext.insert(assistantMessage)
                 messages.append(assistantMessage)
 
+                successfulReplyCount += 1
+                requestReviewIfNeededForSession()
+
                 HapticManager.heartbeat()
 
             } catch is CancellationError {
@@ -271,6 +277,8 @@ final class MultiNoteChatViewModel {
             modelContext.delete(message)
         }
         messages.removeAll()
+        successfulReplyCount = 0
+        hasRequestedReviewForSession = false
 
         conversation.appleFMTranscriptData = nil
         trySave()
@@ -280,6 +288,12 @@ final class MultiNoteChatViewModel {
         }
 
         updateContextFillRatio()
+    }
+
+    private func requestReviewIfNeededForSession() {
+        guard !hasRequestedReviewForSession, successfulReplyCount >= reviewReplyThreshold else { return }
+        hasRequestedReviewForSession = true
+        RateAppManager.requestReviewIfAppropriate()
     }
 
     // MARK: - Compact Chat

--- a/VivaDicta/Views/SmartSearch/SmartSearchChatView.swift
+++ b/VivaDicta/Views/SmartSearch/SmartSearchChatView.swift
@@ -221,6 +221,7 @@ struct SmartSearchChatView: View {
             ForEach(sources) { source in
                 Button {
                     selectedTranscription = source.transcription
+                    RateAppManager.requestReviewIfAppropriate()
                 } label: {
                     HStack(spacing: 5) {
                         Image(systemName: "doc.text")

--- a/VivaDicta/Views/SmartSearch/SmartSearchChatViewModel.swift
+++ b/VivaDicta/Views/SmartSearch/SmartSearchChatViewModel.swift
@@ -329,6 +329,10 @@ final class SmartSearchChatViewModel {
         assistantMessage.smartSearchConversation = conversation
         modelContext.insert(assistantMessage)
         messages.append(assistantMessage)
+
+        if !sourceCitations.isEmpty {
+            RateAppManager.requestReviewIfAppropriate()
+        }
     }
 
     // MARK: - Cancel

--- a/VivaDicta/Views/TranscriptionsContentView.swift
+++ b/VivaDicta/Views/TranscriptionsContentView.swift
@@ -724,6 +724,11 @@ private struct TranscriptionNavigationRow: View {
     var body: some View {
         NavigationLink {
             TranscriptionDetailView(transcription: transcription)
+                .onAppear {
+                    if semanticScore != nil {
+                        RateAppManager.requestReviewIfAppropriate()
+                    }
+                }
         } label: {
             TranscriptionRowView(
                 transcription: transcription,


### PR DESCRIPTION
## Summary
- request App Store reviews after successful Smart Search note opens from semantic results
- request reviews after successful cited Smart Search answers and citation taps
- request reviews after a few successful single-note and multi-note chat replies

## Testing
- `xcodebuild -scheme VivaDicta -configuration Debug -workspace ./VivaDicta.xcodeproj/project.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max,OS=26.4' build 2>&1 | xcsift`\n- Build passed with 0 errors\n\n## Notes\n- This intentionally takes a simple, more aggressive approach and relies on the existing `RateAppManager` gating and Apple review throttling\n- No breaking changes