### PR TITLE
Add AI reminder extraction and Apple Reminders import

### DIFF
--- a/VivaDicta/DataController.swift
+++ b/VivaDicta/DataController.swift
@@ -53,7 +53,7 @@ class DataController {
     /// Preview initializer with in-memory storage.
     convenience init() {
         let config = ModelConfiguration(isStoredInMemoryOnly: true)
-        let container = try! ModelContainer(for: Transcription.self, configurations: config)
+        let container = try! ModelContainer(for: Transcription.self, ExtractedReminderDraft.self, configurations: config)
         self.init(modelContainer: container)
     }
     #endif

--- a/VivaDicta/Info.plist
+++ b/VivaDicta/Info.plist
@@ -123,6 +123,10 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>NSRemindersFullAccessUsageDescription</key>
+	<string>VivaDicta needs access to create reminders from reminder suggestions that you choose to import.</string>
+	<key>NSRemindersUsageDescription</key>
+	<string>VivaDicta uses Reminders access to save reminder suggestions you choose to import.</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>

--- a/VivaDicta/Models/ExtractedReminderDraft.swift
+++ b/VivaDicta/Models/ExtractedReminderDraft.swift
@@ -120,4 +120,8 @@ extension Transcription {
     var pendingExtractedReminderDrafts: [ExtractedReminderDraft] {
         sortedExtractedReminderDrafts.filter { $0.status == .pending }
     }
+
+    var pendingExtractedReminderDraftCount: Int {
+        pendingExtractedReminderDrafts.count
+    }
 }

--- a/VivaDicta/Models/ExtractedReminderDraft.swift
+++ b/VivaDicta/Models/ExtractedReminderDraft.swift
@@ -1,0 +1,123 @@
+//
+//  ExtractedReminderDraft.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.14
+//
+
+import Foundation
+import SwiftData
+
+enum ExtractedReminderDraftStatus: String, Codable, CaseIterable, Sendable {
+    case pending
+    case imported
+    case dismissed
+}
+
+@Model
+final class ExtractedReminderDraft {
+    var id: UUID = UUID()
+    var title: String = ""
+    var optionalDueDateString: String?
+    var rawDueDatePhrase: String?
+    var notes: String?
+    var priorityRawValue: String = ReminderDraftPriority.none.rawValue
+    var statusRawValue: String = ExtractedReminderDraftStatus.pending.rawValue
+    var reminderIdentifier: String?
+    var extractionProviderName: String?
+    var extractionModelName: String?
+    var createdAt: Date = Date()
+    var updatedAt: Date = Date()
+
+    @Relationship(inverse: \Transcription.extractedReminderDrafts)
+    var transcription: Transcription?
+
+    init(
+        title: String = "",
+        optionalDueDateString: String? = nil,
+        rawDueDatePhrase: String? = nil,
+        notes: String? = nil,
+        priority: ReminderDraftPriority = .none,
+        status: ExtractedReminderDraftStatus = .pending,
+        reminderIdentifier: String? = nil,
+        extractionProviderName: String? = nil,
+        extractionModelName: String? = nil,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date()
+    ) {
+        self.title = title
+        self.optionalDueDateString = optionalDueDateString
+        self.rawDueDatePhrase = rawDueDatePhrase
+        self.notes = notes
+        self.priorityRawValue = priority.rawValue
+        self.statusRawValue = status.rawValue
+        self.reminderIdentifier = reminderIdentifier
+        self.extractionProviderName = extractionProviderName
+        self.extractionModelName = extractionModelName
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+
+    var priority: ReminderDraftPriority {
+        get { ReminderDraftPriority(rawValue: priorityRawValue) ?? .none }
+        set { priorityRawValue = newValue.rawValue }
+    }
+
+    var status: ExtractedReminderDraftStatus {
+        get { ExtractedReminderDraftStatus(rawValue: statusRawValue) ?? .pending }
+        set { statusRawValue = newValue.rawValue }
+    }
+
+    var reminderDraft: ReminderDraft {
+        ReminderDraft(
+            title: title,
+            optionalDueDateString: optionalDueDateString,
+            rawDueDatePhrase: rawDueDatePhrase,
+            notes: notes,
+            priority: priority
+        )
+    }
+
+    func update(
+        from draft: ReminderDraft,
+        providerName: String?,
+        modelName: String?,
+        status: ExtractedReminderDraftStatus = .pending
+    ) {
+        title = draft.title
+        optionalDueDateString = draft.optionalDueDateString
+        rawDueDatePhrase = draft.rawDueDatePhrase
+        notes = draft.notes
+        priority = draft.priority
+        self.status = status
+        extractionProviderName = providerName
+        extractionModelName = modelName
+        updatedAt = .now
+    }
+
+    func markImported(reminderIdentifier: String?) {
+        status = .imported
+        self.reminderIdentifier = reminderIdentifier
+        updatedAt = .now
+    }
+
+    func markDismissed() {
+        status = .dismissed
+        updatedAt = .now
+    }
+}
+
+extension Transcription {
+    var sortedExtractedReminderDrafts: [ExtractedReminderDraft] {
+        (extractedReminderDrafts ?? []).sorted { lhs, rhs in
+            if lhs.createdAt != rhs.createdAt {
+                return lhs.createdAt < rhs.createdAt
+            }
+            return lhs.id.uuidString < rhs.id.uuidString
+        }
+    }
+
+    var pendingExtractedReminderDrafts: [ExtractedReminderDraft] {
+        sortedExtractedReminderDrafts.filter { $0.status == .pending }
+    }
+}

--- a/VivaDicta/Models/ExtractedReminderDraft.swift
+++ b/VivaDicta/Models/ExtractedReminderDraft.swift
@@ -117,8 +117,16 @@ extension Transcription {
         }
     }
 
+    var activeExtractedReminderDrafts: [ExtractedReminderDraft] {
+        sortedExtractedReminderDrafts.filter { $0.status != .dismissed }
+    }
+
     var pendingExtractedReminderDrafts: [ExtractedReminderDraft] {
-        sortedExtractedReminderDrafts.filter { $0.status == .pending }
+        activeExtractedReminderDrafts.filter { $0.status == .pending }
+    }
+
+    var activeExtractedReminderDraftCount: Int {
+        activeExtractedReminderDrafts.count
     }
 
     var pendingExtractedReminderDraftCount: Int {

--- a/VivaDicta/Models/ReminderDraft.swift
+++ b/VivaDicta/Models/ReminderDraft.swift
@@ -86,10 +86,10 @@ struct ReminderDraftSchema: Sendable {
     @Guide(description: "A concise reminder title, such as 'Call mom' or 'Visit dentist'. Keep it short and actionable.")
     var title: String
 
-    @Guide(description: "An absolute due date in ISO 8601 format with time zone when confidently known, such as 2026-04-15T12:00:00+01:00. Leave nil when the timing is ambiguous or not mentioned.")
+    @Guide(description: "An absolute due date when confidently known. If the note contains a resolvable weekday or relative due phrase such as 'Saturday at 9 am', 'tomorrow noon', or 'next Thursday at 14:00', calculate the exact date using the current date and time zone. Prefer ISO 8601 date-time like 2026-04-19T09:00:00+01:00. Also accept 2026-04-19T09:00:00 when no time zone suffix is present. If only the date is known, 2026-04-19 is acceptable. Leave nil only when the timing is ambiguous or not mentioned.")
     var optionalDueDateString: String?
 
-    @Guide(description: "The original due date phrase from the note, such as 'tomorrow noon' or 'end of week'. Leave nil when no due phrase exists.")
+    @Guide(description: "The original due date phrase from the note, such as 'tomorrow noon' or 'end of week'. Preserve this whenever a due phrase exists, even if optionalDueDateString is also set. Leave nil when no due phrase exists.")
     var rawDueDatePhrase: String?
 
     @Guide(description: "Optional supporting context for the reminder, such as meeting details or follow-up notes. Leave nil if unnecessary.")

--- a/VivaDicta/Models/ReminderDraft.swift
+++ b/VivaDicta/Models/ReminderDraft.swift
@@ -83,7 +83,7 @@ enum ReminderDraftPrioritySchema: String, Sendable {
 @available(iOS 26, *)
 @Generable(description: "A reminder draft extracted from a transcription note for user review before importing into Apple Reminders.")
 struct ReminderDraftSchema: Sendable {
-    @Guide(description: "A concise reminder title, such as 'Call mom' or 'Visit dentist'. Keep it short and actionable.")
+    @Guide(description: "A concise reminder title grounded in the note text. Keep it short and actionable, and preserve the actual action, person, or object mentioned in the note.")
     var title: String
 
     @Guide(description: "An absolute due date when confidently known. If the note contains a resolvable weekday or relative due phrase such as 'Saturday at 9 am', 'tomorrow noon', or 'next Thursday at 14:00', calculate the exact date using the current date and time zone. Prefer ISO 8601 date-time like 2026-04-19T09:00:00+01:00. Also accept 2026-04-19T09:00:00 when no time zone suffix is present. If only the date is known, 2026-04-19 is acceptable. Leave nil only when the timing is ambiguous or not mentioned.")

--- a/VivaDicta/Models/ReminderDraft.swift
+++ b/VivaDicta/Models/ReminderDraft.swift
@@ -1,0 +1,128 @@
+//
+//  ReminderDraft.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.14
+//
+
+import Foundation
+
+enum ReminderDraftPriority: String, Codable, CaseIterable, Sendable {
+    case none
+    case low
+    case medium
+    case high
+
+    var eventKitPriority: Int {
+        switch self {
+        case .none:
+            0
+        case .high:
+            1
+        case .medium:
+            5
+        case .low:
+            9
+        }
+    }
+}
+
+struct ReminderDraft: Codable, Sendable {
+    var title: String
+
+    var optionalDueDateString: String?
+
+    var rawDueDatePhrase: String?
+
+    var notes: String?
+
+    var priority: ReminderDraftPriority
+
+    nonisolated init(
+        title: String,
+        optionalDueDateString: String? = nil,
+        rawDueDatePhrase: String? = nil,
+        notes: String? = nil,
+        priority: ReminderDraftPriority = .none
+    ) {
+        self.title = title
+        self.optionalDueDateString = optionalDueDateString
+        self.rawDueDatePhrase = rawDueDatePhrase
+        self.notes = notes
+        self.priority = priority
+    }
+}
+
+struct ReminderDraftsResponse: Codable, Sendable {
+    var reminders: [ReminderDraft]
+
+    var summary: String?
+
+    nonisolated init(reminders: [ReminderDraft], summary: String? = nil) {
+        self.reminders = reminders
+        self.summary = summary
+    }
+}
+
+#if canImport(FoundationModels)
+import FoundationModels
+
+@available(iOS 26, *)
+@Generable(description: "Priority level for an extracted reminder draft.")
+enum ReminderDraftPrioritySchema: String, Sendable {
+    case none
+    case low
+    case medium
+    case high
+
+    var reminderPriority: ReminderDraftPriority {
+        ReminderDraftPriority(rawValue: rawValue) ?? .none
+    }
+}
+
+@available(iOS 26, *)
+@Generable(description: "A reminder draft extracted from a transcription note for user review before importing into Apple Reminders.")
+struct ReminderDraftSchema: Sendable {
+    @Guide(description: "A concise reminder title, such as 'Call mom' or 'Visit dentist'. Keep it short and actionable.")
+    var title: String
+
+    @Guide(description: "An absolute due date in ISO 8601 format with time zone when confidently known, such as 2026-04-15T12:00:00+01:00. Leave nil when the timing is ambiguous or not mentioned.")
+    var optionalDueDateString: String?
+
+    @Guide(description: "The original due date phrase from the note, such as 'tomorrow noon' or 'end of week'. Leave nil when no due phrase exists.")
+    var rawDueDatePhrase: String?
+
+    @Guide(description: "Optional supporting context for the reminder, such as meeting details or follow-up notes. Leave nil if unnecessary.")
+    var notes: String?
+
+    @Guide(description: "The reminder priority.")
+    var priority: ReminderDraftPrioritySchema
+
+    var reminderDraft: ReminderDraft {
+        ReminderDraft(
+            title: title,
+            optionalDueDateString: optionalDueDateString,
+            rawDueDatePhrase: rawDueDatePhrase,
+            notes: notes,
+            priority: priority.reminderPriority
+        )
+    }
+}
+
+@available(iOS 26, *)
+@Generable(description: "A structured response containing zero or more reminder drafts extracted from a transcription note.")
+struct ReminderDraftsResponseSchema: Sendable {
+    @Guide(description: "Reminder drafts that should be shown to the user for review. Return an empty array when the note does not contain reminder-worthy actions.")
+    var reminders: [ReminderDraftSchema]
+
+    @Guide(description: "Optional short summary of the extraction result, such as 'Found 2 reminder suggestions'.")
+    var summary: String?
+
+    var reminderDraftsResponse: ReminderDraftsResponse {
+        ReminderDraftsResponse(
+            reminders: reminders.map(\.reminderDraft),
+            summary: summary
+        )
+    }
+}
+#endif

--- a/VivaDicta/Models/ReminderDraft.swift
+++ b/VivaDicta/Models/ReminderDraft.swift
@@ -86,13 +86,13 @@ struct ReminderDraftSchema: Sendable {
     @Guide(description: "A concise reminder title grounded in the note text. Keep it short and actionable, and preserve the actual action, person, or object mentioned in the note.")
     var title: String
 
-    @Guide(description: "An optional due date for the reminder in YYYY-MM-DD format. Leave nil if no date is specified or the timing is ambiguous.")
+    @Guide(description: "An optional due date for the reminder in YYYY-MM-DD format. Leave it null when no date is specified or the timing is ambiguous.")
     var dueDateString: String?
 
-    @Guide(description: "An optional due time for the reminder in HH:mm 24-hour format, such as 10:00 or 14:30. Leave nil if no specific time is mentioned.")
+    @Guide(description: "An optional due time for the reminder in HH:mm 24-hour format, such as 10:00 or 14:30. Leave it null when no specific time is mentioned.")
     var dueTimeString: String?
 
-    @Guide(description: "The original due date phrase from the note, such as 'tomorrow noon' or 'end of week'. Preserve this whenever a due phrase exists, even if dueDateString or dueTimeString is also set. Leave nil when no due phrase exists.")
+    @Guide(description: "The original due date phrase from the note, such as 'tomorrow noon' or 'end of week'. Preserve this whenever a due phrase exists, even if dueDateString or dueTimeString is also set. Leave it null when no due phrase exists.")
     var rawDueDatePhrase: String?
 
     @Guide(description: "Optional supporting context for the reminder, such as meeting details or follow-up notes. Leave nil if unnecessary.")
@@ -105,24 +105,38 @@ struct ReminderDraftSchema: Sendable {
         ReminderDraft(
             title: title,
             optionalDueDateString: combinedDueDateString,
-            rawDueDatePhrase: rawDueDatePhrase,
-            notes: notes,
+            rawDueDatePhrase: sanitizedOptionalString(rawDueDatePhrase),
+            notes: sanitizedOptionalString(notes),
             priority: priority.reminderPriority
         )
     }
 
     private var combinedDueDateString: String? {
-        let trimmedDate = dueDateString?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedDate = sanitizedOptionalString(dueDateString)
         guard let trimmedDate, !trimmedDate.isEmpty else {
             return nil
         }
 
-        let trimmedTime = dueTimeString?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedTime = sanitizedOptionalString(dueTimeString)
         guard let trimmedTime, !trimmedTime.isEmpty else {
             return trimmedDate
         }
 
         return "\(trimmedDate)T\(trimmedTime):00"
+    }
+
+    private func sanitizedOptionalString(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+
+        switch trimmed.lowercased() {
+        case "nil", "null", "none":
+            return nil
+        default:
+            return trimmed
+        }
     }
 }
 

--- a/VivaDicta/Models/ReminderDraft.swift
+++ b/VivaDicta/Models/ReminderDraft.swift
@@ -86,10 +86,13 @@ struct ReminderDraftSchema: Sendable {
     @Guide(description: "A concise reminder title grounded in the note text. Keep it short and actionable, and preserve the actual action, person, or object mentioned in the note.")
     var title: String
 
-    @Guide(description: "An absolute due date when confidently known. If the note contains a resolvable weekday or relative due phrase such as 'Saturday at 9 am', 'tomorrow noon', or 'next Thursday at 14:00', calculate the exact date using the current date and time zone. Prefer ISO 8601 date-time like 2026-04-19T09:00:00+01:00. Also accept 2026-04-19T09:00:00 when no time zone suffix is present. If only the date is known, 2026-04-19 is acceptable. Leave nil only when the timing is ambiguous or not mentioned.")
-    var optionalDueDateString: String?
+    @Guide(description: "An optional due date for the reminder in YYYY-MM-DD format. Leave nil if no date is specified or the timing is ambiguous.")
+    var dueDateString: String?
 
-    @Guide(description: "The original due date phrase from the note, such as 'tomorrow noon' or 'end of week'. Preserve this whenever a due phrase exists, even if optionalDueDateString is also set. Leave nil when no due phrase exists.")
+    @Guide(description: "An optional due time for the reminder in HH:mm 24-hour format, such as 10:00 or 14:30. Leave nil if no specific time is mentioned.")
+    var dueTimeString: String?
+
+    @Guide(description: "The original due date phrase from the note, such as 'tomorrow noon' or 'end of week'. Preserve this whenever a due phrase exists, even if dueDateString or dueTimeString is also set. Leave nil when no due phrase exists.")
     var rawDueDatePhrase: String?
 
     @Guide(description: "Optional supporting context for the reminder, such as meeting details or follow-up notes. Leave nil if unnecessary.")
@@ -101,11 +104,25 @@ struct ReminderDraftSchema: Sendable {
     var reminderDraft: ReminderDraft {
         ReminderDraft(
             title: title,
-            optionalDueDateString: optionalDueDateString,
+            optionalDueDateString: combinedDueDateString,
             rawDueDatePhrase: rawDueDatePhrase,
             notes: notes,
             priority: priority.reminderPriority
         )
+    }
+
+    private var combinedDueDateString: String? {
+        let trimmedDate = dueDateString?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let trimmedDate, !trimmedDate.isEmpty else {
+            return nil
+        }
+
+        let trimmedTime = dueTimeString?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let trimmedTime, !trimmedTime.isEmpty else {
+            return trimmedDate
+        }
+
+        return "\(trimmedDate)T\(trimmedTime):00"
     }
 }
 

--- a/VivaDicta/Models/Transcription.swift
+++ b/VivaDicta/Models/Transcription.swift
@@ -103,6 +103,10 @@ class Transcription {
     @Relationship(deleteRule: .cascade)
     var tagAssignments: [TranscriptionTagAssignment]? = []
 
+    /// AI-extracted reminder drafts awaiting review or already imported/dismissed.
+    @Relationship(deleteRule: .cascade)
+    var extractedReminderDrafts: [ExtractedReminderDraft]? = []
+
     /// Chat conversations that reference this transcription as a source note.
     @Relationship(deleteRule: .cascade, inverse: \ChatConversation.transcription)
     var chatConversations: [ChatConversation]? = []

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -279,6 +279,8 @@ class AIService {
             presetId: mode.presetId,
             aiProvider: mode.aiProvider,
             aiModel: mode.aiModel,
+            reminderExtractorProvider: mode.reminderExtractorProvider,
+            reminderExtractorModel: mode.reminderExtractorModel,
             aiEnhanceEnabled: mode.aiEnhanceEnabled,
             useClipboardContext: mode.useClipboardContext,
 
@@ -347,6 +349,8 @@ class AIService {
                     presetId: mode.presetId,
                     aiProvider: mode.aiProvider,
                     aiModel: mode.aiModel,
+                    reminderExtractorProvider: mode.reminderExtractorProvider,
+                    reminderExtractorModel: mode.reminderExtractorModel,
                     aiEnhanceEnabled: false,
                     useClipboardContext: mode.useClipboardContext,
         
@@ -373,6 +377,8 @@ class AIService {
                     presetId: nil,
                     aiProvider: mode.aiProvider,
                     aiModel: mode.aiModel,
+                    reminderExtractorProvider: mode.reminderExtractorProvider,
+                    reminderExtractorModel: mode.reminderExtractorModel,
                     aiEnhanceEnabled: false,
                     useClipboardContext: mode.useClipboardContext,
         
@@ -399,6 +405,8 @@ class AIService {
                     presetId: mode.presetId,
                     aiProvider: nil,
                     aiModel: "",
+                    reminderExtractorProvider: mode.reminderExtractorProvider,
+                    reminderExtractorModel: mode.reminderExtractorModel,
                     aiEnhanceEnabled: false,
                     useClipboardContext: mode.useClipboardContext,
         
@@ -492,6 +500,8 @@ class AIService {
                 presetId: defaultMode.presetId,
                 aiProvider: defaultMode.aiProvider,
                 aiModel: defaultMode.aiModel,
+                reminderExtractorProvider: defaultMode.reminderExtractorProvider,
+                reminderExtractorModel: defaultMode.reminderExtractorModel,
                 aiEnhanceEnabled: defaultMode.aiEnhanceEnabled,
                 useClipboardContext: defaultMode.useClipboardContext,
                 isAutoTextFormattingEnabled: defaultMode.isAutoTextFormattingEnabled,
@@ -2140,6 +2150,8 @@ class AIService {
                     presetId: mode.presetId,
                     aiProvider: nil,
                     aiModel: "",
+                    reminderExtractorProvider: mode.reminderExtractorProvider,
+                    reminderExtractorModel: mode.reminderExtractorModel,
                     aiEnhanceEnabled: false,
                     useClipboardContext: mode.useClipboardContext,
         

--- a/VivaDicta/Services/AIEnhance/VivaMode.swift
+++ b/VivaDicta/Services/AIEnhance/VivaMode.swift
@@ -61,6 +61,12 @@ struct VivaMode: Identifiable, Hashable, Codable {
     /// The specific AI model name for enhancement.
     var aiModel: String
 
+    /// Optional provider override used only for reminder suggestion extraction.
+    var reminderExtractorProvider: AIProvider?
+
+    /// Optional model override used only for reminder suggestion extraction.
+    var reminderExtractorModel: String?
+
     /// Whether AI processing is enabled for this mode.
     let aiEnhanceEnabled: Bool
 
@@ -82,6 +88,8 @@ struct VivaMode: Identifiable, Hashable, Codable {
          presetId: String? = nil,
          aiProvider: AIProvider? = nil,
          aiModel: String,
+         reminderExtractorProvider: AIProvider? = nil,
+         reminderExtractorModel: String? = nil,
          aiEnhanceEnabled: Bool,
          useClipboardContext: Bool = false,
          isAutoTextFormattingEnabled: Bool = false,
@@ -94,6 +102,8 @@ struct VivaMode: Identifiable, Hashable, Codable {
         self.presetId = presetId
         self.aiProvider = aiProvider
         self.aiModel = aiModel
+        self.reminderExtractorProvider = reminderExtractorProvider
+        self.reminderExtractorModel = reminderExtractorModel
         self.aiEnhanceEnabled = aiEnhanceEnabled
         self.useClipboardContext = useClipboardContext
         self.isAutoTextFormattingEnabled = isAutoTextFormattingEnabled
@@ -112,6 +122,8 @@ struct VivaMode: Identifiable, Hashable, Codable {
         transcriptionLanguage = try container.decodeIfPresent(String.self, forKey: .transcriptionLanguage)
         aiProvider = try container.decodeIfPresent(AIProvider.self, forKey: .aiProvider)
         aiModel = try container.decode(String.self, forKey: .aiModel)
+        reminderExtractorProvider = try container.decodeIfPresent(AIProvider.self, forKey: .reminderExtractorProvider)
+        reminderExtractorModel = try container.decodeIfPresent(String.self, forKey: .reminderExtractorModel)
         aiEnhanceEnabled = try container.decode(Bool.self, forKey: .aiEnhanceEnabled)
         useClipboardContext = try container.decodeIfPresent(Bool.self, forKey: .useClipboardContext) ?? false
         isAutoTextFormattingEnabled = try container.decodeIfPresent(Bool.self, forKey: .isAutoTextFormattingEnabled) ?? true
@@ -134,7 +146,7 @@ struct VivaMode: Identifiable, Hashable, Codable {
     private enum CodingKeys: String, CodingKey {
         case id, name, transcriptionProvider, transcriptionModel, transcriptionLanguage
         case presetId, userPrompt
-        case aiProvider, aiModel, aiEnhanceEnabled
+        case aiProvider, aiModel, reminderExtractorProvider, reminderExtractorModel, aiEnhanceEnabled
         case useClipboardContext
         case isAutoTextFormattingEnabled, isSmartInsertEnabled
     }
@@ -150,6 +162,8 @@ struct VivaMode: Identifiable, Hashable, Codable {
         try container.encodeIfPresent(presetId, forKey: .presetId)
         try container.encodeIfPresent(aiProvider, forKey: .aiProvider)
         try container.encode(aiModel, forKey: .aiModel)
+        try container.encodeIfPresent(reminderExtractorProvider, forKey: .reminderExtractorProvider)
+        try container.encodeIfPresent(reminderExtractorModel, forKey: .reminderExtractorModel)
         try container.encode(aiEnhanceEnabled, forKey: .aiEnhanceEnabled)
         try container.encode(useClipboardContext, forKey: .useClipboardContext)
         try container.encode(isAutoTextFormattingEnabled, forKey: .isAutoTextFormattingEnabled)

--- a/VivaDicta/Services/PresetMigrationService.swift
+++ b/VivaDicta/Services/PresetMigrationService.swift
@@ -125,6 +125,8 @@ enum PresetMigrationService {
                     presetId: builtInId,
                     aiProvider: mode.aiProvider,
                     aiModel: mode.aiModel,
+                    reminderExtractorProvider: mode.reminderExtractorProvider,
+                    reminderExtractorModel: mode.reminderExtractorModel,
                     aiEnhanceEnabled: mode.aiEnhanceEnabled
                 )
                 updated = true
@@ -142,6 +144,8 @@ enum PresetMigrationService {
                         presetId: mappedId,
                         aiProvider: mode.aiProvider,
                         aiModel: mode.aiModel,
+                        reminderExtractorProvider: mode.reminderExtractorProvider,
+                        reminderExtractorModel: mode.reminderExtractorModel,
                         aiEnhanceEnabled: mode.aiEnhanceEnabled
                     )
                     updated = true

--- a/VivaDicta/Services/Reminders/AppleFMReminderExtractionProvider.swift
+++ b/VivaDicta/Services/Reminders/AppleFMReminderExtractionProvider.swift
@@ -72,6 +72,13 @@ final class AppleFMReminderExtractionProvider {
         Do not invent deadlines.
         Use concise, actionable titles.
         Move supporting detail into notes.
+        When the note includes a specific date, weekday, or relative phrase that can be resolved, you must calculate the exact absolute due date using the current date and time zone.
+        Examples of resolvable phrases include 'tomorrow noon', 'Saturday at 9 am', 'next Thursday at 14:00', and 'April 20 at 3 PM'.
+        For resolvable phrases, fill optionalDueDateString with an absolute value.
+        Prefer ISO 8601 date-time with time zone, such as 2026-04-19T09:00:00+01:00.
+        A timezone-less value like 2026-04-19T09:00:00 is acceptable if needed.
+        If only the date is known, a date-only value like 2026-04-19 is acceptable.
+        Preserve the original due wording in rawDueDatePhrase whenever a due phrase exists, even when you also provide optionalDueDateString.
         If a due phrase is ambiguous, leave the normalized due date nil and preserve the original wording in rawDueDatePhrase.
         If no reminder-worthy tasks exist, return an empty reminders array.
 

--- a/VivaDicta/Services/Reminders/AppleFMReminderExtractionProvider.swift
+++ b/VivaDicta/Services/Reminders/AppleFMReminderExtractionProvider.swift
@@ -87,13 +87,12 @@ final class AppleFMReminderExtractionProvider {
         - Extract only genuine reminder-worthy actions, next steps, or commitments that the user is likely to want in Apple Reminders.
         - Use a concise, actionable title grounded in the note text.
         - Do not create a reminder whose title is only a date, time, weekday, or scheduling phrase.
-        - A due phrase belongs in optionalDueDateString and rawDueDatePhrase, not in the title.
-        - If the note includes a resolvable date or time such as 'tomorrow noon', 'Saturday at 10 a.m.', 'next Thursday at 14:00', or 'April 20 at 3 PM', calculate the exact absolute due date.
-        - Prefer ISO 8601 date-time with time zone such as 2026-04-19T10:00:00+01:00.
-        - A timezone-less value like 2026-04-19T10:00:00 is acceptable if needed.
-        - If only the date is known, a date-only value like 2026-04-19 is acceptable.
+        - A due phrase belongs in dueDateString, dueTimeString, and rawDueDatePhrase, not in the title.
+        - If the note includes a resolvable day, date, or time such as 'tomorrow noon', 'Saturday at 10 a.m.', 'next Thursday at 14:00', or 'April 20 at 3 PM', calculate the exact due date and time using the current date and time zone.
+        - Set dueDateString in YYYY-MM-DD format when you can determine the date.
+        - Set dueTimeString in HH:mm 24-hour format only when a specific time is mentioned.
         - Preserve the original due wording in rawDueDatePhrase whenever a due phrase exists.
-        - If the timing is ambiguous, leave optionalDueDateString empty and preserve the original wording in rawDueDatePhrase.
+        - If the timing is ambiguous, leave dueDateString and dueTimeString empty and preserve the original wording in rawDueDatePhrase.
         - Return at most one reminder per actionable task.
         - If the note contains no reminder-worthy task, return an empty reminders array.
 
@@ -132,17 +131,17 @@ final class AppleFMReminderExtractionProvider {
         Example 1
         Note: "Okay, I need to visit the dentist on Saturday at 10 a.m."
         Good response:
-        {"reminders":[{"title":"Visit dentist","optionalDueDateString":"\(saturdayAtTen)","rawDueDatePhrase":"Saturday at 10 a.m.","notes":null,"priority":"high"}],"summary":"Found 1 reminder suggestion."}
+        {"reminders":[{"title":"Visit dentist","dueDateString":"\(datePortion(from: saturdayAtTen) ?? "2026-04-18")","dueTimeString":"\(timePortion(from: saturdayAtTen) ?? "10:00")","rawDueDatePhrase":"Saturday at 10 a.m.","notes":null,"priority":"high"}],"summary":"Found 1 reminder suggestion."}
 
         Example 2
         Note: "Okay, I need to call my parents on Sunday at 10 a.m."
         Good response:
-        {"reminders":[{"title":"Call parents","optionalDueDateString":"\(sundayAtTen)","rawDueDatePhrase":"Sunday at 10 a.m.","notes":null,"priority":"high"}],"summary":"Found 1 reminder suggestion."}
+        {"reminders":[{"title":"Call parents","dueDateString":"\(datePortion(from: sundayAtTen) ?? "2026-04-19")","dueTimeString":"\(timePortion(from: sundayAtTen) ?? "10:00")","rawDueDatePhrase":"Sunday at 10 a.m.","notes":null,"priority":"high"}],"summary":"Found 1 reminder suggestion."}
 
         Example 3
         Note: "I have a dinner with my friends this Friday, so please remind me."
         Good response:
-        {"reminders":[{"title":"Dinner with friends","optionalDueDateString":"\(fridayDateOnly)","rawDueDatePhrase":"this Friday","notes":null,"priority":"high"}],"summary":"Found 1 reminder suggestion."}
+        {"reminders":[{"title":"Dinner with friends","dueDateString":"\(fridayDateOnly)","dueTimeString":null,"rawDueDatePhrase":"this Friday","notes":null,"priority":"high"}],"summary":"Found 1 reminder suggestion."}
 
         Example 4
         Note: "I had coffee and answered emails."
@@ -177,6 +176,29 @@ final class AppleFMReminderExtractionProvider {
         }
 
         return date.ISO8601Format()
+    }
+
+    private func datePortion(from isoString: String) -> String? {
+        let trimmed = isoString.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count >= 10 else {
+            return nil
+        }
+
+        return String(trimmed.prefix(10))
+    }
+
+    private func timePortion(from isoString: String) -> String? {
+        guard let timeStart = isoString.firstIndex(of: "T") else {
+            return nil
+        }
+
+        let timeSection = isoString[isoString.index(after: timeStart)...]
+        let timeValue = timeSection.prefix(5)
+        guard timeValue.count == 5 else {
+            return nil
+        }
+
+        return String(timeValue)
     }
 
     private func nextWeekdayDateOnlyString(

--- a/VivaDicta/Services/Reminders/AppleFMReminderExtractionProvider.swift
+++ b/VivaDicta/Services/Reminders/AppleFMReminderExtractionProvider.swift
@@ -91,6 +91,7 @@ final class AppleFMReminderExtractionProvider {
         - If the note includes a resolvable day, date, or time such as 'tomorrow noon', 'Saturday at 10 a.m.', 'next Thursday at 14:00', or 'April 20 at 3 PM', calculate the exact due date and time using the current date and time zone.
         - Set dueDateString in YYYY-MM-DD format when you can determine the date.
         - Set dueTimeString in HH:mm 24-hour format only when a specific time is mentioned.
+        - When a value is missing, use null, not the words 'nil' or 'null'.
         - Preserve the original due wording in rawDueDatePhrase whenever a due phrase exists.
         - If the timing is ambiguous, leave dueDateString and dueTimeString empty and preserve the original wording in rawDueDatePhrase.
         - Return at most one reminder per actionable task.
@@ -105,21 +106,21 @@ final class AppleFMReminderExtractionProvider {
     }
 
     private func fewShotExamples(now: Date, timeZone: TimeZone) -> String {
-        let saturdayAtTen = nextWeekdayDateString(
+        let saturdayAtTen = nextWeekdayDate(
             weekday: 7,
             hour: 10,
             minute: 0,
             now: now,
             timeZone: timeZone
-        ) ?? "2026-04-18T10:00:00+01:00"
+        )
 
-        let sundayAtTen = nextWeekdayDateString(
+        let sundayAtTen = nextWeekdayDate(
             weekday: 1,
             hour: 10,
             minute: 0,
             now: now,
             timeZone: timeZone
-        ) ?? "2026-04-19T10:00:00+01:00"
+        )
 
         let fridayDateOnly = nextWeekdayDateOnlyString(
             weekday: 6,
@@ -131,12 +132,12 @@ final class AppleFMReminderExtractionProvider {
         Example 1
         Note: "Okay, I need to visit the dentist on Saturday at 10 a.m."
         Good response:
-        {"reminders":[{"title":"Visit dentist","dueDateString":"\(datePortion(from: saturdayAtTen) ?? "2026-04-18")","dueTimeString":"\(timePortion(from: saturdayAtTen) ?? "10:00")","rawDueDatePhrase":"Saturday at 10 a.m.","notes":null,"priority":"high"}],"summary":"Found 1 reminder suggestion."}
+        {"reminders":[{"title":"Visit dentist","dueDateString":"\(formattedDateString(from: saturdayAtTen, timeZone: timeZone) ?? "2026-04-18")","dueTimeString":"\(formattedTimeString(from: saturdayAtTen, timeZone: timeZone) ?? "10:00")","rawDueDatePhrase":"Saturday at 10 a.m.","notes":null,"priority":"high"}],"summary":"Found 1 reminder suggestion."}
 
         Example 2
         Note: "Okay, I need to call my parents on Sunday at 10 a.m."
         Good response:
-        {"reminders":[{"title":"Call parents","dueDateString":"\(datePortion(from: sundayAtTen) ?? "2026-04-19")","dueTimeString":"\(timePortion(from: sundayAtTen) ?? "10:00")","rawDueDatePhrase":"Sunday at 10 a.m.","notes":null,"priority":"high"}],"summary":"Found 1 reminder suggestion."}
+        {"reminders":[{"title":"Call parents","dueDateString":"\(formattedDateString(from: sundayAtTen, timeZone: timeZone) ?? "2026-04-19")","dueTimeString":"\(formattedTimeString(from: sundayAtTen, timeZone: timeZone) ?? "10:00")","rawDueDatePhrase":"Sunday at 10 a.m.","notes":null,"priority":"high"}],"summary":"Found 1 reminder suggestion."}
 
         Example 3
         Note: "I have a dinner with my friends this Friday, so please remind me."
@@ -150,13 +151,13 @@ final class AppleFMReminderExtractionProvider {
         """
     }
 
-    private func nextWeekdayDateString(
+    private func nextWeekdayDate(
         weekday: Int,
         hour: Int,
         minute: Int,
         now: Date,
         timeZone: TimeZone
-    ) -> String? {
+    ) -> Date? {
         let calendar = calendar(timeZone: timeZone)
         var components = DateComponents()
         components.weekday = weekday
@@ -175,30 +176,7 @@ final class AppleFMReminderExtractionProvider {
             return nil
         }
 
-        return date.ISO8601Format()
-    }
-
-    private func datePortion(from isoString: String) -> String? {
-        let trimmed = isoString.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard trimmed.count >= 10 else {
-            return nil
-        }
-
-        return String(trimmed.prefix(10))
-    }
-
-    private func timePortion(from isoString: String) -> String? {
-        guard let timeStart = isoString.firstIndex(of: "T") else {
-            return nil
-        }
-
-        let timeSection = isoString[isoString.index(after: timeStart)...]
-        let timeValue = timeSection.prefix(5)
-        guard timeValue.count == 5 else {
-            return nil
-        }
-
-        return String(timeValue)
+        return date
     }
 
     private func nextWeekdayDateOnlyString(
@@ -237,5 +215,29 @@ final class AppleFMReminderExtractionProvider {
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = timeZone
         return calendar
+    }
+
+    private func formattedDateString(from date: Date?, timeZone: TimeZone) -> String? {
+        guard let date else { return nil }
+
+        return date.formatted(
+            Date.VerbatimFormatStyle(
+                format: "\(year: .defaultDigits)-\(month: .twoDigits)-\(day: .twoDigits)",
+                timeZone: timeZone,
+                calendar: calendar(timeZone: timeZone)
+            )
+        )
+    }
+
+    private func formattedTimeString(from date: Date?, timeZone: TimeZone) -> String? {
+        guard let date else { return nil }
+
+        return date.formatted(
+            Date.VerbatimFormatStyle(
+                format: "\(hour: .twoDigits(clock: .twentyFourHour, hourCycle: .zeroBased)):\(minute: .twoDigits)",
+                timeZone: timeZone,
+                calendar: calendar(timeZone: timeZone)
+            )
+        )
     }
 }

--- a/VivaDicta/Services/Reminders/AppleFMReminderExtractionProvider.swift
+++ b/VivaDicta/Services/Reminders/AppleFMReminderExtractionProvider.swift
@@ -66,6 +66,7 @@ final class AppleFMReminderExtractionProvider {
     private func systemPrompt(now: Date, timeZone: TimeZone) -> String {
         """
         You extract reminder suggestions from transcription notes.
+        The user's next message is the note text itself.
 
         Only extract genuine reminder-worthy actions, next steps, or commitments that the user is likely to want in Apple Reminders.
         Do not invent tasks.
@@ -94,12 +95,6 @@ final class AppleFMReminderExtractionProvider {
 
     @PromptBuilder
     private func userPrompt(noteText: String) -> Prompt {
-        """
-        Extract reminder suggestions from the following transcription note.
-
-        <NOTE>
-        \(noteText)
-        </NOTE>
-        """
+        "\(noteText)"
     }
 }

--- a/VivaDicta/Services/Reminders/AppleFMReminderExtractionProvider.swift
+++ b/VivaDicta/Services/Reminders/AppleFMReminderExtractionProvider.swift
@@ -1,0 +1,93 @@
+//
+//  AppleFMReminderExtractionProvider.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.14
+//
+
+import Foundation
+import FoundationModels
+import os
+
+@available(iOS 26, *)
+@MainActor
+final class AppleFMReminderExtractionProvider {
+    private let logger = Logger(category: .reminderExtraction)
+
+    func extract(
+        noteText: String,
+        now: Date,
+        timeZone: TimeZone
+    ) async throws -> ReminderDraftsResponse {
+        guard AppleFoundationModelAvailability.isAvailable else {
+            throw ReminderExtractionError.appleFoundationModelUnavailable
+        }
+
+        let trimmedText = noteText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedText.isEmpty else {
+            return ReminderDraftsResponse(reminders: [])
+        }
+
+        logger.logNotice("Reminder extraction - Starting Apple Foundation Models request")
+
+        let model = SystemLanguageModel(guardrails: .permissiveContentTransformations)
+        let session = LanguageModelSession(
+            model: model,
+            instructions: systemPrompt(now: now, timeZone: timeZone)
+        )
+
+        do {
+            let response = try await session.respond(
+                generating: ReminderDraftsResponseSchema.self,
+                options: GenerationOptions(sampling: .greedy)
+            ) {
+                userPrompt(noteText: trimmedText)
+            }
+
+            logger.logNotice("Reminder extraction - Apple Foundation Models request completed")
+            return response.content.reminderDraftsResponse
+        } catch let error as LanguageModelSession.GenerationError {
+            logger.logError("Reminder extraction - Apple generation error: \(error.localizedDescription)")
+
+            switch error {
+            case .guardrailViolation:
+                throw ReminderExtractionError.appleGuardrailViolation
+            case .refusal:
+                throw ReminderExtractionError.appleRefusal
+            default:
+                throw ReminderExtractionError.extractionFailed(error.localizedDescription)
+            }
+        } catch {
+            logger.logError("Reminder extraction - Apple unexpected error: \(error.localizedDescription)")
+            throw ReminderExtractionError.extractionFailed(error.localizedDescription)
+        }
+    }
+
+    private func systemPrompt(now: Date, timeZone: TimeZone) -> String {
+        """
+        You extract reminder suggestions from transcription notes.
+
+        Only extract genuine reminder-worthy actions, next steps, or commitments that the user is likely to want in Apple Reminders.
+        Do not invent tasks.
+        Do not invent deadlines.
+        Use concise, actionable titles.
+        Move supporting detail into notes.
+        If a due phrase is ambiguous, leave the normalized due date nil and preserve the original wording in rawDueDatePhrase.
+        If no reminder-worthy tasks exist, return an empty reminders array.
+
+        Current absolute date and time: \(now.ISO8601Format())
+        Current time zone identifier: \(timeZone.identifier)
+        """
+    }
+
+    @PromptBuilder
+    private func userPrompt(noteText: String) -> Prompt {
+        """
+        Extract reminder suggestions from the following transcription note.
+
+        <NOTE>
+        \(noteText)
+        </NOTE>
+        """
+    }
+}

--- a/VivaDicta/Services/Reminders/AppleFMReminderExtractionProvider.swift
+++ b/VivaDicta/Services/Reminders/AppleFMReminderExtractionProvider.swift
@@ -71,6 +71,7 @@ final class AppleFMReminderExtractionProvider {
         Do not invent tasks.
         Do not invent deadlines.
         The current note is the only source of truth. Never carry over tasks from previous notes or earlier requests.
+        Every reminder title must be derived from the words and meaning of the current note. Never copy placeholder or example titles from instructions or schemas unless the same task is explicitly present in the note.
         Use concise, actionable titles.
         Move supporting detail into notes.
         Never create a reminder whose title is only a date, time, weekday, or scheduling phrase such as 'Saturday at 10 am'.

--- a/VivaDicta/Services/Reminders/AppleFMReminderExtractionProvider.swift
+++ b/VivaDicta/Services/Reminders/AppleFMReminderExtractionProvider.swift
@@ -70,8 +70,12 @@ final class AppleFMReminderExtractionProvider {
         Only extract genuine reminder-worthy actions, next steps, or commitments that the user is likely to want in Apple Reminders.
         Do not invent tasks.
         Do not invent deadlines.
+        The current note is the only source of truth. Never carry over tasks from previous notes or earlier requests.
         Use concise, actionable titles.
         Move supporting detail into notes.
+        Never create a reminder whose title is only a date, time, weekday, or scheduling phrase such as 'Saturday at 10 am'.
+        A due phrase belongs in the due-date fields of the task it refers to, not as a separate reminder.
+        Return at most one reminder per actionable task or commitment in the note.
         When the note includes a specific date, weekday, or relative phrase that can be resolved, you must calculate the exact absolute due date using the current date and time zone.
         Examples of resolvable phrases include 'tomorrow noon', 'Saturday at 9 am', 'next Thursday at 14:00', and 'April 20 at 3 PM'.
         For resolvable phrases, fill optionalDueDateString with an absolute value.

--- a/VivaDicta/Services/Reminders/AppleFMReminderExtractionProvider.swift
+++ b/VivaDicta/Services/Reminders/AppleFMReminderExtractionProvider.swift
@@ -41,7 +41,7 @@ final class AppleFMReminderExtractionProvider {
                 generating: ReminderDraftsResponseSchema.self,
                 options: GenerationOptions(sampling: .greedy)
             ) {
-                userPrompt(noteText: trimmedText)
+                userPrompt(noteText: trimmedText, now: now, timeZone: timeZone)
             }
 
             logger.logNotice("Reminder extraction - Apple Foundation Models request completed")
@@ -66,30 +66,9 @@ final class AppleFMReminderExtractionProvider {
     private func systemPrompt(now: Date, timeZone: TimeZone) -> String {
         """
         You extract reminder suggestions from transcription notes.
-        The user's next message is the note text itself.
-
-        Only extract genuine reminder-worthy actions, next steps, or commitments that the user is likely to want in Apple Reminders.
-        Do not invent tasks.
-        Do not invent deadlines.
-        The current note is the only source of truth. Never carry over tasks from previous notes or earlier requests.
-        Every reminder title must be derived from the words and meaning of the current note. Never copy placeholder or example titles from instructions or schemas unless the same task is explicitly present in the note.
-        Use concise, actionable titles.
-        Move supporting detail into notes.
-        Never create a reminder whose title is only a date, time, weekday, or scheduling phrase such as 'Saturday at 10 am'.
-        A due phrase belongs in the due-date fields of the task it refers to, not as a separate reminder.
-        Return at most one reminder per actionable task or commitment in the note.
-        When the note includes a specific date, weekday, or relative phrase that can be resolved, you must calculate the exact absolute due date using the current date and time zone.
-        Examples of resolvable phrases include 'tomorrow noon', 'Saturday at 9 am', 'next Thursday at 14:00', and 'April 20 at 3 PM'.
-        For resolvable phrases, fill optionalDueDateString with an absolute value.
-        Prefer ISO 8601 date-time with time zone, such as 2026-04-19T09:00:00+01:00.
-        A timezone-less value like 2026-04-19T09:00:00 is acceptable if needed.
-        If only the date is known, a date-only value like 2026-04-19 is acceptable.
-        Preserve the original due wording in rawDueDatePhrase whenever a due phrase exists, even when you also provide optionalDueDateString.
-        If a due phrase is ambiguous, leave the normalized due date nil and preserve the original wording in rawDueDatePhrase.
-        If no reminder-worthy tasks exist, return an empty reminders array.
-
-        Good extraction examples:
-        \(fewShotExamples(now: now, timeZone: timeZone))
+        Return structured reminder drafts for user review before importing to Apple Reminders.
+        Use only the current note as the source of truth.
+        Do not invent tasks or deadlines.
 
         Current absolute date and time: \(now.ISO8601Format())
         Current time zone identifier: \(timeZone.identifier)
@@ -97,8 +76,33 @@ final class AppleFMReminderExtractionProvider {
     }
 
     @PromptBuilder
-    private func userPrompt(noteText: String) -> Prompt {
-        "\(noteText)"
+    private func userPrompt(noteText: String, now: Date, timeZone: TimeZone) -> Prompt {
+        """
+        Extract reminder suggestions from this note.
+
+        Current absolute date and time: \(now.ISO8601Format())
+        Current time zone: \(timeZone.identifier)
+
+        Rules:
+        - Extract only genuine reminder-worthy actions, next steps, or commitments that the user is likely to want in Apple Reminders.
+        - Use a concise, actionable title grounded in the note text.
+        - Do not create a reminder whose title is only a date, time, weekday, or scheduling phrase.
+        - A due phrase belongs in optionalDueDateString and rawDueDatePhrase, not in the title.
+        - If the note includes a resolvable date or time such as 'tomorrow noon', 'Saturday at 10 a.m.', 'next Thursday at 14:00', or 'April 20 at 3 PM', calculate the exact absolute due date.
+        - Prefer ISO 8601 date-time with time zone such as 2026-04-19T10:00:00+01:00.
+        - A timezone-less value like 2026-04-19T10:00:00 is acceptable if needed.
+        - If only the date is known, a date-only value like 2026-04-19 is acceptable.
+        - Preserve the original due wording in rawDueDatePhrase whenever a due phrase exists.
+        - If the timing is ambiguous, leave optionalDueDateString empty and preserve the original wording in rawDueDatePhrase.
+        - Return at most one reminder per actionable task.
+        - If the note contains no reminder-worthy task, return an empty reminders array.
+
+        Examples of good extraction:
+        \(fewShotExamples(now: now, timeZone: timeZone))
+
+        Note:
+        \(noteText)
+        """
     }
 
     private func fewShotExamples(now: Date, timeZone: TimeZone) -> String {

--- a/VivaDicta/Services/Reminders/AppleFMReminderExtractionProvider.swift
+++ b/VivaDicta/Services/Reminders/AppleFMReminderExtractionProvider.swift
@@ -88,6 +88,9 @@ final class AppleFMReminderExtractionProvider {
         If a due phrase is ambiguous, leave the normalized due date nil and preserve the original wording in rawDueDatePhrase.
         If no reminder-worthy tasks exist, return an empty reminders array.
 
+        Good extraction examples:
+        \(fewShotExamples(now: now, timeZone: timeZone))
+
         Current absolute date and time: \(now.ISO8601Format())
         Current time zone identifier: \(timeZone.identifier)
         """
@@ -96,5 +99,117 @@ final class AppleFMReminderExtractionProvider {
     @PromptBuilder
     private func userPrompt(noteText: String) -> Prompt {
         "\(noteText)"
+    }
+
+    private func fewShotExamples(now: Date, timeZone: TimeZone) -> String {
+        let saturdayAtTen = nextWeekdayDateString(
+            weekday: 7,
+            hour: 10,
+            minute: 0,
+            now: now,
+            timeZone: timeZone
+        ) ?? "2026-04-18T10:00:00+01:00"
+
+        let sundayAtTen = nextWeekdayDateString(
+            weekday: 1,
+            hour: 10,
+            minute: 0,
+            now: now,
+            timeZone: timeZone
+        ) ?? "2026-04-19T10:00:00+01:00"
+
+        let fridayDateOnly = nextWeekdayDateOnlyString(
+            weekday: 6,
+            now: now,
+            timeZone: timeZone
+        ) ?? "2026-04-17"
+
+        return """
+        Example 1
+        Note: "Okay, I need to visit the dentist on Saturday at 10 a.m."
+        Good response:
+        {"reminders":[{"title":"Visit dentist","optionalDueDateString":"\(saturdayAtTen)","rawDueDatePhrase":"Saturday at 10 a.m.","notes":null,"priority":"high"}],"summary":"Found 1 reminder suggestion."}
+
+        Example 2
+        Note: "Okay, I need to call my parents on Sunday at 10 a.m."
+        Good response:
+        {"reminders":[{"title":"Call parents","optionalDueDateString":"\(sundayAtTen)","rawDueDatePhrase":"Sunday at 10 a.m.","notes":null,"priority":"high"}],"summary":"Found 1 reminder suggestion."}
+
+        Example 3
+        Note: "I have a dinner with my friends this Friday, so please remind me."
+        Good response:
+        {"reminders":[{"title":"Dinner with friends","optionalDueDateString":"\(fridayDateOnly)","rawDueDatePhrase":"this Friday","notes":null,"priority":"high"}],"summary":"Found 1 reminder suggestion."}
+
+        Example 4
+        Note: "I had coffee and answered emails."
+        Good response:
+        {"reminders":[],"summary":"No reminder suggestions found."}
+        """
+    }
+
+    private func nextWeekdayDateString(
+        weekday: Int,
+        hour: Int,
+        minute: Int,
+        now: Date,
+        timeZone: TimeZone
+    ) -> String? {
+        let calendar = calendar(timeZone: timeZone)
+        var components = DateComponents()
+        components.weekday = weekday
+        components.hour = hour
+        components.minute = minute
+        components.second = 0
+        components.timeZone = timeZone
+
+        guard let date = calendar.nextDate(
+            after: now.addingTimeInterval(-1),
+            matching: components,
+            matchingPolicy: .nextTimePreservingSmallerComponents,
+            repeatedTimePolicy: .first,
+            direction: .forward
+        ) else {
+            return nil
+        }
+
+        return date.ISO8601Format()
+    }
+
+    private func nextWeekdayDateOnlyString(
+        weekday: Int,
+        now: Date,
+        timeZone: TimeZone
+    ) -> String? {
+        let calendar = calendar(timeZone: timeZone)
+        var components = DateComponents()
+        components.weekday = weekday
+        components.hour = 9
+        components.minute = 0
+        components.second = 0
+        components.timeZone = timeZone
+
+        guard let date = calendar.nextDate(
+            after: now.addingTimeInterval(-1),
+            matching: components,
+            matchingPolicy: .nextTimePreservingSmallerComponents,
+            repeatedTimePolicy: .first,
+            direction: .forward
+        ) else {
+            return nil
+        }
+
+        return date.formatted(
+            Date.VerbatimFormatStyle(
+                format: "\(year: .defaultDigits)-\(month: .twoDigits)-\(day: .twoDigits)",
+                timeZone: timeZone,
+                calendar: calendar
+            )
+        )
+    }
+
+    private func calendar(timeZone: TimeZone) -> Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = timeZone
+        return calendar
     }
 }

--- a/VivaDicta/Services/Reminders/CloudReminderExtractionProvider.swift
+++ b/VivaDicta/Services/Reminders/CloudReminderExtractionProvider.swift
@@ -1,0 +1,342 @@
+//
+//  CloudReminderExtractionProvider.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.14
+//
+
+import Foundation
+import os
+
+@available(iOS 26, *)
+final class CloudReminderExtractionProvider {
+    private let logger = Logger(category: .reminderExtraction)
+    private let aiService: AIService
+
+    init(aiService: AIService) {
+        self.aiService = aiService
+    }
+
+    func canExtract(
+        provider: AIProvider,
+        model: String
+    ) -> Bool {
+        switch provider {
+        case .apple:
+            return false
+        case .anthropic:
+            return provider.apiKey != nil
+        case .ollama:
+            return true
+        case .customOpenAI:
+            return !aiService.customOpenAIEndpointURL.isEmpty && !aiService.customOpenAIModelName.isEmpty
+        case .copilot:
+            return false
+        default:
+            return provider.apiKey != nil
+        }
+    }
+
+    func extract(
+        noteText: String,
+        provider: AIProvider,
+        model: String,
+        now: Date,
+        timeZone: TimeZone
+    ) async throws -> ReminderDraftsResponse {
+        let trimmedText = noteText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedText.isEmpty else {
+            return ReminderDraftsResponse(reminders: [])
+        }
+
+        switch provider {
+        case .anthropic:
+            return try await makeAnthropicRequest(
+                noteText: trimmedText,
+                model: model,
+                apiKey: try apiKey(for: provider),
+                now: now,
+                timeZone: timeZone
+            )
+        case .copilot:
+            throw ReminderExtractionError.providerUnavailable(
+                "Structured reminder extraction is not supported with GitHub Copilot yet."
+            )
+        default:
+            let requestConfig = try requestConfiguration(for: provider)
+            return try await makeOpenAICompatibleRequest(
+                noteText: trimmedText,
+                provider: provider,
+                model: model,
+                url: requestConfig.url,
+                headers: requestConfig.headers,
+                now: now,
+                timeZone: timeZone
+            )
+        }
+    }
+
+    private func requestConfiguration(for provider: AIProvider) throws -> (url: URL, headers: [String: String]) {
+        switch provider {
+        case .ollama:
+            guard let url = URL(string: "\(aiService.ollamaServerURL)/v1/chat/completions") else {
+                throw ReminderExtractionError.providerUnavailable("Invalid Ollama server URL.")
+            }
+            return (url, [:])
+        case .customOpenAI:
+            let endpointURL = aiService.customOpenAIEndpointURL
+            guard !endpointURL.isEmpty,
+                  let url = URL(string: endpointURL) else {
+                throw ReminderExtractionError.providerUnavailable("Custom AI endpoint URL is not configured.")
+            }
+
+            var headers: [String: String] = [:]
+            if let apiKey = AIProvider.customOpenAI.apiKey, !apiKey.isEmpty {
+                headers["Authorization"] = "Bearer \(apiKey)"
+            }
+            return (url, headers)
+        case .apple, .anthropic, .copilot:
+            throw ReminderExtractionError.providerUnavailable("Unsupported reminder extraction provider: \(provider.displayName).")
+        default:
+            guard let url = URL(string: provider.baseURL) else {
+                throw ReminderExtractionError.providerUnavailable("Invalid URL for \(provider.displayName).")
+            }
+            return (url, ["Authorization": "Bearer \(try apiKey(for: provider))"])
+        }
+    }
+
+    private func makeOpenAICompatibleRequest(
+        noteText: String,
+        provider: AIProvider,
+        model: String,
+        url: URL,
+        headers: [String: String],
+        now: Date,
+        timeZone: TimeZone
+    ) async throws -> ReminderDraftsResponse {
+        logger.logNotice("Reminder extraction - Starting structured cloud request provider=\(provider.rawValue) model=\(model)")
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 300
+
+        for (key, value) in headers {
+            request.addValue(value, forHTTPHeaderField: key)
+        }
+
+        let requestBody = try buildOpenAICompatibleRequestBody(
+            model: model,
+            noteText: noteText,
+            now: now,
+            timeZone: timeZone
+        )
+        request.httpBody = try JSONSerialization.data(withJSONObject: requestBody)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw ReminderExtractionError.invalidResponse
+        }
+
+        guard httpResponse.statusCode == 200 else {
+            let errorString = String(data: data, encoding: .utf8) ?? "Unknown error"
+            throw ReminderExtractionError.providerUnavailable(
+                "\(provider.displayName) reminder extraction failed (HTTP \(httpResponse.statusCode)): \(errorString)"
+            )
+        }
+
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let choices = json["choices"] as? [[String: Any]],
+              let firstChoice = choices.first,
+              let message = firstChoice["message"] as? [String: Any],
+              let content = message["content"] as? String,
+              let contentData = content.data(using: .utf8) else {
+            throw ReminderExtractionError.invalidResponse
+        }
+
+        do {
+            let response = try JSONDecoder().decode(ReminderDraftsResponse.self, from: contentData)
+            logger.logNotice("Reminder extraction - Structured cloud request completed provider=\(provider.rawValue)")
+            return response
+        } catch {
+            logger.logError("Reminder extraction - Failed to decode structured cloud response: \(error.localizedDescription)")
+            throw ReminderExtractionError.invalidResponse
+        }
+    }
+
+    private func makeAnthropicRequest(
+        noteText: String,
+        model: String,
+        apiKey: String,
+        now: Date,
+        timeZone: TimeZone
+    ) async throws -> ReminderDraftsResponse {
+        logger.logNotice("Reminder extraction - Starting Anthropic structured request model=\(model)")
+
+        var request = URLRequest(url: URL(string: AIProvider.anthropic.baseURL)!)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addValue(apiKey, forHTTPHeaderField: "x-api-key")
+        request.addValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+        request.timeoutInterval = 300
+
+        let schema = try reminderSchemaObject()
+        let systemMessage = systemMessage(now: now, timeZone: timeZone)
+        let userMessage = userMessage(noteText: noteText)
+
+        let body: [String: Any] = [
+            "model": model,
+            "max_tokens": 4096,
+            "system": systemMessage,
+            "messages": [
+                ["role": "user", "content": userMessage]
+            ],
+            "tools": [
+                [
+                    "name": "return_reminder_drafts",
+                    "description": "Return reminder drafts extracted from the note using the provided schema.",
+                    "input_schema": schema
+                ]
+            ],
+            "tool_choice": [
+                "type": "tool",
+                "name": "return_reminder_drafts"
+            ]
+        ]
+
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw ReminderExtractionError.invalidResponse
+        }
+
+        guard httpResponse.statusCode == 200 else {
+            let errorString = String(data: data, encoding: .utf8) ?? "Unknown error"
+            throw ReminderExtractionError.providerUnavailable(
+                "Anthropic reminder extraction failed (HTTP \(httpResponse.statusCode)): \(errorString)"
+            )
+        }
+
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let content = json["content"] as? [[String: Any]],
+              let toolCall = content.first(where: { ($0["type"] as? String) == "tool_use" }),
+              let input = toolCall["input"] as? [String: Any] else {
+            throw ReminderExtractionError.invalidResponse
+        }
+
+        let inputData = try JSONSerialization.data(withJSONObject: input)
+        do {
+            let response = try JSONDecoder().decode(ReminderDraftsResponse.self, from: inputData)
+            logger.logNotice("Reminder extraction - Anthropic structured request completed model=\(model)")
+            return response
+        } catch {
+            logger.logError("Reminder extraction - Failed to decode Anthropic tool payload: \(error.localizedDescription)")
+            throw ReminderExtractionError.invalidResponse
+        }
+    }
+
+    private func buildOpenAICompatibleRequestBody(
+        model: String,
+        noteText: String,
+        now: Date,
+        timeZone: TimeZone
+    ) throws -> [String: Any] {
+        let messages: [[String: Any]] = [
+            ["role": "system", "content": systemMessage(now: now, timeZone: timeZone)],
+            ["role": "user", "content": userMessage(noteText: noteText)]
+        ]
+
+        var requestBody: [String: Any] = [
+            "model": model,
+            "messages": messages,
+            "stream": false,
+            "response_format": [
+                "type": "json_schema",
+                "json_schema": [
+                    "name": "reminder_drafts_response",
+                    "strict": true,
+                    "schema": try reminderSchemaObject()
+                ]
+            ]
+        ]
+
+        if model.lowercased().hasPrefix("gpt-5") == false {
+            requestBody["temperature"] = 0.2
+        }
+
+        if let reasoningEffort = ReasoningConfig.getReasoningParameter(for: model) {
+            requestBody["reasoning_effort"] = reasoningEffort
+        }
+
+        if let extraBody = ReasoningConfig.getExtraBodyParameters(for: model) {
+            for (key, value) in extraBody {
+                requestBody[key] = value
+            }
+        }
+
+        return requestBody
+    }
+
+    private func reminderSchemaObject() throws -> [String: Any] {
+        let data = try JSONEncoder().encode(ReminderDraftsResponseSchema.generationSchema)
+        guard var schema = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw ReminderExtractionError.invalidResponse
+        }
+        sanitizeSchema(&schema)
+        return schema
+    }
+
+    private func sanitizeSchema(_ value: inout [String: Any]) {
+        value.removeValue(forKey: "x-order")
+        for (key, child) in value {
+            if var childDictionary = child as? [String: Any] {
+                sanitizeSchema(&childDictionary)
+                value[key] = childDictionary
+            } else if var childArray = child as? [[String: Any]] {
+                for index in childArray.indices {
+                    sanitizeSchema(&childArray[index])
+                }
+                value[key] = childArray
+            }
+        }
+    }
+
+    private func systemMessage(now: Date, timeZone: TimeZone) -> String {
+        """
+        You extract reminder suggestions from transcription notes.
+
+        Only extract genuine reminder-worthy actions, commitments, or follow-ups that belong in Apple Reminders.
+        Do not invent tasks.
+        Do not invent deadlines.
+        Use concise, actionable titles.
+        Put supporting detail into notes.
+        If timing is ambiguous, keep optionalDueDateString null and preserve the original wording in rawDueDatePhrase.
+        If no reminder-worthy tasks exist, return an empty reminders array.
+
+        Current absolute date and time: \(now.ISO8601Format())
+        Current time zone identifier: \(timeZone.identifier)
+        """
+    }
+
+    private func userMessage(noteText: String) -> String {
+        """
+        Extract reminder suggestions from the following transcription note.
+
+        <NOTE>
+        \(noteText)
+        </NOTE>
+        """
+    }
+
+    private func apiKey(for provider: AIProvider) throws -> String {
+        guard let apiKey = provider.apiKey, !apiKey.isEmpty else {
+            throw ReminderExtractionError.providerUnavailable(
+                "Add an API key for \(provider.displayName) to use cloud reminder extraction."
+            )
+        }
+        return apiKey
+    }
+}

--- a/VivaDicta/Services/Reminders/CloudReminderExtractionProvider.swift
+++ b/VivaDicta/Services/Reminders/CloudReminderExtractionProvider.swift
@@ -8,6 +8,65 @@
 import Foundation
 import os
 
+private struct CloudReminderDraftPayload: Codable {
+    var title: String
+    var dueDateString: String?
+    var dueTimeString: String?
+    var rawDueDatePhrase: String?
+    var notes: String?
+    var priority: ReminderDraftPriority
+
+    var reminderDraft: ReminderDraft {
+        ReminderDraft(
+            title: title,
+            optionalDueDateString: combinedDueDateString,
+            rawDueDatePhrase: sanitizedOptionalString(rawDueDatePhrase),
+            notes: sanitizedOptionalString(notes),
+            priority: priority
+        )
+    }
+
+    private var combinedDueDateString: String? {
+        let trimmedDate = sanitizedOptionalString(dueDateString)
+        guard let trimmedDate, !trimmedDate.isEmpty else {
+            return nil
+        }
+
+        let trimmedTime = sanitizedOptionalString(dueTimeString)
+        guard let trimmedTime, !trimmedTime.isEmpty else {
+            return trimmedDate
+        }
+
+        return "\(trimmedDate)T\(trimmedTime):00"
+    }
+
+    private func sanitizedOptionalString(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+
+        switch trimmed.lowercased() {
+        case "nil", "null", "none":
+            return nil
+        default:
+            return trimmed
+        }
+    }
+}
+
+private struct CloudReminderDraftsPayload: Codable {
+    var reminders: [CloudReminderDraftPayload]
+    var summary: String?
+
+    var reminderDraftsResponse: ReminderDraftsResponse {
+        ReminderDraftsResponse(
+            reminders: reminders.map(\.reminderDraft),
+            summary: summary
+        )
+    }
+}
+
 final class CloudReminderExtractionProvider {
     private let logger = Logger(category: .reminderExtraction)
     private let aiService: AIService
@@ -155,9 +214,9 @@ final class CloudReminderExtractionProvider {
         }
 
         do {
-            let response = try JSONDecoder().decode(ReminderDraftsResponse.self, from: contentData)
+            let response = try JSONDecoder().decode(CloudReminderDraftsPayload.self, from: contentData)
             logger.logNotice("Reminder extraction - Structured cloud request completed provider=\(provider.rawValue)")
-            return response
+            return response.reminderDraftsResponse
         } catch {
             logger.logError("Reminder extraction - Failed to decode structured cloud response: \(error.localizedDescription)")
             throw ReminderExtractionError.invalidResponse
@@ -182,7 +241,7 @@ final class CloudReminderExtractionProvider {
 
         let schema = reminderSchemaObject()
         let systemMessage = systemMessage(now: now, timeZone: timeZone)
-        let userMessage = userMessage(noteText: noteText)
+        let userMessage = userMessage(noteText: noteText, now: now, timeZone: timeZone)
 
         let body: [String: Any] = [
             "model": model,
@@ -228,9 +287,9 @@ final class CloudReminderExtractionProvider {
 
         let inputData = try JSONSerialization.data(withJSONObject: input)
         do {
-            let response = try JSONDecoder().decode(ReminderDraftsResponse.self, from: inputData)
+            let response = try JSONDecoder().decode(CloudReminderDraftsPayload.self, from: inputData)
             logger.logNotice("Reminder extraction - Anthropic structured request completed model=\(model)")
-            return response
+            return response.reminderDraftsResponse
         } catch {
             logger.logError("Reminder extraction - Failed to decode Anthropic tool payload: \(error.localizedDescription)")
             throw ReminderExtractionError.invalidResponse
@@ -245,7 +304,7 @@ final class CloudReminderExtractionProvider {
     ) throws -> [String: Any] {
         let messages: [[String: Any]] = [
             ["role": "system", "content": systemMessage(now: now, timeZone: timeZone)],
-            ["role": "user", "content": userMessage(noteText: noteText)]
+            ["role": "user", "content": userMessage(noteText: noteText, now: now, timeZone: timeZone)]
         ]
 
         var requestBody: [String: Any] = [
@@ -286,32 +345,168 @@ final class CloudReminderExtractionProvider {
     private func systemMessage(now: Date, timeZone: TimeZone) -> String {
         """
         You extract reminder suggestions from transcription notes.
-
-        Only extract genuine reminder-worthy actions, commitments, or follow-ups that belong in Apple Reminders.
-        Do not invent tasks.
-        Do not invent deadlines.
-        The current note is the only source of truth. Never carry over tasks from previous notes or earlier requests.
-        Use concise, actionable titles.
-        Put supporting detail into notes.
-        Never create a reminder whose title is only a date, time, weekday, or scheduling phrase such as 'Saturday at 10 am'.
-        A due phrase belongs in the due-date fields of the task it refers to, not as a separate reminder.
-        Return at most one reminder per actionable task or commitment in the note.
-        If timing is ambiguous, keep optionalDueDateString null and preserve the original wording in rawDueDatePhrase.
-        If no reminder-worthy tasks exist, return an empty reminders array.
+        Return structured reminder drafts for user review before importing to Apple Reminders.
+        Use only the current note as the source of truth.
+        Do not invent tasks or deadlines.
 
         Current absolute date and time: \(now.ISO8601Format())
         Current time zone identifier: \(timeZone.identifier)
         """
     }
 
-    private func userMessage(noteText: String) -> String {
+    private func userMessage(noteText: String, now: Date, timeZone: TimeZone) -> String {
         """
-        Extract reminder suggestions from the following transcription note.
+        Extract reminder suggestions from this note.
 
-        <NOTE>
+        Current absolute date and time: \(now.ISO8601Format())
+        Current time zone: \(timeZone.identifier)
+
+        Rules:
+        - Extract only genuine reminder-worthy actions, commitments, or follow-ups that belong in Apple Reminders.
+        - Use a concise, actionable title grounded in the note text.
+        - Do not create a reminder whose title is only a date, time, weekday, or scheduling phrase.
+        - A due phrase belongs in dueDateString, dueTimeString, and rawDueDatePhrase, not in the title.
+        - If the note includes a resolvable day, date, or time such as 'tomorrow noon', 'Saturday at 10 a.m.', 'next Thursday at 14:00', or 'April 20 at 3 PM', calculate the exact due date and time using the current date and time zone.
+        - Set dueDateString in YYYY-MM-DD format when you can determine the date.
+        - Set dueTimeString in HH:mm 24-hour format only when a specific time is mentioned.
+        - When a value is missing, use null, not the words 'nil' or 'null'.
+        - Preserve the original due wording in rawDueDatePhrase whenever a due phrase exists.
+        - If the timing is ambiguous, leave dueDateString and dueTimeString empty and preserve the original wording in rawDueDatePhrase.
+        - Return at most one reminder per actionable task.
+        - If the note contains no reminder-worthy task, return an empty reminders array.
+
+        Examples of good extraction:
+        \(fewShotExamples(now: now, timeZone: timeZone))
+
+        Note:
         \(noteText)
-        </NOTE>
         """
+    }
+
+    private func fewShotExamples(now: Date, timeZone: TimeZone) -> String {
+        let saturdayAtTen = nextWeekdayDate(
+            weekday: 7,
+            hour: 10,
+            minute: 0,
+            now: now,
+            timeZone: timeZone
+        )
+
+        let sundayAtTen = nextWeekdayDate(
+            weekday: 1,
+            hour: 10,
+            minute: 0,
+            now: now,
+            timeZone: timeZone
+        )
+
+        let fridayDateOnly = nextWeekdayDateOnlyString(
+            weekday: 6,
+            now: now,
+            timeZone: timeZone
+        ) ?? "2026-04-17"
+
+        return """
+        Example 1
+        Note: "Okay, I need to visit the dentist on Saturday at 10 a.m."
+        Good response:
+        {"reminders":[{"title":"Visit dentist","dueDateString":"\(formattedDateString(from: saturdayAtTen, timeZone: timeZone) ?? "2026-04-18")","dueTimeString":"\(formattedTimeString(from: saturdayAtTen, timeZone: timeZone) ?? "10:00")","rawDueDatePhrase":"Saturday at 10 a.m.","notes":null,"priority":"high"}],"summary":"Found 1 reminder suggestion."}
+
+        Example 2
+        Note: "Okay, I need to call my parents on Sunday at 10 a.m."
+        Good response:
+        {"reminders":[{"title":"Call parents","dueDateString":"\(formattedDateString(from: sundayAtTen, timeZone: timeZone) ?? "2026-04-19")","dueTimeString":"\(formattedTimeString(from: sundayAtTen, timeZone: timeZone) ?? "10:00")","rawDueDatePhrase":"Sunday at 10 a.m.","notes":null,"priority":"high"}],"summary":"Found 1 reminder suggestion."}
+
+        Example 3
+        Note: "I have a dinner with my friends this Friday, so please remind me."
+        Good response:
+        {"reminders":[{"title":"Dinner with friends","dueDateString":"\(fridayDateOnly)","dueTimeString":null,"rawDueDatePhrase":"this Friday","notes":null,"priority":"high"}],"summary":"Found 1 reminder suggestion."}
+
+        Example 4
+        Note: "I had coffee and answered emails."
+        Good response:
+        {"reminders":[],"summary":"No reminder suggestions found."}
+        """
+    }
+
+    private func nextWeekdayDate(
+        weekday: Int,
+        hour: Int,
+        minute: Int,
+        now: Date,
+        timeZone: TimeZone
+    ) -> Date? {
+        let calendar = calendar(timeZone: timeZone)
+        var components = DateComponents()
+        components.weekday = weekday
+        components.hour = hour
+        components.minute = minute
+        components.second = 0
+        components.timeZone = timeZone
+
+        return calendar.nextDate(
+            after: now.addingTimeInterval(-1),
+            matching: components,
+            matchingPolicy: .nextTimePreservingSmallerComponents,
+            repeatedTimePolicy: .first,
+            direction: .forward
+        )
+    }
+
+    private func nextWeekdayDateOnlyString(
+        weekday: Int,
+        now: Date,
+        timeZone: TimeZone
+    ) -> String? {
+        let calendar = calendar(timeZone: timeZone)
+        var components = DateComponents()
+        components.weekday = weekday
+        components.hour = 9
+        components.minute = 0
+        components.second = 0
+        components.timeZone = timeZone
+
+        guard let date = calendar.nextDate(
+            after: now.addingTimeInterval(-1),
+            matching: components,
+            matchingPolicy: .nextTimePreservingSmallerComponents,
+            repeatedTimePolicy: .first,
+            direction: .forward
+        ) else {
+            return nil
+        }
+
+        return formattedDateString(from: date, timeZone: timeZone)
+    }
+
+    private func calendar(timeZone: TimeZone) -> Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = timeZone
+        return calendar
+    }
+
+    private func formattedDateString(from date: Date?, timeZone: TimeZone) -> String? {
+        guard let date else { return nil }
+
+        return date.formatted(
+            Date.VerbatimFormatStyle(
+                format: "\(year: .defaultDigits)-\(month: .twoDigits)-\(day: .twoDigits)",
+                timeZone: timeZone,
+                calendar: calendar(timeZone: timeZone)
+            )
+        )
+    }
+
+    private func formattedTimeString(from date: Date?, timeZone: TimeZone) -> String? {
+        guard let date else { return nil }
+
+        return date.formatted(
+            Date.VerbatimFormatStyle(
+                format: "\(hour: .twoDigits(clock: .twentyFourHour, hourCycle: .zeroBased)):\(minute: .twoDigits)",
+                timeZone: timeZone,
+                calendar: calendar(timeZone: timeZone)
+            )
+        )
     }
 
     private func apiKey(for provider: AIProvider) throws -> String {

--- a/VivaDicta/Services/Reminders/CloudReminderExtractionProvider.swift
+++ b/VivaDicta/Services/Reminders/CloudReminderExtractionProvider.swift
@@ -290,8 +290,12 @@ final class CloudReminderExtractionProvider {
         Only extract genuine reminder-worthy actions, commitments, or follow-ups that belong in Apple Reminders.
         Do not invent tasks.
         Do not invent deadlines.
+        The current note is the only source of truth. Never carry over tasks from previous notes or earlier requests.
         Use concise, actionable titles.
         Put supporting detail into notes.
+        Never create a reminder whose title is only a date, time, weekday, or scheduling phrase such as 'Saturday at 10 am'.
+        A due phrase belongs in the due-date fields of the task it refers to, not as a separate reminder.
+        Return at most one reminder per actionable task or commitment in the note.
         If timing is ambiguous, keep optionalDueDateString null and preserve the original wording in rawDueDatePhrase.
         If no reminder-worthy tasks exist, return an empty reminders array.
 

--- a/VivaDicta/Services/Reminders/CloudReminderExtractionProvider.swift
+++ b/VivaDicta/Services/Reminders/CloudReminderExtractionProvider.swift
@@ -82,8 +82,6 @@ final class CloudReminderExtractionProvider {
         switch provider {
         case .apple:
             return false
-        case .anthropic:
-            return provider.apiKey != nil
         case .ollama:
             return true
         case .customOpenAI:
@@ -91,7 +89,7 @@ final class CloudReminderExtractionProvider {
         case .copilot:
             return false
         default:
-            return provider.apiKey != nil
+            return aiService.connectedProviders.contains(provider)
         }
     }
 
@@ -109,10 +107,120 @@ final class CloudReminderExtractionProvider {
 
         switch provider {
         case .anthropic:
+            if VivAgentsClient.isEnabled && VivAgentsClient.isAnthropicCliActive {
+                do {
+                    return try await makeVivAgentsRequest(
+                        noteText: trimmedText,
+                        model: model,
+                        provider: "anthropic",
+                        now: now,
+                        timeZone: timeZone
+                    )
+                } catch {
+                    if provider.apiKey != nil {
+                        logger.logWarning("Reminder extraction - Anthropic CLI failed, falling back to API key: \(error.localizedDescription)")
+                    } else {
+                        throw error
+                    }
+                }
+            }
+
             return try await makeAnthropicRequest(
                 noteText: trimmedText,
                 model: model,
                 apiKey: try apiKey(for: provider),
+                now: now,
+                timeZone: timeZone
+            )
+        case .openAI:
+            if aiService.isOpenAISignedIn {
+                do {
+                    return try await makeOpenAIOAuthRequest(
+                        noteText: trimmedText,
+                        model: model,
+                        now: now,
+                        timeZone: timeZone
+                    )
+                } catch {
+                    if (VivAgentsClient.isEnabled && VivAgentsClient.isCodexCliActive) || provider.apiKey != nil {
+                        logger.logWarning("Reminder extraction - OpenAI OAuth failed, falling back: \(error.localizedDescription)")
+                    } else {
+                        throw error
+                    }
+                }
+            }
+
+            if VivAgentsClient.isEnabled && VivAgentsClient.isCodexCliActive {
+                do {
+                    return try await makeVivAgentsRequest(
+                        noteText: trimmedText,
+                        model: model,
+                        provider: "codex",
+                        now: now,
+                        timeZone: timeZone
+                    )
+                } catch {
+                    if provider.apiKey != nil {
+                        logger.logWarning("Reminder extraction - Codex CLI failed, falling back to API key: \(error.localizedDescription)")
+                    } else {
+                        throw error
+                    }
+                }
+            }
+
+            let requestConfig = try requestConfiguration(for: provider)
+            return try await makeOpenAICompatibleRequest(
+                noteText: trimmedText,
+                provider: provider,
+                model: model,
+                url: requestConfig.url,
+                headers: requestConfig.headers,
+                now: now,
+                timeZone: timeZone
+            )
+        case .gemini:
+            if aiService.isGeminiSignedIn {
+                do {
+                    return try await makeGeminiOAuthRequest(
+                        noteText: trimmedText,
+                        model: model,
+                        now: now,
+                        timeZone: timeZone
+                    )
+                } catch {
+                    if (VivAgentsClient.isEnabled && VivAgentsClient.isGeminiCliActive) || provider.apiKey != nil {
+                        logger.logWarning("Reminder extraction - Gemini OAuth failed, falling back: \(error.localizedDescription)")
+                    } else {
+                        throw error
+                    }
+                }
+            }
+
+            if VivAgentsClient.isEnabled && VivAgentsClient.isGeminiCliActive {
+                do {
+                    return try await makeVivAgentsRequest(
+                        noteText: trimmedText,
+                        model: model,
+                        provider: "gemini",
+                        now: now,
+                        timeZone: timeZone
+                    )
+                } catch {
+                    if provider.apiKey != nil {
+                        logger.logWarning("Reminder extraction - Gemini CLI failed, falling back to API key: \(error.localizedDescription)")
+                    } else {
+                        throw error
+                    }
+                }
+            }
+
+            let requestConfig = try requestConfiguration(for: provider)
+            return try await makeOpenAICompatibleRequest(
+                noteText: trimmedText,
+                provider: provider,
+                model: model,
+                url: requestConfig.url,
+                headers: requestConfig.headers,
                 now: now,
                 timeZone: timeZone
             )
@@ -221,6 +329,58 @@ final class CloudReminderExtractionProvider {
             logger.logError("Reminder extraction - Failed to decode structured cloud response: \(error.localizedDescription)")
             throw ReminderExtractionError.invalidResponse
         }
+    }
+
+    private func makeOpenAIOAuthRequest(
+        noteText: String,
+        model: String,
+        now: Date,
+        timeZone: TimeZone
+    ) async throws -> ReminderDraftsResponse {
+        let provider = OpenAIOAuthProvider()
+        let (token, accountId, _) = try await OAuthManager.shared.validAccessToken(for: provider)
+        let responseText = try await OpenAIOAuthClient.enhance(
+            text: textTransportUserMessage(noteText: noteText, now: now, timeZone: timeZone),
+            systemPrompt: systemMessage(now: now, timeZone: timeZone),
+            model: model,
+            accessToken: token,
+            accountId: accountId
+        )
+        return try decodeTextResponse(responseText)
+    }
+
+    private func makeGeminiOAuthRequest(
+        noteText: String,
+        model: String,
+        now: Date,
+        timeZone: TimeZone
+    ) async throws -> ReminderDraftsResponse {
+        let provider = GeminiOAuthProvider()
+        let (token, _, projectId) = try await OAuthManager.shared.validAccessToken(for: provider)
+        let responseText = try await GeminiAPIClient.enhance(
+            text: textTransportUserMessage(noteText: noteText, now: now, timeZone: timeZone),
+            systemPrompt: systemMessage(now: now, timeZone: timeZone),
+            model: model,
+            accessToken: token,
+            projectId: projectId
+        )
+        return try decodeTextResponse(responseText)
+    }
+
+    private func makeVivAgentsRequest(
+        noteText: String,
+        model: String,
+        provider: String,
+        now: Date,
+        timeZone: TimeZone
+    ) async throws -> ReminderDraftsResponse {
+        let responseText = try await VivAgentsClient.enhance(
+            text: textTransportUserMessage(noteText: noteText, now: now, timeZone: timeZone),
+            systemPrompt: systemMessage(now: now, timeZone: timeZone),
+            model: model,
+            provider: provider
+        )
+        return try decodeTextResponse(responseText)
     }
 
     private func makeAnthropicRequest(
@@ -336,6 +496,34 @@ final class CloudReminderExtractionProvider {
         }
 
         return requestBody
+    }
+
+    private func textTransportUserMessage(
+        noteText: String,
+        now: Date,
+        timeZone: TimeZone
+    ) -> String {
+        """
+        \(userMessage(noteText: noteText, now: now, timeZone: timeZone))
+
+        Return only a valid JSON object.
+        Do not wrap the JSON in markdown fences.
+        Do not add explanations before or after the JSON.
+        Use exactly this top-level shape:
+        {
+          "reminders": [
+            {
+              "title": "string",
+              "dueDateString": "YYYY-MM-DD or null",
+              "dueTimeString": "HH:mm or null",
+              "rawDueDatePhrase": "string or null",
+              "notes": "string or null",
+              "priority": "none|low|medium|high"
+            }
+          ],
+          "summary": "string or null"
+        }
+        """
     }
 
     private func reminderSchemaObject() -> [String: Any] {
@@ -516,5 +704,44 @@ final class CloudReminderExtractionProvider {
             )
         }
         return apiKey
+    }
+
+    private func decodeTextResponse(_ text: String) throws -> ReminderDraftsResponse {
+        for candidate in candidateJSONPayloads(from: text) {
+            guard let data = candidate.data(using: .utf8) else { continue }
+            if let response = try? JSONDecoder().decode(CloudReminderDraftsPayload.self, from: data) {
+                return response.reminderDraftsResponse
+            }
+        }
+
+        logger.logError("Reminder extraction - Failed to decode text transport response: \(text)")
+        throw ReminderExtractionError.invalidResponse
+    }
+
+    private func candidateJSONPayloads(from text: String) -> [String] {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        var candidates: [String] = [trimmed]
+
+        if trimmed.hasPrefix("```"), trimmed.hasSuffix("```") {
+            let lines = trimmed.components(separatedBy: .newlines)
+            if lines.count >= 3 {
+                let unfenced = lines.dropFirst().dropLast().joined(separator: "\n")
+                candidates.append(unfenced.trimmingCharacters(in: .whitespacesAndNewlines))
+            }
+        }
+
+        if let start = trimmed.firstIndex(of: "{"),
+           let end = trimmed.lastIndex(of: "}") {
+            let object = String(trimmed[start...end])
+            candidates.append(object)
+        }
+
+        var uniqueCandidates: [String] = []
+        for candidate in candidates where !candidate.isEmpty {
+            if uniqueCandidates.contains(candidate) == false {
+                uniqueCandidates.append(candidate)
+            }
+        }
+        return uniqueCandidates
     }
 }

--- a/VivaDicta/Services/Reminders/CloudReminderExtractionProvider.swift
+++ b/VivaDicta/Services/Reminders/CloudReminderExtractionProvider.swift
@@ -8,7 +8,6 @@
 import Foundation
 import os
 
-@available(iOS 26, *)
 final class CloudReminderExtractionProvider {
     private let logger = Logger(category: .reminderExtraction)
     private let aiService: AIService
@@ -181,7 +180,7 @@ final class CloudReminderExtractionProvider {
         request.addValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
         request.timeoutInterval = 300
 
-        let schema = try reminderSchemaObject()
+        let schema = reminderSchemaObject()
         let systemMessage = systemMessage(now: now, timeZone: timeZone)
         let userMessage = userMessage(noteText: noteText)
 
@@ -258,7 +257,7 @@ final class CloudReminderExtractionProvider {
                 "json_schema": [
                     "name": "reminder_drafts_response",
                     "strict": true,
-                    "schema": try reminderSchemaObject()
+                    "schema": reminderSchemaObject()
                 ]
             ]
         ]
@@ -280,28 +279,8 @@ final class CloudReminderExtractionProvider {
         return requestBody
     }
 
-    private func reminderSchemaObject() throws -> [String: Any] {
-        let data = try JSONEncoder().encode(ReminderDraftsResponseSchema.generationSchema)
-        guard var schema = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            throw ReminderExtractionError.invalidResponse
-        }
-        sanitizeSchema(&schema)
-        return schema
-    }
-
-    private func sanitizeSchema(_ value: inout [String: Any]) {
-        value.removeValue(forKey: "x-order")
-        for (key, child) in value {
-            if var childDictionary = child as? [String: Any] {
-                sanitizeSchema(&childDictionary)
-                value[key] = childDictionary
-            } else if var childArray = child as? [[String: Any]] {
-                for index in childArray.indices {
-                    sanitizeSchema(&childArray[index])
-                }
-                value[key] = childArray
-            }
-        }
+    private func reminderSchemaObject() -> [String: Any] {
+        ReminderDraftsJSONSchema.object
     }
 
     private func systemMessage(now: Date, timeZone: TimeZone) -> String {

--- a/VivaDicta/Services/Reminders/ReminderDraftsJSONSchema.swift
+++ b/VivaDicta/Services/Reminders/ReminderDraftsJSONSchema.swift
@@ -33,7 +33,7 @@ enum ReminderDraftsJSONSchema {
         "properties": [
             "title": [
                 "type": "string",
-                "description": "A concise reminder title, such as 'Call mom' or 'Visit dentist'. Keep it short and actionable."
+                "description": "A concise reminder title grounded in the note text. Keep it short and actionable, and preserve the actual action, person, or object mentioned in the note."
             ],
             "optionalDueDateString": nullableString(
                 description: "An absolute due date when confidently known. If the note contains a resolvable weekday or relative due phrase such as 'Saturday at 9 am', 'tomorrow noon', or 'next Thursday at 14:00', calculate the exact date using the current date and time zone. Prefer ISO 8601 date-time like 2026-04-19T09:00:00+01:00. Also accept 2026-04-19T09:00:00 when no time zone suffix is present. If only the date is known, 2026-04-19 is acceptable. Use null only when the timing is ambiguous or not mentioned."

--- a/VivaDicta/Services/Reminders/ReminderDraftsJSONSchema.swift
+++ b/VivaDicta/Services/Reminders/ReminderDraftsJSONSchema.swift
@@ -36,10 +36,10 @@ enum ReminderDraftsJSONSchema {
                 "description": "A concise reminder title, such as 'Call mom' or 'Visit dentist'. Keep it short and actionable."
             ],
             "optionalDueDateString": nullableString(
-                description: "An absolute due date in ISO 8601 format with time zone when confidently known, such as 2026-04-15T12:00:00+01:00. Use null when the timing is ambiguous or not mentioned."
+                description: "An absolute due date when confidently known. If the note contains a resolvable weekday or relative due phrase such as 'Saturday at 9 am', 'tomorrow noon', or 'next Thursday at 14:00', calculate the exact date using the current date and time zone. Prefer ISO 8601 date-time like 2026-04-19T09:00:00+01:00. Also accept 2026-04-19T09:00:00 when no time zone suffix is present. If only the date is known, 2026-04-19 is acceptable. Use null only when the timing is ambiguous or not mentioned."
             ),
             "rawDueDatePhrase": nullableString(
-                description: "The original due date phrase from the note, such as 'tomorrow noon' or 'end of week'. Use null when no due phrase exists."
+                description: "The original due date phrase from the note, such as 'tomorrow noon' or 'end of week'. Preserve this whenever a due phrase exists, even if optionalDueDateString is also set. Use null when no due phrase exists."
             ),
             "notes": nullableString(
                 description: "Optional supporting context for the reminder, such as meeting details or follow-up notes. Use null if unnecessary."

--- a/VivaDicta/Services/Reminders/ReminderDraftsJSONSchema.swift
+++ b/VivaDicta/Services/Reminders/ReminderDraftsJSONSchema.swift
@@ -35,11 +35,14 @@ enum ReminderDraftsJSONSchema {
                 "type": "string",
                 "description": "A concise reminder title grounded in the note text. Keep it short and actionable, and preserve the actual action, person, or object mentioned in the note."
             ],
-            "optionalDueDateString": nullableString(
-                description: "An absolute due date when confidently known. If the note contains a resolvable weekday or relative due phrase such as 'Saturday at 9 am', 'tomorrow noon', or 'next Thursday at 14:00', calculate the exact date using the current date and time zone. Prefer ISO 8601 date-time like 2026-04-19T09:00:00+01:00. Also accept 2026-04-19T09:00:00 when no time zone suffix is present. If only the date is known, 2026-04-19 is acceptable. Use null only when the timing is ambiguous or not mentioned."
+            "dueDateString": nullableString(
+                description: "An optional due date for the reminder in YYYY-MM-DD format. Leave it null when no date is specified or the timing is ambiguous."
+            ),
+            "dueTimeString": nullableString(
+                description: "An optional due time for the reminder in HH:mm 24-hour format, such as 10:00 or 14:30. Leave it null when no specific time is mentioned."
             ),
             "rawDueDatePhrase": nullableString(
-                description: "The original due date phrase from the note, such as 'tomorrow noon' or 'end of week'. Preserve this whenever a due phrase exists, even if optionalDueDateString is also set. Use null when no due phrase exists."
+                description: "The original due date phrase from the note, such as 'tomorrow noon' or 'end of week'. Preserve this whenever a due phrase exists, even if dueDateString or dueTimeString is also set. Use null when no due phrase exists."
             ),
             "notes": nullableString(
                 description: "Optional supporting context for the reminder, such as meeting details or follow-up notes. Use null if unnecessary."
@@ -52,7 +55,8 @@ enum ReminderDraftsJSONSchema {
         ],
         "required": [
             "title",
-            "optionalDueDateString",
+            "dueDateString",
+            "dueTimeString",
             "rawDueDatePhrase",
             "notes",
             "priority"

--- a/VivaDicta/Services/Reminders/ReminderDraftsJSONSchema.swift
+++ b/VivaDicta/Services/Reminders/ReminderDraftsJSONSchema.swift
@@ -1,0 +1,68 @@
+//
+//  ReminderDraftsJSONSchema.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.14
+//
+
+import Foundation
+
+enum ReminderDraftsJSONSchema {
+    static let object: [String: Any] = [
+        "type": "object",
+        "additionalProperties": false,
+        "properties": [
+            "reminders": [
+                "type": "array",
+                "description": "Reminder drafts that should be shown to the user for review. Return an empty array when the note does not contain reminder-worthy actions.",
+                "items": reminderDraftObject
+            ],
+            "summary": nullableString(
+                description: "Optional short summary of the extraction result, such as 'Found 2 reminder suggestions'."
+            )
+        ],
+        "required": [
+            "reminders",
+            "summary"
+        ]
+    ]
+
+    private static let reminderDraftObject: [String: Any] = [
+        "type": "object",
+        "additionalProperties": false,
+        "properties": [
+            "title": [
+                "type": "string",
+                "description": "A concise reminder title, such as 'Call mom' or 'Visit dentist'. Keep it short and actionable."
+            ],
+            "optionalDueDateString": nullableString(
+                description: "An absolute due date in ISO 8601 format with time zone when confidently known, such as 2026-04-15T12:00:00+01:00. Use null when the timing is ambiguous or not mentioned."
+            ),
+            "rawDueDatePhrase": nullableString(
+                description: "The original due date phrase from the note, such as 'tomorrow noon' or 'end of week'. Use null when no due phrase exists."
+            ),
+            "notes": nullableString(
+                description: "Optional supporting context for the reminder, such as meeting details or follow-up notes. Use null if unnecessary."
+            ),
+            "priority": [
+                "type": "string",
+                "description": "The reminder priority.",
+                "enum": ReminderDraftPriority.allCases.map(\.rawValue)
+            ]
+        ],
+        "required": [
+            "title",
+            "optionalDueDateString",
+            "rawDueDatePhrase",
+            "notes",
+            "priority"
+        ]
+    ]
+
+    private static func nullableString(description: String) -> [String: Any] {
+        [
+            "type": ["string", "null"],
+            "description": description
+        ]
+    }
+}

--- a/VivaDicta/Services/Reminders/ReminderDueDateParser.swift
+++ b/VivaDicta/Services/Reminders/ReminderDueDateParser.swift
@@ -21,7 +21,7 @@ enum ReminderDueDateParser {
     ).parseStrategy
 
     static func parse(_ dueDateString: String?) -> Date? {
-        guard let trimmed = dueDateString?.trimmingCharacters(in: .whitespacesAndNewlines),
+        guard let trimmed = normalizedDueDateString(dueDateString),
               !trimmed.isEmpty else {
             return nil
         }
@@ -39,28 +39,18 @@ enum ReminderDueDateParser {
         }
 
         if trimmed.count == 10 {
-            let parts = trimmed.split(separator: "-")
-            guard parts.count == 3,
-                  let year = Int(parts[0]),
-                  let month = Int(parts[1]),
-                  let day = Int(parts[2]) else {
-                return nil
-            }
-
-            var components = DateComponents()
-            components.calendar = .current
-            components.timeZone = .current
-            components.year = year
-            components.month = month
-            components.day = day
-            components.hour = 9
-            return components.date
+            return dateOnlyComponents(from: trimmed)?.date
         }
 
         return nil
     }
 
     static func dueDateComponents(from dueDateString: String?) -> DateComponents? {
+        if let normalized = normalizedDueDateString(dueDateString),
+           normalized.count == 10 {
+            return dateOnlyComponents(from: normalized)
+        }
+
         guard let dueDate = parse(dueDateString) else {
             return nil
         }
@@ -75,6 +65,12 @@ enum ReminderDueDateParser {
     }
 
     static func displayText(dueDateString: String?, rawDueDatePhrase: String?) -> String? {
+        if let normalized = normalizedDueDateString(dueDateString),
+           normalized.count == 10,
+           let dateOnly = parse(normalized) {
+            return dateOnly.formatted(date: .abbreviated, time: .omitted)
+        }
+
         if let dueDate = parse(dueDateString) {
             return dueDate.formatted(date: .abbreviated, time: .shortened)
         }
@@ -164,14 +160,12 @@ enum ReminderDueDateParser {
 
         var components = DateComponents()
         components.weekday = weekdayEntry.value
-        components.hour = 9
-        components.minute = 0
-        components.second = 0
         components.timeZone = timeZone
 
         if let hourValue {
             components.hour = convertedHour(hourValue, meridiem: meridiem)
             components.minute = minuteValue
+            components.second = 0
         }
 
         guard let resolvedDate = searchCalendar.nextDate(
@@ -184,7 +178,49 @@ enum ReminderDueDateParser {
             return nil
         }
 
+        if hourValue == nil {
+            return resolvedDate.formatted(
+                Date.VerbatimFormatStyle(
+                    format: "\(year: .defaultDigits)-\(month: .twoDigits)-\(day: .twoDigits)",
+                    timeZone: timeZone,
+                    calendar: searchCalendar
+                )
+            )
+        }
+
         return resolvedDate.ISO8601Format()
+    }
+
+    private static func normalizedDueDateString(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+
+        switch trimmed.lowercased() {
+        case "nil", "null", "none":
+            return nil
+        default:
+            return trimmed
+        }
+    }
+
+    private static func dateOnlyComponents(from value: String) -> DateComponents? {
+        let parts = value.split(separator: "-")
+        guard parts.count == 3,
+              let year = Int(parts[0]),
+              let month = Int(parts[1]),
+              let day = Int(parts[2]) else {
+            return nil
+        }
+
+        var components = DateComponents()
+        components.calendar = .current
+        components.timeZone = .current
+        components.year = year
+        components.month = month
+        components.day = day
+        return components
     }
 
     private static func convertedHour(_ hour: Int, meridiem: Substring?) -> Int {

--- a/VivaDicta/Services/Reminders/ReminderDueDateParser.swift
+++ b/VivaDicta/Services/Reminders/ReminderDueDateParser.swift
@@ -8,6 +8,18 @@
 import Foundation
 
 enum ReminderDueDateParser {
+    private static let isoWithoutTimeZoneParseStrategy = Date.VerbatimFormatStyle(
+        format: "\(year: .defaultDigits)-\(month: .twoDigits)-\(day: .twoDigits)T\(hour: .twoDigits(clock: .twentyFourHour, hourCycle: .zeroBased)):\(minute: .twoDigits):\(second: .twoDigits)",
+        timeZone: .current,
+        calendar: .current
+    ).parseStrategy
+
+    private static let spacedDateTimeParseStrategy = Date.VerbatimFormatStyle(
+        format: "\(year: .defaultDigits)-\(month: .twoDigits)-\(day: .twoDigits) \(hour: .twoDigits(clock: .twentyFourHour, hourCycle: .zeroBased)):\(minute: .twoDigits):\(second: .twoDigits)",
+        timeZone: .current,
+        calendar: .current
+    ).parseStrategy
+
     static func parse(_ dueDateString: String?) -> Date? {
         guard let trimmed = dueDateString?.trimmingCharacters(in: .whitespacesAndNewlines),
               !trimmed.isEmpty else {
@@ -15,6 +27,14 @@ enum ReminderDueDateParser {
         }
 
         if let date = try? Date(trimmed, strategy: .iso8601) {
+            return date
+        }
+
+        if let date = try? Date(trimmed, strategy: isoWithoutTimeZoneParseStrategy) {
+            return date
+        }
+
+        if let date = try? Date(trimmed, strategy: spacedDateTimeParseStrategy) {
             return date
         }
 

--- a/VivaDicta/Services/Reminders/ReminderDueDateParser.swift
+++ b/VivaDicta/Services/Reminders/ReminderDueDateParser.swift
@@ -1,0 +1,69 @@
+//
+//  ReminderDueDateParser.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.14
+//
+
+import Foundation
+
+enum ReminderDueDateParser {
+    static func parse(_ dueDateString: String?) -> Date? {
+        guard let trimmed = dueDateString?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+
+        if let date = try? Date(trimmed, strategy: .iso8601) {
+            return date
+        }
+
+        if trimmed.count == 10 {
+            let parts = trimmed.split(separator: "-")
+            guard parts.count == 3,
+                  let year = Int(parts[0]),
+                  let month = Int(parts[1]),
+                  let day = Int(parts[2]) else {
+                return nil
+            }
+
+            var components = DateComponents()
+            components.calendar = .current
+            components.timeZone = .current
+            components.year = year
+            components.month = month
+            components.day = day
+            components.hour = 9
+            return components.date
+        }
+
+        return nil
+    }
+
+    static func dueDateComponents(from dueDateString: String?) -> DateComponents? {
+        guard let dueDate = parse(dueDateString) else {
+            return nil
+        }
+
+        var components = Calendar.current.dateComponents(
+            [.calendar, .timeZone, .year, .month, .day, .hour, .minute, .second],
+            from: dueDate
+        )
+        components.calendar = .current
+        components.timeZone = .current
+        return components
+    }
+
+    static func displayText(dueDateString: String?, rawDueDatePhrase: String?) -> String? {
+        if let dueDate = parse(dueDateString) {
+            return dueDate.formatted(date: .abbreviated, time: .shortened)
+        }
+
+        guard let rawDueDatePhrase,
+              !rawDueDatePhrase.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return nil
+        }
+
+        return rawDueDatePhrase
+    }
+}

--- a/VivaDicta/Services/Reminders/ReminderDueDateParser.swift
+++ b/VivaDicta/Services/Reminders/ReminderDueDateParser.swift
@@ -86,4 +86,144 @@ enum ReminderDueDateParser {
 
         return rawDueDatePhrase
     }
+
+    static func splitEmbeddedDuePhrase(
+        from title: String,
+        now: Date,
+        timeZone: TimeZone
+    ) -> (cleanTitle: String, rawDueDatePhrase: String?, dueDateString: String?) {
+        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedTitle.isEmpty else {
+            return ("", nil, nil)
+        }
+
+        if let match = match(
+            pattern: #"(?i)^(.*?)(?:\s+on\s+(?:a\s+)?)((?:monday|tuesday|wednesday|thursday|friday|saturday|sunday)(?:\s+at\s+\d{1,2}(?::\d{2})?\s*(?:a\.?m\.?|p\.?m\.?))?)\.?$"#,
+            in: trimmedTitle
+        ) {
+            let cleanTitle = cleanedActionTitle(match.prefix)
+            let rawPhrase = cleanedDuePhrase(match.suffix)
+            return (
+                cleanTitle,
+                rawPhrase,
+                resolvedDueDateString(from: rawPhrase, now: now, timeZone: timeZone)
+            )
+        }
+
+        if let match = match(
+            pattern: #"(?i)^(.*?)(?:\s+)(this\s+(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday)(?:\s+at\s+\d{1,2}(?::\d{2})?\s*(?:a\.?m\.?|p\.?m\.?))?)\.?$"#,
+            in: trimmedTitle
+        ) {
+            let cleanTitle = cleanedActionTitle(match.prefix)
+            let rawPhrase = cleanedDuePhrase(match.suffix)
+            return (
+                cleanTitle,
+                rawPhrase,
+                resolvedDueDateString(from: rawPhrase, now: now, timeZone: timeZone)
+            )
+        }
+
+        return (trimmedTitle, nil, nil)
+    }
+
+    private static func resolvedDueDateString(
+        from rawPhrase: String?,
+        now: Date,
+        timeZone: TimeZone
+    ) -> String? {
+        guard let rawPhrase else { return nil }
+
+        let normalized = rawPhrase
+            .lowercased()
+            .replacingOccurrences(of: ".", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let weekdays: [String: Int] = [
+            "sunday": 1,
+            "monday": 2,
+            "tuesday": 3,
+            "wednesday": 4,
+            "thursday": 5,
+            "friday": 6,
+            "saturday": 7
+        ]
+
+        guard let weekdayEntry = weekdays.first(where: { normalized.contains($0.key) }) else {
+            return nil
+        }
+
+        let calendar = Calendar(identifier: .gregorian)
+        var searchCalendar = calendar
+        searchCalendar.timeZone = timeZone
+
+        let timePattern = /(\d{1,2})(?::(\d{2}))?\s*(am|pm)/
+        let timeMatch = normalized.firstMatch(of: timePattern)
+        let hourValue = Int(timeMatch?.output.1 ?? "")
+        let minuteValue = Int(timeMatch?.output.2 ?? "") ?? 0
+        let meridiem = timeMatch?.output.3
+
+        var components = DateComponents()
+        components.weekday = weekdayEntry.value
+        components.hour = 9
+        components.minute = 0
+        components.second = 0
+        components.timeZone = timeZone
+
+        if let hourValue {
+            components.hour = convertedHour(hourValue, meridiem: meridiem)
+            components.minute = minuteValue
+        }
+
+        guard let resolvedDate = searchCalendar.nextDate(
+            after: now.addingTimeInterval(-1),
+            matching: components,
+            matchingPolicy: .nextTimePreservingSmallerComponents,
+            repeatedTimePolicy: .first,
+            direction: .forward
+        ) else {
+            return nil
+        }
+
+        return resolvedDate.ISO8601Format()
+    }
+
+    private static func convertedHour(_ hour: Int, meridiem: Substring?) -> Int {
+        guard let meridiem else { return hour }
+        switch meridiem {
+        case "pm" where hour < 12:
+            return hour + 12
+        case "am" where hour == 12:
+            return 0
+        default:
+            return hour
+        }
+    }
+
+    private static func cleanedActionTitle(_ value: Substring) -> String {
+        value
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+    }
+
+    private static func cleanedDuePhrase(_ value: Substring) -> String {
+        value
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+    }
+
+    private static func match(pattern: String, in text: String) -> (prefix: Substring, suffix: Substring)? {
+        guard let regex = try? NSRegularExpression(pattern: pattern) else {
+            return nil
+        }
+
+        let range = NSRange(text.startIndex..., in: text)
+        guard let result = regex.firstMatch(in: text, options: [], range: range),
+              result.numberOfRanges >= 3,
+              let prefixRange = Range(result.range(at: 1), in: text),
+              let suffixRange = Range(result.range(at: 2), in: text) else {
+            return nil
+        }
+
+        return (text[prefixRange], text[suffixRange])
+    }
 }

--- a/VivaDicta/Services/Reminders/ReminderExtractionService.swift
+++ b/VivaDicta/Services/Reminders/ReminderExtractionService.swift
@@ -157,7 +157,7 @@ final class ReminderExtractionService {
         backend: ReminderExtractionBackend,
         modelContext: ModelContext
     ) -> [ExtractedReminderDraft] {
-        let existingDrafts = transcription.sortedExtractedReminderDrafts
+        let existingDrafts = reminderDrafts(for: transcription, modelContext: modelContext)
         let importedDrafts = existingDrafts.filter { $0.status == .imported }
 
         existingDrafts
@@ -175,10 +175,11 @@ final class ReminderExtractionService {
             modelName = model
         }
 
+        let sanitizedDrafts = sanitizeDrafts(drafts)
         var seenKeys = Set<String>()
         var persistedDrafts: [ExtractedReminderDraft] = []
 
-        for draft in drafts {
+        for draft in sanitizedDrafts {
             let normalizedDraftTitle = normalizedTitle(for: draft.title)
             guard !normalizedDraftTitle.isEmpty else { continue }
 
@@ -209,6 +210,96 @@ final class ReminderExtractionService {
         return persistedDrafts
     }
 
+    private func reminderDrafts(
+        for transcription: Transcription,
+        modelContext: ModelContext
+    ) -> [ExtractedReminderDraft] {
+        let descriptor = FetchDescriptor<ExtractedReminderDraft>(
+            sortBy: [SortDescriptor(\.createdAt), SortDescriptor(\.id)]
+        )
+        let allDrafts = (try? modelContext.fetch(descriptor)) ?? []
+        return allDrafts.filter { $0.transcription?.id == transcription.id }
+    }
+
+    private func sanitizeDrafts(_ drafts: [ReminderDraft]) -> [ReminderDraft] {
+        var mergedDrafts: [ReminderDraft] = []
+
+        for draft in drafts {
+            guard shouldKeepDraft(draft) else { continue }
+
+            let normalizedCandidateTitle = normalizedTitle(for: draft.title)
+            guard !normalizedCandidateTitle.isEmpty else { continue }
+
+            if let existingIndex = mergedDrafts.firstIndex(where: {
+                normalizedTitle(for: $0.title) == normalizedCandidateTitle
+            }) {
+                let existingDraft = mergedDrafts[existingIndex]
+                let shouldMerge = existingDraft.optionalDueDateString == draft.optionalDueDateString
+                    || existingDraft.optionalDueDateString == nil
+                    || draft.optionalDueDateString == nil
+                    || normalizedTitle(for: existingDraft.rawDueDatePhrase ?? "") == normalizedTitle(for: draft.rawDueDatePhrase ?? "")
+
+                if shouldMerge {
+                    mergedDrafts[existingIndex] = mergedDraft(existingDraft, with: draft)
+                    continue
+                }
+            }
+
+            mergedDrafts.append(normalizedDraft(draft))
+        }
+
+        return mergedDrafts
+    }
+
+    private func shouldKeepDraft(_ draft: ReminderDraft) -> Bool {
+        let normalizedDraftTitle = normalizedTitle(for: draft.title)
+        guard !normalizedDraftTitle.isEmpty else { return false }
+
+        let normalizedDuePhrase = normalizedTitle(for: draft.rawDueDatePhrase ?? "")
+        if !normalizedDuePhrase.isEmpty && normalizedDraftTitle == normalizedDuePhrase {
+            return false
+        }
+
+        return likelyTimingOnlyTitle(draft.title) == false
+    }
+
+    private func normalizedDraft(_ draft: ReminderDraft) -> ReminderDraft {
+        ReminderDraft(
+            title: draft.title.trimmingCharacters(in: .whitespacesAndNewlines),
+            optionalDueDateString: normalizedOptionalString(draft.optionalDueDateString),
+            rawDueDatePhrase: normalizedOptionalString(draft.rawDueDatePhrase),
+            notes: normalizedOptionalString(draft.notes),
+            priority: draft.priority
+        )
+    }
+
+    private func mergedDraft(_ lhs: ReminderDraft, with rhs: ReminderDraft) -> ReminderDraft {
+        let preferred = draftScore(lhs) >= draftScore(rhs) ? lhs : rhs
+        let secondary = preferred.title == lhs.title
+            && preferred.optionalDueDateString == lhs.optionalDueDateString
+            && preferred.rawDueDatePhrase == lhs.rawDueDatePhrase
+            && preferred.notes == lhs.notes
+            && preferred.priority == lhs.priority ? rhs : lhs
+
+        return ReminderDraft(
+            title: preferred.title,
+            optionalDueDateString: preferred.optionalDueDateString ?? secondary.optionalDueDateString,
+            rawDueDatePhrase: preferred.rawDueDatePhrase ?? secondary.rawDueDatePhrase,
+            notes: preferred.notes ?? secondary.notes,
+            priority: mergedPriority(preferred.priority, secondary.priority)
+        )
+    }
+
+    private func draftScore(_ draft: ReminderDraft) -> Int {
+        var score = 0
+        if normalizedOptionalString(draft.optionalDueDateString) != nil { score += 4 }
+        if normalizedOptionalString(draft.rawDueDatePhrase) != nil { score += 2 }
+        if normalizedOptionalString(draft.notes) != nil { score += 2 }
+        if draft.priority != .none { score += 1 }
+        score += draft.title.count / 20
+        return score
+    }
+
     private func normalizedTitle(for title: String) -> String {
         title
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -217,7 +308,48 @@ final class ReminderExtractionService {
             .joined(separator: " ")
     }
 
+    private func normalizedOptionalString(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
+    }
+
+    private func likelyTimingOnlyTitle(_ title: String) -> Bool {
+        let normalized = normalizedTitle(for: title)
+        guard !normalized.isEmpty else { return false }
+
+        let dateWords = [
+            "monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday",
+            "today", "tomorrow", "tonight", "morning", "afternoon", "evening", "noon"
+        ]
+
+        let containsDateWord = dateWords.contains { normalized.contains($0) }
+        let containsTimeMarker = normalized.contains("am") || normalized.contains("pm") || normalized.contains(":")
+
+        guard containsDateWord else { return false }
+        return containsTimeMarker || normalized.split(separator: " ").count <= 3
+    }
+
     private func draftKey(title: String, dueDateString: String?) -> String {
         "\(title)|\(dueDateString ?? "")"
+    }
+
+    private func mergedPriority(_ lhs: ReminderDraftPriority, _ rhs: ReminderDraftPriority) -> ReminderDraftPriority {
+        func rank(_ priority: ReminderDraftPriority) -> Int {
+            switch priority {
+            case .high:
+                3
+            case .medium:
+                2
+            case .low:
+                1
+            case .none:
+                0
+            }
+        }
+
+        return rank(lhs) >= rank(rhs) ? lhs : rhs
     }
 }

--- a/VivaDicta/Services/Reminders/ReminderExtractionService.swift
+++ b/VivaDicta/Services/Reminders/ReminderExtractionService.swift
@@ -1,0 +1,209 @@
+//
+//  ReminderExtractionService.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.14
+//
+
+import Foundation
+import SwiftData
+import os
+
+enum ReminderExtractionError: LocalizedError {
+    case unsupportedOS
+    case noExtractorAvailable
+    case providerUnavailable(String)
+    case appleFoundationModelUnavailable
+    case appleGuardrailViolation
+    case appleRefusal
+    case extractionFailed(String)
+    case invalidResponse
+
+    var errorDescription: String? {
+        switch self {
+        case .unsupportedOS:
+            return "Reminder extraction requires iOS 26 or later."
+        case .noExtractorAvailable:
+            return "No reminder extraction model is available for the current mode."
+        case .providerUnavailable(let message):
+            return message
+        case .appleFoundationModelUnavailable:
+            return "Apple Intelligence is not available on this device right now."
+        case .appleGuardrailViolation:
+            return "Apple Intelligence blocked this reminder extraction request due to safety guardrails."
+        case .appleRefusal:
+            return "Apple Intelligence declined to extract reminders from this note."
+        case .extractionFailed(let message):
+            return "Reminder extraction failed: \(message)"
+        case .invalidResponse:
+            return "The reminder extraction response could not be parsed."
+        }
+    }
+}
+
+@available(iOS 26, *)
+private enum ReminderExtractionBackend {
+    case apple
+    case cloud(provider: AIProvider, model: String)
+}
+
+@MainActor
+final class ReminderExtractionService {
+    private let logger = Logger(category: .reminderExtraction)
+    private let aiService: AIService
+
+    init(aiService: AIService) {
+        self.aiService = aiService
+    }
+
+    func canExtractReminders(using mode: VivaMode? = nil) -> Bool {
+        guard #available(iOS 26, *) else {
+            return false
+        }
+
+        do {
+            return try resolvedBackend(for: mode ?? aiService.selectedMode) != nil
+        } catch {
+            return false
+        }
+    }
+
+    func extractAndPersist(
+        for transcription: Transcription,
+        modelContext: ModelContext,
+        mode: VivaMode? = nil
+    ) async throws -> [ExtractedReminderDraft] {
+        guard #available(iOS 26, *) else {
+            throw ReminderExtractionError.unsupportedOS
+        }
+
+        let activeMode = mode ?? aiService.selectedMode
+        guard let backend = try resolvedBackend(for: activeMode) else {
+            throw ReminderExtractionError.noExtractorAvailable
+        }
+
+        let now = Date()
+        let timeZone = TimeZone.current
+        let response: ReminderDraftsResponse
+
+        switch backend {
+        case .apple:
+            response = try await AppleFMReminderExtractionProvider().extract(
+                noteText: transcription.text,
+                now: now,
+                timeZone: timeZone
+            )
+        case .cloud(let provider, let model):
+            response = try await CloudReminderExtractionProvider(aiService: aiService).extract(
+                noteText: transcription.text,
+                provider: provider,
+                model: model,
+                now: now,
+                timeZone: timeZone
+            )
+        }
+
+        let persistedDrafts = persist(
+            response.reminders,
+            on: transcription,
+            backend: backend,
+            modelContext: modelContext
+        )
+
+        try modelContext.save()
+        logger.logNotice("Reminder extraction - Persisted \(persistedDrafts.count) draft(s) for note \(transcription.id.uuidString)")
+        return persistedDrafts
+    }
+
+    @available(iOS 26, *)
+    private func resolvedBackend(for mode: VivaMode) throws -> ReminderExtractionBackend? {
+        if let provider = mode.aiProvider,
+           !mode.aiModel.isEmpty {
+            if provider == .apple, AppleFoundationModelAvailability.isAvailable {
+                return .apple
+            }
+
+            let cloudProvider = CloudReminderExtractionProvider(aiService: aiService)
+            if cloudProvider.canExtract(provider: provider, model: mode.aiModel) {
+                return .cloud(provider: provider, model: mode.aiModel)
+            }
+        }
+
+        if AppleFoundationModelAvailability.isAvailable {
+            return .apple
+        }
+
+        return nil
+    }
+
+    @available(iOS 26, *)
+    private func persist(
+        _ drafts: [ReminderDraft],
+        on transcription: Transcription,
+        backend: ReminderExtractionBackend,
+        modelContext: ModelContext
+    ) -> [ExtractedReminderDraft] {
+        let existingDrafts = transcription.sortedExtractedReminderDrafts
+        let importedDrafts = existingDrafts.filter { $0.status == .imported }
+
+        existingDrafts
+            .filter { $0.status != .imported }
+            .forEach { modelContext.delete($0) }
+
+        let providerName: String?
+        let modelName: String?
+        switch backend {
+        case .apple:
+            providerName = AIProvider.apple.displayName
+            modelName = AIProvider.apple.defaultModel
+        case .cloud(let provider, let model):
+            providerName = provider.displayName
+            modelName = model
+        }
+
+        var seenKeys = Set<String>()
+        var persistedDrafts: [ExtractedReminderDraft] = []
+
+        for draft in drafts {
+            let normalizedDraftTitle = normalizedTitle(for: draft.title)
+            guard !normalizedDraftTitle.isEmpty else { continue }
+
+            let dedupeKey = draftKey(title: normalizedDraftTitle, dueDateString: draft.optionalDueDateString)
+            guard !seenKeys.contains(dedupeKey) else { continue }
+            seenKeys.insert(dedupeKey)
+
+            let alreadyImported = importedDrafts.contains {
+                draftKey(
+                    title: normalizedTitle(for: $0.title),
+                    dueDateString: $0.optionalDueDateString
+                ) == dedupeKey
+            }
+
+            guard !alreadyImported else { continue }
+
+            let storedDraft = ExtractedReminderDraft()
+            storedDraft.update(
+                from: draft,
+                providerName: providerName,
+                modelName: modelName
+            )
+            storedDraft.transcription = transcription
+            modelContext.insert(storedDraft)
+            persistedDrafts.append(storedDraft)
+        }
+
+        return persistedDrafts
+    }
+
+    private func normalizedTitle(for title: String) -> String {
+        title
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .split(whereSeparator: \.isWhitespace)
+            .joined(separator: " ")
+    }
+
+    private func draftKey(title: String, dueDateString: String?) -> String {
+        "\(title)|\(dueDateString ?? "")"
+    }
+}

--- a/VivaDicta/Services/Reminders/ReminderExtractionService.swift
+++ b/VivaDicta/Services/Reminders/ReminderExtractionService.swift
@@ -69,6 +69,10 @@ final class ReminderExtractionService {
             throw ReminderExtractionError.noExtractorAvailable
         }
 
+        logger.logInfo(
+            "Reminder extraction - Start noteId=\(transcription.id.uuidString) backend=\(backendDescription(backend)) text='\(preview(transcription.text))'"
+        )
+
         let now = Date()
         let timeZone = TimeZone.current
         let response: ReminderDraftsResponse
@@ -92,6 +96,11 @@ final class ReminderExtractionService {
                 timeZone: timeZone
             )
         }
+
+        logDrafts(
+            response.reminders,
+            prefix: "Reminder extraction - Raw model output noteId=\(transcription.id.uuidString)"
+        )
 
         let persistedDrafts = persist(
             response.reminders,
@@ -159,6 +168,13 @@ final class ReminderExtractionService {
     ) -> [ExtractedReminderDraft] {
         let existingDrafts = reminderDrafts(for: transcription, modelContext: modelContext)
         let importedDrafts = existingDrafts.filter { $0.status == .imported }
+        logger.logInfo(
+            "Reminder extraction - Existing drafts before replace noteId=\(transcription.id.uuidString) count=\(existingDrafts.count) imported=\(importedDrafts.count)"
+        )
+        logStoredDrafts(
+            existingDrafts,
+            prefix: "Reminder extraction - Existing draft snapshot noteId=\(transcription.id.uuidString)"
+        )
 
         existingDrafts
             .filter { $0.status != .imported }
@@ -176,6 +192,10 @@ final class ReminderExtractionService {
         }
 
         let sanitizedDrafts = sanitizeDrafts(drafts)
+        logDrafts(
+            sanitizedDrafts,
+            prefix: "Reminder extraction - Sanitized drafts noteId=\(transcription.id.uuidString)"
+        )
         var seenKeys = Set<String>()
         var persistedDrafts: [ExtractedReminderDraft] = []
 
@@ -205,6 +225,9 @@ final class ReminderExtractionService {
             storedDraft.transcription = transcription
             modelContext.insert(storedDraft)
             persistedDrafts.append(storedDraft)
+            logger.logInfo(
+                "Reminder extraction - Persisting draft noteId=\(transcription.id.uuidString) draftId=\(storedDraft.id.uuidString) title='\(storedDraft.title)' due='\(storedDraft.optionalDueDateString ?? "nil")' raw='\(storedDraft.rawDueDatePhrase ?? "nil")'"
+            )
         }
 
         return persistedDrafts
@@ -218,7 +241,19 @@ final class ReminderExtractionService {
             sortBy: [SortDescriptor(\.createdAt), SortDescriptor(\.id)]
         )
         let allDrafts = (try? modelContext.fetch(descriptor)) ?? []
-        return allDrafts.filter { $0.transcription?.id == transcription.id }
+        logger.logDebug(
+            "Reminder extraction - Fetch all drafts total=\(allDrafts.count) targetNoteId=\(transcription.id.uuidString)"
+        )
+        logStoredDrafts(
+            allDrafts,
+            prefix: "Reminder extraction - All stored drafts before note filter"
+        )
+        let filteredDrafts = allDrafts.filter { $0.transcription?.id == transcription.id }
+        logStoredDrafts(
+            filteredDrafts,
+            prefix: "Reminder extraction - Filtered stored drafts targetNoteId=\(transcription.id.uuidString)"
+        )
+        return filteredDrafts
     }
 
     private func sanitizeDrafts(_ drafts: [ReminderDraft]) -> [ReminderDraft] {
@@ -351,5 +386,50 @@ final class ReminderExtractionService {
         }
 
         return rank(lhs) >= rank(rhs) ? lhs : rhs
+    }
+
+    private func backendDescription(_ backend: ReminderExtractionBackend) -> String {
+        switch backend {
+        case .apple:
+            "apple"
+        case .cloud(let provider, let model):
+            "\(provider.rawValue)/\(model)"
+        }
+    }
+
+    private func logDrafts(_ drafts: [ReminderDraft], prefix: String) {
+        if drafts.isEmpty {
+            logger.logDebug("\(prefix) count=0")
+            return
+        }
+
+        for (index, draft) in drafts.enumerated() {
+            logger.logDebug(
+                "\(prefix) [\(index)] title='\(draft.title)' due='\(draft.optionalDueDateString ?? "nil")' raw='\(draft.rawDueDatePhrase ?? "nil")' notes='\(draft.notes ?? "nil")' priority=\(draft.priority.rawValue)"
+            )
+        }
+    }
+
+    private func logStoredDrafts(_ drafts: [ExtractedReminderDraft], prefix: String) {
+        if drafts.isEmpty {
+            logger.logDebug("\(prefix) count=0")
+            return
+        }
+
+        for (index, draft) in drafts.enumerated() {
+            logger.logDebug(
+                "\(prefix) [\(index)] draftId=\(draft.id.uuidString) noteId=\(draft.transcription?.id.uuidString ?? "nil") status=\(draft.status.rawValue) title='\(draft.title)' due='\(draft.optionalDueDateString ?? "nil")' raw='\(draft.rawDueDatePhrase ?? "nil")'"
+            )
+        }
+    }
+
+    private func preview(_ text: String, limit: Int = 120) -> String {
+        let normalized = text
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacing("\n", with: " ")
+        if normalized.count <= limit {
+            return normalized
+        }
+        return String(normalized.prefix(limit)) + "..."
     }
 }

--- a/VivaDicta/Services/Reminders/ReminderExtractionService.swift
+++ b/VivaDicta/Services/Reminders/ReminderExtractionService.swift
@@ -165,7 +165,7 @@ final class ReminderExtractionService {
         now: Date,
         timeZone: TimeZone
     ) -> [ExtractedReminderDraft] {
-        let existingDrafts = reminderDrafts(for: transcription, modelContext: modelContext)
+        let existingDrafts = reminderDrafts(for: transcription)
         let importedDrafts = existingDrafts.filter { $0.status == .imported }
 
         existingDrafts
@@ -219,14 +219,9 @@ final class ReminderExtractionService {
     }
 
     private func reminderDrafts(
-        for transcription: Transcription,
-        modelContext: ModelContext
+        for transcription: Transcription
     ) -> [ExtractedReminderDraft] {
-        let descriptor = FetchDescriptor<ExtractedReminderDraft>(
-            sortBy: [SortDescriptor(\.createdAt), SortDescriptor(\.id)]
-        )
-        let allDrafts = (try? modelContext.fetch(descriptor)) ?? []
-        return allDrafts.filter { $0.transcription?.id == transcription.id }
+        transcription.sortedExtractedReminderDrafts
     }
 
     private func sanitizeDrafts(
@@ -388,19 +383,29 @@ final class ReminderExtractionService {
     }
 
     private func likelyTimingOnlyTitle(_ title: String) -> Bool {
-        let normalized = normalizedTitle(for: title)
-        guard !normalized.isEmpty else { return false }
+        let tokens = title
+            .lowercased()
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { !$0.isEmpty }
 
-        let dateWords = [
+        guard !tokens.isEmpty else { return false }
+
+        let timingWords: Set<String> = [
+            "at", "on", "this", "next",
             "monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday",
-            "today", "tomorrow", "tonight", "morning", "afternoon", "evening", "noon"
+            "today", "tomorrow", "tonight", "morning", "afternoon", "evening", "noon",
+            "am", "pm", "a", "p"
         ]
 
-        let containsDateWord = dateWords.contains { normalized.contains($0) }
-        let containsTimeMarker = normalized.contains("am") || normalized.contains("pm") || normalized.contains(":")
+        let hasTimingSignal = tokens.contains { token in
+            timingWords.contains(token) || token.allSatisfy(\.isNumber)
+        } || title.localizedStandardContains(":")
 
-        guard containsDateWord else { return false }
-        return containsTimeMarker || normalized.split(separator: " ").count <= 3
+        guard hasTimingSignal else { return false }
+
+        return tokens.allSatisfy { token in
+            timingWords.contains(token) || token.allSatisfy(\.isNumber)
+        }
     }
 
     private func draftKey(title: String, dueDateString: String?) -> String {

--- a/VivaDicta/Services/Reminders/ReminderExtractionService.swift
+++ b/VivaDicta/Services/Reminders/ReminderExtractionService.swift
@@ -97,11 +97,6 @@ final class ReminderExtractionService {
             )
         }
 
-        logDrafts(
-            response.reminders,
-            prefix: "Reminder extraction - Raw model output noteId=\(transcription.id.uuidString)"
-        )
-
         let persistedDrafts = persist(
             response.reminders,
             on: transcription,
@@ -172,13 +167,6 @@ final class ReminderExtractionService {
     ) -> [ExtractedReminderDraft] {
         let existingDrafts = reminderDrafts(for: transcription, modelContext: modelContext)
         let importedDrafts = existingDrafts.filter { $0.status == .imported }
-        logger.logInfo(
-            "Reminder extraction - Existing drafts before replace noteId=\(transcription.id.uuidString) count=\(existingDrafts.count) imported=\(importedDrafts.count)"
-        )
-        logStoredDrafts(
-            existingDrafts,
-            prefix: "Reminder extraction - Existing draft snapshot noteId=\(transcription.id.uuidString)"
-        )
 
         existingDrafts
             .filter { $0.status != .imported }
@@ -196,10 +184,6 @@ final class ReminderExtractionService {
         }
 
         let sanitizedDrafts = sanitizeDrafts(drafts, now: now, timeZone: timeZone)
-        logDrafts(
-            sanitizedDrafts,
-            prefix: "Reminder extraction - Sanitized drafts noteId=\(transcription.id.uuidString)"
-        )
         var seenKeys = Set<String>()
         var persistedDrafts: [ExtractedReminderDraft] = []
 
@@ -229,9 +213,6 @@ final class ReminderExtractionService {
             storedDraft.transcription = transcription
             modelContext.insert(storedDraft)
             persistedDrafts.append(storedDraft)
-            logger.logInfo(
-                "Reminder extraction - Persisting draft noteId=\(transcription.id.uuidString) draftId=\(storedDraft.id.uuidString) title='\(storedDraft.title)' due='\(storedDraft.optionalDueDateString ?? "nil")' raw='\(storedDraft.rawDueDatePhrase ?? "nil")'"
-            )
         }
 
         return persistedDrafts
@@ -245,19 +226,7 @@ final class ReminderExtractionService {
             sortBy: [SortDescriptor(\.createdAt), SortDescriptor(\.id)]
         )
         let allDrafts = (try? modelContext.fetch(descriptor)) ?? []
-        logger.logDebug(
-            "Reminder extraction - Fetch all drafts total=\(allDrafts.count) targetNoteId=\(transcription.id.uuidString)"
-        )
-        logStoredDrafts(
-            allDrafts,
-            prefix: "Reminder extraction - All stored drafts before note filter"
-        )
-        let filteredDrafts = allDrafts.filter { $0.transcription?.id == transcription.id }
-        logStoredDrafts(
-            filteredDrafts,
-            prefix: "Reminder extraction - Filtered stored drafts targetNoteId=\(transcription.id.uuidString)"
-        )
-        return filteredDrafts
+        return allDrafts.filter { $0.transcription?.id == transcription.id }
     }
 
     private func sanitizeDrafts(
@@ -461,32 +430,6 @@ final class ReminderExtractionService {
             "apple"
         case .cloud(let provider, let model):
             "\(provider.rawValue)/\(model)"
-        }
-    }
-
-    private func logDrafts(_ drafts: [ReminderDraft], prefix: String) {
-        if drafts.isEmpty {
-            logger.logDebug("\(prefix) count=0")
-            return
-        }
-
-        for (index, draft) in drafts.enumerated() {
-            logger.logDebug(
-                "\(prefix) [\(index)] title='\(draft.title)' due='\(draft.optionalDueDateString ?? "nil")' raw='\(draft.rawDueDatePhrase ?? "nil")' notes='\(draft.notes ?? "nil")' priority=\(draft.priority.rawValue)"
-            )
-        }
-    }
-
-    private func logStoredDrafts(_ drafts: [ExtractedReminderDraft], prefix: String) {
-        if drafts.isEmpty {
-            logger.logDebug("\(prefix) count=0")
-            return
-        }
-
-        for (index, draft) in drafts.enumerated() {
-            logger.logDebug(
-                "\(prefix) [\(index)] draftId=\(draft.id.uuidString) noteId=\(draft.transcription?.id.uuidString ?? "nil") status=\(draft.status.rawValue) title='\(draft.title)' due='\(draft.optionalDueDateString ?? "nil")' raw='\(draft.rawDueDatePhrase ?? "nil")'"
-            )
         }
     }
 

--- a/VivaDicta/Services/Reminders/ReminderExtractionService.swift
+++ b/VivaDicta/Services/Reminders/ReminderExtractionService.swift
@@ -22,7 +22,7 @@ enum ReminderExtractionError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .unsupportedOS:
-            return "Reminder extraction requires iOS 26 or later."
+            return "This reminder extraction option is not available on the current OS version."
         case .noExtractorAvailable:
             return "No reminder extraction model is available for the current mode."
         case .providerUnavailable(let message):
@@ -41,7 +41,6 @@ enum ReminderExtractionError: LocalizedError {
     }
 }
 
-@available(iOS 26, *)
 private enum ReminderExtractionBackend {
     case apple
     case cloud(provider: AIProvider, model: String)
@@ -57,15 +56,7 @@ final class ReminderExtractionService {
     }
 
     func canExtractReminders(using mode: VivaMode? = nil) -> Bool {
-        guard #available(iOS 26, *) else {
-            return false
-        }
-
-        do {
-            return try resolvedBackend(for: mode ?? aiService.selectedMode) != nil
-        } catch {
-            return false
-        }
+        resolvedBackend(for: mode ?? aiService.selectedMode) != nil
     }
 
     func extractAndPersist(
@@ -73,12 +64,8 @@ final class ReminderExtractionService {
         modelContext: ModelContext,
         mode: VivaMode? = nil
     ) async throws -> [ExtractedReminderDraft] {
-        guard #available(iOS 26, *) else {
-            throw ReminderExtractionError.unsupportedOS
-        }
-
         let activeMode = mode ?? aiService.selectedMode
-        guard let backend = try resolvedBackend(for: activeMode) else {
+        guard let backend = resolvedBackend(for: activeMode) else {
             throw ReminderExtractionError.noExtractorAvailable
         }
 
@@ -88,6 +75,9 @@ final class ReminderExtractionService {
 
         switch backend {
         case .apple:
+            guard #available(iOS 26, *) else {
+                throw ReminderExtractionError.unsupportedOS
+            }
             response = try await AppleFMReminderExtractionProvider().extract(
                 noteText: transcription.text,
                 now: now,
@@ -115,16 +105,16 @@ final class ReminderExtractionService {
         return persistedDrafts
     }
 
-    @available(iOS 26, *)
-    private func resolvedBackend(for mode: VivaMode) throws -> ReminderExtractionBackend? {
+    private func resolvedBackend(for mode: VivaMode) -> ReminderExtractionBackend? {
+        let cloudProvider = CloudReminderExtractionProvider(aiService: aiService)
+
         if let provider = mode.aiProvider,
            !mode.aiModel.isEmpty {
-            if provider == .apple, AppleFoundationModelAvailability.isAvailable {
-                return .apple
-            }
-
-            let cloudProvider = CloudReminderExtractionProvider(aiService: aiService)
-            if cloudProvider.canExtract(provider: provider, model: mode.aiModel) {
+            if provider == .apple {
+                if AppleFoundationModelAvailability.isAvailable {
+                    return .apple
+                }
+            } else if cloudProvider.canExtract(provider: provider, model: mode.aiModel) {
                 return .cloud(provider: provider, model: mode.aiModel)
             }
         }
@@ -136,7 +126,6 @@ final class ReminderExtractionService {
         return nil
     }
 
-    @available(iOS 26, *)
     private func persist(
         _ drafts: [ReminderDraft],
         on transcription: Transcription,

--- a/VivaDicta/Services/Reminders/ReminderExtractionService.swift
+++ b/VivaDicta/Services/Reminders/ReminderExtractionService.swift
@@ -106,7 +106,9 @@ final class ReminderExtractionService {
             response.reminders,
             on: transcription,
             backend: backend,
-            modelContext: modelContext
+            modelContext: modelContext,
+            now: now,
+            timeZone: timeZone
         )
 
         try modelContext.save()
@@ -164,7 +166,9 @@ final class ReminderExtractionService {
         _ drafts: [ReminderDraft],
         on transcription: Transcription,
         backend: ReminderExtractionBackend,
-        modelContext: ModelContext
+        modelContext: ModelContext,
+        now: Date,
+        timeZone: TimeZone
     ) -> [ExtractedReminderDraft] {
         let existingDrafts = reminderDrafts(for: transcription, modelContext: modelContext)
         let importedDrafts = existingDrafts.filter { $0.status == .imported }
@@ -191,7 +195,7 @@ final class ReminderExtractionService {
             modelName = model
         }
 
-        let sanitizedDrafts = sanitizeDrafts(drafts)
+        let sanitizedDrafts = sanitizeDrafts(drafts, now: now, timeZone: timeZone)
         logDrafts(
             sanitizedDrafts,
             prefix: "Reminder extraction - Sanitized drafts noteId=\(transcription.id.uuidString)"
@@ -256,31 +260,36 @@ final class ReminderExtractionService {
         return filteredDrafts
     }
 
-    private func sanitizeDrafts(_ drafts: [ReminderDraft]) -> [ReminderDraft] {
+    private func sanitizeDrafts(
+        _ drafts: [ReminderDraft],
+        now: Date,
+        timeZone: TimeZone
+    ) -> [ReminderDraft] {
         var mergedDrafts: [ReminderDraft] = []
 
         for draft in drafts {
-            guard shouldKeepDraft(draft) else { continue }
+            let normalizedCandidate = normalizedDraft(draft, now: now, timeZone: timeZone)
+            guard shouldKeepDraft(normalizedCandidate) else { continue }
 
-            let normalizedCandidateTitle = normalizedTitle(for: draft.title)
+            let normalizedCandidateTitle = normalizedTitle(for: normalizedCandidate.title)
             guard !normalizedCandidateTitle.isEmpty else { continue }
 
             if let existingIndex = mergedDrafts.firstIndex(where: {
                 normalizedTitle(for: $0.title) == normalizedCandidateTitle
             }) {
                 let existingDraft = mergedDrafts[existingIndex]
-                let shouldMerge = existingDraft.optionalDueDateString == draft.optionalDueDateString
+                let shouldMerge = existingDraft.optionalDueDateString == normalizedCandidate.optionalDueDateString
                     || existingDraft.optionalDueDateString == nil
-                    || draft.optionalDueDateString == nil
-                    || normalizedTitle(for: existingDraft.rawDueDatePhrase ?? "") == normalizedTitle(for: draft.rawDueDatePhrase ?? "")
+                    || normalizedCandidate.optionalDueDateString == nil
+                    || normalizedTitle(for: existingDraft.rawDueDatePhrase ?? "") == normalizedTitle(for: normalizedCandidate.rawDueDatePhrase ?? "")
 
                 if shouldMerge {
-                    mergedDrafts[existingIndex] = mergedDraft(existingDraft, with: draft)
+                    mergedDrafts[existingIndex] = mergedDraft(existingDraft, with: normalizedCandidate)
                     continue
                 }
             }
 
-            mergedDrafts.append(normalizedDraft(draft))
+            mergedDrafts.append(normalizedCandidate)
         }
 
         return mergedDrafts
@@ -298,11 +307,21 @@ final class ReminderExtractionService {
         return likelyTimingOnlyTitle(draft.title) == false
     }
 
-    private func normalizedDraft(_ draft: ReminderDraft) -> ReminderDraft {
-        ReminderDraft(
-            title: draft.title.trimmingCharacters(in: .whitespacesAndNewlines),
-            optionalDueDateString: normalizedOptionalString(draft.optionalDueDateString),
-            rawDueDatePhrase: normalizedOptionalString(draft.rawDueDatePhrase),
+    private func normalizedDraft(
+        _ draft: ReminderDraft,
+        now: Date,
+        timeZone: TimeZone
+    ) -> ReminderDraft {
+        let recoveredTitleData = ReminderDueDateParser.splitEmbeddedDuePhrase(
+            from: draft.title,
+            now: now,
+            timeZone: timeZone
+        )
+
+        return ReminderDraft(
+            title: recoveredTitleData.cleanTitle,
+            optionalDueDateString: normalizedOptionalString(draft.optionalDueDateString) ?? recoveredTitleData.dueDateString,
+            rawDueDatePhrase: normalizedOptionalString(draft.rawDueDatePhrase) ?? recoveredTitleData.rawDueDatePhrase,
             notes: normalizedOptionalString(draft.notes),
             priority: draft.priority
         )

--- a/VivaDicta/Services/Reminders/ReminderExtractionService.swift
+++ b/VivaDicta/Services/Reminders/ReminderExtractionService.swift
@@ -108,19 +108,44 @@ final class ReminderExtractionService {
     private func resolvedBackend(for mode: VivaMode) -> ReminderExtractionBackend? {
         let cloudProvider = CloudReminderExtractionProvider(aiService: aiService)
 
-        if let provider = mode.aiProvider,
-           !mode.aiModel.isEmpty {
-            if provider == .apple {
-                if AppleFoundationModelAvailability.isAvailable {
-                    return .apple
-                }
-            } else if cloudProvider.canExtract(provider: provider, model: mode.aiModel) {
-                return .cloud(provider: provider, model: mode.aiModel)
-            }
+        if mode.reminderExtractorProvider != nil {
+            return backend(
+                for: mode.reminderExtractorProvider,
+                model: mode.reminderExtractorModel,
+                cloudProvider: cloudProvider
+            )
+        }
+
+        if let backend = backend(
+            for: mode.aiProvider,
+            model: mode.aiModel,
+            cloudProvider: cloudProvider
+        ) {
+            return backend
         }
 
         if AppleFoundationModelAvailability.isAvailable {
             return .apple
+        }
+
+        return nil
+    }
+
+    private func backend(
+        for provider: AIProvider?,
+        model: String?,
+        cloudProvider: CloudReminderExtractionProvider
+    ) -> ReminderExtractionBackend? {
+        guard let provider else { return nil }
+
+        if provider == .apple {
+            return AppleFoundationModelAvailability.isAvailable ? .apple : nil
+        }
+
+        guard let model, !model.isEmpty else { return nil }
+
+        if cloudProvider.canExtract(provider: provider, model: model) {
+            return .cloud(provider: provider, model: model)
         }
 
         return nil

--- a/VivaDicta/Services/Reminders/ReminderExtractionService.swift
+++ b/VivaDicta/Services/Reminders/ReminderExtractionService.swift
@@ -275,18 +275,11 @@ final class ReminderExtractionService {
             guard !normalizedCandidateTitle.isEmpty else { continue }
 
             if let existingIndex = mergedDrafts.firstIndex(where: {
-                normalizedTitle(for: $0.title) == normalizedCandidateTitle
+                shouldMergeDrafts($0, normalizedCandidate)
             }) {
                 let existingDraft = mergedDrafts[existingIndex]
-                let shouldMerge = existingDraft.optionalDueDateString == normalizedCandidate.optionalDueDateString
-                    || existingDraft.optionalDueDateString == nil
-                    || normalizedCandidate.optionalDueDateString == nil
-                    || normalizedTitle(for: existingDraft.rawDueDatePhrase ?? "") == normalizedTitle(for: normalizedCandidate.rawDueDatePhrase ?? "")
-
-                if shouldMerge {
-                    mergedDrafts[existingIndex] = mergedDraft(existingDraft, with: normalizedCandidate)
-                    continue
-                }
+                mergedDrafts[existingIndex] = mergedDraft(existingDraft, with: normalizedCandidate)
+                continue
             }
 
             mergedDrafts.append(normalizedCandidate)
@@ -344,6 +337,43 @@ final class ReminderExtractionService {
         )
     }
 
+    private func shouldMergeDrafts(_ lhs: ReminderDraft, _ rhs: ReminderDraft) -> Bool {
+        let lhsTitle = normalizedTitle(for: lhs.title)
+        let rhsTitle = normalizedTitle(for: rhs.title)
+
+        if lhsTitle == rhsTitle {
+            return compatibleDueTiming(lhs, rhs)
+        }
+
+        guard compatibleDueTiming(lhs, rhs) else {
+            return false
+        }
+
+        let lhsFingerprint = titleFingerprint(for: lhs.title)
+        let rhsFingerprint = titleFingerprint(for: rhs.title)
+        guard !lhsFingerprint.isEmpty, lhsFingerprint == rhsFingerprint else {
+            return false
+        }
+
+        return true
+    }
+
+    private func compatibleDueTiming(_ lhs: ReminderDraft, _ rhs: ReminderDraft) -> Bool {
+        if lhs.optionalDueDateString == rhs.optionalDueDateString {
+            return true
+        }
+
+        if lhs.optionalDueDateString == nil || rhs.optionalDueDateString == nil {
+            let lhsRaw = normalizedTitle(for: lhs.rawDueDatePhrase ?? "")
+            let rhsRaw = normalizedTitle(for: rhs.rawDueDatePhrase ?? "")
+            if !lhsRaw.isEmpty, lhsRaw == rhsRaw {
+                return true
+            }
+        }
+
+        return false
+    }
+
     private func draftScore(_ draft: ReminderDraft) -> Int {
         var score = 0
         if normalizedOptionalString(draft.optionalDueDateString) != nil { score += 4 }
@@ -359,6 +389,24 @@ final class ReminderExtractionService {
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
             .split(whereSeparator: \.isWhitespace)
+            .joined(separator: " ")
+    }
+
+    private func titleFingerprint(for title: String) -> String {
+        let stopWords: Set<String> = [
+            "a", "an", "and", "appointment", "at", "book", "buy", "call", "check",
+            "create", "do", "email", "follow", "for", "make", "me",
+            "meeting", "message", "my", "need", "on", "pay", "please", "remind",
+            "schedule", "send", "task", "text", "the", "to", "todo", "up", "visit",
+            "with"
+        ]
+
+        return title
+            .lowercased()
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { token in
+                !token.isEmpty && !stopWords.contains(token)
+            }
             .joined(separator: " ")
     }
 

--- a/VivaDicta/Services/Reminders/RemindersImportService.swift
+++ b/VivaDicta/Services/Reminders/RemindersImportService.swift
@@ -27,6 +27,15 @@ enum RemindersImportError: LocalizedError {
             return "No default Reminders list is available on this device."
         }
     }
+
+    var shouldOfferSettingsShortcut: Bool {
+        switch self {
+        case .accessDenied, .readAccessRequired:
+            true
+        case .unknownAuthorizationStatus, .defaultReminderListUnavailable:
+            false
+        }
+    }
 }
 
 @MainActor

--- a/VivaDicta/Services/Reminders/RemindersImportService.swift
+++ b/VivaDicta/Services/Reminders/RemindersImportService.swift
@@ -49,7 +49,8 @@ final class RemindersImportService {
         let reminder = EKReminder(eventStore: eventStore)
         reminder.title = draft.title
         reminder.notes = draft.notes
-        reminder.priority = draft.priority.eventKitPriority
+        // Keep imported reminders neutral for now.
+        // We still persist extracted priority in our draft model so we can revisit EventKit mapping later.
         reminder.calendar = try defaultReminderCalendar()
 
         if let dueDateComponents = ReminderDueDateParser.dueDateComponents(from: draft.optionalDueDateString) {

--- a/VivaDicta/Services/Reminders/RemindersImportService.swift
+++ b/VivaDicta/Services/Reminders/RemindersImportService.swift
@@ -1,0 +1,93 @@
+//
+//  RemindersImportService.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.14
+//
+
+import EventKit
+import Foundation
+import os
+
+enum RemindersImportError: LocalizedError {
+    case accessDenied
+    case readAccessRequired
+    case unknownAuthorizationStatus
+    case defaultReminderListUnavailable
+
+    var errorDescription: String? {
+        switch self {
+        case .accessDenied:
+            return "Reminders access was denied. Enable it in Settings to import reminder suggestions."
+        case .readAccessRequired:
+            return "Full Reminders access is required to create reminders."
+        case .unknownAuthorizationStatus:
+            return "Reminders permission status is unknown."
+        case .defaultReminderListUnavailable:
+            return "No default Reminders list is available on this device."
+        }
+    }
+}
+
+@MainActor
+final class RemindersImportService {
+    private let logger = Logger(category: .remindersImport)
+    private let eventStore = EKEventStore()
+
+    func importDraft(_ draft: ReminderDraft) async throws -> String? {
+        try await ensureAccess()
+
+        let reminder = EKReminder(eventStore: eventStore)
+        reminder.title = draft.title
+        reminder.notes = draft.notes
+        reminder.priority = draft.priority.eventKitPriority
+        reminder.calendar = try defaultReminderCalendar()
+
+        if let dueDateComponents = ReminderDueDateParser.dueDateComponents(from: draft.optionalDueDateString) {
+            reminder.dueDateComponents = dueDateComponents
+        }
+
+        try eventStore.save(reminder, commit: true)
+        let identifier = reminder.calendarItemExternalIdentifier.isEmpty
+            ? reminder.calendarItemIdentifier
+            : reminder.calendarItemExternalIdentifier
+        logger.logNotice("Reminder import - Created reminder title='\(draft.title)'")
+        return identifier
+    }
+
+    func importDrafts(_ drafts: [ReminderDraft]) async throws -> [String?] {
+        var identifiers: [String?] = []
+        identifiers.reserveCapacity(drafts.count)
+
+        for draft in drafts {
+            identifiers.append(try await importDraft(draft))
+        }
+
+        return identifiers
+    }
+
+    private func ensureAccess() async throws {
+        switch EKEventStore.authorizationStatus(for: .reminder) {
+        case .notDetermined:
+            let granted = try await eventStore.requestFullAccessToReminders()
+            guard granted else {
+                throw RemindersImportError.accessDenied
+            }
+        case .restricted, .denied:
+            throw RemindersImportError.accessDenied
+        case .writeOnly:
+            throw RemindersImportError.readAccessRequired
+        case .authorized, .fullAccess:
+            break
+        @unknown default:
+            throw RemindersImportError.unknownAuthorizationStatus
+        }
+    }
+
+    private func defaultReminderCalendar() throws -> EKCalendar {
+        guard let calendar = eventStore.defaultCalendarForNewReminders() else {
+            throw RemindersImportError.defaultReminderListUnavailable
+        }
+        return calendar
+    }
+}

--- a/VivaDicta/Shared/UserDefaultsStorage.swift
+++ b/VivaDicta/Shared/UserDefaultsStorage.swift
@@ -60,6 +60,7 @@ enum UserDefaultsStorage {
 
         // Auto-copy
         static let isAutoCopyAfterRecordingEnabled = "isAutoCopyAfterRecordingEnabled"
+        static let isAutoReminderExtractionEnabled = "isAutoReminderExtractionEnabled"
 
         // Custom OpenAI Provider Configuration
         static let customOpenAIEndpointURL = "customOpenAIEndpointURL"

--- a/VivaDicta/Utilities/LoggerExtension.swift
+++ b/VivaDicta/Utilities/LoggerExtension.swift
@@ -65,6 +65,8 @@ public enum LogCategory: String {
     case ragIndexing = "RAGIndexing"
     case ragSearch = "RAGSearch"
     case smartSearchChat = "SmartSearchChat"
+    case reminderExtraction = "ReminderExtraction"
+    case remindersImport = "RemindersImport"
 
     // MARK: - Watch Connectivity
     case watchConnectivity = "WatchConnectivity"

--- a/VivaDicta/Utils/PreviewContainer.swift
+++ b/VivaDicta/Utils/PreviewContainer.swift
@@ -11,7 +11,7 @@ import SwiftData
 struct TranscriptionsMockData: PreviewModifier {
 
     static func makeSharedContext() async throws -> ModelContainer {
-        let container = try ModelContainer(for: Transcription.self, VocabularyWord.self, WordReplacement.self, configurations: .init(isStoredInMemoryOnly: true))
+        let container = try ModelContainer(for: Transcription.self, ExtractedReminderDraft.self, VocabularyWord.self, WordReplacement.self, configurations: .init(isStoredInMemoryOnly: true))
         Transcription.mockData.forEach { container.mainContext.insert($0) }
         return container
     }
@@ -28,7 +28,7 @@ extension PreviewTrait where T == Preview.ViewTraits {
 struct TranscriptionsMockDataMany: PreviewModifier {
 
     static func makeSharedContext() async throws -> ModelContainer {
-        let container = try ModelContainer(for: Transcription.self, VocabularyWord.self, WordReplacement.self, configurations: .init(isStoredInMemoryOnly: true))
+        let container = try ModelContainer(for: Transcription.self, ExtractedReminderDraft.self, VocabularyWord.self, WordReplacement.self, configurations: .init(isStoredInMemoryOnly: true))
         Transcription.mockDataMany.forEach { container.mainContext.insert($0) }
         return container
     }

--- a/VivaDicta/Views/RecordViewModel.swift
+++ b/VivaDicta/Views/RecordViewModel.swift
@@ -721,6 +721,10 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
                 do {
                     try pending.modelContext.save()
                     logger.logInfo("📱 Saved transcription without enhancement")
+                    scheduleAutomaticReminderExtractionIfNeeded(
+                        for: transcription,
+                        modelContext: pending.modelContext
+                    )
 
                     // Haptic feedback for successful save
                     HapticManager.heartbeat()
@@ -831,6 +835,11 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
             activity.becomeCurrent()
         }
 
+        scheduleAutomaticReminderExtractionIfNeeded(
+            for: transcription,
+            modelContext: modelContext
+        )
+
         return transcription
     }
 
@@ -879,6 +888,37 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
             modelContext: modelContext,
             sourceTag: sourceTag
         )
+    }
+
+    private func scheduleAutomaticReminderExtractionIfNeeded(
+        for transcription: Transcription,
+        modelContext: ModelContext
+    ) {
+        guard UserDefaultsStorage.appPrivate.bool(forKey: UserDefaultsStorage.Keys.isAutoReminderExtractionEnabled) else {
+            return
+        }
+
+        let extractionMode = aiService.selectedMode
+        let extractionService = ReminderExtractionService(aiService: aiService)
+        guard extractionService.canExtractReminders(using: extractionMode) else {
+            logger.logDebug("Reminder extraction - Auto extraction skipped because no extractor is available for mode \(extractionMode.name)")
+            return
+        }
+
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+
+            do {
+                let drafts = try await extractionService.extractAndPersist(
+                    for: transcription,
+                    modelContext: modelContext,
+                    mode: extractionMode
+                )
+                logger.logNotice("Reminder extraction - Auto extracted \(drafts.count) draft(s) for note \(transcription.id.uuidString)")
+            } catch {
+                logger.logWarning("Reminder extraction - Auto extraction failed for note \(transcription.id.uuidString): \(error.localizedDescription)")
+            }
+        }
     }
 
     func resetValues() {

--- a/VivaDicta/Views/Reminders/ExtractedRemindersSheet.swift
+++ b/VivaDicta/Views/Reminders/ExtractedRemindersSheet.swift
@@ -17,7 +17,6 @@ struct ExtractedRemindersSheet: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.modelContext) private var modelContext
     @Environment(\.openURL) private var openURL
-    @Query(sort: \ExtractedReminderDraft.createdAt) private var allReminderDrafts: [ExtractedReminderDraft]
 
     @State private var importingDraftIDs = Set<UUID>()
     @State private var isImportingAll = false
@@ -26,9 +25,7 @@ struct ExtractedRemindersSheet: View {
     @State private var shouldOfferSettingsShortcut = false
 
     private var pendingDrafts: [ExtractedReminderDraft] {
-        allReminderDrafts.filter {
-            $0.transcription?.id == transcription.id && $0.status == .pending
-        }
+        transcription.pendingExtractedReminderDrafts
     }
 
     private var isBusy: Bool {
@@ -138,12 +135,14 @@ struct ExtractedRemindersSheet: View {
             isImportingAll = false
         }
 
+        let importService = RemindersImportService()
+
         do {
-            let identifiers = try await RemindersImportService().importDrafts(draftsToImport.map(\.reminderDraft))
-            for (draft, identifier) in zip(draftsToImport, identifiers) {
+            for draft in draftsToImport {
+                let identifier = try await importService.importDraft(draft.reminderDraft)
                 draft.markImported(reminderIdentifier: identifier)
+                try modelContext.save()
             }
-            try modelContext.save()
         } catch {
             presentError(error)
         }

--- a/VivaDicta/Views/Reminders/ExtractedRemindersSheet.swift
+++ b/VivaDicta/Views/Reminders/ExtractedRemindersSheet.swift
@@ -7,7 +7,6 @@
 
 import SwiftUI
 import SwiftData
-import os
 #if canImport(UIKit)
 import UIKit
 #endif
@@ -25,8 +24,6 @@ struct ExtractedRemindersSheet: View {
     @State private var showErrorAlert = false
     @State private var errorMessage = ""
     @State private var shouldOfferSettingsShortcut = false
-
-    private let logger = Logger(category: .reminderExtraction)
 
     private var pendingDrafts: [ExtractedReminderDraft] {
         allReminderDrafts.filter {
@@ -96,9 +93,6 @@ struct ExtractedRemindersSheet: View {
                 }
             }
         }
-        .onAppear {
-            logSheetSnapshot(context: "appear")
-        }
         .alert("Reminder Import Failed", isPresented: $showErrorAlert) {
             if shouldOfferSettingsShortcut {
                 Button("Settings") {
@@ -159,17 +153,6 @@ struct ExtractedRemindersSheet: View {
         errorMessage = error.localizedDescription
         shouldOfferSettingsShortcut = (error as? RemindersImportError)?.shouldOfferSettingsShortcut ?? false
         showErrorAlert = true
-    }
-
-    private func logSheetSnapshot(context: String) {
-        logger.logInfo(
-            "Reminder sheet - \(context) noteId=\(transcription.id.uuidString) pendingCount=\(pendingDrafts.count) allDraftsCount=\(allReminderDrafts.count)"
-        )
-        for (index, draft) in pendingDrafts.enumerated() {
-            logger.logDebug(
-                "Reminder sheet - \(context) [\(index)] draftId=\(draft.id.uuidString) noteId=\(draft.transcription?.id.uuidString ?? "nil") title='\(draft.title)' due='\(draft.optionalDueDateString ?? "nil")' raw='\(draft.rawDueDatePhrase ?? "nil")'"
-            )
-        }
     }
 
     private func openAppSettings() {

--- a/VivaDicta/Views/Reminders/ExtractedRemindersSheet.swift
+++ b/VivaDicta/Views/Reminders/ExtractedRemindersSheet.swift
@@ -24,6 +24,10 @@ struct ExtractedRemindersSheet: View {
     @State private var errorMessage = ""
     @State private var shouldOfferSettingsShortcut = false
 
+    private var visibleDrafts: [ExtractedReminderDraft] {
+        transcription.activeExtractedReminderDrafts
+    }
+
     private var pendingDrafts: [ExtractedReminderDraft] {
         transcription.pendingExtractedReminderDrafts
     }
@@ -35,7 +39,7 @@ struct ExtractedRemindersSheet: View {
     var body: some View {
         NavigationStack {
             Group {
-                if pendingDrafts.isEmpty {
+                if visibleDrafts.isEmpty {
                     ContentUnavailableView(
                         "No Reminder Suggestions",
                         systemImage: "checklist",
@@ -43,19 +47,21 @@ struct ExtractedRemindersSheet: View {
                     )
                 } else {
                     List {
-                        ForEach(pendingDrafts, id: \.id) { draft in
+                        ForEach(visibleDrafts, id: \.id) { draft in
                             ExtractedReminderDraftRow(
                                 draft: draft,
                                 isImporting: importingDraftIDs.contains(draft.id) || isImportingAll
                             )
                             .swipeActions(edge: .leading, allowsFullSwipe: true) {
-                                Button("Add to Reminders", systemImage: "checkmark.circle.fill") {
-                                    Task {
-                                        await importDraft(draft)
+                                if draft.status == .pending {
+                                    Button("Add to Reminders", systemImage: "checkmark.circle.fill") {
+                                        Task {
+                                            await importDraft(draft)
+                                        }
                                     }
+                                    .tint(.green)
+                                    .disabled(isBusy)
                                 }
-                                .tint(.green)
-                                .disabled(isBusy)
                             }
                             .swipeActions(edge: .trailing, allowsFullSwipe: false) {
                                 Button("Dismiss", systemImage: "trash") {
@@ -173,6 +179,17 @@ private struct ExtractedReminderDraftRow: View {
         )
     }
 
+    private var statusText: String? {
+        switch draft.status {
+        case .pending:
+            nil
+        case .imported:
+            "Added to Reminders"
+        case .dismissed:
+            "Dismissed"
+        }
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(alignment: .top, spacing: 12) {
@@ -198,6 +215,12 @@ private struct ExtractedReminderDraftRow: View {
                         Text(priorityLabel(for: draft.priority))
                             .font(.caption)
                             .foregroundStyle(priorityColor(for: draft.priority))
+                    }
+
+                    if let statusText {
+                        Text(statusText)
+                            .font(.caption)
+                            .foregroundStyle(.green)
                     }
                 }
 

--- a/VivaDicta/Views/Reminders/ExtractedRemindersSheet.swift
+++ b/VivaDicta/Views/Reminders/ExtractedRemindersSheet.swift
@@ -1,0 +1,220 @@
+//
+//  ExtractedRemindersSheet.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.14
+//
+
+import SwiftUI
+import SwiftData
+
+struct ExtractedRemindersSheet: View {
+    @Bindable var transcription: Transcription
+
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var modelContext
+
+    @State private var importingDraftIDs = Set<UUID>()
+    @State private var isImportingAll = false
+    @State private var showErrorAlert = false
+    @State private var errorMessage = ""
+
+    private var pendingDrafts: [ExtractedReminderDraft] {
+        transcription.pendingExtractedReminderDrafts
+    }
+
+    private var isBusy: Bool {
+        isImportingAll || !importingDraftIDs.isEmpty
+    }
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if pendingDrafts.isEmpty {
+                    ContentUnavailableView(
+                        "No Reminder Suggestions",
+                        systemImage: "checklist",
+                        description: Text("Extracted reminder drafts will appear here for review before importing to Apple Reminders.")
+                    )
+                } else {
+                    List {
+                        ForEach(pendingDrafts, id: \.id) { draft in
+                            ExtractedReminderDraftRow(
+                                draft: draft,
+                                isImporting: importingDraftIDs.contains(draft.id) || isImportingAll
+                            )
+                            .swipeActions(edge: .leading, allowsFullSwipe: true) {
+                                Button("Add to Reminders", systemImage: "checkmark.circle.fill") {
+                                    Task {
+                                        await importDraft(draft)
+                                    }
+                                }
+                                .tint(.green)
+                                .disabled(isBusy)
+                            }
+                            .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                                Button("Dismiss", systemImage: "trash") {
+                                    dismissDraft(draft)
+                                }
+                                .tint(.red)
+                                .disabled(isBusy)
+                            }
+                        }
+                    }
+                    .scrollIndicators(.hidden)
+                }
+            }
+            .navigationTitle("Reminder Suggestions")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Close") {
+                        dismiss()
+                    }
+                }
+
+                if pendingDrafts.count > 1 {
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("Add All") {
+                            Task {
+                                await importAllDrafts()
+                            }
+                        }
+                        .disabled(isBusy)
+                    }
+                }
+            }
+        }
+        .alert("Reminder Import Failed", isPresented: $showErrorAlert) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(errorMessage)
+        }
+    }
+
+    private func dismissDraft(_ draft: ExtractedReminderDraft) {
+        draft.markDismissed()
+        do {
+            try modelContext.save()
+        } catch {
+            presentError(error)
+        }
+    }
+
+    private func importDraft(_ draft: ExtractedReminderDraft) async {
+        importingDraftIDs.insert(draft.id)
+        defer {
+            importingDraftIDs.remove(draft.id)
+        }
+
+        do {
+            let identifier = try await RemindersImportService().importDraft(draft.reminderDraft)
+            draft.markImported(reminderIdentifier: identifier)
+            try modelContext.save()
+        } catch {
+            presentError(error)
+        }
+    }
+
+    private func importAllDrafts() async {
+        let draftsToImport = pendingDrafts
+        guard !draftsToImport.isEmpty else { return }
+
+        isImportingAll = true
+        defer {
+            isImportingAll = false
+        }
+
+        do {
+            let identifiers = try await RemindersImportService().importDrafts(draftsToImport.map(\.reminderDraft))
+            for (draft, identifier) in zip(draftsToImport, identifiers) {
+                draft.markImported(reminderIdentifier: identifier)
+            }
+            try modelContext.save()
+        } catch {
+            presentError(error)
+        }
+    }
+
+    private func presentError(_ error: any Error) {
+        errorMessage = error.localizedDescription
+        showErrorAlert = true
+    }
+}
+
+private struct ExtractedReminderDraftRow: View {
+    let draft: ExtractedReminderDraft
+    let isImporting: Bool
+
+    private var dueDateText: String? {
+        ReminderDueDateParser.displayText(
+            dueDateString: draft.optionalDueDateString,
+            rawDueDatePhrase: draft.rawDueDatePhrase
+        )
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .top, spacing: 12) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(draft.title)
+                        .font(.body)
+                        .bold()
+
+                    if let dueDateText {
+                        Label(dueDateText, systemImage: "calendar")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    if let notes = draft.notes,
+                       !notes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        Text(notes)
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    if draft.priority != .none {
+                        Text(priorityLabel(for: draft.priority))
+                            .font(.caption)
+                            .foregroundStyle(priorityColor(for: draft.priority))
+                    }
+                }
+
+                Spacer(minLength: 0)
+
+                if isImporting {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    private func priorityLabel(for priority: ReminderDraftPriority) -> String {
+        switch priority {
+        case .none:
+            "No Priority"
+        case .low:
+            "Low Priority"
+        case .medium:
+            "Medium Priority"
+        case .high:
+            "High Priority"
+        }
+    }
+
+    private func priorityColor(for priority: ReminderDraftPriority) -> Color {
+        switch priority {
+        case .none:
+            .secondary
+        case .low:
+            .blue
+        case .medium:
+            .orange
+        case .high:
+            .red
+        }
+    }
+}

--- a/VivaDicta/Views/Reminders/ExtractedRemindersSheet.swift
+++ b/VivaDicta/Views/Reminders/ExtractedRemindersSheet.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import SwiftData
+import os
 #if canImport(UIKit)
 import UIKit
 #endif
@@ -24,6 +25,8 @@ struct ExtractedRemindersSheet: View {
     @State private var showErrorAlert = false
     @State private var errorMessage = ""
     @State private var shouldOfferSettingsShortcut = false
+
+    private let logger = Logger(category: .reminderExtraction)
 
     private var pendingDrafts: [ExtractedReminderDraft] {
         allReminderDrafts.filter {
@@ -93,6 +96,9 @@ struct ExtractedRemindersSheet: View {
                 }
             }
         }
+        .onAppear {
+            logSheetSnapshot(context: "appear")
+        }
         .alert("Reminder Import Failed", isPresented: $showErrorAlert) {
             if shouldOfferSettingsShortcut {
                 Button("Settings") {
@@ -153,6 +159,17 @@ struct ExtractedRemindersSheet: View {
         errorMessage = error.localizedDescription
         shouldOfferSettingsShortcut = (error as? RemindersImportError)?.shouldOfferSettingsShortcut ?? false
         showErrorAlert = true
+    }
+
+    private func logSheetSnapshot(context: String) {
+        logger.logInfo(
+            "Reminder sheet - \(context) noteId=\(transcription.id.uuidString) pendingCount=\(pendingDrafts.count) allDraftsCount=\(allReminderDrafts.count)"
+        )
+        for (index, draft) in pendingDrafts.enumerated() {
+            logger.logDebug(
+                "Reminder sheet - \(context) [\(index)] draftId=\(draft.id.uuidString) noteId=\(draft.transcription?.id.uuidString ?? "nil") title='\(draft.title)' due='\(draft.optionalDueDateString ?? "nil")' raw='\(draft.rawDueDatePhrase ?? "nil")'"
+            )
+        }
     }
 
     private func openAppSettings() {

--- a/VivaDicta/Views/Reminders/ExtractedRemindersSheet.swift
+++ b/VivaDicta/Views/Reminders/ExtractedRemindersSheet.swift
@@ -7,17 +7,22 @@
 
 import SwiftUI
 import SwiftData
+#if canImport(UIKit)
+import UIKit
+#endif
 
 struct ExtractedRemindersSheet: View {
     @Bindable var transcription: Transcription
 
     @Environment(\.dismiss) private var dismiss
     @Environment(\.modelContext) private var modelContext
+    @Environment(\.openURL) private var openURL
 
     @State private var importingDraftIDs = Set<UUID>()
     @State private var isImportingAll = false
     @State private var showErrorAlert = false
     @State private var errorMessage = ""
+    @State private var shouldOfferSettingsShortcut = false
 
     private var pendingDrafts: [ExtractedReminderDraft] {
         transcription.pendingExtractedReminderDrafts
@@ -86,6 +91,11 @@ struct ExtractedRemindersSheet: View {
             }
         }
         .alert("Reminder Import Failed", isPresented: $showErrorAlert) {
+            if shouldOfferSettingsShortcut {
+                Button("Settings") {
+                    openAppSettings()
+                }
+            }
             Button("OK", role: .cancel) {}
         } message: {
             Text(errorMessage)
@@ -138,7 +148,15 @@ struct ExtractedRemindersSheet: View {
 
     private func presentError(_ error: any Error) {
         errorMessage = error.localizedDescription
+        shouldOfferSettingsShortcut = (error as? RemindersImportError)?.shouldOfferSettingsShortcut ?? false
         showErrorAlert = true
+    }
+
+    private func openAppSettings() {
+#if canImport(UIKit)
+        guard let settingsURL = URL(string: UIApplication.openSettingsURLString) else { return }
+        openURL(settingsURL)
+#endif
     }
 }
 

--- a/VivaDicta/Views/Reminders/ExtractedRemindersSheet.swift
+++ b/VivaDicta/Views/Reminders/ExtractedRemindersSheet.swift
@@ -17,6 +17,7 @@ struct ExtractedRemindersSheet: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.modelContext) private var modelContext
     @Environment(\.openURL) private var openURL
+    @Query(sort: \ExtractedReminderDraft.createdAt) private var allReminderDrafts: [ExtractedReminderDraft]
 
     @State private var importingDraftIDs = Set<UUID>()
     @State private var isImportingAll = false
@@ -25,7 +26,9 @@ struct ExtractedRemindersSheet: View {
     @State private var shouldOfferSettingsShortcut = false
 
     private var pendingDrafts: [ExtractedReminderDraft] {
-        transcription.pendingExtractedReminderDrafts
+        allReminderDrafts.filter {
+            $0.transcription?.id == transcription.id && $0.status == .pending
+        }
     }
 
     private var isBusy: Bool {

--- a/VivaDicta/Views/Reminders/ExtractedRemindersSheet.swift
+++ b/VivaDicta/Views/Reminders/ExtractedRemindersSheet.swift
@@ -211,12 +211,6 @@ private struct ExtractedReminderDraftRow: View {
                             .foregroundStyle(.secondary)
                     }
 
-                    if draft.priority != .none {
-                        Text(priorityLabel(for: draft.priority))
-                            .font(.caption)
-                            .foregroundStyle(priorityColor(for: draft.priority))
-                    }
-
                     if let statusText {
                         Text(statusText)
                             .font(.caption)
@@ -233,31 +227,5 @@ private struct ExtractedReminderDraftRow: View {
             }
         }
         .padding(.vertical, 4)
-    }
-
-    private func priorityLabel(for priority: ReminderDraftPriority) -> String {
-        switch priority {
-        case .none:
-            "No Priority"
-        case .low:
-            "Low Priority"
-        case .medium:
-            "Medium Priority"
-        case .high:
-            "High Priority"
-        }
-    }
-
-    private func priorityColor(for priority: ReminderDraftPriority) -> Color {
-        switch priority {
-        case .none:
-            .secondary
-        case .low:
-            .blue
-        case .medium:
-            .orange
-        case .high:
-            .red
-        }
     }
 }

--- a/VivaDicta/Views/SettingsScreen/ModeEditView.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditView.swift
@@ -21,6 +21,7 @@ struct ModeEditView: View {
     @FocusState private var isNameFieldFocused: Bool
     @State private var showPresetPicker: Bool = false
     @State private var showAIModelPicker: Bool = false
+    @State private var showReminderExtractorModelPicker: Bool = false
     @State private var hasAttemptedSave: Bool = false
     @State private var shakeTrigger: Int = 0
     
@@ -591,6 +592,157 @@ struct ModeEditView: View {
                     // Refresh model selection when returning from configuration screens
                     viewModel.refreshAIModelSelection()
                 }
+
+                Section(header: reminderSuggestionsSectionHeader,
+                        footer: reminderExtractorSectionFooter) {
+                    Toggle(
+                        isOn: Binding(
+                            get: { viewModel.usesSeparateReminderExtractor },
+                            set: { newValue in
+                                viewModel.setSeparateReminderExtractorEnabled(newValue)
+                                HapticManager.selectionChanged()
+                            }
+                        )
+                    ) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Use Separate Extractor")
+                                .font(.body)
+                            Text("Choose a different provider or model for reminder suggestions than the one used for regular AI processing.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .id("reminderExtractorSection")
+
+                    if viewModel.usesSeparateReminderExtractor {
+                        Picker(selection: $viewModel.reminderExtractorProvider) {
+                            if viewModel.isAppleFoundationModelAvailable {
+                                Section("On-Device") {
+                                    Label("Apple", systemImage: "apple.intelligence")
+                                        .tag(AIProvider.apple)
+                                }
+                            }
+
+                            Section("Cloud") {
+                                ForEach(AIProvider.cloudProviders) { provider in
+                                    if viewModel.isProviderReady(provider) {
+                                        Text(provider.displayName).tag(provider)
+                                    } else {
+                                        HStack(spacing: 4) {
+                                            Text(provider.displayName)
+                                            if provider == .ollama || provider == .customOpenAI {
+                                                Image(systemName: "gear")
+                                            } else {
+                                                Image(systemName: "key.slash.fill")
+                                            }
+                                        }
+                                        .tag(provider)
+                                    }
+                                }
+                            }
+                        } label: {
+                            HStack {
+                                Image(systemName: "checklist")
+                                    .foregroundStyle(aiEnhancementGradient)
+                                Text("Reminder Provider")
+                            }
+                        }
+                        .alignmentGuide(.listRowSeparatorLeading) { _ in 0 }
+                        .onChange(of: viewModel.reminderExtractorProvider) { _, newProvider in
+                            viewModel.updateReminderExtractorProvider(newProvider)
+                            HapticManager.selectionChanged()
+                        }
+                        .onAppear {
+                            viewModel.refreshConnectedProviders()
+                            viewModel.selectFirstReminderExtractorProviderIfNeeded()
+                        }
+
+                        if let provider = viewModel.reminderExtractorProvider {
+                            if viewModel.isProviderReady(provider) {
+                                if provider == .apple {
+                                    HStack {
+                                        Image(systemName: "wand.and.sparkles")
+                                            .foregroundStyle(aiEnhancementGradient)
+                                        Text("Reminder Model")
+                                        Spacer()
+                                        Text("Foundation Model")
+                                            .foregroundStyle(.secondary)
+                                    }
+                                    .alignmentGuide(.listRowSeparatorLeading) { _ in 0 }
+                                } else if provider == .customOpenAI {
+                                    HStack {
+                                        Image(systemName: "wand.and.sparkles")
+                                            .foregroundStyle(aiEnhancementGradient)
+                                        Text("Reminder Model")
+                                        Spacer()
+                                        Text(viewModel.aiService.customOpenAIModelName)
+                                            .foregroundStyle(.secondary)
+                                    }
+                                    .alignmentGuide(.listRowSeparatorLeading) { _ in 0 }
+                                } else {
+                                    Button {
+                                        showReminderExtractorModelPicker = true
+                                    } label: {
+                                        HStack {
+                                            Image(systemName: "wand.and.sparkles")
+                                                .foregroundStyle(aiEnhancementGradient)
+                                            Text("Reminder Model")
+                                            Spacer()
+                                            Text(viewModel.reminderExtractorModel ?? "Select")
+                                                .foregroundStyle(.secondary)
+                                                .lineLimit(1)
+                                            Image(systemName: "chevron.up.chevron.down")
+                                                .font(.system(size: 10, weight: .semibold))
+                                                .foregroundStyle(.tertiary)
+                                        }
+                                    }
+                                    .tint(.primary)
+                                    .alignmentGuide(.listRowSeparatorLeading) { _ in 0 }
+                                    .sheet(isPresented: $showReminderExtractorModelPicker) {
+                                        ModelPickerSheet(
+                                            models: viewModel.aiService.getAvailableModels(for: provider),
+                                            selectedModel: $viewModel.reminderExtractorModel
+                                        )
+                                        .presentationDetents([.medium, .large])
+                                    }
+                                    .onChange(of: viewModel.reminderExtractorModel) { _, newModel in
+                                        viewModel.updateReminderExtractorModel(newModel)
+                                        HapticManager.selectionChanged()
+                                    }
+                                }
+                            } else if provider == .apple {
+                                HStack {
+                                    Image(systemName: "exclamationmark.triangle.fill")
+                                        .foregroundStyle(.orange)
+                                    Text(viewModel.appleFoundationModelStatusMessage)
+                                        .font(.callout)
+                                }
+                                .alignmentGuide(.listRowSeparatorLeading) { _ in 0 }
+                            } else {
+                                Button {
+                                    navigationPath.append(SettingsDestination.aiProviders)
+                                } label: {
+                                    HStack {
+                                        Image(systemName: "exclamationmark.triangle.fill")
+                                            .foregroundStyle(.orange)
+                                        Text("Open AI Providers Settings")
+                                        Spacer()
+                                        Text("Required")
+                                            .font(.caption)
+                                            .foregroundStyle(.secondary)
+                                        Image(systemName: "chevron.right")
+                                            .foregroundStyle(.secondary)
+                                    }
+                                }
+                                .tint(.primary)
+                                .alignmentGuide(.listRowSeparatorLeading) { _ in 0 }
+                            }
+                        }
+                    }
+                }
+                .onAppear {
+                    viewModel.refreshReminderExtractorModelSelection()
+                }
             }
 
             if viewModel.isEditing {
@@ -756,12 +908,51 @@ struct ModeEditView: View {
         }
     }
 
+    private var reminderSuggestionsSectionHeader: some View {
+        HStack(spacing: 4) {
+            Text("Reminder Suggestions")
+            if viewModel.hasReminderExtractorError {
+                Image(systemName: "exclamationmark.circle.fill")
+                    .foregroundStyle(.orange)
+                    .font(.caption2)
+                    .keyframeAnimator(initialValue: CGFloat.zero, trigger: shakeTrigger) { content, value in
+                        content.offset(x: value)
+                    } keyframes: { _ in
+                        SpringKeyframe(8, duration: 0.08, spring: .bouncy)
+                        SpringKeyframe(-6, duration: 0.08, spring: .bouncy)
+                        SpringKeyframe(4, duration: 0.08, spring: .bouncy)
+                        SpringKeyframe(0, duration: 0.1, spring: .bouncy)
+                    }
+            }
+        }
+    }
+
     @ViewBuilder
     private var nameValidationFooter: some View {
         if hasAttemptedSave && viewModel.hasNameError {
             Label("Enter a mode name to continue", systemImage: "info.circle")
                 .foregroundStyle(.orange)
                 .font(.caption)
+        }
+    }
+
+    @ViewBuilder
+    private var reminderExtractorSectionFooter: some View {
+        if let validationMessage = viewModel.reminderExtractorValidationMessage {
+            Label(validationMessage, systemImage: "info.circle")
+                .foregroundStyle(.orange)
+                .font(.caption)
+                .accessibilityLabel("Required: \(validationMessage)")
+                .keyframeAnimator(initialValue: CGFloat.zero, trigger: shakeTrigger) { content, value in
+                    content.offset(x: value)
+                } keyframes: { _ in
+                    SpringKeyframe(8, duration: 0.08, spring: .bouncy)
+                    SpringKeyframe(-6, duration: 0.08, spring: .bouncy)
+                    SpringKeyframe(4, duration: 0.08, spring: .bouncy)
+                    SpringKeyframe(0, duration: 0.1, spring: .bouncy)
+                }
+        } else {
+            Text("Leave this off to use the mode's regular AI setup for reminder suggestions when available.")
         }
     }
 
@@ -780,6 +971,8 @@ struct ModeEditView: View {
                     scrollProxy.scrollTo("transcriptionSection", anchor: .top)
                 } else if viewModel.hasAIProcessingError {
                     scrollProxy.scrollTo("aiProcessingSection", anchor: .top)
+                } else if viewModel.hasReminderExtractorError {
+                    scrollProxy.scrollTo("reminderExtractorSection", anchor: .top)
                 }
             }
         }

--- a/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
@@ -21,6 +21,9 @@ class ModeEditViewModel {
     var aiEnhanceEnabled: Bool = false
     var aiProvider: AIProvider?
     var aiModel: String?
+    var usesSeparateReminderExtractor: Bool = false
+    var reminderExtractorProvider: AIProvider?
+    var reminderExtractorModel: String?
     var selectedPresetId: String?
     var useClipboardContext: Bool = false
     var isAutoTextFormattingEnabled: Bool = false
@@ -58,7 +61,19 @@ class ModeEditViewModel {
             aiEnhancementReady = false
         }
 
-        return hasName && transcriptionReady && aiEnhancementReady
+        let reminderExtractorReady: Bool
+        if !usesSeparateReminderExtractor {
+            reminderExtractorReady = true
+        } else if let provider = reminderExtractorProvider,
+                  let model = reminderExtractorModel,
+                  !model.isEmpty,
+                  isProviderReady(provider) {
+            reminderExtractorReady = true
+        } else {
+            reminderExtractorReady = false
+        }
+
+        return hasName && transcriptionReady && aiEnhancementReady && reminderExtractorReady
     }
 
     var hasNameError: Bool {
@@ -91,6 +106,7 @@ class ModeEditViewModel {
     }
 
     private static let disableHint = ", or disable AI Processing"
+    private static let disableReminderExtractorHint = ", or turn off the separate extractor"
 
     var aiEnhancementValidationMessage: String? {
         guard aiEnhanceEnabled else { return nil }
@@ -118,6 +134,33 @@ class ModeEditViewModel {
         return nil
     }
 
+    var hasReminderExtractorError: Bool {
+        reminderExtractorValidationMessage != nil
+    }
+
+    var reminderExtractorValidationMessage: String? {
+        guard usesSeparateReminderExtractor else { return nil }
+        guard let provider = reminderExtractorProvider else {
+            return "Select a reminder extractor provider\(Self.disableReminderExtractorHint)"
+        }
+        if !isProviderReady(provider) {
+            if provider == .apple {
+                return "\(appleFoundationModelStatusMessage)\(Self.disableReminderExtractorHint)"
+            }
+            if provider == .ollama {
+                return "Configure Ollama server in AI Providers settings\(Self.disableReminderExtractorHint)"
+            }
+            if provider == .customOpenAI {
+                return "Configure Custom AI Provider in AI Providers settings\(Self.disableReminderExtractorHint)"
+            }
+            return "Add API key to continue\(Self.disableReminderExtractorHint)"
+        }
+        if reminderExtractorModel == nil || reminderExtractorModel?.isEmpty == true {
+            return "Select a reminder extractor model\(Self.disableReminderExtractorHint)"
+        }
+        return nil
+    }
+
     init(mode: VivaMode?,
          aiService: AIService,
          presetManager: PresetManager,
@@ -135,6 +178,9 @@ class ModeEditViewModel {
             aiEnhanceEnabled = existingMode.aiEnhanceEnabled
             aiProvider = existingMode.aiProvider
             aiModel = existingMode.aiModel
+            usesSeparateReminderExtractor = existingMode.reminderExtractorProvider != nil
+            reminderExtractorProvider = existingMode.reminderExtractorProvider
+            reminderExtractorModel = existingMode.reminderExtractorModel
             selectedPresetId = existingMode.presetId
             useClipboardContext = existingMode.useClipboardContext
             isAutoTextFormattingEnabled = existingMode.isAutoTextFormattingEnabled
@@ -142,6 +188,7 @@ class ModeEditViewModel {
 
             validateLanguageSelection()
             validateAIModelSelection()
+            validateReminderExtractorModelSelection()
         } else {
             transcriptionProvider = .whisperKit
             transcriptionModel = ""
@@ -170,6 +217,8 @@ class ModeEditViewModel {
             presetId: aiEnhanceEnabled ? selectedPresetId : nil,
             aiProvider: aiEnhanceEnabled ? aiProvider : nil,
             aiModel: aiModel ?? "",
+            reminderExtractorProvider: usesSeparateReminderExtractor ? reminderExtractorProvider : nil,
+            reminderExtractorModel: usesSeparateReminderExtractor ? reminderExtractorModel : nil,
             aiEnhanceEnabled: aiEnhanceEnabled,
             useClipboardContext: aiEnhanceEnabled ? useClipboardContext : false,
             isAutoTextFormattingEnabled: isAutoTextFormattingEnabled,
@@ -264,6 +313,35 @@ class ModeEditViewModel {
         }
     }
 
+    private func validateReminderExtractorModelSelection() {
+        guard let provider = reminderExtractorProvider else { return }
+
+        if provider == .ollama {
+            let availableModels = aiService.ollamaModels
+            guard let currentModel = reminderExtractorModel else { return }
+
+            if !availableModels.contains(currentModel) {
+                let oldModel = currentModel
+                if let firstModel = availableModels.first {
+                    reminderExtractorModel = firstModel
+                    logger.logInfo("Reminder extractor Ollama model '\(oldModel)' not available, reset to '\(firstModel)'")
+                } else {
+                    reminderExtractorModel = nil
+                    logger.logInfo("Reminder extractor Ollama model '\(oldModel)' not available and no models found")
+                }
+            }
+        } else if provider == .customOpenAI {
+            let configuredModel = aiService.customOpenAIModelName
+            if configuredModel.isEmpty {
+                reminderExtractorModel = nil
+                logger.logInfo("Reminder extractor Custom OpenAI model not configured")
+            } else if reminderExtractorModel != configuredModel {
+                reminderExtractorModel = configuredModel
+                logger.logInfo("Reminder extractor Custom OpenAI model updated to configured: '\(configuredModel)'")
+            }
+        }
+    }
+
     // MARK: - Language Settings
     public func isLanguageSelectionAvailable() -> Bool {
         guard isTranscriptionProviderConfigured(transcriptionProvider) else { return false }
@@ -347,104 +425,169 @@ class ModeEditViewModel {
     }
 
     // MARK: - AI Processing settings
+    private enum ModelSelectionTarget {
+        case aiEnhancement
+        case reminderExtraction
+
+        var logName: String {
+            switch self {
+            case .aiEnhancement:
+                "AI"
+            case .reminderExtraction:
+                "reminder extractor"
+            }
+        }
+    }
+
     func selectFirstProviderIfNeeded() {
         guard aiProvider == nil else { return }
 
-        // First try Apple if available (on-device is preferred)
-        if aiService.connectedProviders.contains(.apple) {
-            aiProvider = .apple
-            aiModel = AIProvider.apple.defaultModel
-            logger.logInfo("Auto-selected Apple Foundation Model (on-device)")
+        if let provider = preferredProviderForSelection() {
+            aiProvider = provider
+            aiModel = defaultModel(for: provider)
+            logger.logInfo("Auto-selected provider: \(provider.rawValue)")
+        }
+    }
+
+    func selectFirstReminderExtractorProviderIfNeeded() {
+        guard reminderExtractorProvider == nil else { return }
+
+        if let provider = preferredProviderForSelection() {
+            reminderExtractorProvider = provider
+            reminderExtractorModel = defaultModel(for: provider)
+            logger.logInfo("Auto-selected reminder extractor provider: \(provider.rawValue)")
+        }
+    }
+
+    func setSeparateReminderExtractorEnabled(_ isEnabled: Bool) {
+        usesSeparateReminderExtractor = isEnabled
+
+        if !isEnabled {
+            reminderExtractorProvider = nil
+            reminderExtractorModel = nil
+            logger.logInfo("Disabled separate reminder extractor")
             return
         }
 
-        // Then try to find a cloud provider with API key configured
-        let firstConnectedProvider = AIProvider.cloudProviders.first { provider in
-            aiService.connectedProviders.contains(provider)
-        }
-
-        // If no connected provider, just select the first cloud provider (so UI shows "Add API Key")
-        let providerToSelect = firstConnectedProvider ?? AIProvider.cloudProviders.first
-
-        if let provider = providerToSelect {
-            aiProvider = provider
-
-            // For Ollama, select first available model if default isn't available
-            if provider == .ollama {
-                let availableModels = aiService.ollamaModels
-                if availableModels.contains(provider.defaultModel) {
-                    aiModel = provider.defaultModel
-                } else if let firstModel = availableModels.first {
-                    aiModel = firstModel
-                } else {
-                    aiModel = nil // No models available
-                }
+        if reminderExtractorProvider == nil {
+            if let provider = aiProvider,
+               isProviderReady(provider),
+               let model = aiModel,
+               !model.isEmpty {
+                reminderExtractorProvider = provider
+                reminderExtractorModel = model
+                logger.logInfo("Prefilled separate reminder extractor from AI processing provider: \(provider.rawValue)")
             } else {
-                aiModel = provider.defaultModel
+                selectFirstReminderExtractorProviderIfNeeded()
             }
-
-            logger.logInfo("Auto-selected provider: \(provider.rawValue)")
         }
     }
 
     func updateProvider(_ newProvider: AIProvider?) {
         aiProvider = newProvider
-
-        // For Ollama, select first available model if default isn't available
-        if let provider = newProvider, provider == .ollama {
-            let availableModels = aiService.ollamaModels
-            if availableModels.contains(provider.defaultModel) {
-                aiModel = provider.defaultModel
-            } else if let firstModel = availableModels.first {
-                aiModel = firstModel
-            } else {
-                aiModel = nil // No models available
-            }
-
-            // Verify Ollama connection when selected
-            verifyOllamaConnection()
-        } else if let provider = newProvider, provider == .customOpenAI {
-            // For Custom OpenAI, use the configured model name
-            let modelName = aiService.customOpenAIModelName
-            aiModel = modelName.isEmpty ? nil : modelName
-
-            // Verify Custom OpenAI connection when selected
-            verifyCustomOpenAIConnection()
-        } else {
-            aiModel = newProvider?.defaultModel
-        }
-
+        aiModel = defaultModel(for: newProvider)
+        triggerProviderVerificationIfNeeded(for: newProvider, target: .aiEnhancement)
         logger.logInfo("Updated provider to: \(newProvider?.rawValue ?? "none"), model: \(aiModel ?? "none")")
     }
 
-    /// Verifies Ollama connection when user selects it as provider
-    private func verifyOllamaConnection() {
+    func updateReminderExtractorProvider(_ newProvider: AIProvider?) {
+        reminderExtractorProvider = newProvider
+        reminderExtractorModel = defaultModel(for: newProvider)
+        triggerProviderVerificationIfNeeded(for: newProvider, target: .reminderExtraction)
+        logger.logInfo("Updated reminder extractor provider to: \(newProvider?.rawValue ?? "none"), model: \(reminderExtractorModel ?? "none")")
+    }
+
+    func updateModel(_ newModel: String?) {
+        aiModel = newModel
+        logger.logInfo("Updated model to: \(newModel ?? "none")")
+    }
+
+    func updateReminderExtractorModel(_ newModel: String?) {
+        reminderExtractorModel = newModel
+        logger.logInfo("Updated reminder extractor model to: \(newModel ?? "none")")
+    }
+
+    /// Refreshes the AI model selection based on current provider state
+    /// Called when returning from configuration screens to sync with any changes
+    func refreshAIModelSelection() {
+        guard let provider = aiProvider else { return }
+        refreshModelSelection(for: provider, target: .aiEnhancement)
+    }
+
+    func refreshReminderExtractorModelSelection() {
+        guard let provider = reminderExtractorProvider else { return }
+        refreshModelSelection(for: provider, target: .reminderExtraction)
+    }
+
+    private func preferredProviderForSelection() -> AIProvider? {
+        if aiService.connectedProviders.contains(.apple) {
+            return .apple
+        }
+
+        let firstConnectedProvider = AIProvider.cloudProviders.first { provider in
+            aiService.connectedProviders.contains(provider)
+        }
+
+        return firstConnectedProvider ?? AIProvider.cloudProviders.first
+    }
+
+    private func defaultModel(for provider: AIProvider?) -> String? {
+        guard let provider else { return nil }
+
+        if provider == .ollama {
+            let availableModels = aiService.ollamaModels
+            if availableModels.contains(provider.defaultModel) {
+                return provider.defaultModel
+            }
+            return availableModels.first
+        }
+
+        if provider == .customOpenAI {
+            let modelName = aiService.customOpenAIModelName
+            return modelName.isEmpty ? nil : modelName
+        }
+
+        return provider.defaultModel
+    }
+
+    private func triggerProviderVerificationIfNeeded(
+        for provider: AIProvider?,
+        target: ModelSelectionTarget
+    ) {
+        guard let provider else { return }
+
+        if provider == .ollama {
+            verifyOllamaConnection(for: target)
+        } else if provider == .customOpenAI {
+            verifyCustomOpenAIConnection(for: target)
+        }
+    }
+
+    private func verifyOllamaConnection(for target: ModelSelectionTarget) {
         Task {
             let result = await aiService.verifyOllamaSetup()
             await MainActor.run {
                 if result.success {
                     logger.logInfo("Ollama connection verified: \(result.message)")
-                    // Update model selection with fresh models list
                     if let firstModel = aiService.ollamaModels.first {
-                        if aiModel == nil || !aiService.ollamaModels.contains(aiModel!) {
-                            aiModel = firstModel
+                        if let currentModel = currentModel(for: target),
+                           aiService.ollamaModels.contains(currentModel) {
+                            return
                         }
+                        setModel(firstModel, for: target)
                     }
                 } else {
                     logger.logWarning("Ollama connection failed: \(result.message)")
-                    // Clear models and disable for all modes
                     aiService.ollamaModels = []
                     aiService.disableOllamaEnhancementForAllModes()
-                    aiModel = nil
+                    setModel(nil, for: target)
                 }
                 aiService.refreshConnectedProviders()
             }
         }
     }
 
-    /// Verifies Custom OpenAI connection when user selects it as provider
-    private func verifyCustomOpenAIConnection() {
-        // Only verify if configuration exists
+    private func verifyCustomOpenAIConnection(for target: ModelSelectionTarget) {
         guard !aiService.customOpenAIEndpointURL.isEmpty,
               !aiService.customOpenAIModelName.isEmpty else {
             return
@@ -456,47 +599,64 @@ class ModeEditViewModel {
                 if result.success {
                     aiService.customOpenAIIsVerified = true
                     logger.logInfo("Custom OpenAI connection verified: \(result.message)")
+                    let configuredModel = aiService.customOpenAIModelName
+                    if !configuredModel.isEmpty {
+                        setModel(configuredModel, for: target)
+                    }
                 } else {
                     aiService.customOpenAIIsVerified = false
                     aiService.disableCustomOpenAIEnhancementForAllModes()
                     logger.logWarning("Custom OpenAI connection failed: \(result.message)")
+                    setModel(nil, for: target)
                 }
                 aiService.refreshConnectedProviders()
             }
         }
     }
 
-    func updateModel(_ newModel: String?) {
-        aiModel = newModel
-        logger.logInfo("Updated model to: \(newModel ?? "none")")
-    }
-
-    /// Refreshes the AI model selection based on current provider state
-    /// Called when returning from configuration screens to sync with any changes
-    func refreshAIModelSelection() {
-        guard let provider = aiProvider else { return }
-
+    private func refreshModelSelection(
+        for provider: AIProvider,
+        target: ModelSelectionTarget
+    ) {
         if provider == .ollama {
             let availableModels = aiService.ollamaModels
-            if let currentModel = aiModel, availableModels.contains(currentModel) {
-                // Current model is still valid, keep it
+            if let currentModel = currentModel(for: target),
+               availableModels.contains(currentModel) {
                 return
             }
-            // Select first available model
+
             if let firstModel = availableModels.first {
-                aiModel = firstModel
-                logger.logInfo("Refreshed Ollama model to: \(firstModel)")
+                setModel(firstModel, for: target)
+                logger.logInfo("Refreshed \(target.logName) Ollama model to: \(firstModel)")
             } else {
-                aiModel = nil
+                setModel(nil, for: target)
             }
         } else if provider == .customOpenAI {
             let configuredModel = aiService.customOpenAIModelName
-            if !configuredModel.isEmpty && aiModel != configuredModel {
-                aiModel = configuredModel
-                logger.logInfo("Refreshed Custom OpenAI model to: \(configuredModel)")
+            if !configuredModel.isEmpty && currentModel(for: target) != configuredModel {
+                setModel(configuredModel, for: target)
+                logger.logInfo("Refreshed \(target.logName) Custom OpenAI model to: \(configuredModel)")
             } else if configuredModel.isEmpty {
-                aiModel = nil
+                setModel(nil, for: target)
             }
+        }
+    }
+
+    private func currentModel(for target: ModelSelectionTarget) -> String? {
+        switch target {
+        case .aiEnhancement:
+            aiModel
+        case .reminderExtraction:
+            reminderExtractorModel
+        }
+    }
+
+    private func setModel(_ model: String?, for target: ModelSelectionTarget) {
+        switch target {
+        case .aiEnhancement:
+            aiModel = model
+        case .reminderExtraction:
+            reminderExtractorModel = model
         }
     }
 

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -21,6 +21,8 @@ struct SettingsView: View {
     private var isVADEnabled = true
     @AppStorage(UserDefaultsStorage.Keys.isAutoCopyAfterRecordingEnabled)
     private var isAutoCopyAfterRecordingEnabled = false
+    @AppStorage(UserDefaultsStorage.Keys.isAutoReminderExtractionEnabled, store: UserDefaultsStorage.appPrivate)
+    private var isAutoReminderExtractionEnabled = false
     @AppStorage(UserDefaultsStorage.Keys.audioSessionTimeout)
     private var audioSessionTimeout: Int = 180
     private let prewarmManager = AudioPrewarmManager.shared
@@ -194,6 +196,18 @@ struct SettingsView: View {
                     }
                     NavigationLink(value: SettingsDestination.presetsSettings) {
                         Text("AI Presets")
+                    }
+                    Toggle(isOn: $isAutoReminderExtractionEnabled) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Extract Reminder Suggestions Automatically")
+                                .font(.body)
+                            Text("After saving a new note, detect reminder-worthy tasks in the background and keep them ready for review.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .onChange(of: isAutoReminderExtractionEnabled) { _, _ in
+                        HapticManager.selectionChanged()
                     }
                     NavigationLink(value: SettingsDestination.chatTools) {
                         HStack {

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -759,6 +759,14 @@ private struct ModeInfoRow: View {
         }
     }
 
+    private var reminderExtractorSummary: String? {
+        guard let provider = mode.reminderExtractorProvider else { return nil }
+        if let model = mode.reminderExtractorModel, !model.isEmpty, provider != .apple {
+            return "Reminders: \(provider.displayName) - \(model)"
+        }
+        return "Reminders: \(provider.displayName)"
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             Text(mode.name)
@@ -833,6 +841,13 @@ private struct ModeInfoRow: View {
                 }
                 .font(.caption2)
                 .padding(.leading, 4)
+            }
+
+            if let reminderExtractorSummary {
+                Label(reminderExtractorSummary, systemImage: "checklist")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                    .padding(.leading, 4)
             }
         }
         .padding(.vertical, 4)

--- a/VivaDicta/Views/SettingsScreen/Tags/TranscriptionTagChipsView.swift
+++ b/VivaDicta/Views/SettingsScreen/Tags/TranscriptionTagChipsView.swift
@@ -11,12 +11,21 @@ import SwiftData
 /// Horizontal scrollable row of tag chips for a transcription.
 struct TranscriptionTagChipsView: View {
     let transcription: Transcription
+    var onReviewReminderSuggestions: (() -> Void)?
     @Query(sort: \TranscriptionTag.sortOrder) private var allTags: [TranscriptionTag]
     @Binding var showTagPicker: Bool
 
     private var assignedTags: [TranscriptionTag] {
         let assignedIds = Set((transcription.tagAssignments ?? []).map(\.tagId))
         return allTags.filter { assignedIds.contains($0.id) }
+    }
+
+    private var pendingReminderCount: Int {
+        transcription.pendingExtractedReminderDraftCount
+    }
+
+    private var pendingReminderTitle: String {
+        pendingReminderCount == 1 ? "1 Task" : "\(pendingReminderCount) Tasks"
     }
 
     var body: some View {
@@ -42,6 +51,24 @@ struct TranscriptionTagChipsView: View {
                         .background((Color(hex: tag.colorHex) ?? .blue).opacity(0.15))
                         .foregroundStyle(Color(hex: tag.colorHex) ?? .blue)
                         .clipShape(.capsule)
+                }
+
+                if pendingReminderCount > 0,
+                   let onReviewReminderSuggestions {
+                    Button(action: onReviewReminderSuggestions) {
+                        HStack(spacing: 4) {
+                            Image(systemName: "checklist")
+                            Text(pendingReminderTitle)
+                        }
+                        .font(.caption)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(.blue.opacity(0.15))
+                        .foregroundStyle(.blue)
+                        .clipShape(.capsule)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Review \(pendingReminderTitle.lowercased())")
                 }
 
                 // Add tag button

--- a/VivaDicta/Views/SettingsScreen/Tags/TranscriptionTagChipsView.swift
+++ b/VivaDicta/Views/SettingsScreen/Tags/TranscriptionTagChipsView.swift
@@ -11,6 +11,7 @@ import SwiftData
 /// Horizontal scrollable row of tag chips for a transcription.
 struct TranscriptionTagChipsView: View {
     let transcription: Transcription
+    let reviewReminderCount: Int
     let pendingReminderCount: Int
     var onReviewReminderSuggestions: (() -> Void)?
     @Query(sort: \TranscriptionTag.sortOrder) private var allTags: [TranscriptionTag]
@@ -21,8 +22,9 @@ struct TranscriptionTagChipsView: View {
         return allTags.filter { assignedIds.contains($0.id) }
     }
 
-    private var pendingReminderTitle: String {
-        pendingReminderCount == 1 ? "1 Task" : "\(pendingReminderCount) Tasks"
+    private var reminderTitle: String {
+        let count = pendingReminderCount > 0 ? pendingReminderCount : reviewReminderCount
+        return count == 1 ? "1 Task" : "\(count) Tasks"
     }
 
     var body: some View {
@@ -50,12 +52,12 @@ struct TranscriptionTagChipsView: View {
                         .clipShape(.capsule)
                 }
 
-                if pendingReminderCount > 0,
+                if reviewReminderCount > 0,
                    let onReviewReminderSuggestions {
                     Button(action: onReviewReminderSuggestions) {
                         HStack(spacing: 4) {
                             Image(systemName: "checklist")
-                            Text(pendingReminderTitle)
+                            Text(reminderTitle)
                         }
                         .font(.caption)
                         .padding(.horizontal, 8)
@@ -65,7 +67,7 @@ struct TranscriptionTagChipsView: View {
                         .clipShape(.capsule)
                     }
                     .buttonStyle(.plain)
-                    .accessibilityLabel("Review \(pendingReminderTitle.lowercased())")
+                    .accessibilityLabel("Review \(reminderTitle.lowercased())")
                 }
 
                 // Add tag button

--- a/VivaDicta/Views/SettingsScreen/Tags/TranscriptionTagChipsView.swift
+++ b/VivaDicta/Views/SettingsScreen/Tags/TranscriptionTagChipsView.swift
@@ -11,6 +11,7 @@ import SwiftData
 /// Horizontal scrollable row of tag chips for a transcription.
 struct TranscriptionTagChipsView: View {
     let transcription: Transcription
+    let pendingReminderCount: Int
     var onReviewReminderSuggestions: (() -> Void)?
     @Query(sort: \TranscriptionTag.sortOrder) private var allTags: [TranscriptionTag]
     @Binding var showTagPicker: Bool
@@ -18,10 +19,6 @@ struct TranscriptionTagChipsView: View {
     private var assignedTags: [TranscriptionTag] {
         let assignedIds = Set((transcription.tagAssignments ?? []).map(\.tagId))
         return allTags.filter { assignedIds.contains($0.id) }
-    }
-
-    private var pendingReminderCount: Int {
-        transcription.pendingExtractedReminderDraftCount
     }
 
     private var pendingReminderTitle: String {

--- a/VivaDicta/Views/TranscriptionDetailView.swift
+++ b/VivaDicta/Views/TranscriptionDetailView.swift
@@ -358,6 +358,9 @@ struct TranscriptionDetailView: View {
             VStack(spacing: 0) {
                 TranscriptionTagChipsView(
                     transcription: transcription,
+                    onReviewReminderSuggestions: transcription.pendingExtractedReminderDraftCount > 0 ? {
+                        showExtractedRemindersSheet = true
+                    } : nil,
                     showTagPicker: $showTagPicker
                 )
                 .padding(.horizontal)

--- a/VivaDicta/Views/TranscriptionDetailView.swift
+++ b/VivaDicta/Views/TranscriptionDetailView.swift
@@ -376,7 +376,6 @@ struct TranscriptionDetailView: View {
                     transcription: transcription,
                     pendingReminderCount: pendingReminderDraftCount,
                     onReviewReminderSuggestions: pendingReminderDraftCount > 0 ? {
-                        logReminderDraftSnapshot(context: "review_chip")
                         showExtractedRemindersSheet = true
                     } : nil,
                     showTagPicker: $showTagPicker
@@ -403,7 +402,6 @@ struct TranscriptionDetailView: View {
                 existingVariationIds: Set(sortedVariations.map(\.presetId)),
                 onReviewExtractedTasks: pendingReminderDrafts.isEmpty ? nil : {
                     showPresetPicker = false
-                    logReminderDraftSnapshot(context: "preset_sheet_review")
                     showExtractedRemindersSheet = true
                 },
                 onExtractTasks: canOpenAISheet ? {
@@ -977,7 +975,6 @@ struct TranscriptionDetailView: View {
 
                 guard !Task.isCancelled else { return }
                 processingState = .idle
-                logReminderDraftSnapshot(context: "post_extract_before_sheet")
                 showExtractedRemindersSheet = true
             } catch is CancellationError {
                 processingState = .idle
@@ -986,17 +983,6 @@ struct TranscriptionDetailView: View {
                 enhancementErrorMessage = error.localizedDescription
                 showEnhancementErrorAlert = true
             }
-        }
-    }
-
-    private func logReminderDraftSnapshot(context: String) {
-        logger.logInfo(
-            "Reminder detail - \(context) noteId=\(transcription.id.uuidString) filteredCount=\(pendingReminderDraftCount) allDraftsCount=\(allReminderDrafts.count)"
-        )
-        for (index, draft) in pendingReminderDrafts.enumerated() {
-            logger.logDebug(
-                "Reminder detail - \(context) [\(index)] draftId=\(draft.id.uuidString) noteId=\(draft.transcription?.id.uuidString ?? "nil") title='\(draft.title)' due='\(draft.optionalDueDateString ?? "nil")' raw='\(draft.rawDueDatePhrase ?? "nil")'"
-            )
         }
     }
 

--- a/VivaDicta/Views/TranscriptionDetailView.swift
+++ b/VivaDicta/Views/TranscriptionDetailView.swift
@@ -26,6 +26,7 @@ struct TranscriptionDetailView: View {
     @State private var showEnhancementErrorAlert: Bool = false
     @State private var enhancementErrorMessage: String = ""
     @State private var showPresetPicker: Bool = false
+    @State private var showExtractedRemindersSheet: Bool = false
     @State private var showMetaInfo: Bool = false
     @State private var showConfigureAI: Bool = false
     @State private var showConfigureChat: Bool = false
@@ -82,6 +83,10 @@ struct TranscriptionDetailView: View {
     private var isAIConfigured: Bool {
         appState.aiService.isProperlyConfigured()
     }
+
+    private var canOpenAISheet: Bool {
+        isAIConfigured || ReminderExtractionService(aiService: appState.aiService).canExtractReminders()
+    }
     
     
     @ViewBuilder
@@ -92,11 +97,11 @@ struct TranscriptionDetailView: View {
                 Text("AI")
             }
             .font(.system(size: 16, weight: .bold))
-            .foregroundStyle(isAIConfigured ? .white : .secondary)
+            .foregroundStyle(canOpenAISheet ? .white : .secondary)
             .padding(.horizontal, 20)
             .padding(.vertical, 10)
             .background {
-                if isAIConfigured {
+                if canOpenAISheet {
                     if colorScheme == .dark {
                         // Dark mode: edge-glow HUD style
                         AnimatedMeshGradient()
@@ -159,11 +164,11 @@ struct TranscriptionDetailView: View {
                 Text("AI")
             }
             .font(.system(size: 16, weight: .bold))
-            .foregroundStyle(isAIConfigured ? .white : .secondary)
+            .foregroundStyle(canOpenAISheet ? .white : .secondary)
             .padding(.horizontal, 20)
             .padding(.vertical, 10)
             .background {
-                if isAIConfigured {
+                if canOpenAISheet {
                     if colorScheme == .dark {
                         // Dark mode: edge-glow HUD style
                         AnimatedMeshGradient()
@@ -375,12 +380,24 @@ struct TranscriptionDetailView: View {
             PresetPickerSheet(
                 presetManager: appState.presetManager,
                 existingVariationIds: Set(sortedVariations.map(\.presetId)),
+                onReviewExtractedTasks: transcription.pendingExtractedReminderDrafts.isEmpty ? nil : {
+                    showPresetPicker = false
+                    showExtractedRemindersSheet = true
+                },
+                onExtractTasks: canOpenAISheet ? {
+                    showPresetPicker = false
+                    extractReminderSuggestions()
+                } : nil,
                 onSelect: { preset in
                     showPresetPicker = false
                     generateVariation(preset: preset)
                 }
             )
             .presentationDetents([.medium, .large])
+        }
+        .sheet(isPresented: $showExtractedRemindersSheet) {
+            ExtractedRemindersSheet(transcription: transcription)
+                .presentationDetents([.medium, .large])
         }
         .sheet(isPresented: $showTextEditor) {
             TextEditSheet(
@@ -613,7 +630,7 @@ struct TranscriptionDetailView: View {
                 // Button 2: AI Presets picker
                 Button {
                     HapticManager.lightImpact()
-                    if isAIConfigured {
+                    if canOpenAISheet {
                         showPresetPicker = true
                     } else {
                         showConfigureAI = true
@@ -923,6 +940,32 @@ struct TranscriptionDetailView: View {
         generateVariation(preset: preset)
     }
 
+    private func extractReminderSuggestions() {
+        HapticManager.lightImpact()
+        cancelProcessing()
+        processingState = .enhancing
+
+        let service = ReminderExtractionService(aiService: appState.aiService)
+        processingTask = Task {
+            do {
+                _ = try await service.extractAndPersist(
+                    for: transcription,
+                    modelContext: modelContext
+                )
+
+                guard !Task.isCancelled else { return }
+                processingState = .idle
+                showExtractedRemindersSheet = true
+            } catch is CancellationError {
+                processingState = .idle
+            } catch {
+                processingState = .idle
+                enhancementErrorMessage = error.localizedDescription
+                showEnhancementErrorAlert = true
+            }
+        }
+    }
+
     private func generateVariation(preset: Preset) {
         let shouldStreamResponse = appState.aiService.currentModeSupportsResponseStreaming
         generatingPresetId = preset.id
@@ -1225,6 +1268,8 @@ private struct MetaInfoSheet: View {
 private struct PresetPickerSheet: View {
     let presetManager: PresetManager
     let existingVariationIds: Set<String>
+    let onReviewExtractedTasks: (() -> Void)?
+    let onExtractTasks: (() -> Void)?
     let onSelect: (Preset) -> Void
 
     @State private var filter: PresetFilter = .all
@@ -1273,6 +1318,54 @@ private struct PresetPickerSheet: View {
     var body: some View {
         NavigationStack {
             List {
+                if let onExtractTasks {
+                    Section("Smart Actions") {
+                        if let onReviewExtractedTasks {
+                            Button {
+                                onReviewExtractedTasks()
+                            } label: {
+                                HStack(spacing: 10) {
+                                    Image(systemName: "tray.full")
+                                        .frame(width: 20)
+                                        .foregroundStyle(.secondary)
+
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text("Review Reminder Suggestions")
+                                            .font(.body)
+                                        Text("Open the reminder suggestions already extracted from this note.")
+                                            .font(.caption)
+                                            .foregroundStyle(.secondary)
+                                    }
+
+                                    Spacer()
+                                }
+                            }
+                            .tint(.primary)
+                        }
+
+                        Button {
+                            onExtractTasks()
+                        } label: {
+                            HStack(spacing: 10) {
+                                Image(systemName: "checklist")
+                                    .frame(width: 20)
+                                    .foregroundStyle(.secondary)
+
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text("Extract Tasks to Reminders")
+                                        .font(.body)
+                                    Text("Find reminder suggestions in this note and review them before importing to Apple Reminders.")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+
+                                Spacer()
+                            }
+                        }
+                        .tint(.primary)
+                    }
+                }
+
                 Section {
                     Picker("Filter", selection: $filter) {
                         ForEach(PresetFilter.allCases) { filter in
@@ -1293,7 +1386,7 @@ private struct PresetPickerSheet: View {
                 }
                 .listSectionSpacing(0)
 
-                if typeFilteredPresets.isEmpty {
+                if typeFilteredPresets.isEmpty, onExtractTasks == nil {
                     ContentUnavailableView {
                         Label(searchText.isEmpty ? "No Visible Presets" : "No Presets Found", systemImage: "eye.slash")
                     } description: {
@@ -1331,7 +1424,7 @@ private struct PresetPickerSheet: View {
                     selectedCategory = nil
                 }
             }
-            .navigationTitle("AI Rewrite")
+            .navigationTitle("AI Actions")
             .navigationBarTitleDisplayMode(.inline)
         }
     }

--- a/VivaDicta/Views/TranscriptionDetailView.swift
+++ b/VivaDicta/Views/TranscriptionDetailView.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 import SwiftData
 import CoreSpotlight
-import os
 
 struct TranscriptionDetailView: View {
     var transcription: Transcription
@@ -16,7 +15,6 @@ struct TranscriptionDetailView: View {
     @Environment(AppState.self) var appState
     @Environment(\.modelContext) private var modelContext
     @Environment(\.colorScheme) private var colorScheme
-    @Query(sort: \ExtractedReminderDraft.createdAt) private var allReminderDrafts: [ExtractedReminderDraft]
 
     /// "original" or a variation's presetId
     @State private var selectedChipId: String = "original"
@@ -43,8 +41,6 @@ struct TranscriptionDetailView: View {
     // Ripple effect state for processing animations
     @State private var rippleEffectTimer: Timer?
     @State private var rippleEffectTrigger = false
-
-    private let logger = Logger(category: .reminderExtraction)
 
     private var sortedVariations: [TranscriptionVariation] {
         (transcription.variations ?? []).sorted { $0.createdAt < $1.createdAt }
@@ -88,16 +84,12 @@ struct TranscriptionDetailView: View {
         appState.aiService.isProperlyConfigured()
     }
 
-    private var reminderDraftsForCurrentTranscription: [ExtractedReminderDraft] {
-        allReminderDrafts.filter { $0.transcription?.id == transcription.id }
-    }
-
     private var pendingReminderDrafts: [ExtractedReminderDraft] {
-        reminderDraftsForCurrentTranscription.filter { $0.status == .pending }
+        transcription.pendingExtractedReminderDrafts
     }
 
     private var pendingReminderDraftCount: Int {
-        pendingReminderDrafts.count
+        transcription.pendingExtractedReminderDraftCount
     }
 
     private var canOpenAISheet: Bool {

--- a/VivaDicta/Views/TranscriptionDetailView.swift
+++ b/VivaDicta/Views/TranscriptionDetailView.swift
@@ -88,6 +88,14 @@ struct TranscriptionDetailView: View {
         transcription.pendingExtractedReminderDrafts
     }
 
+    private var reviewableReminderDrafts: [ExtractedReminderDraft] {
+        transcription.activeExtractedReminderDrafts
+    }
+
+    private var reviewableReminderDraftCount: Int {
+        transcription.activeExtractedReminderDraftCount
+    }
+
     private var pendingReminderDraftCount: Int {
         transcription.pendingExtractedReminderDraftCount
     }
@@ -366,8 +374,9 @@ struct TranscriptionDetailView: View {
             VStack(spacing: 0) {
                 TranscriptionTagChipsView(
                     transcription: transcription,
+                    reviewReminderCount: reviewableReminderDraftCount,
                     pendingReminderCount: pendingReminderDraftCount,
-                    onReviewReminderSuggestions: pendingReminderDraftCount > 0 ? {
+                    onReviewReminderSuggestions: reviewableReminderDraftCount > 0 ? {
                         showExtractedRemindersSheet = true
                     } : nil,
                     showTagPicker: $showTagPicker
@@ -392,7 +401,7 @@ struct TranscriptionDetailView: View {
             PresetPickerSheet(
                 presetManager: appState.presetManager,
                 existingVariationIds: Set(sortedVariations.map(\.presetId)),
-                onReviewExtractedTasks: pendingReminderDrafts.isEmpty ? nil : {
+                onReviewExtractedTasks: reviewableReminderDrafts.isEmpty ? nil : {
                     showPresetPicker = false
                     showExtractedRemindersSheet = true
                 },

--- a/VivaDicta/Views/TranscriptionDetailView.swift
+++ b/VivaDicta/Views/TranscriptionDetailView.swift
@@ -15,6 +15,7 @@ struct TranscriptionDetailView: View {
     @Environment(AppState.self) var appState
     @Environment(\.modelContext) private var modelContext
     @Environment(\.colorScheme) private var colorScheme
+    @Query(sort: \ExtractedReminderDraft.createdAt) private var allReminderDrafts: [ExtractedReminderDraft]
 
     /// "original" or a variation's presetId
     @State private var selectedChipId: String = "original"
@@ -82,6 +83,18 @@ struct TranscriptionDetailView: View {
 
     private var isAIConfigured: Bool {
         appState.aiService.isProperlyConfigured()
+    }
+
+    private var reminderDraftsForCurrentTranscription: [ExtractedReminderDraft] {
+        allReminderDrafts.filter { $0.transcription?.id == transcription.id }
+    }
+
+    private var pendingReminderDrafts: [ExtractedReminderDraft] {
+        reminderDraftsForCurrentTranscription.filter { $0.status == .pending }
+    }
+
+    private var pendingReminderDraftCount: Int {
+        pendingReminderDrafts.count
     }
 
     private var canOpenAISheet: Bool {
@@ -358,7 +371,8 @@ struct TranscriptionDetailView: View {
             VStack(spacing: 0) {
                 TranscriptionTagChipsView(
                     transcription: transcription,
-                    onReviewReminderSuggestions: transcription.pendingExtractedReminderDraftCount > 0 ? {
+                    pendingReminderCount: pendingReminderDraftCount,
+                    onReviewReminderSuggestions: pendingReminderDraftCount > 0 ? {
                         showExtractedRemindersSheet = true
                     } : nil,
                     showTagPicker: $showTagPicker
@@ -383,7 +397,7 @@ struct TranscriptionDetailView: View {
             PresetPickerSheet(
                 presetManager: appState.presetManager,
                 existingVariationIds: Set(sortedVariations.map(\.presetId)),
-                onReviewExtractedTasks: transcription.pendingExtractedReminderDrafts.isEmpty ? nil : {
+                onReviewExtractedTasks: pendingReminderDrafts.isEmpty ? nil : {
                     showPresetPicker = false
                     showExtractedRemindersSheet = true
                 },

--- a/VivaDicta/Views/TranscriptionDetailView.swift
+++ b/VivaDicta/Views/TranscriptionDetailView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import SwiftData
 import CoreSpotlight
+import os
 
 struct TranscriptionDetailView: View {
     var transcription: Transcription
@@ -42,6 +43,8 @@ struct TranscriptionDetailView: View {
     // Ripple effect state for processing animations
     @State private var rippleEffectTimer: Timer?
     @State private var rippleEffectTrigger = false
+
+    private let logger = Logger(category: .reminderExtraction)
 
     private var sortedVariations: [TranscriptionVariation] {
         (transcription.variations ?? []).sorted { $0.createdAt < $1.createdAt }
@@ -373,6 +376,7 @@ struct TranscriptionDetailView: View {
                     transcription: transcription,
                     pendingReminderCount: pendingReminderDraftCount,
                     onReviewReminderSuggestions: pendingReminderDraftCount > 0 ? {
+                        logReminderDraftSnapshot(context: "review_chip")
                         showExtractedRemindersSheet = true
                     } : nil,
                     showTagPicker: $showTagPicker
@@ -399,6 +403,7 @@ struct TranscriptionDetailView: View {
                 existingVariationIds: Set(sortedVariations.map(\.presetId)),
                 onReviewExtractedTasks: pendingReminderDrafts.isEmpty ? nil : {
                     showPresetPicker = false
+                    logReminderDraftSnapshot(context: "preset_sheet_review")
                     showExtractedRemindersSheet = true
                 },
                 onExtractTasks: canOpenAISheet ? {
@@ -972,6 +977,7 @@ struct TranscriptionDetailView: View {
 
                 guard !Task.isCancelled else { return }
                 processingState = .idle
+                logReminderDraftSnapshot(context: "post_extract_before_sheet")
                 showExtractedRemindersSheet = true
             } catch is CancellationError {
                 processingState = .idle
@@ -980,6 +986,17 @@ struct TranscriptionDetailView: View {
                 enhancementErrorMessage = error.localizedDescription
                 showEnhancementErrorAlert = true
             }
+        }
+    }
+
+    private func logReminderDraftSnapshot(context: String) {
+        logger.logInfo(
+            "Reminder detail - \(context) noteId=\(transcription.id.uuidString) filteredCount=\(pendingReminderDraftCount) allDraftsCount=\(allReminderDrafts.count)"
+        )
+        for (index, draft) in pendingReminderDrafts.enumerated() {
+            logger.logDebug(
+                "Reminder detail - \(context) [\(index)] draftId=\(draft.id.uuidString) noteId=\(draft.transcription?.id.uuidString ?? "nil") title='\(draft.title)' due='\(draft.optionalDueDateString ?? "nil")' raw='\(draft.rawDueDatePhrase ?? "nil")'"
+            )
         }
     }
 

--- a/VivaDicta/VivaDictaApp.swift
+++ b/VivaDicta/VivaDictaApp.swift
@@ -58,14 +58,14 @@ struct VivaDictaApp: App {
                     : .none
             )
             modelContainer = try ModelContainer(
-                for: Transcription.self, VocabularyWord.self, WordReplacement.self, TranscriptionVariation.self, CustomRewritePreset.self, RewritePreset.self, TranscriptionTag.self, TranscriptionTagAssignment.self, ChatMessage.self, ChatConversation.self, MultiNoteConversation.self, SmartSearchConversation.self,
+                for: Transcription.self, VocabularyWord.self, WordReplacement.self, TranscriptionVariation.self, ExtractedReminderDraft.self, CustomRewritePreset.self, RewritePreset.self, TranscriptionTag.self, TranscriptionTagAssignment.self, ChatMessage.self, ChatConversation.self, MultiNoteConversation.self, SmartSearchConversation.self,
                 configurations: config
             )
         } catch {
             print("Error loading ModelContainer; switching to in-memory storage. \(error)")
             let config = ModelConfiguration(isStoredInMemoryOnly: true)
             modelContainer = try! ModelContainer(
-                for: Transcription.self, VocabularyWord.self, WordReplacement.self, TranscriptionVariation.self, CustomRewritePreset.self, RewritePreset.self, TranscriptionTag.self, TranscriptionTagAssignment.self, ChatMessage.self, ChatConversation.self, MultiNoteConversation.self, SmartSearchConversation.self,
+                for: Transcription.self, VocabularyWord.self, WordReplacement.self, TranscriptionVariation.self, ExtractedReminderDraft.self, CustomRewritePreset.self, RewritePreset.self, TranscriptionTag.self, TranscriptionTagAssignment.self, ChatMessage.self, ChatConversation.self, MultiNoteConversation.self, SmartSearchConversation.self,
                 configurations: config
             )
         }

--- a/documentation/Smart-Search-RAG-Flow.md
+++ b/documentation/Smart-Search-RAG-Flow.md
@@ -1,0 +1,131 @@
+# Smart Search RAG Flow
+
+This document summarizes the high-level Smart Search RAG pipeline in VivaDicta.
+
+## Architecture
+
+```text
+┌──────────────────────────────────────────────────────────────────────┐
+│ User sends a message in Smart Search chat                           │
+└──────────────────────────────────┬───────────────────────────────────┘
+                                   │
+                                   ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│ SmartSearchChatViewModel.sendMessage()                              │
+│ - validate provider/model                                           │
+│ - create pending user message                                       │
+│ - choose retrieval size: Apple = 3, Cloud = 5                      │
+└──────────────────────────────────┬───────────────────────────────────┘
+                                   │
+                                   ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│ RAGIndexingService.search(query, topK)                              │
+│ - ensure local index is ready                                       │
+│ - semantic vector search over note chunks                           │
+│ - threshold = 0.4                                                   │
+│ - over-fetch topK * 2                                               │
+│ - map chunk ids back to note ids                                    │
+│ - keep best chunk per note                                          │
+└──────────────────────────────────┬───────────────────────────────────┘
+                                   │
+                ┌──────────────────┴──────────────────┐
+                │                                     │
+                ▼                                     ▼
+┌──────────────────────────────┐      ┌────────────────────────────────┐
+│ No retrieval hits            │      │ Retrieval hits found           │
+│ - use raw user question      │      │ - resolve Transcription models │
+│ - no source citations        │      │ - build source citations       │
+└──────────────┬───────────────┘      └──────────────┬─────────────────┘
+               │                                      │
+               └──────────────────┬───────────────────┘
+                                  ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│ SmartSearchContextManager.assembleAugmentedPrompt()                 │
+│ - inject SOURCE blocks                                              │
+│ - each block contains title, date, excerpt                          │
+│ - append USER QUESTION                                              │
+│ - if 0 usable excerpts, return raw query                            │
+└──────────────────────────────────┬───────────────────────────────────┘
+                                   │
+                                   ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│ LLM request                                                         │
+│ - Cloud: system prompt + message history + latest augmented turn    │
+│ - Apple FM: system prompt in session + latest augmented turn        │
+└──────────────────────────────────┬───────────────────────────────────┘
+                                   │
+                                   ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│ Assistant response persisted                                        │
+│ - response text                                                     │
+│ - source note ids                                                   │
+│ - source citations with excerpt + relevance                         │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+## What gets indexed
+
+- Smart Search indexes `transcription.text`
+- It does not index `enhancedText`
+- It does not index `TranscriptionVariation`
+- Chunking is semantic with `chunkSize = 500` and `overlap = 15%`
+- Embeddings use `minishlab/potion-base-32M`
+
+## When indexing happens
+
+- On app launch via `indexAllIfNeeded()`
+- When a note is created
+- When a note is appended to or edited
+- When a note is retranscribed
+- When a note is deleted, its chunks are removed from the index
+
+## What gets injected into the LLM
+
+### Smart Search system prompt
+
+This is the exact system prompt used by Smart Search:
+
+```text
+You are a helpful AI assistant with access to the user's voice transcription notes.
+Relevant note excerpts are retrieved automatically for each question and provided in source sections.
+
+Guidelines:
+- Answer questions using the provided note context
+- When referencing a specific note, mention its title or date
+- The provided source sections are excerpts, not always full notes
+- Never mention prompt structure, source numbering, or internal formatting in your answer
+- If the provided notes don't contain enough information to answer, say so clearly in plain natural language
+- You may combine information from multiple notes to form a complete answer
+- Keep responses concise unless the user asks for detail
+- Do not use long em-dashes; use normal hyphens instead
+- Do not fabricate information that isn't in the provided notes
+```
+
+### The retrieved context is injected as plain text:
+
+```text
+Here are relevant excerpts from the user's notes:
+
+SOURCE 1
+Title: ...
+Date: ...
+Excerpt:
+...
+
+SOURCE 2
+Title: ...
+Date: ...
+Excerpt:
+...
+
+USER QUESTION:
+...
+```
+
+Important behavior:
+
+- Retrieval is performed for every submitted user turn
+- Retrieval happens before the LLM call
+- Only the latest user turn gets fresh retrieved context injected
+- Older chat turns remain as their original text in history
+- If retrieval finds nothing, the raw question is sent without note excerpts


### PR DESCRIPTION
## Summary
- add reminder suggestion extraction and persistence for transcription notes
- add review/import flow for Apple Reminders, automatic extraction setting, and per-mode extractor override
- support Apple Foundation Models plus cloud providers with structured reminder extraction, improved date handling, and cleaner date-only behavior

## Testing
- `xcodebuild -scheme VivaDicta -configuration Debug -workspace ./VivaDicta.xcodeproj/project.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max,OS=26.4' build 2>&1 | xcsift`
- on-device Apple Foundation Models smoke tests for:
  - `Okay, I need to visit the dentist on Saturday at 10 a.m.`
  - `Okay, I need to call my parents on Sunday at 10 a.m.`
  - `I have a dinner with my friends this Friday, so please remind me.`

## Notes
- reminder drafts are persisted and reviewable before import
- date-only reminders no longer invent a time on import or display
- CloudKit schema deployment is required before shipping because this adds persisted reminder draft data
