### PR TITLE
Restyle keyboard and watch record buttons

### DIFF
--- a/VivaDicta/Shared/MicButton.swift
+++ b/VivaDicta/Shared/MicButton.swift
@@ -8,36 +8,36 @@
 import SwiftUI
 
 struct MicButton: View {
-    @State var isAnimating = false
-    
+    @State private var isAnimating = false
+
     var fontSize: CGFloat
     var padding: CGFloat
     var backgroundColor: Color
     var borderWidth: CGFloat
-    
+
     var onTapAction: () -> Void
-    
-    
+
     var body: some View {
-        
-        
         Button {
             onTapAction()
         } label: {
-            
             Image(systemName: "microphone.circle")
-                .foregroundColor(.primary)
+                .foregroundStyle(.primary)
                 .font(.system(size: fontSize))
                 .padding(padding)
                 .background(backgroundColor.gradient, in: .circle)
-                
                 .background {
                     Circle()
-                    
-                        .fill(AngularGradient(colors: [.teal, .pink, .teal], center: .center, angle: .degrees(isAnimating ? 360 : 0)))
+                        .fill(
+                            AngularGradient(
+                                colors: [.teal, .pink, .teal],
+                                center: .center,
+                                angle: .degrees(isAnimating ? 360 : 0)
+                            )
+                        )
                         .blur(radius: 10)
                         .onAppear {
-                            withAnimation(Animation.linear(duration: 7).repeatForever(autoreverses: false)) {
+                            withAnimation(.linear(duration: 7).repeatForever(autoreverses: false)) {
                                 isAnimating = true
                             }
                         }
@@ -59,5 +59,6 @@ struct MicButton: View {
         padding: 6,
         backgroundColor: .orange.opacity(0.5),
         borderWidth: 0.5,
-        onTapAction: {})
+        onTapAction: {}
+    )
 }

--- a/VivaDicta/Views/Onboarding/KeyboardIllustration.swift
+++ b/VivaDicta/Views/Onboarding/KeyboardIllustration.swift
@@ -45,4 +45,3 @@ struct KeyboardIllustration: View {
             }
     }
 }
-

--- a/VivaDictaKeyboard/KeyboardViewController.swift
+++ b/VivaDictaKeyboard/KeyboardViewController.swift
@@ -234,25 +234,10 @@ struct VivaDictaKeyboardToolbarView: View {
             Spacer()
 
             // Always show MicButton - it handles notReady state by opening main app
-            if #available(iOS 26.0, *) {
-                MicButton(
-                    fontSize: 34,
-                    padding: 6,
-                    backgroundColor: .orange.opacity(0.5),
-                    borderWidth: 0,
-                    onTapAction: handleMic)
-                    .glassEffect(.regular.tint(.orange.opacity(1.0)).interactive())
-            } else {
-                MicButton(
-                    fontSize: 36,
-                    padding: 0,
-                    backgroundColor: .orange,
-                    borderWidth: 0.5,
-                    onTapAction: handleMic)
-            }
+            KeyboardMicButton(onTapAction: handleMic)
         }
         .padding(.horizontal, 16)
-        .padding(.top, 16)
+        .padding(.top, 6)
         .padding(.bottom, 8)
     }
 
