### PR TITLE
Add bulk Markdown export and ZIP sharing for selected notes

### DIFF
--- a/VivaDicta/Services/MarkdownExportItem.swift
+++ b/VivaDicta/Services/MarkdownExportItem.swift
@@ -1,0 +1,26 @@
+//
+//  MarkdownExportItem.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.13
+//
+
+import CoreTransferable
+import Foundation
+import UniformTypeIdentifiers
+
+struct MarkdownExportItem: Transferable {
+    static let contentType = UTType(filenameExtension: "md") ?? .plainText
+
+    let filename: String
+    let text: String
+
+    static var transferRepresentation: some TransferRepresentation {
+        DataRepresentation(exportedContentType: contentType) { item in
+            Data(item.text.utf8)
+        }
+        .suggestedFileName { item in
+            item.filename
+        }
+    }
+}

--- a/VivaDicta/Services/MarkdownZipExportService.swift
+++ b/VivaDicta/Services/MarkdownZipExportService.swift
@@ -1,0 +1,190 @@
+//
+//  MarkdownZipExportService.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.13
+//
+
+import Foundation
+
+enum MarkdownZipExportService {
+    nonisolated static func createArchive(from items: [MarkdownExportItem], now: Date = .now) throws -> URL {
+        let directoryURL = URL.temporaryDirectory.appending(path: UUID().uuidString, directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+
+        let archiveURL = directoryURL.appending(path: archiveFilename(for: items.count, now: now))
+        let entries = items.map { ZipArchiveEntry(filename: $0.filename, data: Data($0.text.utf8)) }
+
+        try ZipArchiveWriter.write(entries: entries, to: archiveURL)
+        return archiveURL
+    }
+
+    nonisolated static func cleanupArchive(at archiveURL: URL) {
+        try? FileManager.default.removeItem(at: archiveURL)
+
+        let parentDirectory = archiveURL.deletingLastPathComponent()
+        try? FileManager.default.removeItem(at: parentDirectory)
+    }
+
+    nonisolated private static func archiveFilename(for count: Int, now: Date) -> String {
+        let components = Calendar.current.dateComponents(
+            [.year, .month, .day, .hour, .minute, .second],
+            from: now
+        )
+
+        let year = components.year ?? 0
+        let month = components.month ?? 0
+        let day = components.day ?? 0
+        let hour = components.hour ?? 0
+        let minute = components.minute ?? 0
+        let second = components.second ?? 0
+        let noteLabel = count == 1 ? "note" : "notes"
+
+        return "VivaDicta-\(count)-\(noteLabel)-\(year)-\(twoDigit(month))-\(twoDigit(day))_\(twoDigit(hour))\(twoDigit(minute))\(twoDigit(second)).zip"
+    }
+
+    nonisolated private static func twoDigit(_ value: Int) -> String {
+        if value < 10 {
+            return "0\(value)"
+        }
+
+        return "\(value)"
+    }
+}
+
+struct ZipArchiveEntry: Sendable {
+    let filename: String
+    let data: Data
+}
+
+enum ZipArchiveWriter {
+    nonisolated static func write(entries: [ZipArchiveEntry], to url: URL) throws {
+        let dosDateTime = dosDateTime(from: .now)
+        var archiveData = Data()
+        var centralDirectory = Data()
+        var localHeaderOffset: UInt32 = 0
+
+        for entry in entries {
+            let filenameData = Data(entry.filename.utf8)
+            let crc32 = CRC32.checksum(for: entry.data)
+            let uncompressedSize = try uint32(entry.data.count)
+            let filenameLength = try uint16(filenameData.count)
+
+            archiveData.append(littleEndian: UInt32(0x04034B50))
+            archiveData.append(littleEndian: UInt16(20))
+            archiveData.append(littleEndian: UInt16(0))
+            archiveData.append(littleEndian: UInt16(0))
+            archiveData.append(littleEndian: dosDateTime.time)
+            archiveData.append(littleEndian: dosDateTime.date)
+            archiveData.append(littleEndian: crc32)
+            archiveData.append(littleEndian: uncompressedSize)
+            archiveData.append(littleEndian: uncompressedSize)
+            archiveData.append(littleEndian: filenameLength)
+            archiveData.append(littleEndian: UInt16(0))
+            archiveData.append(filenameData)
+            archiveData.append(entry.data)
+
+            centralDirectory.append(littleEndian: UInt32(0x02014B50))
+            centralDirectory.append(littleEndian: UInt16(20))
+            centralDirectory.append(littleEndian: UInt16(20))
+            centralDirectory.append(littleEndian: UInt16(0))
+            centralDirectory.append(littleEndian: UInt16(0))
+            centralDirectory.append(littleEndian: dosDateTime.time)
+            centralDirectory.append(littleEndian: dosDateTime.date)
+            centralDirectory.append(littleEndian: crc32)
+            centralDirectory.append(littleEndian: uncompressedSize)
+            centralDirectory.append(littleEndian: uncompressedSize)
+            centralDirectory.append(littleEndian: filenameLength)
+            centralDirectory.append(littleEndian: UInt16(0))
+            centralDirectory.append(littleEndian: UInt16(0))
+            centralDirectory.append(littleEndian: UInt16(0))
+            centralDirectory.append(littleEndian: UInt16(0))
+            centralDirectory.append(littleEndian: UInt32(0))
+            centralDirectory.append(littleEndian: localHeaderOffset)
+            centralDirectory.append(filenameData)
+
+            localHeaderOffset = try uint32(archiveData.count)
+        }
+
+        let centralDirectoryOffset = try uint32(archiveData.count)
+        archiveData.append(centralDirectory)
+
+        let entryCount = try uint16(entries.count)
+        let centralDirectorySize = try uint32(centralDirectory.count)
+
+        archiveData.append(littleEndian: UInt32(0x06054B50))
+        archiveData.append(littleEndian: UInt16(0))
+        archiveData.append(littleEndian: UInt16(0))
+        archiveData.append(littleEndian: entryCount)
+        archiveData.append(littleEndian: entryCount)
+        archiveData.append(littleEndian: centralDirectorySize)
+        archiveData.append(littleEndian: centralDirectoryOffset)
+        archiveData.append(littleEndian: UInt16(0))
+
+        try archiveData.write(to: url, options: .atomic)
+    }
+
+    nonisolated private static func uint16(_ value: Int) throws -> UInt16 {
+        guard let converted = UInt16(exactly: value) else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+
+        return converted
+    }
+
+    nonisolated private static func uint32(_ value: Int) throws -> UInt32 {
+        guard let converted = UInt32(exactly: value) else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+
+        return converted
+    }
+
+    nonisolated private static func dosDateTime(from date: Date) -> (date: UInt16, time: UInt16) {
+        let components = Calendar.current.dateComponents(
+            [.year, .month, .day, .hour, .minute, .second],
+            from: date
+        )
+
+        let year = max((components.year ?? 1980) - 1980, 0)
+        let month = max(components.month ?? 1, 1)
+        let day = max(components.day ?? 1, 1)
+        let hour = max(components.hour ?? 0, 0)
+        let minute = max(components.minute ?? 0, 0)
+        let second = max(components.second ?? 0, 0) / 2
+
+        let dosDate = UInt16((year << 9) | (month << 5) | day)
+        let dosTime = UInt16((hour << 11) | (minute << 5) | second)
+
+        return (dosDate, dosTime)
+    }
+}
+
+private enum CRC32 {
+    nonisolated static func checksum(for data: Data) -> UInt32 {
+        var crc: UInt32 = 0xFFFF_FFFF
+
+        for byte in data {
+            crc ^= UInt32(byte)
+
+            for _ in 0..<8 {
+                if crc & 1 == 1 {
+                    crc = (crc >> 1) ^ 0xEDB8_8320
+                } else {
+                    crc >>= 1
+                }
+            }
+        }
+
+        return crc ^ 0xFFFF_FFFF
+    }
+}
+
+private extension Data {
+    nonisolated mutating func append<T: FixedWidthInteger>(littleEndian value: T) {
+        var littleEndianValue = value.littleEndian
+        Swift.withUnsafeBytes(of: &littleEndianValue) { buffer in
+            append(buffer.bindMemory(to: UInt8.self))
+        }
+    }
+}

--- a/VivaDicta/Services/MarkdownZipExportService.swift
+++ b/VivaDicta/Services/MarkdownZipExportService.swift
@@ -15,8 +15,13 @@ enum MarkdownZipExportService {
         let archiveURL = directoryURL.appending(path: archiveFilename(for: items.count, now: now))
         let entries = items.map { ZipArchiveEntry(filename: $0.filename, data: Data($0.text.utf8)) }
 
-        try ZipArchiveWriter.write(entries: entries, to: archiveURL)
-        return archiveURL
+        do {
+            try ZipArchiveWriter.write(entries: entries, to: archiveURL)
+            return archiveURL
+        } catch {
+            cleanupArchive(at: archiveURL)
+            throw error
+        }
     }
 
     nonisolated static func cleanupArchive(at archiveURL: URL) {

--- a/VivaDicta/Services/TranscriptionMarkdownExportService.swift
+++ b/VivaDicta/Services/TranscriptionMarkdownExportService.swift
@@ -1,0 +1,127 @@
+//
+//  TranscriptionMarkdownExportService.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.13
+//
+
+import Foundation
+
+enum TranscriptionMarkdownExportService {
+    static func item(for transcription: Transcription) -> MarkdownExportItem {
+        MarkdownExportItem(
+            filename: markdownFilename(for: transcription),
+            text: generateMarkdown(for: transcription)
+        )
+    }
+
+    static func items(for transcriptions: [Transcription]) -> [MarkdownExportItem] {
+        transcriptions
+            .sorted { $0.timestamp > $1.timestamp }
+            .map(item(for:))
+    }
+
+    private static let exportTimestampFormat = Date.FormatStyle()
+        .year()
+        .month(.abbreviated)
+        .day()
+        .hour()
+        .minute()
+
+    private static func generateMarkdown(for transcription: Transcription) -> String {
+        var lines: [String] = [
+            "# Transcription - \(transcription.timestamp.formatted(exportTimestampFormat))",
+            ""
+        ]
+
+        let metadata = metadataLines(for: transcription)
+        if !metadata.isEmpty {
+            lines.append(contentsOf: metadata)
+            lines.append("")
+        }
+
+        lines.append("## Original")
+        lines.append("")
+        lines.append(transcription.text.trimmingCharacters(in: .whitespacesAndNewlines))
+        lines.append("")
+
+        for variation in sortedVariations(for: transcription) {
+            let title = PresetCatalog.displayName(
+                for: variation.presetId,
+                fallback: variation.presetDisplayName
+            )
+            lines.append("## \(title)")
+            lines.append("")
+            lines.append(variation.text.trimmingCharacters(in: .whitespacesAndNewlines))
+            lines.append("")
+        }
+
+        return lines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines) + "\n"
+    }
+
+    private static func markdownFilename(for transcription: Transcription) -> String {
+        let components = Calendar.current.dateComponents(
+            [.year, .month, .day, .hour, .minute, .second],
+            from: transcription.timestamp
+        )
+
+        let year = components.year ?? 0
+        let month = components.month ?? 0
+        let day = components.day ?? 0
+        let hour = components.hour ?? 0
+        let minute = components.minute ?? 0
+        let second = components.second ?? 0
+
+        return "VivaDicta-\(year)-\(twoDigit(month))-\(twoDigit(day))_\(twoDigit(hour))\(twoDigit(minute))\(twoDigit(second)).md"
+    }
+
+    private static func metadataLines(for transcription: Transcription) -> [String] {
+        var metadata: [String] = []
+
+        if let model = transcription.transcriptionModelName, !model.isEmpty {
+            metadata.append("- **Transcription Model:** \(model)")
+        }
+
+        let mode = powerModeDisplay(name: transcription.powerModeName, emoji: transcription.powerModeEmoji)
+        if !mode.isEmpty {
+            metadata.append("- **Mode:** \(mode)")
+        }
+
+        if transcription.audioDuration > 0 {
+            metadata.append("- **Duration:** \(transcription.getDurationFormatted(transcription.audioDuration))")
+        }
+
+        if let sourceTag = transcription.sourceTag, !sourceTag.isEmpty {
+            metadata.append("- **Source:** \(sourceTag)")
+        }
+
+        return metadata
+    }
+
+    private static func sortedVariations(for transcription: Transcription) -> [TranscriptionVariation] {
+        (transcription.variations ?? []).sorted { lhs, rhs in
+            if lhs.createdAt == rhs.createdAt {
+                return lhs.presetDisplayName.localizedStandardCompare(rhs.presetDisplayName) == .orderedAscending
+            }
+
+            return lhs.createdAt < rhs.createdAt
+        }
+    }
+
+    private static func powerModeDisplay(name: String?, emoji: String?) -> String {
+        let trimmedName = name?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let trimmedEmoji = emoji?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+        if trimmedName.isEmpty { return "" }
+        if trimmedEmoji.isEmpty { return trimmedName }
+        return "\(trimmedEmoji) \(trimmedName)"
+    }
+
+    private static func twoDigit(_ value: Int) -> String {
+        if value < 10 {
+            return "0\(value)"
+        }
+
+        return "\(value)"
+    }
+}

--- a/VivaDicta/Services/TranscriptionMarkdownExportService.swift
+++ b/VivaDicta/Services/TranscriptionMarkdownExportService.swift
@@ -9,16 +9,21 @@ import Foundation
 
 enum TranscriptionMarkdownExportService {
     static func item(for transcription: Transcription) -> MarkdownExportItem {
-        MarkdownExportItem(
-            filename: markdownFilename(for: transcription),
-            text: generateMarkdown(for: transcription)
-        )
+        markdownItem(for: transcription, filename: markdownFilename(for: transcription))
     }
 
     static func items(for transcriptions: [Transcription]) -> [MarkdownExportItem] {
-        transcriptions
+        var seenFilenames: [String: Int] = [:]
+
+        return transcriptions
             .sorted { $0.timestamp > $1.timestamp }
-            .map(item(for:))
+            .map { transcription in
+                let filename = uniquedFilename(
+                    markdownFilename(for: transcription),
+                    seenFilenames: &seenFilenames
+                )
+                return markdownItem(for: transcription, filename: filename)
+            }
     }
 
     private static let exportTimestampFormat = Date.FormatStyle()
@@ -27,6 +32,13 @@ enum TranscriptionMarkdownExportService {
         .day()
         .hour()
         .minute()
+
+    private static func markdownItem(for transcription: Transcription, filename: String) -> MarkdownExportItem {
+        MarkdownExportItem(
+            filename: filename,
+            text: generateMarkdown(for: transcription)
+        )
+    }
 
     private static func generateMarkdown(for transcription: Transcription) -> String {
         var lines: [String] = [
@@ -73,6 +85,24 @@ enum TranscriptionMarkdownExportService {
         let second = components.second ?? 0
 
         return "VivaDicta-\(year)-\(twoDigit(month))-\(twoDigit(day))_\(twoDigit(hour))\(twoDigit(minute))\(twoDigit(second)).md"
+    }
+
+    private static func uniquedFilename(_ filename: String, seenFilenames: inout [String: Int]) -> String {
+        let duplicateCount = seenFilenames[filename, default: 0]
+        seenFilenames[filename] = duplicateCount + 1
+
+        guard duplicateCount > 0 else { return filename }
+        return filenameByAppendingDuplicateIndex(duplicateCount + 1, to: filename)
+    }
+
+    private static func filenameByAppendingDuplicateIndex(_ duplicateIndex: Int, to filename: String) -> String {
+        guard let extensionStartIndex = filename.lastIndex(of: ".") else {
+            return "\(filename)-\(duplicateIndex)"
+        }
+
+        let basename = filename[..<extensionStartIndex]
+        let extensionSuffix = filename[extensionStartIndex...]
+        return "\(basename)-\(duplicateIndex)\(extensionSuffix)"
     }
 
     private static func metadataLines(for transcription: Transcription) -> [String] {

--- a/VivaDicta/Services/TranscriptionMarkdownExportService.swift
+++ b/VivaDicta/Services/TranscriptionMarkdownExportService.swift
@@ -8,45 +8,96 @@
 import Foundation
 
 enum TranscriptionMarkdownExportService {
-    static func item(for transcription: Transcription) -> MarkdownExportItem {
-        markdownItem(for: transcription, filename: markdownFilename(for: transcription))
+    struct Snapshot: Sendable {
+        let timestamp: Date
+        let text: String
+        let transcriptionModelName: String?
+        let powerModeDisplay: String
+        let durationText: String?
+        let sourceTag: String?
+        let variations: [VariationSnapshot]
     }
 
-    static func items(for transcriptions: [Transcription]) -> [MarkdownExportItem] {
+    struct VariationSnapshot: Sendable {
+        let title: String
+        let sortKey: String
+        let text: String
+        let createdAt: Date
+    }
+
+    @MainActor static func item(for transcription: Transcription) -> MarkdownExportItem {
+        item(forSnapshot: snapshot(for: transcription))
+    }
+
+    @MainActor static func items(for transcriptions: [Transcription]) -> [MarkdownExportItem] {
+        items(forSnapshots: snapshots(for: transcriptions))
+    }
+
+    @MainActor static func snapshots(for transcriptions: [Transcription]) -> [Snapshot] {
+        transcriptions.map(snapshot(for:))
+    }
+
+    nonisolated static func item(forSnapshot snapshot: Snapshot) -> MarkdownExportItem {
+        markdownItem(for: snapshot, filename: markdownFilename(for: snapshot))
+    }
+
+    nonisolated static func items(forSnapshots snapshots: [Snapshot]) -> [MarkdownExportItem] {
         var seenFilenames: [String: Int] = [:]
 
-        return transcriptions
+        return snapshots
             .sorted { $0.timestamp > $1.timestamp }
-            .map { transcription in
+            .map { snapshot in
                 let filename = uniquedFilename(
-                    markdownFilename(for: transcription),
+                    markdownFilename(for: snapshot),
                     seenFilenames: &seenFilenames
                 )
-                return markdownItem(for: transcription, filename: filename)
+                return markdownItem(for: snapshot, filename: filename)
             }
     }
 
-    private static let exportTimestampFormat = Date.FormatStyle()
+    nonisolated private static let exportTimestampFormat = Date.FormatStyle()
         .year()
         .month(.abbreviated)
         .day()
         .hour()
         .minute()
 
-    private static func markdownItem(for transcription: Transcription, filename: String) -> MarkdownExportItem {
-        MarkdownExportItem(
-            filename: filename,
-            text: generateMarkdown(for: transcription)
+    @MainActor private static func snapshot(for transcription: Transcription) -> Snapshot {
+        Snapshot(
+            timestamp: transcription.timestamp,
+            text: transcription.text,
+            transcriptionModelName: transcription.transcriptionModelName,
+            powerModeDisplay: powerModeDisplay(name: transcription.powerModeName, emoji: transcription.powerModeEmoji),
+            durationText: transcription.audioDuration > 0 ? transcription.getDurationFormatted(transcription.audioDuration) : nil,
+            sourceTag: transcription.sourceTag,
+            variations: (transcription.variations ?? []).map {
+                VariationSnapshot(
+                    title: PresetCatalog.displayName(
+                        for: $0.presetId,
+                        fallback: $0.presetDisplayName
+                    ),
+                    sortKey: $0.presetDisplayName,
+                    text: $0.text,
+                    createdAt: $0.createdAt
+                )
+            }
         )
     }
 
-    private static func generateMarkdown(for transcription: Transcription) -> String {
+    nonisolated private static func markdownItem(for snapshot: Snapshot, filename: String) -> MarkdownExportItem {
+        MarkdownExportItem(
+            filename: filename,
+            text: generateMarkdown(for: snapshot)
+        )
+    }
+
+    nonisolated private static func generateMarkdown(for snapshot: Snapshot) -> String {
         var lines: [String] = [
-            "# Transcription - \(transcription.timestamp.formatted(exportTimestampFormat))",
+            "# Transcription - \(snapshot.timestamp.formatted(exportTimestampFormat))",
             ""
         ]
 
-        let metadata = metadataLines(for: transcription)
+        let metadata = metadataLines(for: snapshot)
         if !metadata.isEmpty {
             lines.append(contentsOf: metadata)
             lines.append("")
@@ -54,15 +105,11 @@ enum TranscriptionMarkdownExportService {
 
         lines.append("## Original")
         lines.append("")
-        lines.append(transcription.text.trimmingCharacters(in: .whitespacesAndNewlines))
+        lines.append(snapshot.text.trimmingCharacters(in: .whitespacesAndNewlines))
         lines.append("")
 
-        for variation in sortedVariations(for: transcription) {
-            let title = PresetCatalog.displayName(
-                for: variation.presetId,
-                fallback: variation.presetDisplayName
-            )
-            lines.append("## \(title)")
+        for variation in sortedVariations(for: snapshot) {
+            lines.append("## \(variation.title)")
             lines.append("")
             lines.append(variation.text.trimmingCharacters(in: .whitespacesAndNewlines))
             lines.append("")
@@ -71,10 +118,10 @@ enum TranscriptionMarkdownExportService {
         return lines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines) + "\n"
     }
 
-    private static func markdownFilename(for transcription: Transcription) -> String {
+    nonisolated private static func markdownFilename(for snapshot: Snapshot) -> String {
         let components = Calendar.current.dateComponents(
             [.year, .month, .day, .hour, .minute, .second],
-            from: transcription.timestamp
+            from: snapshot.timestamp
         )
 
         let year = components.year ?? 0
@@ -87,7 +134,7 @@ enum TranscriptionMarkdownExportService {
         return "VivaDicta-\(year)-\(twoDigit(month))-\(twoDigit(day))_\(twoDigit(hour))\(twoDigit(minute))\(twoDigit(second)).md"
     }
 
-    private static func uniquedFilename(_ filename: String, seenFilenames: inout [String: Int]) -> String {
+    nonisolated private static func uniquedFilename(_ filename: String, seenFilenames: inout [String: Int]) -> String {
         let duplicateCount = seenFilenames[filename, default: 0]
         seenFilenames[filename] = duplicateCount + 1
 
@@ -95,7 +142,7 @@ enum TranscriptionMarkdownExportService {
         return filenameByAppendingDuplicateIndex(duplicateCount + 1, to: filename)
     }
 
-    private static func filenameByAppendingDuplicateIndex(_ duplicateIndex: Int, to filename: String) -> String {
+    nonisolated private static func filenameByAppendingDuplicateIndex(_ duplicateIndex: Int, to filename: String) -> String {
         guard let extensionStartIndex = filename.lastIndex(of: ".") else {
             return "\(filename)-\(duplicateIndex)"
         }
@@ -105,20 +152,19 @@ enum TranscriptionMarkdownExportService {
         return "\(basename)-\(duplicateIndex)\(extensionSuffix)"
     }
 
-    private static func metadataLines(for transcription: Transcription) -> [String] {
+    nonisolated private static func metadataLines(for transcription: Snapshot) -> [String] {
         var metadata: [String] = []
 
         if let model = transcription.transcriptionModelName, !model.isEmpty {
             metadata.append("- **Transcription Model:** \(model)")
         }
 
-        let mode = powerModeDisplay(name: transcription.powerModeName, emoji: transcription.powerModeEmoji)
-        if !mode.isEmpty {
-            metadata.append("- **Mode:** \(mode)")
+        if !transcription.powerModeDisplay.isEmpty {
+            metadata.append("- **Mode:** \(transcription.powerModeDisplay)")
         }
 
-        if transcription.audioDuration > 0 {
-            metadata.append("- **Duration:** \(transcription.getDurationFormatted(transcription.audioDuration))")
+        if let durationText = transcription.durationText, !durationText.isEmpty {
+            metadata.append("- **Duration:** \(durationText)")
         }
 
         if let sourceTag = transcription.sourceTag, !sourceTag.isEmpty {
@@ -128,17 +174,17 @@ enum TranscriptionMarkdownExportService {
         return metadata
     }
 
-    private static func sortedVariations(for transcription: Transcription) -> [TranscriptionVariation] {
-        (transcription.variations ?? []).sorted { lhs, rhs in
+    nonisolated private static func sortedVariations(for transcription: Snapshot) -> [VariationSnapshot] {
+        transcription.variations.sorted { lhs, rhs in
             if lhs.createdAt == rhs.createdAt {
-                return lhs.presetDisplayName.localizedStandardCompare(rhs.presetDisplayName) == .orderedAscending
+                return lhs.sortKey.localizedStandardCompare(rhs.sortKey) == .orderedAscending
             }
 
             return lhs.createdAt < rhs.createdAt
         }
     }
 
-    private static func powerModeDisplay(name: String?, emoji: String?) -> String {
+    nonisolated private static func powerModeDisplay(name: String?, emoji: String?) -> String {
         let trimmedName = name?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         let trimmedEmoji = emoji?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
 
@@ -147,7 +193,7 @@ enum TranscriptionMarkdownExportService {
         return "\(trimmedEmoji) \(trimmedName)"
     }
 
-    private static func twoDigit(_ value: Int) -> String {
+    nonisolated private static func twoDigit(_ value: Int) -> String {
         if value < 10 {
             return "0\(value)"
         }

--- a/VivaDicta/Views/Components/ActivityShareSheet.swift
+++ b/VivaDicta/Views/Components/ActivityShareSheet.swift
@@ -1,0 +1,22 @@
+//
+//  ActivityShareSheet.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.13
+//
+
+import SwiftUI
+import UIKit
+
+struct ActivityShareSheet: UIViewControllerRepresentable {
+    let activityItems: [Any]
+    let completion: UIActivityViewController.CompletionWithItemsHandler?
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        let controller = UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
+        controller.completionWithItemsHandler = completion
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
+}

--- a/VivaDicta/Views/MainView.swift
+++ b/VivaDicta/Views/MainView.swift
@@ -488,7 +488,7 @@ struct MainView: View {
                 } label: {
                     Label("Export", systemImage: isPreparingZipShare ? "hourglass" : "square.and.arrow.up")
                 }
-                .disabled(selectedTranscriptionIDs.isEmpty)
+                .disabled(selectedTranscriptionIDs.isEmpty || isPreparingZipShare)
             }
             
             if #available(iOS 26.0, *) {

--- a/VivaDicta/Views/MainView.swift
+++ b/VivaDicta/Views/MainView.swift
@@ -10,6 +10,7 @@ import SwiftData
 import TipKit
 import UniformTypeIdentifiers
 import os
+import CoreTransferable
 
 struct MainView: View {
     @Environment(AppState.self) var appState
@@ -36,6 +37,10 @@ struct MainView: View {
     @State private var showNoModelAlert = false
     @State private var showFileErrorAlert = false
     @State private var fileErrorMessage = ""
+    @State private var exportItem: MarkdownExportItem?
+    @State private var exportItems: [MarkdownExportItem] = []
+    @State private var zipShareFile: ExportedShareFile?
+    @State private var isPreparingZipShare = false
 
     private let logger = Logger(category: .mainView)
 
@@ -173,6 +178,30 @@ struct MainView: View {
             allowsMultipleSelection: false
         ) { result in
             handleFileImport(result)
+        }
+        .fileExporter(
+            isPresented: singleExportSheetBinding,
+            item: exportItem,
+            contentTypes: [MarkdownExportItem.contentType],
+            defaultFilename: exportItem?.filename
+        ) { result in
+            handleSingleExportCompletion(result)
+        } onCancellation: {
+            clearExportState()
+        }
+        .fileExporter(
+            isPresented: multipleExportSheetBinding,
+            items: exportItems,
+            contentTypes: [MarkdownExportItem.contentType]
+        ) { result in
+            handleMultipleExportCompletion(result)
+        } onCancellation: {
+            clearExportState()
+        }
+        .sheet(item: $zipShareFile, onDismiss: cleanupSharedZipIfNeeded) { exportedFile in
+            ActivityShareSheet(activityItems: [exportedFile.url]) { _, _, _, _ in
+                cleanupSharedZipIfNeeded()
+            }
         }
         .navigationDestination(for: Transcription.self) { transcription in
             TranscriptionDetailView(transcription: transcription)
@@ -436,6 +465,31 @@ struct MainView: View {
                 }
                 .disabled(selectedTranscriptionIDs.isEmpty)
             }
+
+            if #available(iOS 26.0, *) {
+                ToolbarSpacer(.fixed, placement: .bottomBar)
+            }
+
+            ToolbarItem(placement: .bottomBar) {
+                Menu {
+                    Button {
+                        HapticManager.lightImpact()
+                        exportSelectedTranscriptions()
+                    } label: {
+                        Label("Markdown Files", systemImage: "doc.text")
+                    }
+
+                    Button {
+                        HapticManager.lightImpact()
+                        prepareZipShare()
+                    } label: {
+                        Label("Share ZIP", systemImage: "doc.zipper")
+                    }
+                } label: {
+                    Label("Export", systemImage: isPreparingZipShare ? "hourglass" : "square.and.arrow.up")
+                }
+                .disabled(selectedTranscriptionIDs.isEmpty)
+            }
             
             if #available(iOS 26.0, *) {
                 ToolbarSpacer(.flexible, placement: .bottomBar)
@@ -463,6 +517,28 @@ struct MainView: View {
 
     private var allDisplayedSelected: Bool {
         !displayedTranscriptionIDs.isEmpty && displayedTranscriptionIDs.isSubset(of: selectedTranscriptionIDs)
+    }
+
+    private var singleExportSheetBinding: Binding<Bool> {
+        Binding(
+            get: { exportItem != nil },
+            set: { isPresented in
+                if !isPresented {
+                    clearExportState()
+                }
+            }
+        )
+    }
+
+    private var multipleExportSheetBinding: Binding<Bool> {
+        Binding(
+            get: { !exportItems.isEmpty },
+            set: { isPresented in
+                if !isPresented {
+                    clearExportState()
+                }
+            }
+        )
     }
 
     private func enterSelectionMode() {
@@ -514,6 +590,83 @@ struct MainView: View {
         }
 
         exitSelectionMode()
+    }
+
+    private func exportSelectedTranscriptions() {
+        let selected = transcriptions.filter { selectedTranscriptionIDs.contains($0.id) }
+        guard !selected.isEmpty else { return }
+
+        clearExportState()
+
+        if selected.count == 1, let transcription = selected.first {
+            exportItem = TranscriptionMarkdownExportService.item(for: transcription)
+        } else {
+            exportItems = TranscriptionMarkdownExportService.items(for: selected)
+        }
+    }
+
+    private func prepareZipShare() {
+        let selected = transcriptions.filter { selectedTranscriptionIDs.contains($0.id) }
+        guard !selected.isEmpty, !isPreparingZipShare else { return }
+
+        let items = TranscriptionMarkdownExportService.items(for: selected)
+        isPreparingZipShare = true
+
+        Task {
+            do {
+                let archiveURL = try await Task.detached(priority: .userInitiated) {
+                    try MarkdownZipExportService.createArchive(from: items)
+                }.value
+
+                zipShareFile = ExportedShareFile(url: archiveURL)
+            } catch {
+                presentExportErrorIfNeeded(error)
+            }
+
+            isPreparingZipShare = false
+        }
+    }
+
+    private func handleSingleExportCompletion(_ result: Result<URL, any Error>) {
+        switch result {
+        case .success:
+            HapticManager.success()
+        case .failure(let error):
+            presentExportErrorIfNeeded(error)
+        }
+
+        clearExportState()
+    }
+
+    private func handleMultipleExportCompletion(_ result: Result<[URL], any Error>) {
+        switch result {
+        case .success:
+            HapticManager.success()
+        case .failure(let error):
+            presentExportErrorIfNeeded(error)
+        }
+
+        clearExportState()
+    }
+
+    private func presentExportErrorIfNeeded(_ error: any Error) {
+        if error is CancellationError { return }
+
+        logger.logError("Markdown export failed: \(error.localizedDescription)")
+        fileErrorMessage = error.localizedDescription
+        showFileErrorAlert = true
+    }
+
+    private func clearExportState() {
+        exportItem = nil
+        exportItems = []
+    }
+
+    private func cleanupSharedZipIfNeeded() {
+        guard let zipShareFile else { return }
+
+        MarkdownZipExportService.cleanupArchive(at: zipShareFile.url)
+        self.zipShareFile = nil
     }
 
     // MARK: - Multi-Note Chat from Selection
@@ -704,6 +857,11 @@ struct MainView: View {
             showFileErrorAlert = true
         }
     }
+}
+
+private struct ExportedShareFile: Identifiable {
+    let id = UUID()
+    let url: URL
 }
 
 #if DEBUG || QA

--- a/VivaDicta/Views/MainView.swift
+++ b/VivaDicta/Views/MainView.swift
@@ -609,21 +609,22 @@ struct MainView: View {
         let selected = transcriptions.filter { selectedTranscriptionIDs.contains($0.id) }
         guard !selected.isEmpty, !isPreparingZipShare else { return }
 
-        let items = TranscriptionMarkdownExportService.items(for: selected)
         isPreparingZipShare = true
+        let exportSnapshots = TranscriptionMarkdownExportService.snapshots(for: selected)
 
         Task {
+            defer { isPreparingZipShare = false }
+
             do {
                 let archiveURL = try await Task.detached(priority: .userInitiated) {
-                    try MarkdownZipExportService.createArchive(from: items)
+                    let items = TranscriptionMarkdownExportService.items(forSnapshots: exportSnapshots)
+                    return try MarkdownZipExportService.createArchive(from: items)
                 }.value
 
                 zipShareFile = ExportedShareFile(url: archiveURL)
             } catch {
                 presentExportErrorIfNeeded(error)
             }
-
-            isPreparingZipShare = false
         }
     }
 


### PR DESCRIPTION
## Summary
- add bulk export for selected notes from selection mode on the main screen
- export selected notes as separate Markdown files on iOS to match the macOS app behavior
- add a Share ZIP action so the selected Markdown files can be emailed or shared in one archive

## Testing
- xcodebuild -scheme VivaDicta -configuration Debug -workspace ./VivaDicta.xcodeproj/project.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max,OS=26.4' build 2>&1 | xcsift

## Notes
- export actions live in the selection-mode bottom toolbar alongside the other bulk actions
- no breaking changes expected
