### PR TITLE
Add persistent notes filter

### DIFF
--- a/VivaDicta/Shared/SavedNotesFilter.swift
+++ b/VivaDicta/Shared/SavedNotesFilter.swift
@@ -1,0 +1,57 @@
+//
+//  SavedNotesFilter.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.13
+//
+
+import Foundation
+
+struct SavedNotesFilter: Equatable {
+    var sourceTags: Set<String> = []
+    var userTagIds: Set<UUID> = []
+
+    var isActive: Bool {
+        !sourceTags.isEmpty || !userTagIds.isEmpty
+    }
+}
+
+enum SavedNotesFilterStorage {
+    static func load(userDefaults: UserDefaults = UserDefaultsStorage.appPrivate) -> SavedNotesFilter {
+        let sourceTags = Set(userDefaults.stringArray(forKey: UserDefaultsStorage.Keys.savedNotesFilterSourceTags) ?? [])
+        let userTagIds = Set(
+            (userDefaults.stringArray(forKey: UserDefaultsStorage.Keys.savedNotesFilterUserTagIds) ?? [])
+                .compactMap(UUID.init(uuidString:))
+        )
+
+        return SavedNotesFilter(sourceTags: sourceTags, userTagIds: userTagIds)
+    }
+
+    static func save(_ filter: SavedNotesFilter, userDefaults: UserDefaults = UserDefaultsStorage.appPrivate) {
+        if filter.sourceTags.isEmpty {
+            userDefaults.removeObject(forKey: UserDefaultsStorage.Keys.savedNotesFilterSourceTags)
+        } else {
+            userDefaults.set(filter.sourceTags.sorted(), forKey: UserDefaultsStorage.Keys.savedNotesFilterSourceTags)
+        }
+
+        if filter.userTagIds.isEmpty {
+            userDefaults.removeObject(forKey: UserDefaultsStorage.Keys.savedNotesFilterUserTagIds)
+        } else {
+            userDefaults.set(
+                filter.userTagIds.map(\.uuidString).sorted(),
+                forKey: UserDefaultsStorage.Keys.savedNotesFilterUserTagIds
+            )
+        }
+    }
+
+    static func sanitize(
+        _ filter: SavedNotesFilter,
+        availableSourceTags: [String],
+        availableUserTagIds: Set<UUID>
+    ) -> SavedNotesFilter {
+        SavedNotesFilter(
+            sourceTags: filter.sourceTags.intersection(Set(availableSourceTags)),
+            userTagIds: filter.userTagIds.intersection(availableUserTagIds)
+        )
+    }
+}

--- a/VivaDicta/Shared/UserDefaultsStorage.swift
+++ b/VivaDicta/Shared/UserDefaultsStorage.swift
@@ -70,5 +70,9 @@ enum UserDefaultsStorage {
 
         // What's New
         static let lastSeenWhatsNewVersion = "lastSeenWhatsNewVersion"
+
+        // Notes filter
+        static let savedNotesFilterSourceTags = "savedNotesFilterSourceTags"
+        static let savedNotesFilterUserTagIds = "savedNotesFilterUserTagIds"
     }
 }