@@ -318,6 +303,88 @@ struct VivaDictaKeyboardToolbarView: View {
             return Color.primary.opacity(0.1)
         case .error:
             return Color.orange.opacity(0.15)
+        }
+    }
+}
+
+private struct KeyboardMicButton: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    let onTapAction: () -> Void
+
+    var body: some View {
+        Button {
+            onTapAction()
+        } label: {
+            icon
+                .padding(16)
+                .background(background)
+        }
+        .accessibilityLabel("Record")
+    }
+
+    private var icon: some View {
+        
+        Image(systemName: "microphone.fill")
+            .font(.system(size: 26))
+            .foregroundStyle(.white)
+        
+    }
+
+    @ViewBuilder
+    private var background: some View {
+        if #available(iOS 26, *) {
+            styledBackground
+                .glassEffect(.clear.interactive(), in: .circle)
+        } else {
+            styledBackground
+        }
+    }
+
+    @ViewBuilder
+    private var styledBackground: some View {
+        if colorScheme == .dark {
+            AnimatedMeshGradient()
+                .mask(
+                    Circle()
+                        .stroke(lineWidth: 12)
+                        .blur(radius: 5)
+                )
+                .blendMode(.lighten)
+                .overlay(
+                    Circle()
+                        .stroke(lineWidth: 1.5)
+                        .fill(Color.white)
+                        .blur(radius: 1)
+                        .blendMode(.overlay)
+                )
+                .overlay(
+                    Circle()
+                        .stroke(lineWidth: 0.4)
+                        .fill(Color.white)
+                        .blur(radius: 0.3)
+                        .blendMode(.overlay)
+                )
+                .background(.black)
+                .clipShape(.circle)
+        } else {
+            AnimatedMeshGradient2()
+                .overlay(
+                    Circle()
+                        .stroke(lineWidth: 3)
+                        .fill(Color.black.opacity(0.7))
+                        .blur(radius: 2)
+                        .blendMode(.overlay)
+                )
+                .overlay(
+                    Circle()
+                        .stroke(lineWidth: 1)
+                        .fill(Color.black.opacity(1.0))
+                        .blur(radius: 1)
+                        .blendMode(.overlay)
+                )
+                .clipShape(.circle)
+                .shadow(color: .black.opacity(0.45), radius: 8, x: 0, y: 4)
         }
     }
 }

