### PR TITLE
Add preset hiding for pickers and keyboard

### DIFF
--- a/VivaDicta/Services/PresetManager.swift
+++ b/VivaDicta/Services/PresetManager.swift
@@ -23,18 +23,25 @@ class PresetManager {
     private let logger = Logger(category: .presetManager)
     private let userDefaults: UserDefaults
     private let storageKey: String
+    private let hiddenPresetIDsStorageKey: String
 
     /// All available presets (built-in + custom from UserDefaults).
     private(set) var presets: [Preset] = []
+
+    /// Preset IDs hidden from pickers and keyboard on this device.
+    private(set) var hiddenPresetIDs: Set<String> = []
 
     /// Sync service for writing preset changes to SwiftData/CloudKit.
     var syncService: PresetSyncService?
 
     init(userDefaults: UserDefaults = UserDefaultsStorage.shared,
-         storageKey: String = UserDefaultsStorage.SharedKeys.presets) {
+         storageKey: String = UserDefaultsStorage.SharedKeys.presets,
+         hiddenPresetIDsStorageKey: String = UserDefaultsStorage.SharedKeys.hiddenPresetIDs) {
         self.userDefaults = userDefaults
         self.storageKey = storageKey
+        self.hiddenPresetIDsStorageKey = hiddenPresetIDsStorageKey
         loadPresets()
+        loadHiddenPresetIDs()
         populateBuiltInsIfNeeded()
     }
 
@@ -43,6 +50,11 @@ class PresetManager {
     /// Returns a preset by its ID.
     func preset(for id: String) -> Preset? {
         presets.first { $0.id == id }
+    }
+
+    /// Returns presets visible in pickers and keyboard on this device.
+    var visiblePresets: [Preset] {
+        presets.filter { !hiddenPresetIDs.contains($0.id) }
     }
 
     /// Returns all presets for a given category.
@@ -55,22 +67,38 @@ class PresetManager {
         presets.contains { $0.isFavorite }
     }
 
+    /// Whether any visible presets are marked as favorites.
+    var hasVisibleFavorites: Bool {
+        visiblePresets.contains { $0.isFavorite }
+    }
+
     /// Returns ordered category names using explicit category ordering.
     var categories: [String] {
-        var seen = Set<String>()
-        var result: [String] = []
-        for preset in presets {
-            if !seen.contains(preset.category) {
-                seen.insert(preset.category)
-                result.append(preset.category)
-            }
+        categories(from: presets)
+    }
+
+    /// Returns ordered category names for presets visible in pickers and keyboard.
+    var visibleCategories: [String] {
+        categories(from: visiblePresets)
+    }
+
+    /// Returns whether the preset is hidden from pickers and keyboard on this device.
+    func isPresetHidden(presetId: String) -> Bool {
+        hiddenPresetIDs.contains(presetId)
+    }
+
+    /// Updates whether the preset is hidden from pickers and keyboard on this device.
+    func setPresetHidden(presetId: String, isHidden: Bool) {
+        guard preset(for: presetId) != nil else { return }
+
+        if isHidden {
+            hiddenPresetIDs.insert(presetId)
+        } else {
+            hiddenPresetIDs.remove(presetId)
         }
-        return result.sorted { lhs, rhs in
-            let lhsIdx = PresetCatalog.categoryOrder.firstIndex(of: lhs) ?? Int.max
-            let rhsIdx = PresetCatalog.categoryOrder.firstIndex(of: rhs) ?? Int.max
-            if lhsIdx != rhsIdx { return lhsIdx < rhsIdx }
-            return lhs < rhs
-        }
+
+        saveHiddenPresetIDs()
+        logger.logInfo("Updated preset visibility: \(presetId) → hidden=\(isHidden)")
     }
 
     // MARK: - CRUD
@@ -109,7 +137,9 @@ class PresetManager {
             return
         }
         presets.removeAll { $0.id == preset.id }
+        hiddenPresetIDs.remove(preset.id)
         savePresets()
+        saveHiddenPresetIDs()
 
         if preset.id.hasPrefix("custom_") {
             syncService?.deletePresetRecord(presetId: preset.id)
@@ -224,7 +254,39 @@ class PresetManager {
         logger.logInfo("Saved \(self.presets.count) presets")
     }
 
+    private func loadHiddenPresetIDs() {
+        guard let ids = userDefaults.array(forKey: hiddenPresetIDsStorageKey) as? [String] else {
+            hiddenPresetIDs = []
+            return
+        }
+
+        hiddenPresetIDs = Set(ids)
+        logger.logInfo("Loaded \(ids.count) hidden preset IDs")
+    }
+
+    private func saveHiddenPresetIDs() {
+        userDefaults.set(Array(hiddenPresetIDs).sorted(), forKey: hiddenPresetIDsStorageKey)
+        logger.logInfo("Saved \(hiddenPresetIDs.count) hidden preset IDs")
+    }
+
     // MARK: - Helpers
+
+    private func categories(from presets: [Preset]) -> [String] {
+        var seen = Set<String>()
+        var result: [String] = []
+        for preset in presets {
+            if !seen.contains(preset.category) {
+                seen.insert(preset.category)
+                result.append(preset.category)
+            }
+        }
+        return result.sorted { lhs, rhs in
+            let lhsIdx = PresetCatalog.categoryOrder.firstIndex(of: lhs) ?? Int.max
+            let rhsIdx = PresetCatalog.categoryOrder.firstIndex(of: rhs) ?? Int.max
+            if lhsIdx != rhsIdx { return lhsIdx < rhsIdx }
+            return lhs < rhs
+        }
+    }
 
     private func normalizeForComparison(_ name: String) -> String {
         name.split(separator: /\s+/).joined().lowercased()

--- a/VivaDicta/Shared/UserDefaultsStorage.swift
+++ b/VivaDicta/Shared/UserDefaultsStorage.swift
@@ -25,6 +25,7 @@ enum UserDefaultsStorage {
 
     enum SharedKeys {
         static let presets = "Presets_v1"
+        static let hiddenPresetIDs = "HiddenPresetIDs_v1"
     }
 
     // MARK: - App-Private Keys

--- a/VivaDicta/Views/SettingsScreen/ModeEditView.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditView.swift
@@ -843,9 +843,9 @@ private struct ModePresetPickerSheet: View {
 
     private var typeFilteredPresets: [Preset] {
         let byType: [Preset] = switch filter {
-        case .all: presetManager.presets
-        case .system: presetManager.presets.filter(\.isBuiltIn)
-        case .custom: presetManager.presets.filter { !$0.isBuiltIn }
+        case .all: presetManager.visiblePresets
+        case .system: presetManager.visiblePresets.filter(\.isBuiltIn)
+        case .custom: presetManager.visiblePresets.filter { !$0.isBuiltIn }
         }
         guard !searchText.isEmpty else { return byType }
         return byType.filter {
@@ -896,27 +896,37 @@ private struct ModePresetPickerSheet: View {
                     CategoryChipsView(
                         categories: allCategories,
                         selectedCategory: $selectedCategory,
-                        showFavorites: presetManager.hasFavorites
+                        showFavorites: presetManager.hasVisibleFavorites
                     )
                     .listRowInsets(EdgeInsets())
                     .listRowBackground(Color.clear)
                 }
 
-                if selectedCategory == nil {
-                    let favorites = typeFilteredPresets.filter(\.isFavorite)
-                    if !favorites.isEmpty {
-                        Section("Favorites") {
-                            ForEach(favorites) { preset in
-                                modePresetRow(preset)
+                if typeFilteredPresets.isEmpty {
+                    ContentUnavailableView {
+                        Label(searchText.isEmpty ? "No Visible Presets" : "No Presets Found", systemImage: "eye.slash")
+                    } description: {
+                        Text(searchText.isEmpty
+                             ? "Unhide presets in AI Presets to show them here."
+                             : "Try a different search or filter.")
+                    }
+                } else {
+                    if selectedCategory == nil {
+                        let favorites = typeFilteredPresets.filter(\.isFavorite)
+                        if !favorites.isEmpty {
+                            Section("Favorites") {
+                                ForEach(favorites) { preset in
+                                    modePresetRow(preset)
+                                }
                             }
                         }
                     }
-                }
 
-                ForEach(filteredCategories, id: \.self) { category in
-                    Section(category) {
-                        ForEach(filteredPresets.filter { $0.category == category }) { preset in
-                            modePresetRow(preset)
+                    ForEach(filteredCategories, id: \.self) { category in
+                        Section(category) {
+                            ForEach(filteredPresets.filter { $0.category == category }) { preset in
+                                modePresetRow(preset)
+                            }
                         }
                     }
                 }
@@ -925,8 +935,8 @@ private struct ModePresetPickerSheet: View {
             .onChange(of: filter) { _, _ in
                 selectedCategory = nil
             }
-            .onChange(of: presetManager.hasFavorites) {
-                if !presetManager.hasFavorites && selectedCategory == CategoryChipsView.favoritesFilter {
+            .onChange(of: presetManager.hasVisibleFavorites) {
+                if !presetManager.hasVisibleFavorites && selectedCategory == CategoryChipsView.favoritesFilter {
                     selectedCategory = nil
                 }
             }

--- a/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
@@ -560,7 +560,7 @@ class ModeEditViewModel {
     }
 
     func selectFirstPresetIfNeeded() {
-        if selectedPresetId == nil, let firstPreset = presetManager.presets.first {
+        if selectedPresetId == nil, let firstPreset = presetManager.visiblePresets.first {
             selectedPresetId = firstPreset.id
             logger.logInfo("Auto-selected first preset: \(firstPreset.name)")
         }

--- a/VivaDicta/Views/SettingsScreen/Presets/PresetSettings.swift
+++ b/VivaDicta/Views/SettingsScreen/Presets/PresetSettings.swift
@@ -80,18 +80,7 @@ struct PresetSettings: View {
                 if !favorites.isEmpty {
                     Section("Favorites") {
                         ForEach(favorites) { preset in
-                            NavigationLink(value: preset) {
-                                PresetRowView(preset: preset, onToggleFavorite: {
-                                    presetManager.toggleFavorite(presetId: preset.id)
-                                })
-                            }
-                            .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                                if !preset.isBuiltIn {
-                                    Button("Delete", role: .destructive) {
-                                        deletePreset(preset)
-                                    }
-                                }
-                            }
+                            presetRowLink(for: preset)
                         }
                     }
                 }
@@ -100,18 +89,7 @@ struct PresetSettings: View {
             ForEach(filteredCategories, id: \.self) { category in
                 Section(category) {
                     ForEach(filteredPresets.filter { $0.category == category }) { preset in
-                        NavigationLink(value: preset) {
-                            PresetRowView(preset: preset, onToggleFavorite: {
-                                presetManager.toggleFavorite(presetId: preset.id)
-                            })
-                        }
-                        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                            if !preset.isBuiltIn {
-                                Button("Delete", role: .destructive) {
-                                    deletePreset(preset)
-                                }
-                            }
-                        }
+                        presetRowLink(for: preset)
                     }
                 }
             }
@@ -145,6 +123,41 @@ struct PresetSettings: View {
         HapticManager.mediumImpact()
         presetManager.deletePreset(preset)
     }
+
+    private func togglePresetVisibility(_ preset: Preset) {
+        HapticManager.lightImpact()
+        let isHidden = presetManager.isPresetHidden(presetId: preset.id)
+        presetManager.setPresetHidden(presetId: preset.id, isHidden: !isHidden)
+    }
+
+    private func presetRowLink(for preset: Preset) -> some View {
+        let isHidden = presetManager.isPresetHidden(presetId: preset.id)
+
+        return NavigationLink(value: preset) {
+            PresetRowView(
+                preset: preset,
+                isHidden: isHidden,
+                onToggleFavorite: {
+                    presetManager.toggleFavorite(presetId: preset.id)
+                }
+            )
+        }
+        .swipeActions(edge: .leading, allowsFullSwipe: false) {
+            Button {
+                togglePresetVisibility(preset)
+            } label: {
+                Label(isHidden ? "Show" : "Hide", systemImage: isHidden ? "eye" : "eye.slash")
+            }
+            .tint(isHidden ? .green : .indigo)
+        }
+        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+            if !preset.isBuiltIn {
+                Button("Delete", role: .destructive) {
+                    deletePreset(preset)
+                }
+            }
+        }
+    }
 }
 
 enum PresetFilter: String, CaseIterable, Identifiable {
@@ -163,6 +176,7 @@ enum PresetFilter: String, CaseIterable, Identifiable {
 
 private struct PresetRowView: View {
     let preset: Preset
+    let isHidden: Bool
     var onToggleFavorite: (() -> Void)?
 
     var body: some View {
@@ -193,6 +207,13 @@ private struct PresetRowView: View {
             }
 
             Spacer()
+
+            if isHidden {
+                Image(systemName: "eye.slash")
+                    .foregroundStyle(.secondary.opacity(0.7))
+                    .font(.system(size: 14))
+                    .accessibilityLabel("Hidden from pickers and keyboard")
+            }
 
             if let onToggleFavorite {
                 Button {

--- a/VivaDicta/Views/TranscriptionDetailView.swift
+++ b/VivaDicta/Views/TranscriptionDetailView.swift
@@ -1203,9 +1203,9 @@ private struct PresetPickerSheet: View {
 
     private var typeFilteredPresets: [Preset] {
         let byType: [Preset] = switch filter {
-        case .all: presetManager.presets
-        case .system: presetManager.presets.filter(\.isBuiltIn)
-        case .custom: presetManager.presets.filter { !$0.isBuiltIn }
+        case .all: presetManager.visiblePresets
+        case .system: presetManager.visiblePresets.filter(\.isBuiltIn)
+        case .custom: presetManager.visiblePresets.filter { !$0.isBuiltIn }
         }
         guard !searchText.isEmpty else { return byType }
         return byType.filter {
@@ -1256,28 +1256,38 @@ private struct PresetPickerSheet: View {
                     CategoryChipsView(
                         categories: allCategories,
                         selectedCategory: $selectedCategory,
-                        showFavorites: presetManager.hasFavorites
+                        showFavorites: presetManager.hasVisibleFavorites
                     )
                     .listRowInsets(EdgeInsets())
                     .listRowBackground(Color.clear)
                 }
                 .listSectionSpacing(0)
 
-                if selectedCategory == nil {
-                    let favorites = typeFilteredPresets.filter(\.isFavorite)
-                    if !favorites.isEmpty {
-                        Section("Favorites") {
-                            ForEach(favorites) { preset in
-                                presetRow(preset)
+                if typeFilteredPresets.isEmpty {
+                    ContentUnavailableView {
+                        Label(searchText.isEmpty ? "No Visible Presets" : "No Presets Found", systemImage: "eye.slash")
+                    } description: {
+                        Text(searchText.isEmpty
+                             ? "Unhide presets in AI Presets to show them here."
+                             : "Try a different search or filter.")
+                    }
+                } else {
+                    if selectedCategory == nil {
+                        let favorites = typeFilteredPresets.filter(\.isFavorite)
+                        if !favorites.isEmpty {
+                            Section("Favorites") {
+                                ForEach(favorites) { preset in
+                                    presetRow(preset)
+                                }
                             }
                         }
                     }
-                }
 
-                ForEach(filteredCategories, id: \.self) { category in
-                    Section(category) {
-                        ForEach(filteredPresets.filter { $0.category == category }) { preset in
-                            presetRow(preset)
+                    ForEach(filteredCategories, id: \.self) { category in
+                        Section(category) {
+                            ForEach(filteredPresets.filter { $0.category == category }) { preset in
+                                presetRow(preset)
+                            }
                         }
                     }
                 }
@@ -1286,8 +1296,8 @@ private struct PresetPickerSheet: View {
             .onChange(of: filter) { _, _ in
                 selectedCategory = nil
             }
-            .onChange(of: presetManager.hasFavorites) {
-                if !presetManager.hasFavorites && selectedCategory == CategoryChipsView.favoritesFilter {
+            .onChange(of: presetManager.hasVisibleFavorites) {
+                if !presetManager.hasVisibleFavorites && selectedCategory == CategoryChipsView.favoritesFilter {
                     selectedCategory = nil
                 }
             }

--- a/VivaDictaKeyboard/Models/KeyboardPresetLoader.swift
+++ b/VivaDictaKeyboard/Models/KeyboardPresetLoader.swift
@@ -13,6 +13,7 @@ import Foundation
 /// are available via target membership. This loader reads the persisted preset array directly.
 enum KeyboardPresetLoader {
     private static let storageKey = UserDefaultsStorage.SharedKeys.presets
+    private static let hiddenPresetIDsStorageKey = UserDefaultsStorage.SharedKeys.hiddenPresetIDs
 
     /// Loads all presets from shared UserDefaults.
     static func loadPresets() -> [Preset] {
@@ -21,5 +22,20 @@ enum KeyboardPresetLoader {
             return []
         }
         return (try? JSONDecoder().decode([Preset].self, from: data)) ?? []
+    }
+
+    /// Loads presets visible in pickers and keyboard on this device.
+    static func loadVisiblePresets() -> [Preset] {
+        let hiddenPresetIDs = loadHiddenPresetIDs()
+        return loadPresets().filter { !hiddenPresetIDs.contains($0.id) }
+    }
+
+    private static func loadHiddenPresetIDs() -> Set<String> {
+        guard let defaults = UserDefaults(suiteName: AppGroupCoordinator.shared.appGroupId),
+              let ids = defaults.array(forKey: hiddenPresetIDsStorageKey) as? [String] else {
+            return []
+        }
+
+        return Set(ids)
     }
 }

--- a/VivaDictaKeyboard/Views/RewriteModesView.swift
+++ b/VivaDictaKeyboard/Views/RewriteModesView.swift
@@ -86,7 +86,7 @@ struct RewriteModesView: View {
         }
         .frame(height: 260)
         .onAppear {
-            presets = KeyboardPresetLoader.loadPresets()
+            presets = KeyboardPresetLoader.loadVisiblePresets()
         }
     }
 
@@ -133,27 +133,61 @@ struct RewriteModesView: View {
             )
             .padding(.bottom, 6)
 
-            ScrollView {
-                LazyVStack(alignment: .leading, spacing: 0) {
-                    // Favorites section when no category filter is active
-                    if selectedCategory == nil {
-                        let favorites = presets.filter(\.isFavorite)
-                        if !favorites.isEmpty {
-                            presetSection(title: "Favorites", presets: favorites)
+            if presets.isEmpty {
+                VStack(spacing: 10) {
+                    Spacer()
+
+                    Image(systemName: "eye.slash")
+                        .font(.system(size: 20))
+                        .foregroundStyle(.secondary)
+
+                    Text("No Visible Presets")
+                        .font(.system(size: 16, weight: .semibold))
+
+                    Text("Unhide presets in the app to use them from the keyboard.")
+                        .font(.system(size: 13))
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+
+                    Button {
+                        HapticManager.mediumImpact()
+                        onOpenApp()
+                    } label: {
+                        Label("Open VivaDicta", systemImage: "arrow.up.forward.app")
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundStyle(.primary)
+                            .padding(.horizontal, 18)
+                            .padding(.vertical, 10)
+                    }
+                    .prominentButton(color: .orange)
+                    .padding(.top, 2)
+
+                    Spacer()
+                }
+                .padding(.horizontal, 24)
+            } else {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        // Favorites section when no category filter is active
+                        if selectedCategory == nil {
+                            let favorites = presets.filter(\.isFavorite)
+                            if !favorites.isEmpty {
+                                presetSection(title: "Favorites", presets: favorites)
+                            }
+                        }
+
+                        ForEach(orderedCategories, id: \.self) { category in
+                            presetSection(
+                                title: category,
+                                presets: filteredPresets.filter { $0.category == category }
+                            )
                         }
                     }
-
-                    ForEach(orderedCategories, id: \.self) { category in
-                        presetSection(
-                            title: category,
-                            presets: filteredPresets.filter { $0.category == category }
-                        )
-                    }
+                    .padding(.horizontal, 12)
+                    .padding(.bottom, 8)
                 }
-                .padding(.horizontal, 12)
-                .padding(.bottom, 8)
+                .scrollIndicators(.hidden)
             }
-            .scrollIndicators(.hidden)
         }
     }
 

--- a/VivaDictaTests/ModeEditViewModelTests.swift
+++ b/VivaDictaTests/ModeEditViewModelTests.swift
@@ -13,12 +13,21 @@ struct ModeEditViewModelTests {
 
     // MARK: - Test Helpers
 
+    private func makePresetManager(suiteName: String = "ModeEditViewModelTests") -> PresetManager {
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removeObject(forKey: "testPresets")
+        defaults.removeObject(forKey: "testHiddenPresetIDs")
+
+        return PresetManager(
+            userDefaults: defaults,
+            storageKey: "testPresets",
+            hiddenPresetIDsStorageKey: "testHiddenPresetIDs"
+        )
+    }
+
     private func makeViewModel() -> ModeEditViewModel {
         let aiService = AIService()
-        let presetManager = PresetManager(
-            userDefaults: UserDefaults(suiteName: "ModeEditViewModelTests")!,
-            storageKey: "testPresets"
-        )
+        let presetManager = makePresetManager()
         let transcriptionManager = TranscriptionManager()
 
         return ModeEditViewModel(
@@ -197,10 +206,7 @@ struct ModeEditViewModelTests {
 
     @Test func testIsEditing_existingMode_returnsTrue() {
         let aiService = AIService()
-        let presetManager = PresetManager(
-            userDefaults: UserDefaults(suiteName: "ModeEditViewModelTests")!,
-            storageKey: "testPresets"
-        )
+        let presetManager = makePresetManager()
         let transcriptionManager = TranscriptionManager()
 
         let existingMode = VivaMode(
@@ -220,6 +226,28 @@ struct ModeEditViewModelTests {
         )
 
         #expect(viewModel.isEditing == true)
+    }
+
+    @Test func testSelectFirstPresetIfNeeded_skipsHiddenPresets() {
+        let viewModel = makeViewModel()
+
+        viewModel.presetManager.setPresetHidden(presetId: "regular", isHidden: true)
+        viewModel.selectedPresetId = nil
+        viewModel.selectFirstPresetIfNeeded()
+
+        #expect(viewModel.selectedPresetId == viewModel.presetManager.visiblePresets.first?.id)
+    }
+
+    @Test func testSelectFirstPresetIfNeeded_allHidden_leavesSelectionNil() {
+        let viewModel = makeViewModel()
+        for preset in viewModel.presetManager.visiblePresets {
+            viewModel.presetManager.setPresetHidden(presetId: preset.id, isHidden: true)
+        }
+
+        viewModel.selectedPresetId = nil
+        viewModel.selectFirstPresetIfNeeded()
+
+        #expect(viewModel.selectedPresetId == nil)
     }
 
     // MARK: - Mode Name Validation Tests

--- a/VivaDictaTests/PresetManagerTests.swift
+++ b/VivaDictaTests/PresetManagerTests.swift
@@ -16,7 +16,12 @@ struct PresetManagerTests {
     private func makeManager(suiteName: String = "PresetManagerTests") -> PresetManager {
         let defaults = UserDefaults(suiteName: suiteName)!
         defaults.removeObject(forKey: "testPresets")
-        return PresetManager(userDefaults: defaults, storageKey: "testPresets")
+        defaults.removeObject(forKey: "testHiddenPresetIDs")
+        return PresetManager(
+            userDefaults: defaults,
+            storageKey: "testPresets",
+            hiddenPresetIDsStorageKey: "testHiddenPresetIDs"
+        )
     }
 
     private func makeCustomPreset(
@@ -196,6 +201,28 @@ struct PresetManagerTests {
         #expect(manager.hasFavorites == true)
     }
 
+    @Test func visiblePresets_excludesHiddenPresets() {
+        let manager = makeManager()
+
+        #expect(manager.visiblePresets.contains { $0.id == "regular" })
+
+        manager.setPresetHidden(presetId: "regular", isHidden: true)
+
+        #expect(!manager.visiblePresets.contains { $0.id == "regular" })
+        #expect(manager.isPresetHidden(presetId: "regular") == true)
+    }
+
+    @Test func hasVisibleFavorites_ignoresHiddenFavorites() {
+        let manager = makeManager()
+        manager.toggleFavorite(presetId: "regular")
+
+        #expect(manager.hasVisibleFavorites == true)
+
+        manager.setPresetHidden(presetId: "regular", isHidden: true)
+
+        #expect(manager.hasVisibleFavorites == false)
+    }
+
     // MARK: - Duplicate Detection Tests
 
     @Test func isPresetNameDuplicate_detectsDuplicates() {
@@ -225,14 +252,48 @@ struct PresetManagerTests {
         let suiteName = "PresetManagerPersistenceTest_\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
         defaults.removeObject(forKey: "testPresets")
+        defaults.removeObject(forKey: "testHiddenPresetIDs")
 
-        let manager1 = PresetManager(userDefaults: defaults, storageKey: "testPresets")
+        let manager1 = PresetManager(
+            userDefaults: defaults,
+            storageKey: "testPresets",
+            hiddenPresetIDsStorageKey: "testHiddenPresetIDs"
+        )
         let preset = makeCustomPreset()
         manager1.addPreset(preset)
 
-        let manager2 = PresetManager(userDefaults: defaults, storageKey: "testPresets")
+        let manager2 = PresetManager(
+            userDefaults: defaults,
+            storageKey: "testPresets",
+            hiddenPresetIDsStorageKey: "testHiddenPresetIDs"
+        )
 
         #expect(manager2.preset(for: preset.id) != nil)
+
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    @Test func persistence_hiddenPresetIDsPersistAcrossInstances() {
+        let suiteName = "PresetManagerHiddenPersistenceTest_\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removeObject(forKey: "testPresets")
+        defaults.removeObject(forKey: "testHiddenPresetIDs")
+
+        let manager1 = PresetManager(
+            userDefaults: defaults,
+            storageKey: "testPresets",
+            hiddenPresetIDsStorageKey: "testHiddenPresetIDs"
+        )
+        manager1.setPresetHidden(presetId: "regular", isHidden: true)
+
+        let manager2 = PresetManager(
+            userDefaults: defaults,
+            storageKey: "testPresets",
+            hiddenPresetIDsStorageKey: "testHiddenPresetIDs"
+        )
+
+        #expect(manager2.isPresetHidden(presetId: "regular") == true)
+        #expect(!manager2.visiblePresets.contains { $0.id == "regular" })
 
         defaults.removePersistentDomain(forName: suiteName)
     }
@@ -254,5 +315,16 @@ struct PresetManagerTests {
         if let lastBuiltIn = builtInIndices.last, let firstCustom = customIndices.first {
             #expect(lastBuiltIn < firstCustom)
         }
+    }
+
+    @Test func deletePreset_removesHiddenState() {
+        let manager = makeManager()
+        let preset = makeCustomPreset()
+        manager.addPreset(preset)
+        manager.setPresetHidden(presetId: preset.id, isHidden: true)
+
+        manager.deletePreset(preset)
+
+        #expect(manager.isPresetHidden(presetId: preset.id) == false)
     }
 }


### PR DESCRIPTION
## Summary
- add local shared preset visibility state in App Group storage via `PresetManager`
- hide hidden presets from mode pickers, variation pickers, and the keyboard while keeping them manageable in AI Presets
- add empty states plus tests for hidden preset persistence and first visible preset selection

## Testing
- `xcodebuild -scheme VivaDicta -configuration Debug -workspace ./VivaDicta.xcodeproj/project.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max,OS=26.4' test -only-testing:VivaDictaTests/PresetManagerTests -only-testing:VivaDictaTests/ModeEditViewModelTests 2>&1 | xcsift`

## Notes
- preset visibility is local to iOS/iPadOS and the keyboard on the same device
- this PR does not change CloudKit or macOS preset visibility behavior