--- a/VivaDicta/Views/MainView.swift
+++ b/VivaDicta/Views/MainView.swift
@@ -163,22 +163,12 @@ struct MainView: View {
 
     @ViewBuilder
     private var mainContentView: some View {
-        let selectedSourceTags = Binding(
-            get: { savedNotesFilter.sourceTags },
-            set: { savedNotesFilter.sourceTags = $0 }
-        )
-        let selectedUserTagIds = Binding(
-            get: { savedNotesFilter.userTagIds },
-            set: { savedNotesFilter.userTagIds = $0 }
-        )
-
         TranscriptionsContentView(
             searchText: $searchText,
             isSelectionMode: $isSelectionMode,
             selectedTranscriptionIDs: $selectedTranscriptionIDs,
             displayedTranscriptionIDs: $displayedTranscriptionIDs,
-            selectedSourceTags: selectedSourceTags,
-            selectedUserTagIds: selectedUserTagIds,
+            savedFilter: savedNotesFilter,
             floatingControls: .init(
                 sheetTransitions: sheetTransitions,
                 onShowChats: {

--- a/VivaDicta/Views/MainView.swift
+++ b/VivaDicta/Views/MainView.swift
@@ -16,9 +16,11 @@ struct MainView: View {
     @Environment(AppState.self) var appState
     @Environment(Router.self) var router
     @Query private var transcriptions: [Transcription]
+    @Query(sort: \TranscriptionTag.sortOrder) private var transcriptionTags: [TranscriptionTag]
 
     @State private var showingRecordingSheet = false
     @State private var showingSettings = false
+    @State private var showingNotesFilter = false
     @State private var showingFileImport = false
     @State private var searchText = ""
 
@@ -37,6 +39,7 @@ struct MainView: View {
     @State private var showNoModelAlert = false
     @State private var showFileErrorAlert = false
     @State private var fileErrorMessage = ""
+    @State private var savedNotesFilter = SavedNotesFilterStorage.load()
     @State private var exportItem: MarkdownExportItem?
     @State private var exportItems: [MarkdownExportItem] = []
     @State private var zipShareFile: ExportedShareFile?
@@ -51,80 +54,131 @@ struct MainView: View {
     var selectTranscriptionModelTipMainView = SelectTranscriptionModelTipMainView()
         
     var body: some View {
-        @Bindable var appState = appState
+        configuredNavigationView
+    }
+
+    @ViewBuilder
+    private var rootNavigationStack: some View {
         @Bindable var router = router
 
         NavigationStack(path: $router.path) {
             mainContentView
         }
-        .overlay { recordingOverlay }
-        .overlay { hudOverlay }
-        .animation(.default, value: appState.recordViewModel?.recordingState)
-        .onChange(of: appState.recordViewModel?.recordingState) { _, newState in
-            showingRecordingSheet = (newState == .recording)
-        }
-        .onChange(of: appState.shouldStartRecording) { _, newValue in
-            if newValue {
-                startRecording()
-                appState.shouldStartRecording = false
+    }
+
+    @ViewBuilder
+    private var configuredNavigationView: some View {
+        lifecycleWrappedNavigationView
+            .onChange(of: appState.transcriptionManager.hasAvailableTranscriptionModels) { _, newValue in
+                SelectTranscriptionModelTipMainView.isTranscriptionReady = newValue
+                SelectTranscriptionModelTipSettingsView.isTranscriptionReady = newValue
             }
-        }
-        .onChange(of: appState.shouldNavigateToModels) { _, newValue in
-            if newValue { showingSettings = true }
-        }
-        .onChange(of: appState.shouldTranscribeSharedAudio) { _, newValue in
-            if newValue {
-                showingSettings = false
-                showingRecordingSheet = false
-                router.popToRoot()
-                handleSharedAudioTranscription()
-                appState.shouldTranscribeSharedAudio = false
+    }
+
+    @ViewBuilder
+    private var lifecycleWrappedNavigationView: some View {
+        presentedNavigationView
+            .onAppear { handleOnAppear() }
+            .onChange(of: savedNotesFilter) { _, newValue in
+                SavedNotesFilterStorage.save(newValue)
             }
-        }
-        .onChange(of: appState.openedAudioFileURL) { _, newValue in
-            if newValue != nil {
-                showingSettings = false
-                showingRecordingSheet = false
-                router.popToRoot()
-                handleOpenedAudioTranscription()
+            .onChange(of: transcriptions) { _, _ in
+                sanitizeSavedNotesFilter()
             }
-        }
-        .overlay(alignment: .top) {
-            if appState.showKeyboardFlowToast {
-                KeyboardFlowToast()
-                    .padding(.top, 60)
-                    .transition(.move(edge: .top).combined(with: .opacity))
+            .onChange(of: transcriptionTags) { _, _ in
+                sanitizeSavedNotesFilter()
             }
-        }
-        .animation(.spring(duration: 0.4, bounce: 0.2), value: appState.showKeyboardFlowToast)
-        .sheet(isPresented: $showWhatsNew) {
-            if let release = whatsNewRelease {
-                WhatsNewView(release: release) {
-                    showWhatsNew = false
+            .task {
+                await performMaintenanceTasks()
+            }
+    }
+
+    @ViewBuilder
+    private var presentedNavigationView: some View {
+        contentNavigationView
+            .sheet(isPresented: $showWhatsNew) {
+                if let release = whatsNewRelease {
+                    WhatsNewView(release: release) {
+                        showWhatsNew = false
+                    }
                 }
             }
-        }
-        .onAppear { handleOnAppear() }
-        .task {
-            await NoteCleanupService.shared.performCleanupIfNeeded(modelContext: modelContext)
-            await AudioCleanupService.shared.performCleanupIfNeeded(modelContext: modelContext)
-            await ChatCleanupService.shared.performCleanupIfNeeded(modelContext: modelContext)
-        }
-        .onChange(of: appState.transcriptionManager.hasAvailableTranscriptionModels) { _, newValue in
-            SelectTranscriptionModelTipMainView.isTranscriptionReady = newValue
-            SelectTranscriptionModelTipSettingsView.isTranscriptionReady = newValue
-        }
+            .sheet(isPresented: $showingNotesFilter) {
+                NotesFilterView(
+                    sourceTags: availableSourceTags,
+                    userTags: transcriptionTags,
+                    appliedFilter: savedNotesFilter
+                ) { filter in
+                    savedNotesFilter = filter
+                }
+            }
+    }
+
+    @ViewBuilder
+    private var contentNavigationView: some View {
+        rootNavigationStack
+            .overlay { recordingOverlay }
+            .overlay { hudOverlay }
+            .animation(.default, value: appState.recordViewModel?.recordingState)
+            .onChange(of: appState.recordViewModel?.recordingState) { _, newState in
+                showingRecordingSheet = (newState == .recording)
+            }
+            .onChange(of: appState.shouldStartRecording) { _, newValue in
+                if newValue {
+                    startRecording()
+                    appState.shouldStartRecording = false
+                }
+            }
+            .onChange(of: appState.shouldNavigateToModels) { _, newValue in
+                if newValue { showingSettings = true }
+            }
+            .onChange(of: appState.shouldTranscribeSharedAudio) { _, newValue in
+                if newValue {
+                    showingSettings = false
+                    showingRecordingSheet = false
+                    router.popToRoot()
+                    handleSharedAudioTranscription()
+                    appState.shouldTranscribeSharedAudio = false
+                }
+            }
+            .onChange(of: appState.openedAudioFileURL) { _, newValue in
+                if newValue != nil {
+                    showingSettings = false
+                    showingRecordingSheet = false
+                    router.popToRoot()
+                    handleOpenedAudioTranscription()
+                }
+            }
+            .overlay(alignment: .top) {
+                if appState.showKeyboardFlowToast {
+                    KeyboardFlowToast()
+                        .padding(.top, 60)
+                        .transition(.move(edge: .top).combined(with: .opacity))
+                }
+            }
+            .animation(.spring(duration: 0.4, bounce: 0.2), value: appState.showKeyboardFlowToast)
     }
 
     // MARK: - Main Content View
 
     @ViewBuilder
     private var mainContentView: some View {
+        let selectedSourceTags = Binding(
+            get: { savedNotesFilter.sourceTags },
+            set: { savedNotesFilter.sourceTags = $0 }
+        )
+        let selectedUserTagIds = Binding(
+            get: { savedNotesFilter.userTagIds },
+            set: { savedNotesFilter.userTagIds = $0 }
+        )
+
         TranscriptionsContentView(
             searchText: $searchText,
             isSelectionMode: $isSelectionMode,
             selectedTranscriptionIDs: $selectedTranscriptionIDs,
             displayedTranscriptionIDs: $displayedTranscriptionIDs,
+            selectedSourceTags: selectedSourceTags,
+            selectedUserTagIds: selectedUserTagIds,
             floatingControls: .init(
                 sheetTransitions: sheetTransitions,
                 onShowChats: {
@@ -320,6 +374,7 @@ struct MainView: View {
     private func handleOnAppear() {
         SelectTranscriptionModelTipMainView.isTranscriptionReady = appState.transcriptionManager.hasAvailableTranscriptionModels
         SelectTranscriptionModelTipSettingsView.isTranscriptionReady = appState.transcriptionManager.hasAvailableTranscriptionModels
+        sanitizeSavedNotesFilter()
 
         // Request app rating on app start (with delay to not be jarring)
         Task {
@@ -361,7 +416,23 @@ struct MainView: View {
                 }
             }
         } else {
-            ToolbarItem(placement: .navigationBarTrailing) {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    HapticManager.lightImpact()
+                    showingNotesFilter = true
+                } label: {
+                    Image(systemName: savedNotesFilter.isActive
+                          ? "line.3.horizontal.decrease.circle.fill"
+                          : "line.3.horizontal.decrease.circle")
+                }
+                .accessibilityLabel(savedNotesFilter.isActive ? "Edit Active Notes Filter" : "Filter Notes")
+            }
+
+            if #available(iOS 26.0, *) {
+                ToolbarSpacer(.fixed, placement: .topBarTrailing)
+            }
+
+            ToolbarItem(placement: .topBarTrailing) {
                 Button {
                     HapticManager.lightImpact()
                     showingSettings = true
@@ -590,6 +661,29 @@ struct MainView: View {
         }
 
         exitSelectionMode()
+    }
+
+    private var availableSourceTags: [String] {
+        var seen = Set<String>()
+        return transcriptions.compactMap(\.sourceTag).filter { seen.insert($0).inserted }
+    }
+
+    private func sanitizeSavedNotesFilter() {
+        let sanitizedFilter = SavedNotesFilterStorage.sanitize(
+            savedNotesFilter,
+            availableSourceTags: availableSourceTags,
+            availableUserTagIds: Set(transcriptionTags.map(\.id))
+        )
+
+        if sanitizedFilter != savedNotesFilter {
+            savedNotesFilter = sanitizedFilter
+        }
+    }
+
+    private func performMaintenanceTasks() async {
+        await NoteCleanupService.shared.performCleanupIfNeeded(modelContext: modelContext)
+        await AudioCleanupService.shared.performCleanupIfNeeded(modelContext: modelContext)
+        await ChatCleanupService.shared.performCleanupIfNeeded(modelContext: modelContext)
     }
 
     private func exportSelectedTranscriptions() {

--- a/VivaDicta/Views/NotesFilterView.swift
+++ b/VivaDicta/Views/NotesFilterView.swift
@@ -1,0 +1,190 @@
+//
+//  NotesFilterView.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.13
+//
+
+import SwiftUI
+
+struct NotesFilterView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    let sourceTags: [String]
+    let userTags: [TranscriptionTag]
+    let appliedFilter: SavedNotesFilter
+    let onApply: (SavedNotesFilter) -> Void
+
+    @State private var draftSourceTags: Set<String>
+    @State private var draftUserTagIds: Set<UUID>
+
+    init(
+        sourceTags: [String],
+        userTags: [TranscriptionTag],
+        appliedFilter: SavedNotesFilter,
+        onApply: @escaping (SavedNotesFilter) -> Void
+    ) {
+        self.sourceTags = sourceTags
+        self.userTags = userTags
+        self.appliedFilter = appliedFilter
+        self.onApply = onApply
+
+        let sanitizedFilter = SavedNotesFilterStorage.sanitize(
+            appliedFilter,
+            availableSourceTags: sourceTags,
+            availableUserTagIds: Set(userTags.map(\.id))
+        )
+        _draftSourceTags = State(initialValue: sanitizedFilter.sourceTags)
+        _draftUserTagIds = State(initialValue: sanitizedFilter.userTagIds)
+    }
+
+    private var draftFilter: SavedNotesFilter {
+        SavedNotesFilter(sourceTags: draftSourceTags, userTagIds: draftUserTagIds)
+    }
+
+    private var hasChanges: Bool {
+        draftFilter != appliedFilter
+    }
+
+    private var hasAvailableFilters: Bool {
+        !sourceTags.isEmpty || !userTags.isEmpty
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                if !hasAvailableFilters {
+                    ContentUnavailableView(
+                        "No Filters Yet",
+                        systemImage: "line.3.horizontal.decrease.circle",
+                        description: Text("Create tags or add more notes to start filtering.")
+                    )
+                } else {
+                    if !sourceTags.isEmpty {
+                        Section("Sources") {
+                            ForEach(sourceTags, id: \.self) { tag in
+                                selectionRow(
+                                    title: SourceTag.displayName(for: tag),
+                                    icon: SourceTag.icon(for: tag),
+                                    tint: SourceTag.color(for: tag),
+                                    isSelected: draftSourceTags.contains(tag)
+                                ) {
+                                    toggleSourceTag(tag)
+                                }
+                            }
+                        }
+                    }
+
+                    if !userTags.isEmpty {
+                        Section("Tags") {
+                            ForEach(userTags) { tag in
+                                selectionRow(
+                                    title: tag.name,
+                                    icon: tag.icon,
+                                    tint: Color(hex: tag.colorHex) ?? .blue,
+                                    isSelected: draftUserTagIds.contains(tag.id)
+                                ) {
+                                    toggleUserTag(tag.id)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Notes Filter")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+            }
+            .safeAreaInset(edge: .bottom) {
+                bottomActions
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var bottomActions: some View {
+        if hasAvailableFilters {
+            VStack(spacing: 12) {
+                Button("Apply Filter", systemImage: "checkmark.circle.fill") {
+                    onApply(draftFilter)
+                    dismiss()
+                }
+                .frame(maxWidth: .infinity)
+                .prominentButton(color: .accentColor)
+                .disabled(!hasChanges)
+
+                if appliedFilter.isActive {
+                    Button("Disable Filter", systemImage: "line.3.horizontal.decrease.circle") {
+                        onApply(SavedNotesFilter())
+                        dismiss()
+                    }
+                    .frame(maxWidth: .infinity)
+                    .buttonStyle(.bordered)
+                }
+            }
+            .padding()
+            .background(.bar)
+        }
+    }
+
+    private func toggleSourceTag(_ tag: String) {
+        if draftSourceTags.contains(tag) {
+            draftSourceTags.remove(tag)
+        } else {
+            draftSourceTags.insert(tag)
+        }
+    }
+
+    private func toggleUserTag(_ tagId: UUID) {
+        if draftUserTagIds.contains(tagId) {
+            draftUserTagIds.remove(tagId)
+        } else {
+            draftUserTagIds.insert(tagId)
+        }
+    }
+
+    private func selectionRow(
+        title: String,
+        icon: String,
+        tint: Color,
+        isSelected: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: 12) {
+                Image(systemName: icon)
+                    .foregroundStyle(.white)
+                    .frame(width: 32, height: 32)
+                    .background(tint)
+                    .clipShape(.rect(cornerRadius: 8))
+
+                Text(title)
+
+                Spacer()
+
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .foregroundStyle(isSelected ? tint : Color.secondary)
+            }
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+#Preview {
+    NotesFilterView(
+        sourceTags: [SourceTag.app, SourceTag.keyboard],
+        userTags: [
+            TranscriptionTag(name: "Work", colorHex: "#007AFF", icon: "briefcase.fill"),
+            TranscriptionTag(name: "Ideas", colorHex: "#FF9500", icon: "lightbulb.fill")
+        ],
+        appliedFilter: SavedNotesFilter(
+            sourceTags: [SourceTag.app],
+            userTagIds: []
+        )
+    ) { _ in }
+}

--- a/VivaDicta/Views/TranscriptionsContentView.swift
+++ b/VivaDicta/Views/TranscriptionsContentView.swift
@@ -39,8 +39,7 @@ struct TranscriptionsContentView: View {
     @Binding var isSelectionMode: Bool
     @Binding var selectedTranscriptionIDs: Set<UUID>
     @Binding var displayedTranscriptionIDs: Set<UUID>
-    @Binding var selectedSourceTags: Set<String>
-    @Binding var selectedUserTagIds: Set<UUID>
+    let savedFilter: SavedNotesFilter
     let floatingControls: TranscriptionsFloatingControls?
 
     @State private var filteredTranscriptions: [Transcription] = []
@@ -50,6 +49,8 @@ struct TranscriptionsContentView: View {
     @State private var newlyInsertedIDs: Set<UUID> = []
     @State private var previousTranscriptionCount = 0
     @State private var showGoToTopButton = false
+    @State private var selectedSourceTags: Set<String>
+    @State private var selectedUserTagIds: Set<UUID>
     @State private var searchMode: TranscriptionSearchMode = .all
 
     private let topAnchorID = "topAnchor"
@@ -62,16 +63,16 @@ struct TranscriptionsContentView: View {
         isSelectionMode: Binding<Bool>,
         selectedTranscriptionIDs: Binding<Set<UUID>>,
         displayedTranscriptionIDs: Binding<Set<UUID>>,
-        selectedSourceTags: Binding<Set<String>>,
-        selectedUserTagIds: Binding<Set<UUID>>,
+        savedFilter: SavedNotesFilter,
         floatingControls: TranscriptionsFloatingControls? = nil
     ) {
         self._searchText = searchText
         self._isSelectionMode = isSelectionMode
         self._selectedTranscriptionIDs = selectedTranscriptionIDs
         self._displayedTranscriptionIDs = displayedTranscriptionIDs
-        self._selectedSourceTags = selectedSourceTags
-        self._selectedUserTagIds = selectedUserTagIds
+        self.savedFilter = savedFilter
+        self._selectedSourceTags = State(initialValue: savedFilter.sourceTags)
+        self._selectedUserTagIds = State(initialValue: savedFilter.userTagIds)
         self.floatingControls = floatingControls
     }
 
@@ -190,6 +191,10 @@ struct TranscriptionsContentView: View {
         }
         .onChange(of: selectedUserTagIds) {
             syncDisplayedIDs()
+        }
+        .onChange(of: savedFilter) { _, newValue in
+            selectedSourceTags = newValue.sourceTags
+            selectedUserTagIds = newValue.userTagIds
         }
         .onChange(of: searchMode) {
             if !searchText.isEmpty {
@@ -834,16 +839,13 @@ private struct TranscriptionNavigationRow: View {
     @Previewable @State var searchText = ""
     @Previewable @State var isSelectionMode = false
     @Previewable @State var selectedIDs: Set<UUID> = []
-    @Previewable @State var selectedSourceTags: Set<String> = []
-    @Previewable @State var selectedUserTagIds: Set<UUID> = []
     NavigationStack {
         TranscriptionsContentView(
             searchText: $searchText,
             isSelectionMode: $isSelectionMode,
             selectedTranscriptionIDs: $selectedIDs,
             displayedTranscriptionIDs: .constant([]),
-            selectedSourceTags: $selectedSourceTags,
-            selectedUserTagIds: $selectedUserTagIds
+            savedFilter: SavedNotesFilter()
         )
     }
     .environment(AppState())

--- a/VivaDicta/Views/TranscriptionsContentView.swift
+++ b/VivaDicta/Views/TranscriptionsContentView.swift
@@ -39,6 +39,8 @@ struct TranscriptionsContentView: View {
     @Binding var isSelectionMode: Bool
     @Binding var selectedTranscriptionIDs: Set<UUID>
     @Binding var displayedTranscriptionIDs: Set<UUID>
+    @Binding var selectedSourceTags: Set<String>
+    @Binding var selectedUserTagIds: Set<UUID>
     let floatingControls: TranscriptionsFloatingControls?
 
     @State private var filteredTranscriptions: [Transcription] = []
@@ -48,8 +50,6 @@ struct TranscriptionsContentView: View {
     @State private var newlyInsertedIDs: Set<UUID> = []
     @State private var previousTranscriptionCount = 0
     @State private var showGoToTopButton = false
-    @State private var selectedSourceTags: Set<String> = []
-    @State private var selectedUserTagIds: Set<UUID> = []
     @State private var searchMode: TranscriptionSearchMode = .all
 
     private let topAnchorID = "topAnchor"
@@ -62,12 +62,16 @@ struct TranscriptionsContentView: View {
         isSelectionMode: Binding<Bool>,
         selectedTranscriptionIDs: Binding<Set<UUID>>,
         displayedTranscriptionIDs: Binding<Set<UUID>>,
+        selectedSourceTags: Binding<Set<String>>,
+        selectedUserTagIds: Binding<Set<UUID>>,
         floatingControls: TranscriptionsFloatingControls? = nil
     ) {
         self._searchText = searchText
         self._isSelectionMode = isSelectionMode
         self._selectedTranscriptionIDs = selectedTranscriptionIDs
         self._displayedTranscriptionIDs = displayedTranscriptionIDs
+        self._selectedSourceTags = selectedSourceTags
+        self._selectedUserTagIds = selectedUserTagIds
         self.floatingControls = floatingControls
     }
 
@@ -830,12 +834,16 @@ private struct TranscriptionNavigationRow: View {
     @Previewable @State var searchText = ""
     @Previewable @State var isSelectionMode = false
     @Previewable @State var selectedIDs: Set<UUID> = []
+    @Previewable @State var selectedSourceTags: Set<String> = []
+    @Previewable @State var selectedUserTagIds: Set<UUID> = []
     NavigationStack {
         TranscriptionsContentView(
             searchText: $searchText,
             isSelectionMode: $isSelectionMode,
             selectedTranscriptionIDs: $selectedIDs,
-            displayedTranscriptionIDs: .constant([])
+            displayedTranscriptionIDs: .constant([]),
+            selectedSourceTags: $selectedSourceTags,
+            selectedUserTagIds: $selectedUserTagIds
         )
     }
     .environment(AppState())


### PR DESCRIPTION
## Summary
- add a saved notes filter model backed by app-private user defaults
- add a dedicated Notes Filter screen for selecting source tags and user tags, with apply and disable actions
- wire the main notes list and toolbar filter button to the same persistent filter state so the selection survives app relaunches

## Testing
- xcodebuild -scheme VivaDicta -configuration Debug -workspace ./VivaDicta.xcodeproj/project.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max,OS=26.4' build 2>&1 | xcsift

## Notes
- no breaking changes
- on iOS 26, the filter and settings buttons are separated with a fixed top-bar toolbar spacer