--- a/VivaDictaKeyboard/KeyboardViewController.swift
+++ b/VivaDictaKeyboard/KeyboardViewController.swift
@@ -344,7 +344,7 @@ private struct KeyboardMicButton: View {
     @ViewBuilder
     private var styledBackground: some View {
         if colorScheme == .dark {
-            AnimatedMeshGradient()
+            KeyboardAnimatedMeshGradient()
                 .mask(
                     Circle()
                         .stroke(lineWidth: 12)
@@ -368,7 +368,7 @@ private struct KeyboardMicButton: View {
                 .background(.black)
                 .clipShape(.circle)
         } else {
-            AnimatedMeshGradient2()
+            KeyboardAnimatedMeshGradient2()
                 .overlay(
                     Circle()
                         .stroke(lineWidth: 3)
@@ -387,4 +387,56 @@ private struct KeyboardMicButton: View {
                 .shadow(color: .black.opacity(0.45), radius: 8, x: 0, y: 4)
         }
     }
+}
+
+private struct KeyboardAnimatedMeshGradient: View {
+    @State private var startDate = Date.now
+
+    var body: some View {
+        TimelineView(.animation) { timeline in
+            let t = Float(timeline.date.timeIntervalSince(startDate)) * 10
+            MeshGradient(width: 3, height: 3, points: [
+                .init(0, 0), .init(0.5, 0), .init(1, 0),
+                [keyboardSinInRange(-0.8...(-0.2), offset: 0.439, timeScale: 0.342, t: t), keyboardSinInRange(0.3...0.7, offset: 3.42, timeScale: 0.984, t: t)],
+                [keyboardSinInRange(0.1...0.8, offset: 0.239, timeScale: 0.084, t: t), keyboardSinInRange(0.2...0.8, offset: 5.21, timeScale: 0.242, t: t)],
+                [keyboardSinInRange(1.0...1.5, offset: 0.939, timeScale: 0.084, t: t), keyboardSinInRange(0.4...0.8, offset: 0.25, timeScale: 0.642, t: t)],
+                [keyboardSinInRange(-0.8...0.0, offset: 1.439, timeScale: 0.442, t: t), keyboardSinInRange(1.4...1.9, offset: 3.42, timeScale: 0.984, t: t)],
+                [keyboardSinInRange(0.3...0.6, offset: 0.339, timeScale: 0.784, t: t), keyboardSinInRange(1.0...1.2, offset: 1.22, timeScale: 0.772, t: t)],
+                [keyboardSinInRange(1.0...1.5, offset: 0.939, timeScale: 0.056, t: t), keyboardSinInRange(1.3...1.7, offset: 0.47, timeScale: 0.342, t: t)]
+            ], colors: [
+                .red, .purple, .indigo,
+                .orange, .white, .blue,
+                .yellow, .black, .mint
+            ])
+        }
+    }
+}
+
+private struct KeyboardAnimatedMeshGradient2: View {
+    @State private var startDate = Date.now
+
+    var body: some View {
+        TimelineView(.animation) { timeline in
+            let t = Float(timeline.date.timeIntervalSince(startDate)) * 10
+            MeshGradient(width: 3, height: 3, points: [
+                .init(0, 0), .init(0.5, 0), .init(1, 0),
+                [keyboardSinInRange(-0.8...(-0.2), offset: 0.439, timeScale: 0.342, t: t), keyboardSinInRange(0.3...0.7, offset: 3.42, timeScale: 0.984, t: t)],
+                [keyboardSinInRange(0.1...0.8, offset: 0.239, timeScale: 0.084, t: t), keyboardSinInRange(0.2...0.8, offset: 5.21, timeScale: 0.242, t: t)],
+                [keyboardSinInRange(1.0...1.5, offset: 0.939, timeScale: 0.084, t: t), keyboardSinInRange(0.4...0.8, offset: 0.25, timeScale: 0.642, t: t)],
+                [keyboardSinInRange(-0.8...0.0, offset: 1.439, timeScale: 0.442, t: t), keyboardSinInRange(1.4...1.9, offset: 3.42, timeScale: 0.984, t: t)],
+                [keyboardSinInRange(0.3...0.6, offset: 0.339, timeScale: 0.784, t: t), keyboardSinInRange(1.0...1.2, offset: 1.22, timeScale: 0.772, t: t)],
+                [keyboardSinInRange(1.0...1.5, offset: 0.939, timeScale: 0.056, t: t), keyboardSinInRange(1.3...1.7, offset: 0.47, timeScale: 0.342, t: t)]
+            ], colors: [
+                .blue, .red, .orange,
+                .orange, .indigo, .red,
+                .cyan, .purple, .mint
+            ])
+        }
+    }
+}
+
+private func keyboardSinInRange(_ range: ClosedRange<Float>, offset: Float, timeScale: Float, t: Float) -> Float {
+    let amplitude = (range.upperBound - range.lowerBound) / 2
+    let midPoint = (range.upperBound + range.lowerBound) / 2
+    return midPoint + amplitude * sin(timeScale * t + offset)
 }

--- a/VivaDictaWatch Watch App/Views/WatchRecordView.swift
+++ b/VivaDictaWatch Watch App/Views/WatchRecordView.swift
@@ -147,10 +147,14 @@ struct WatchRecordView: View {
                     isGlowAnimating = false
                 }
         } else {
-            AngularGradient(
-                colors: [.orange, .red, .pink, .orange],
-                center: .center
-            )
+            Circle()
+                .fill(
+                    AngularGradient(
+                        colors: [.orange, .red, .pink, .orange],
+                        center: .center,
+                        angle: .degrees(isGlowAnimating ? 360 : 0)
+                    )
+                )
             .mask {
                 Circle()
                     .stroke(lineWidth: size * 0.16)
@@ -159,6 +163,14 @@ struct WatchRecordView: View {
             .scaleEffect(1.04)
             .blur(radius: size * 0.09)
             .opacity(0.9)
+            .onAppear {
+                withAnimation(.linear(duration: 7).repeatForever(autoreverses: false)) {
+                    isGlowAnimating = true
+                }
+            }
+            .onDisappear {
+                isGlowAnimating = false
+            }
         }
     }
 

--- a/VivaDictaWatch Watch App/Views/WatchRecordView.swift
+++ b/VivaDictaWatch Watch App/Views/WatchRecordView.swift
@@ -15,7 +15,7 @@ struct WatchRecordView: View {
 
     var body: some View {
         GeometryReader { geometry in
-            let buttonSize = geometry.size.width * 0.25
+            let buttonSize = geometry.size.width * 0.5
 
             VStack(spacing: 12) {
                 Spacer()
@@ -59,8 +59,8 @@ struct WatchRecordView: View {
             Image(systemName: viewModel.state == .idle ? "microphone.fill" : "stop.circle.fill")
                 .contentTransition(.symbolEffect(.replace))
                 .foregroundStyle(.primary)
-                .font(.system(size: size))
-                .padding(26)
+                .font(.system(size: 50))
+                .frame(width: size, height: size)
                 .background { mainButtonBackground }
         }
         .buttonStyle(.plain)

--- a/VivaDictaWatch Watch App/Views/WatchRecordView.swift
+++ b/VivaDictaWatch Watch App/Views/WatchRecordView.swift
@@ -82,7 +82,7 @@ struct WatchRecordView: View {
         let darkBackground = WatchAnimatedMeshGradient()
             .mask(
                 Circle()
-                    .stroke(lineWidth: 26)
+                    .stroke(lineWidth: 22)
                     .blur(radius: 6)
             )
             .blendMode(.lighten)
@@ -100,7 +100,7 @@ struct WatchRecordView: View {
                     .blur(radius: 1)
                     .blendMode(.overlay)
             )
-            .clipShape(Circle())
+            .clipShape(.circle)
         
         
         

--- a/VivaDictaWatch Watch App/Views/WatchRecordView.swift
+++ b/VivaDictaWatch Watch App/Views/WatchRecordView.swift
@@ -12,6 +12,7 @@ struct WatchRecordView: View {
     @Bindable var viewModel: WatchRecordViewModel
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.scenePhase) private var scenePhase
+    @State private var isGlowAnimating = false
 
     var body: some View {
         GeometryReader { geometry in
@@ -61,7 +62,12 @@ struct WatchRecordView: View {
                 .foregroundStyle(.primary)
                 .font(.system(size: 50))
                 .frame(width: size, height: size)
-                .background { mainButtonBackground }
+                .background {
+                    ZStack {
+                        mainButtonGlow(size: size)
+                        mainButtonBackground
+                    }
+                }
         }
         .buttonStyle(.plain)
         .accessibilityIdentifier("WatchRecordView.mainButton")
@@ -111,6 +117,49 @@ struct WatchRecordView: View {
             darkBackground
         }
         
+    }
+
+    @ViewBuilder
+    private func mainButtonGlow(size: CGFloat) -> some View {
+        if viewModel.state == .idle {
+            Circle()
+                .fill(
+                    AngularGradient(
+                        colors: [.teal, .pink, .teal],
+                        center: .center,
+                        angle: .degrees(isGlowAnimating ? 360 : 0)
+                    )
+                )
+                .mask {
+                    Circle()
+                        .stroke(lineWidth: size * 0.16)
+                        .blur(radius: size * 0.04)
+                }
+                .scaleEffect(1.04)
+                .blur(radius: size * 0.09)
+                .opacity(0.95)
+                .onAppear {
+                    withAnimation(.linear(duration: 7).repeatForever(autoreverses: false)) {
+                        isGlowAnimating = true
+                    }
+                }
+                .onDisappear {
+                    isGlowAnimating = false
+                }
+        } else {
+            AngularGradient(
+                colors: [.orange, .red, .pink, .orange],
+                center: .center
+            )
+            .mask {
+                Circle()
+                    .stroke(lineWidth: size * 0.16)
+                    .blur(radius: size * 0.04)
+            }
+            .scaleEffect(1.04)
+            .blur(radius: size * 0.09)
+            .opacity(0.9)
+        }
     }
 
     @ViewBuilder

--- a/VivaDictaWatch Watch App/Views/WatchRecordView.swift
+++ b/VivaDictaWatch Watch App/Views/WatchRecordView.swift
@@ -10,12 +10,12 @@ import WatchKit
 
 struct WatchRecordView: View {
     @Bindable var viewModel: WatchRecordViewModel
+    @Environment(\.colorScheme) private var colorScheme
     @Environment(\.scenePhase) private var scenePhase
-    @State private var isGlowAnimating = false
 
     var body: some View {
         GeometryReader { geometry in
-            let buttonSize = geometry.size.width * 0.5
+            let buttonSize = geometry.size.width * 0.25
 
             VStack(spacing: 12) {
                 Spacer()
@@ -56,32 +56,73 @@ struct WatchRecordView: View {
 
     private func mainButton(size: CGFloat) -> some View {
         Button(action: viewModel.toggleRecording) {
-            Image(systemName: viewModel.state == .idle ? "microphone.circle" : "stop.circle.fill")
+            Image(systemName: viewModel.state == .idle ? "microphone.fill" : "stop.circle.fill")
                 .contentTransition(.symbolEffect(.replace))
                 .foregroundStyle(.primary)
                 .font(.system(size: size))
-                .padding(6)
-                .glassEffectColor(isInteractive: true, color: viewModel.state == .idle ? .orange : .red, opacity: 0.8)
-                .background {
-                    Circle()
-                        .fill(AngularGradient(
-                            colors: viewModel.state == .idle ? [.teal, .pink, .teal] : [.orange, .green, .orange],
-                            center: .center,
-                            angle: .degrees(isGlowAnimating ? 360 : 0)
-                        ))
-                        .blur(radius: 20)
-                        .onAppear {
-                            withAnimation(.linear(duration: 7).repeatForever(autoreverses: false)) {
-                                isGlowAnimating = true
-                            }
-                        }
-                        .onDisappear {
-                            isGlowAnimating = false
-                        }
-                }
+                .padding(26)
+                .background { mainButtonBackground }
         }
         .buttonStyle(.plain)
         .accessibilityIdentifier("WatchRecordView.mainButton")
+    }
+
+    @ViewBuilder
+    private var mainButtonBackground: some View {
+        if viewModel.state == .idle {
+            idleButtonBackground
+        } else {
+            stopButtonBackground
+        }
+    }
+
+    @ViewBuilder
+    private var idleButtonBackground: some View {
+        
+        let darkBackground = WatchAnimatedMeshGradient()
+            .mask(
+                Circle()
+                    .stroke(lineWidth: 26)
+                    .blur(radius: 6)
+            )
+            .blendMode(.lighten)
+            .overlay(
+                Circle()
+                    .stroke(lineWidth: 3)
+                    .fill(Color.white)
+                    .blur(radius: 2)
+                    .blendMode(.overlay)
+            )
+            .overlay(
+                Circle()
+                    .stroke(lineWidth: 1)
+                    .fill(Color.white)
+                    .blur(radius: 1)
+                    .blendMode(.overlay)
+            )
+            .clipShape(Circle())
+        
+        
+        
+        if #available(watchOS 26, *) {
+            darkBackground
+                .glassEffect(.clear.interactive())
+        } else {
+            darkBackground
+        }
+        
+    }
+
+    @ViewBuilder
+    private var stopButtonBackground: some View {
+        if #available(watchOS 26, *) {
+            Circle()
+//                .fill(.red.opacity(0.85))
+                .glassEffect(.regular.tint(.red.opacity(0.85)).interactive(), in: .circle)
+        } else {
+            Circle()
+                .fill(.red.gradient)
+        }
     }
 
     @ViewBuilder
@@ -149,55 +190,70 @@ struct WatchRecordView: View {
     }
 }
 
+private struct WatchAnimatedMeshGradient: View {
+    @State private var startDate = Date.now
 
-struct GlassEffectColorModifier: ViewModifier {
-    var isInteractive: Bool
-    var color: Color
-    var opacity: Double
-    
-    func body(content: Content) -> some View {
-        if #available(watchOS 26, *){
-            content
-                .glassEffect(.regular.tint(color.opacity(opacity)).interactive(isInteractive))
+    @ViewBuilder
+    var body: some View {
+        if #available(watchOS 11, *) {
+            TimelineView(.animation) { timeline in
+                let t = Float(timeline.date.timeIntervalSince(startDate)) * 10
+                MeshGradient(width: 3, height: 3, points: [
+                    .init(0, 0), .init(0.5, 0), .init(1, 0),
+                    [watchSinInRange(-0.8...(-0.2), offset: 0.439, timeScale: 0.342, t: t), watchSinInRange(0.3...0.7, offset: 3.42, timeScale: 0.984, t: t)],
+                    [watchSinInRange(0.1...0.8, offset: 0.239, timeScale: 0.084, t: t), watchSinInRange(0.2...0.8, offset: 5.21, timeScale: 0.242, t: t)],
+                    [watchSinInRange(1.0...1.5, offset: 0.939, timeScale: 0.084, t: t), watchSinInRange(0.4...0.8, offset: 0.25, timeScale: 0.642, t: t)],
+                    [watchSinInRange(-0.8...0.0, offset: 1.439, timeScale: 0.442, t: t), watchSinInRange(1.4...1.9, offset: 3.42, timeScale: 0.984, t: t)],
+                    [watchSinInRange(0.3...0.6, offset: 0.339, timeScale: 0.784, t: t), watchSinInRange(1.0...1.2, offset: 1.22, timeScale: 0.772, t: t)],
+                    [watchSinInRange(1.0...1.5, offset: 0.939, timeScale: 0.056, t: t), watchSinInRange(1.3...1.7, offset: 0.47, timeScale: 0.342, t: t)]
+                ], colors: [
+                    .red, .purple, .indigo,
+                    .orange, .white, .blue,
+                    .yellow, .black, .mint
+                ])
+            }
         } else {
-            content
-                .background(color.gradient, in: .circle)
+            AngularGradient(
+                colors: [.red, .purple, .indigo, .blue, .mint, .orange, .red],
+                center: .center
+            )
         }
     }
 }
 
-extension View {
-    func glassEffectColor(isInteractive: Bool = true,
-                          color: Color = .clear,
-                          opacity: Double = 1.0) -> some View {
-        modifier(GlassEffectColorModifier(
-            isInteractive: isInteractive,
-            color: color,
-            opacity: opacity))
-    }
-}
+private struct WatchAnimatedMeshGradient2: View {
+    @State private var startDate = Date.now
 
-
-struct GlassEffectClearModifier: ViewModifier {
-    
-    var isInteractive: Bool
-    
-    func body(content: Content) -> some View {
-        if #available(watchOS 26, *){
-            content
-                .glassEffect(.clear.interactive(isInteractive))
+    @ViewBuilder
+    var body: some View {
+        if #available(watchOS 11, *) {
+            TimelineView(.animation) { timeline in
+                let t = Float(timeline.date.timeIntervalSince(startDate)) * 10
+                MeshGradient(width: 3, height: 3, points: [
+                    .init(0, 0), .init(0.5, 0), .init(1, 0),
+                    [watchSinInRange(-0.8...(-0.2), offset: 0.439, timeScale: 0.342, t: t), watchSinInRange(0.3...0.7, offset: 3.42, timeScale: 0.984, t: t)],
+                    [watchSinInRange(0.1...0.8, offset: 0.239, timeScale: 0.084, t: t), watchSinInRange(0.2...0.8, offset: 5.21, timeScale: 0.242, t: t)],
+                    [watchSinInRange(1.0...1.5, offset: 0.939, timeScale: 0.084, t: t), watchSinInRange(0.4...0.8, offset: 0.25, timeScale: 0.642, t: t)],
+                    [watchSinInRange(-0.8...0.0, offset: 1.439, timeScale: 0.442, t: t), watchSinInRange(1.4...1.9, offset: 3.42, timeScale: 0.984, t: t)],
+                    [watchSinInRange(0.3...0.6, offset: 0.339, timeScale: 0.784, t: t), watchSinInRange(1.0...1.2, offset: 1.22, timeScale: 0.772, t: t)],
+                    [watchSinInRange(1.0...1.5, offset: 0.939, timeScale: 0.056, t: t), watchSinInRange(1.3...1.7, offset: 0.47, timeScale: 0.342, t: t)]
+                ], colors: [
+                    .blue, .red, .orange,
+                    .orange, .indigo, .red,
+                    .cyan, .purple, .mint
+                ])
+            }
         } else {
-            content
-                .background {
-                    Capsule()
-                        .stroke(.gray, lineWidth: 1)
-                }
+            AngularGradient(
+                colors: [.blue, .indigo, .purple, .orange, .mint, .red, .blue],
+                center: .center
+            )
         }
     }
 }
 
-extension View {
-    func glassEffectClear(isInteractive: Bool = true) -> some View {
-        modifier(GlassEffectClearModifier(isInteractive: isInteractive))
-    }
+private func watchSinInRange(_ range: ClosedRange<Float>, offset: Float, timeScale: Float, t: Float) -> Float {
+    let amplitude = (range.upperBound - range.lowerBound) / 2
+    let midPoint = (range.upperBound + range.lowerBound) / 2
+    return midPoint + amplitude * sin(timeScale * t + offset)
 }


### PR DESCRIPTION
## Summary
- restyle the keyboard mic button with a dedicated mesh-gradient implementation
- restyle the watch record button with the new mesh ring, glass treatment, and circular glow
- keep watch sizing frame-based so the button stays at half the screen width with a fixed icon size

## Testing
- xcodebuild -scheme VivaDicta -configuration Debug -workspace ./VivaDicta.xcodeproj/project.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max,OS=26.4' build 2>&1 | xcsift\n\n## Notes\n- the watch view uses watch-local gradient helpers because the shared iPhone gradient view is not part of the watch target\n- no breaking changes