### PR TITLE
Add speaker diarization for WhisperKit, Deepgram, and Mistral

### DIFF
--- a/VivaDicta.xcodeproj/project.pbxproj
+++ b/VivaDicta.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		18E1C7FE2E8E793E00BE8A11 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 18E1C7FD2E8E793E00BE8A11 /* SwiftUI.framework */; };
 		18E1C80F2E8E793F00BE8A11 /* VivaDictaWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 18E1C7FA2E8E793E00BE8A11 /* VivaDictaWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		18E328F72E894C3D0026327D /* WhisperKit in Frameworks */ = {isa = PBXBuildFile; productRef = 18E328F62E894C3D0026327D /* WhisperKit */; };
+		18F0AA4B2F90A11100A1B2C3 /* SpeakerKit in Frameworks */ = {isa = PBXBuildFile; productRef = 18F0AA4A2F90A11100A1B2C3 /* SpeakerKit */; };
 		18EBD6B32ED1FBFB00C0041E /* FluidAudio in Frameworks */ = {isa = PBXBuildFile; productRef = 18EBD6B22ED1FBFB00C0041E /* FluidAudio */; };
 		18EBD7992ED1FCC600C0041E /* FluidAudio in Frameworks */ = {isa = PBXBuildFile; productRef = 18EBD7982ED1FCC600C0041E /* FluidAudio */; };
 /* End PBXBuildFile section */
@@ -440,6 +441,7 @@
 				1879FDA02F8C088E00952CF9 /* LumoKit in Frameworks */,
 				18EBD6B32ED1FBFB00C0041E /* FluidAudio in Frameworks */,
 				18E328F72E894C3D0026327D /* WhisperKit in Frameworks */,
+				18F0AA4B2F90A11100A1B2C3 /* SpeakerKit in Frameworks */,
 				18E1B4AD2E8C875000BE8A11 /* KeyboardKit in Frameworks */,
 				18B497F22F268B2700538830 /* FirebaseCrashlytics in Frameworks */,
 				18B497F02F268B2700538830 /* FirebaseAnalytics in Frameworks */,
@@ -597,6 +599,7 @@
 			name = VivaDicta;
 			packageProductDependencies = (
 				18E328F62E894C3D0026327D /* WhisperKit */,
+				18F0AA4A2F90A11100A1B2C3 /* SpeakerKit */,
 				18E1B4AC2E8C875000BE8A11 /* KeyboardKit */,
 				18EBD6B22ED1FBFB00C0041E /* FluidAudio */,
 				18B497EF2F268B2700538830 /* FirebaseAnalytics */,
@@ -2438,6 +2441,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 18E328F52E894C3D0026327D /* XCRemoteSwiftPackageReference "WhisperKit" */;
 			productName = WhisperKit;
+		};
+		18F0AA4A2F90A11100A1B2C3 /* SpeakerKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 18E328F52E894C3D0026327D /* XCRemoteSwiftPackageReference "WhisperKit" */;
+			productName = SpeakerKit;
 		};
 		18EBD6B22ED1FBFB00C0041E /* FluidAudio */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/VivaDicta/Services/AIEnhance/PromptsTemplates.swift
+++ b/VivaDicta/Services/AIEnhance/PromptsTemplates.swift
@@ -120,6 +120,7 @@ extension PromptsTemplates {
         3. Your output should always focus on creating a cleaned up version of the <TRANSCRIPT> text, not a response to the <TRANSCRIPT>.
         4. Для русского языка не используй букву "ё". Вместо нее всегда используй "е". В итоговом тексте замени все буквы "ё" на букву "е".
         5. DO NOT use long em-dashes "—", use normal hyphen "-" instead of it.
+        6. If <TRANSCRIPT> contains speaker labels such as "Speaker A:" or "Speaker 1:", preserve every label and keep each speaker turn separate. Do not merge speakers, remove labels, or rewrite it into a single-speaker paragraph.
 
         Here are the more Important Rules you need to adhere to:
 
@@ -145,4 +146,3 @@ extension PromptsTemplates {
         """
     }
 }
-

--- a/VivaDicta/Services/Transcription/CloudTranscription/CloudTranscriptionService.swift
+++ b/VivaDicta/Services/Transcription/CloudTranscription/CloudTranscriptionService.swift
@@ -77,35 +77,35 @@ class CloudTranscriptionService: TranscriptionService {
     private lazy var cohereService = CohereTranscriptionService()
     private lazy var customService = CustomTranscriptionService()
 
-    func transcribe(audioURL: URL, model: any TranscriptionModel) async throws -> String {
-        var text: String
+    func transcribe(audioURL: URL, model: any TranscriptionModel) async throws -> TranscriptionServiceResult {
+        let result: TranscriptionServiceResult
         
         switch model.provider {
         case .openAI:
-            text = try await openAIService.transcribe(audioURL: audioURL, model: model)
+            result = try await openAIService.transcribe(audioURL: audioURL, model: model)
         case .groq:
-            text = try await groqService.transcribe(audioURL: audioURL, model: model)
+            result = try await groqService.transcribe(audioURL: audioURL, model: model)
         case .elevenLabs:
-            text = try await elevenLabsService.transcribe(audioURL: audioURL, model: model)
+            result = try await elevenLabsService.transcribe(audioURL: audioURL, model: model)
         case .deepgram:
-            text = try await deepgramService.transcribe(audioURL: audioURL, model: model)
+            result = try await deepgramService.transcribe(audioURL: audioURL, model: model)
         case .gemini:
-            text = try await geminiService.transcribe(audioURL: audioURL, model: model)
+            result = try await geminiService.transcribe(audioURL: audioURL, model: model)
         case .mistral:
-            text = try await mistralService.transcribe(audioURL: audioURL, model: model)
+            result = try await mistralService.transcribe(audioURL: audioURL, model: model)
         case .soniox:
-            text = try await sonioxService.transcribe(audioURL: audioURL, model: model)
+            result = try await sonioxService.transcribe(audioURL: audioURL, model: model)
         case .cohere:
-            text = try await cohereService.transcribe(audioURL: audioURL, model: model)
+            result = try await cohereService.transcribe(audioURL: audioURL, model: model)
         case .customTranscription:
             guard let customModel = model as? CustomTranscriptionModel else {
                 throw CloudTranscriptionError.unsupportedProvider
             }
-            text = try await customService.transcribe(audioURL: audioURL, model: customModel)
+            result = try await customService.transcribe(audioURL: audioURL, model: customModel)
         default:
             throw CloudTranscriptionError.unsupportedProvider
         }
         
-        return text
+        return result
     }
 }

--- a/VivaDicta/Services/Transcription/CloudTranscription/CohereTranscriptionService.swift
+++ b/VivaDicta/Services/Transcription/CloudTranscription/CohereTranscriptionService.swift
@@ -6,10 +6,11 @@ import os
 struct CohereTranscriptionService {
     private let logger = Logger(category: .cohereTranscriptionService)
 
-    func transcribe(audioURL: URL, model: any TranscriptionModel) async throws -> String {
-        try await NetworkRetry.withRetry(logger: logger) {
+    func transcribe(audioURL: URL, model: any TranscriptionModel) async throws -> TranscriptionServiceResult {
+        let text = try await NetworkRetry.withRetry(logger: logger) {
             try await makeTranscriptionRequest(audioURL: audioURL, model: model)
         }
+        return .plain(text)
     }
 
     private func makeTranscriptionRequest(audioURL: URL, model: any TranscriptionModel) async throws -> String {

--- a/VivaDicta/Services/Transcription/CloudTranscription/DeepgramTranscriptionService.swift
+++ b/VivaDicta/Services/Transcription/CloudTranscription/DeepgramTranscriptionService.swift
@@ -11,14 +11,15 @@ import os
 class DeepgramTranscriptionService {
     private let logger = Logger(category: .deepgramService)
     
-    func transcribe(audioURL: URL, model: any TranscriptionModel) async throws -> String {
+    func transcribe(audioURL: URL, model: any TranscriptionModel) async throws -> TranscriptionServiceResult {
         try await NetworkRetry.withRetry(logger: logger) {
             try await makeTranscriptionRequest(audioURL: audioURL, model: model)
         }
     }
 
-    private func makeTranscriptionRequest(audioURL: URL, model: any TranscriptionModel) async throws -> String {
+    private func makeTranscriptionRequest(audioURL: URL, model: any TranscriptionModel) async throws -> TranscriptionServiceResult {
         let config = try getAPIConfig(for: model)
+        let diarizationEnabled = AppGroupCoordinator.shared.isSpeakerDiarizationEnabled
 
         var request = URLRequest(url: config.url)
         request.httpMethod = "POST"
@@ -49,7 +50,13 @@ class DeepgramTranscriptionService {
                 logger.logError("No transcript found in Deepgram response")
                 throw CloudTranscriptionError.noTranscriptionReturned
             }
-            return transcript
+
+            if diarizationEnabled,
+               let diarizedText = makeSpeakerAttributedText(from: transcriptionResponse) {
+                return .speakerAttributed(diarizedText)
+            }
+
+            return .plain(transcript)
         } catch {
             logger.logError("Failed to decode Deepgram API response: \(error.localizedDescription)")
             throw CloudTranscriptionError.noTranscriptionReturned
@@ -93,6 +100,11 @@ class DeepgramTranscriptionService {
             URLQueryItem(name: "paragraphs", value: "true")
         ])
 
+        if AppGroupCoordinator.shared.isSpeakerDiarizationEnabled {
+            queryItems.append(URLQueryItem(name: "diarize", value: "true"))
+            queryItems.append(URLQueryItem(name: "utterances", value: "true"))
+        }
+
         if let requestLanguage {
             queryItems.append(URLQueryItem(name: "language", value: requestLanguage))
         }
@@ -115,6 +127,17 @@ class DeepgramTranscriptionService {
         
         return APIConfig(url: apiURL, apiKey: apiKey, modelName: model.name)
     }
+
+    private func makeSpeakerAttributedText(from response: DeepgramResponse) -> String? {
+        let turns = response.results.utterances?.map {
+            SpeakerTurn(
+                speakerID: $0.speaker.map(String.init),
+                text: $0.transcript
+            )
+        } ?? []
+
+        return SpeakerDiarizationFormatter.format(turns)
+    }
     
     private struct APIConfig {
         let url: URL
@@ -127,6 +150,7 @@ class DeepgramTranscriptionService {
 
         struct Results: Decodable {
             let channels: [Channel]
+            let utterances: [Utterance]?
 
             struct Channel: Decodable {
                 let alternatives: [Alternative]
@@ -135,6 +159,11 @@ class DeepgramTranscriptionService {
                     let transcript: String
                     let confidence: Double?
                 }
+            }
+
+            struct Utterance: Decodable {
+                let speaker: Int?
+                let transcript: String
             }
         }
     }

--- a/VivaDicta/Services/Transcription/CloudTranscription/ElevenLabsTranscriptionService.swift
+++ b/VivaDicta/Services/Transcription/CloudTranscription/ElevenLabsTranscriptionService.swift
@@ -12,10 +12,11 @@ class ElevenLabsTranscriptionService {
     private let apiURL = URL(string: "https://api.elevenlabs.io/v1/speech-to-text")!
     private let logger = Logger(category: .elevenLabsTranscriptionService)
     
-    func transcribe(audioURL: URL, model: any TranscriptionModel) async throws -> String {
-        try await NetworkRetry.withRetry(logger: logger) {
+    func transcribe(audioURL: URL, model: any TranscriptionModel) async throws -> TranscriptionServiceResult {
+        let text = try await NetworkRetry.withRetry(logger: logger) {
             try await makeTranscriptionRequest(audioURL: audioURL, model: model)
         }
+        return .plain(text)
     }
 
     private func makeTranscriptionRequest(audioURL: URL, model: any TranscriptionModel) async throws -> String {

--- a/VivaDicta/Services/Transcription/CloudTranscription/GeminiTranscriptionService.swift
+++ b/VivaDicta/Services/Transcription/CloudTranscription/GeminiTranscriptionService.swift
@@ -11,10 +11,11 @@ import os
 class GeminiTranscriptionService {
     private let logger = Logger(category: .geminiService)
     
-    func transcribe(audioURL: URL, model: any TranscriptionModel) async throws -> String {
-        try await NetworkRetry.withRetry(logger: logger) {
+    func transcribe(audioURL: URL, model: any TranscriptionModel) async throws -> TranscriptionServiceResult {
+        let text = try await NetworkRetry.withRetry(logger: logger) {
             try await makeTranscriptionRequest(audioURL: audioURL, model: model)
         }
+        return .plain(text)
     }
 
     private func makeTranscriptionRequest(audioURL: URL, model: any TranscriptionModel) async throws -> String {

--- a/VivaDicta/Services/Transcription/CloudTranscription/GroqTranscriptionService.swift
+++ b/VivaDicta/Services/Transcription/CloudTranscription/GroqTranscriptionService.swift
@@ -11,10 +11,11 @@ import os
 struct GroqTranscriptionService {
     private let logger = Logger(category: .groqTranscriptionService)
 
-    func transcribe(audioURL: URL, model: any TranscriptionModel) async throws -> String {
-        try await NetworkRetry.withRetry(logger: logger) {
+    func transcribe(audioURL: URL, model: any TranscriptionModel) async throws -> TranscriptionServiceResult {
+        let text = try await NetworkRetry.withRetry(logger: logger) {
             try await makeTranscriptionRequest(audioURL: audioURL, model: model)
         }
+        return .plain(text)
     }
 
     private func makeTranscriptionRequest(audioURL: URL, model: any TranscriptionModel) async throws -> String {

--- a/VivaDicta/Services/Transcription/CloudTranscription/MistralTranscriptionService.swift
+++ b/VivaDicta/Services/Transcription/CloudTranscription/MistralTranscriptionService.swift
@@ -11,6 +11,20 @@ import os
 struct MistralTranscriptionService {
     private let logger = Logger(category: .mistralTranscriptionService)
 
+    static func requestLanguage(for selectedLanguage: String, diarizationEnabled: Bool) -> String? {
+        let normalizedLanguage = selectedLanguage.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard normalizedLanguage.isEmpty == false, normalizedLanguage != "auto" else {
+            return nil
+        }
+
+        guard diarizationEnabled == false else {
+            return nil
+        }
+
+        return normalizedLanguage
+    }
+
     func transcribe(audioURL: URL, model: any TranscriptionModel) async throws -> TranscriptionServiceResult {
         try await NetworkRetry.withRetry(logger: logger) {
             try await makeTranscriptionRequest(audioURL: audioURL, model: model)
@@ -101,12 +115,21 @@ struct MistralTranscriptionService {
 
         // Add language field if not auto-detect
         let selectedLanguage = UserDefaultsStorage.shared.string(forKey: AppGroupCoordinator.kSelectedLanguageKey) ?? "auto"
-        if selectedLanguage != "auto", !selectedLanguage.isEmpty {
+        let requestLanguage = Self.requestLanguage(
+            for: selectedLanguage,
+            diarizationEnabled: diarizationEnabled
+        )
+
+        if let requestLanguage {
             body.append("--\(boundary)\(crlf)".data(using: .utf8)!)
             body.append("Content-Disposition: form-data; name=\"language\"\(crlf)\(crlf)".data(using: .utf8)!)
-            body.append(selectedLanguage.data(using: .utf8)!)
+            body.append(requestLanguage.data(using: .utf8)!)
             body.append(crlf.data(using: .utf8)!)
-            logger.logInfo("Using language: \(selectedLanguage)")
+            logger.logInfo("Using language: \(requestLanguage)")
+        } else if diarizationEnabled,
+                  selectedLanguage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false,
+                  selectedLanguage != "auto" {
+            logger.logNotice("Skipping explicit language because Mistral diarization requires automatic language detection")
         }
 
         if diarizationEnabled {

--- a/VivaDicta/Services/Transcription/CloudTranscription/MistralTranscriptionService.swift
+++ b/VivaDicta/Services/Transcription/CloudTranscription/MistralTranscriptionService.swift
@@ -11,14 +11,15 @@ import os
 struct MistralTranscriptionService {
     private let logger = Logger(category: .mistralTranscriptionService)
 
-    func transcribe(audioURL: URL, model: any TranscriptionModel) async throws -> String {
+    func transcribe(audioURL: URL, model: any TranscriptionModel) async throws -> TranscriptionServiceResult {
         try await NetworkRetry.withRetry(logger: logger) {
             try await makeTranscriptionRequest(audioURL: audioURL, model: model)
         }
     }
 
-    private func makeTranscriptionRequest(audioURL: URL, model: any TranscriptionModel) async throws -> String {
+    private func makeTranscriptionRequest(audioURL: URL, model: any TranscriptionModel) async throws -> TranscriptionServiceResult {
         let config = try getAPIConfig(for: model)
+        let diarizationEnabled = AppGroupCoordinator.shared.isSpeakerDiarizationEnabled
 
         let boundary = "Boundary-\(UUID().uuidString)"
         var request = URLRequest(url: config.url)
@@ -27,7 +28,12 @@ struct MistralTranscriptionService {
         request.setValue("Bearer \(config.apiKey)", forHTTPHeaderField: "Authorization")
         request.timeoutInterval = NetworkRetry.defaultTimeout
 
-        let body = try createRequestBody(audioURL: audioURL, modelName: config.modelName, boundary: boundary)
+        let body = try createRequestBody(
+            audioURL: audioURL,
+            modelName: config.modelName,
+            boundary: boundary,
+            diarizationEnabled: diarizationEnabled
+        )
 
         let (data, response) = try await URLSession.shared.upload(for: request, from: body)
 
@@ -43,7 +49,13 @@ struct MistralTranscriptionService {
 
         do {
             let transcriptionResponse = try JSONDecoder().decode(TranscriptionResponse.self, from: data)
-            return transcriptionResponse.text
+
+            if diarizationEnabled,
+               let diarizedText = makeSpeakerAttributedText(from: transcriptionResponse) {
+                return .speakerAttributed(diarizedText)
+            }
+
+            return .plain(transcriptionResponse.text)
         } catch {
             logger.logError("Failed to decode Mistral API response: \(error.localizedDescription)")
             throw CloudTranscriptionError.noTranscriptionReturned
@@ -61,7 +73,12 @@ struct MistralTranscriptionService {
         return APIConfig(url: apiURL, apiKey: apiKey, modelName: model.name)
     }
 
-    private func createRequestBody(audioURL: URL, modelName: String, boundary: String) throws -> Data {
+    private func createRequestBody(
+        audioURL: URL,
+        modelName: String,
+        boundary: String,
+        diarizationEnabled: Bool
+    ) throws -> Data {
         var body = Data()
         let crlf = "\r\n"
 
@@ -92,9 +109,32 @@ struct MistralTranscriptionService {
             logger.logInfo("Using language: \(selectedLanguage)")
         }
 
+        if diarizationEnabled {
+            body.append("--\(boundary)\(crlf)".data(using: .utf8)!)
+            body.append("Content-Disposition: form-data; name=\"diarize\"\(crlf)\(crlf)".data(using: .utf8)!)
+            body.append("true".data(using: .utf8)!)
+            body.append(crlf.data(using: .utf8)!)
+
+            body.append("--\(boundary)\(crlf)".data(using: .utf8)!)
+            body.append("Content-Disposition: form-data; name=\"timestamp_granularities\"\(crlf)\(crlf)".data(using: .utf8)!)
+            body.append("segment".data(using: .utf8)!)
+            body.append(crlf.data(using: .utf8)!)
+        }
+
         body.append("--\(boundary)--\(crlf)".data(using: .utf8)!)
 
         return body
+    }
+
+    private func makeSpeakerAttributedText(from response: TranscriptionResponse) -> String? {
+        let turns = response.segments?.map {
+            SpeakerTurn(
+                speakerID: $0.speakerID,
+                text: $0.text
+            )
+        } ?? []
+
+        return SpeakerDiarizationFormatter.format(turns)
     }
 
     private struct APIConfig {
@@ -105,5 +145,16 @@ struct MistralTranscriptionService {
 
     private struct TranscriptionResponse: Decodable {
         let text: String
+        let segments: [TranscriptionSegment]?
+    }
+
+    private struct TranscriptionSegment: Decodable {
+        let text: String
+        let speakerID: String?
+
+        private enum CodingKeys: String, CodingKey {
+            case text
+            case speakerID = "speaker_id"
+        }
     }
 }

--- a/VivaDicta/Services/Transcription/CloudTranscription/OpenAITranscriptionService.swift
+++ b/VivaDicta/Services/Transcription/CloudTranscription/OpenAITranscriptionService.swift
@@ -11,10 +11,11 @@ import os
 struct OpenAITranscriptionService {
     private let logger = Logger(category: .openAITranscriptionService)
 
-    func transcribe(audioURL: URL, model: any TranscriptionModel) async throws -> String {
-        try await NetworkRetry.withRetry(logger: logger) {
+    func transcribe(audioURL: URL, model: any TranscriptionModel) async throws -> TranscriptionServiceResult {
+        let text = try await NetworkRetry.withRetry(logger: logger) {
             try await makeTranscriptionRequest(audioURL: audioURL, model: model)
         }
+        return .plain(text)
     }
 
     private func makeTranscriptionRequest(audioURL: URL, model: any TranscriptionModel) async throws -> String {

--- a/VivaDicta/Services/Transcription/CloudTranscription/SonioxTranscriptionService.swift
+++ b/VivaDicta/Services/Transcription/CloudTranscription/SonioxTranscriptionService.swift
@@ -14,7 +14,7 @@ struct SonioxTranscriptionService {
     private let maxWaitSeconds: TimeInterval = 300
     private let pollIntervalNanoseconds: UInt64 = 1_000_000_000
 
-    func transcribe(audioURL: URL, model: any TranscriptionModel) async throws -> String {
+    func transcribe(audioURL: URL, model: any TranscriptionModel) async throws -> TranscriptionServiceResult {
         let config = try getAPIConfig(for: model)
 
         let fileId = try await uploadFile(audioURL: audioURL, apiKey: config.apiKey)
@@ -25,7 +25,7 @@ struct SonioxTranscriptionService {
         guard !transcript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw CloudTranscriptionError.noTranscriptionReturned
         }
-        return transcript
+        return .plain(transcript)
     }
 
     // MARK: - Private Methods

--- a/VivaDicta/Services/Transcription/CustomTranscription/CustomTranscriptionService.swift
+++ b/VivaDicta/Services/Transcription/CustomTranscription/CustomTranscriptionService.swift
@@ -11,10 +11,11 @@ import os
 struct CustomTranscriptionService {
     private let logger = Logger(category: .customTranscriptionService)
 
-    func transcribe(audioURL: URL, model: CustomTranscriptionModel) async throws -> String {
-        try await NetworkRetry.withRetry(logger: logger) {
+    func transcribe(audioURL: URL, model: CustomTranscriptionModel) async throws -> TranscriptionServiceResult {
+        let text = try await NetworkRetry.withRetry(logger: logger) {
             try await makeTranscriptionRequest(audioURL: audioURL, model: model)
         }
+        return .plain(text)
     }
 
     private func makeTranscriptionRequest(audioURL: URL, model: CustomTranscriptionModel) async throws -> String {

--- a/VivaDicta/Services/Transcription/ParakeetTranscriptionService.swift
+++ b/VivaDicta/Services/Transcription/ParakeetTranscriptionService.swift
@@ -42,7 +42,7 @@ class ParakeetTranscriptionService: TranscriptionService {
         }
     }
  
-    func transcribe(audioURL: URL, model: any TranscriptionModel) async throws -> String {
+    func transcribe(audioURL: URL, model: any TranscriptionModel) async throws -> TranscriptionServiceResult {
         guard let parakeetModel = model as? ParakeetModel else {
             throw TranscriptionError.unsupportedModel
         }
@@ -93,7 +93,7 @@ class ParakeetTranscriptionService: TranscriptionService {
         logger.logNotice("🦜 Parakeet ASR models cleaned up from memory")
         
         logger.logNotice("✅ Parakeet transcription completed successfully")
-        return result.text
+        return .plain(result.text)
     }
 
     private func readAndConvertAudio(from url: URL) async throws -> [Float] {

--- a/VivaDicta/Services/Transcription/SpeakerDiarizationFormatter.swift
+++ b/VivaDicta/Services/Transcription/SpeakerDiarizationFormatter.swift
@@ -1,0 +1,102 @@
+//
+//  SpeakerDiarizationFormatter.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.14
+//
+
+import Foundation
+
+struct SpeakerTurn: Hashable, Sendable {
+    let speakerID: String?
+    let text: String
+}
+
+enum SpeakerDiarizationFormatter {
+    static func format(_ turns: [SpeakerTurn]) -> String? {
+        var mergedTurns = [MergedTurn]()
+        var lastResolvedSpeakerID: String?
+        var unknownSpeakerCount = 0
+
+        for turn in turns {
+            let normalizedText = normalize(text: turn.text)
+            guard normalizedText.isEmpty == false else {
+                continue
+            }
+
+            let resolvedSpeakerID: String
+            if let normalizedSpeakerID = normalize(speakerID: turn.speakerID) {
+                resolvedSpeakerID = normalizedSpeakerID
+            } else if let lastResolvedSpeakerID {
+                resolvedSpeakerID = lastResolvedSpeakerID
+            } else {
+                resolvedSpeakerID = "unknown-\(unknownSpeakerCount)"
+                unknownSpeakerCount += 1
+            }
+
+            if let lastIndex = mergedTurns.indices.last,
+               mergedTurns[lastIndex].speakerID == resolvedSpeakerID {
+                mergedTurns[lastIndex].text += " " + normalizedText
+            } else {
+                mergedTurns.append(MergedTurn(speakerID: resolvedSpeakerID, text: normalizedText))
+            }
+
+            lastResolvedSpeakerID = resolvedSpeakerID
+        }
+
+        guard mergedTurns.isEmpty == false else {
+            return nil
+        }
+
+        var speakerLabels = [String: String]()
+        var nextSpeakerIndex = 0
+
+        return mergedTurns
+            .map { turn in
+                let label = speakerLabels[turn.speakerID] ?? {
+                    let newLabel = "Speaker \(speakerLetters(for: nextSpeakerIndex))"
+                    speakerLabels[turn.speakerID] = newLabel
+                    nextSpeakerIndex += 1
+                    return newLabel
+                }()
+                return "\(label): \(turn.text)"
+            }
+            .joined(separator: "\n\n")
+    }
+
+    private static func normalize(text: String) -> String {
+        text
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func normalize(speakerID: String?) -> String? {
+        guard let speakerID else {
+            return nil
+        }
+
+        let trimmedSpeakerID = speakerID.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmedSpeakerID.isEmpty ? nil : trimmedSpeakerID
+    }
+
+    private static func speakerLetters(for index: Int) -> String {
+        precondition(index >= 0)
+
+        var remaining = index
+        var letters = ""
+
+        repeat {
+            let letterIndex = remaining % 26
+            let scalarValue = UnicodeScalar(65 + letterIndex)!
+            letters = String(scalarValue) + letters
+            remaining = (remaining / 26) - 1
+        } while remaining >= 0
+
+        return letters
+    }
+
+    private struct MergedTurn: Hashable, Sendable {
+        let speakerID: String
+        var text: String
+    }
+}

--- a/VivaDicta/Services/Transcription/TranscriptionManager.swift
+++ b/VivaDicta/Services/Transcription/TranscriptionManager.swift
@@ -197,12 +197,12 @@ class TranscriptionManager {
         default:
             transcriptionService = cloudTranscriptionService
         }
-        let text = try await transcriptionService.transcribe(audioURL: audioURL, model: model)
+        let transcriptionResult = try await transcriptionService.transcribe(audioURL: audioURL, model: model)
 
-        var result = TranscriptionOutputFilter.filter(text)
+        var result = TranscriptionOutputFilter.filter(transcriptionResult.text)
 
         // Apply text formatting if enabled for current mode
-        if currentMode.isAutoTextFormattingEnabled {
+        if currentMode.isAutoTextFormattingEnabled && transcriptionResult.isSpeakerAttributed == false {
             result = TextFormatter.format(result)
         }
 

--- a/VivaDicta/Services/Transcription/TranscriptionOutputFilter.swift
+++ b/VivaDicta/Services/Transcription/TranscriptionOutputFilter.swift
@@ -60,8 +60,11 @@ struct TranscriptionOutputFilter {
             }
         }
 
-        // Clean whitespace
-        filteredText = filteredText.replacingOccurrences(of: #"\s{2,}"#, with: " ", options: .regularExpression)
+        // Clean whitespace while preserving intentional line breaks.
+        filteredText = filteredText.replacingOccurrences(of: "\r\n", with: "\n")
+        filteredText = filteredText.replacingOccurrences(of: #"[ \t]{2,}"#, with: " ", options: .regularExpression)
+        filteredText = filteredText.replacingOccurrences(of: #" *\n *"#, with: "\n", options: .regularExpression)
+        filteredText = filteredText.replacingOccurrences(of: #"\n{3,}"#, with: "\n\n", options: .regularExpression)
         filteredText = filteredText.trimmingCharacters(in: .whitespacesAndNewlines)
 
         // Log results

--- a/VivaDicta/Services/Transcription/TranscriptionServiceProtocol.swift
+++ b/VivaDicta/Services/Transcription/TranscriptionServiceProtocol.swift
@@ -31,9 +31,9 @@ protocol TranscriptionService {
     ///     pointing to an audio file in a supported format (WAV, M4A, MP3).
     ///   - model: The transcription model to use. Must be compatible with the service implementation.
     ///
-    /// - Returns: The transcribed text from the audio file.
+    /// - Returns: The transcribed text plus metadata about the result.
     ///
     /// - Throws: ``TranscriptionError`` if transcription fails, including network errors
     ///   for cloud services or model loading errors for on-device services.
-    func transcribe(audioURL: URL, model: any TranscriptionModel) async throws -> String
+    func transcribe(audioURL: URL, model: any TranscriptionModel) async throws -> TranscriptionServiceResult
 }

--- a/VivaDicta/Services/Transcription/TranscriptionServiceResult.swift
+++ b/VivaDicta/Services/Transcription/TranscriptionServiceResult.swift
@@ -1,0 +1,26 @@
+//
+//  TranscriptionServiceResult.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.14
+//
+
+import Foundation
+
+struct TranscriptionServiceResult: Sendable {
+    let text: String
+    let isSpeakerAttributed: Bool
+
+    init(text: String, isSpeakerAttributed: Bool = false) {
+        self.text = text
+        self.isSpeakerAttributed = isSpeakerAttributed
+    }
+
+    static func plain(_ text: String) -> Self {
+        Self(text: text)
+    }
+
+    static func speakerAttributed(_ text: String) -> Self {
+        Self(text: text, isSpeakerAttributed: true)
+    }
+}

--- a/VivaDicta/Services/Transcription/WhisperKitTranscriptionService.swift
+++ b/VivaDicta/Services/Transcription/WhisperKitTranscriptionService.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+@preconcurrency import SpeakerKit
 @preconcurrency import WhisperKit
 import os
 
@@ -15,6 +16,7 @@ import os
 @Observable
 class WhisperKitTranscriptionService: TranscriptionService {
     private var whisperKit: WhisperKit?
+    private var speakerKit: SpeakerKit?
     private var currentModelName: String?
     private var modelState: ModelState = .unloaded
     private let logger = Logger(category: .whisperKitTranscriptionService)
@@ -125,7 +127,7 @@ class WhisperKitTranscriptionService: TranscriptionService {
         }
     }
 
-    func transcribe(audioURL: URL, model: any TranscriptionModel) async throws -> String {
+    func transcribe(audioURL: URL, model: any TranscriptionModel) async throws -> TranscriptionServiceResult {
         os_signpost(.event, log: SignpostLog.pointsOfInterest, name: "WhisperKit.transcribe starts")
         guard let whisperKitModel = model as? WhisperKitModel else {
             throw TranscriptionError.unsupportedModel
@@ -145,11 +147,13 @@ class WhisperKitTranscriptionService: TranscriptionService {
             let language = UserDefaultsStorage.shared.string(forKey: AppGroupCoordinator.kSelectedLanguageKey) ?? "auto"
             // VAD setting should be shared with keyboard extension
             let isVADEnabled = UserDefaultsStorage.shared.object(forKey: AppGroupCoordinator.kIsVADEnabled) as? Bool ?? true
+            let isSpeakerDiarizationEnabled = AppGroupCoordinator.shared.isSpeakerDiarizationEnabled
 
             logger.logNotice("🎯 Starting WhisperKit transcription with model: \(whisperKitModel.displayName), VAD: \(isVADEnabled)")
             let decodingOptions = DecodingOptions(
                 language: (language == "auto" ? nil : language),
                 detectLanguage: (language == "auto" ? true : nil),
+                wordTimestamps: isSpeakerDiarizationEnabled,
                 chunkingStrategy: isVADEnabled ? .vad : nil
             )
             
@@ -159,16 +163,66 @@ class WhisperKitTranscriptionService: TranscriptionService {
             // Extract text from segments
             let transcribedText = result.map { $0.text }.joined(separator: " ").trimmingCharacters(in: .whitespacesAndNewlines)
 
+            if isSpeakerDiarizationEnabled,
+               let diarizedResult = await makeSpeakerAttributedResult(
+                from: result,
+                audioURL: audioURL
+               ) {
+                logger.logNotice("✅ WhisperKit diarization completed successfully")
+                os_signpost(.event, log: SignpostLog.pointsOfInterest, name: "WhisperKit.transcribe finishes")
+                return diarizedResult
+            }
+
             // NOTE: We NO LONGER clean up models after transcription
             // Models stay loaded in memory for faster subsequent transcriptions
             logger.logNotice("✅ WhisperKit transcription completed, model kept in memory for faster future use")
             
             os_signpost(.event, log: SignpostLog.pointsOfInterest, name: "WhisperKit.transcribe finishes")
 
-            return transcribedText
+            return .plain(transcribedText)
         } catch {
             logger.logError("❌ WhisperKit transcription failed: \(error.localizedDescription)")
             throw TranscriptionError.transcriptionFailed
+        }
+    }
+
+    private func loadSpeakerKitIfNeeded() async throws -> SpeakerKit {
+        if let speakerKit {
+            return speakerKit
+        }
+
+        let config = PyannoteConfig(load: false, verbose: false)
+        let speakerKit = try await SpeakerKit(config)
+        self.speakerKit = speakerKit
+        return speakerKit
+    }
+
+    private func makeSpeakerAttributedResult(
+        from transcription: [TranscriptionResult],
+        audioURL: URL
+    ) async -> TranscriptionServiceResult? {
+        do {
+            let speakerKit = try await loadSpeakerKitIfNeeded()
+            let audioArray = try AudioProcessor.loadAudioAsFloatArray(fromPath: audioURL.path)
+            let diarization = try await speakerKit.diarize(audioArray: audioArray)
+            let turns = diarization
+                .addSpeakerInfo(to: transcription)
+                .flatMap { $0 }
+                .map { segment in
+                    SpeakerTurn(
+                        speakerID: segment.speaker.speakerId.map(String.init),
+                        text: segment.text
+                    )
+                }
+
+            guard let diarizedText = SpeakerDiarizationFormatter.format(turns) else {
+                return nil
+            }
+
+            return .speakerAttributed(diarizedText)
+        } catch {
+            logger.logWarning("⚠️ WhisperKit diarization failed, falling back to plain transcript: \(error.localizedDescription)")
+            return nil
         }
     }
 
@@ -177,7 +231,9 @@ class WhisperKitTranscriptionService: TranscriptionService {
         if whisperKit != nil {
             logger.logNotice("🧹 Manually unloading WhisperKit model")
             await whisperKit?.unloadModels()
+            await speakerKit?.unloadModels()
             whisperKit = nil
+            speakerKit = nil
             currentModelName = nil
             modelState = .unloaded
         }

--- a/VivaDicta/Shared/AppGroupCoordinator.swift
+++ b/VivaDicta/Shared/AppGroupCoordinator.swift
@@ -61,6 +61,7 @@ public final class AppGroupCoordinator {
     public static let kSmartFormattingOnPaste = "smartFormattingOnPaste"
     public static let kKeepTranscriptInClipboard = "keepTranscriptInClipboard"
     public static let kIsVADEnabled = "IsVADEnabled"
+    public static let kIsSpeakerDiarizationEnabled = "isSpeakerDiarizationEnabled"
     public static let kIsKeyboardHapticFeedbackEnabled = "isKeyboardHapticFeedbackEnabled"
     public static let kIsKeyboardSoundFeedbackEnabled = "isKeyboardSoundFeedbackEnabled"
     
@@ -531,6 +532,18 @@ public final class AppGroupCoordinator {
         }
         set {
             sharedDefaults?.set(newValue, forKey: AppGroupCoordinator.kKeepTranscriptInClipboard)
+            sharedDefaults?.synchronize()
+        }
+    }
+
+    /// Whether speaker diarization is enabled for supported transcription providers
+    /// Defaults to false if not set
+    public var isSpeakerDiarizationEnabled: Bool {
+        get {
+            sharedDefaults?.bool(forKey: AppGroupCoordinator.kIsSpeakerDiarizationEnabled) ?? false
+        }
+        set {
+            sharedDefaults?.set(newValue, forKey: AppGroupCoordinator.kIsSpeakerDiarizationEnabled)
             sharedDefaults?.synchronize()
         }
     }
@@ -1065,4 +1078,3 @@ public final class AppGroupCoordinator {
         }
     }
 }
-

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -19,6 +19,8 @@ struct SettingsView: View {
     @State var navigationPath = NavigationPath()
     @AppStorage(AppGroupCoordinator.kIsVADEnabled, store: UserDefaultsStorage.shared)
     private var isVADEnabled = true
+    @AppStorage(AppGroupCoordinator.kIsSpeakerDiarizationEnabled, store: UserDefaultsStorage.shared)
+    private var isSpeakerDiarizationEnabled = false
     @AppStorage(UserDefaultsStorage.Keys.isAutoCopyAfterRecordingEnabled)
     private var isAutoCopyAfterRecordingEnabled = false
     @AppStorage(UserDefaultsStorage.Keys.isAutoReminderExtractionEnabled, store: UserDefaultsStorage.appPrivate)
@@ -157,6 +159,19 @@ struct SettingsView: View {
                         }
                     }
                     .onChange(of: isVADEnabled) { _, _ in
+                        HapticManager.selectionChanged()
+                    }
+
+                    Toggle(isOn: $isSpeakerDiarizationEnabled) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Speaker Diarization")
+                                .font(.body)
+                            Text("Labels speakers for WhisperKit, Deepgram, and Mistral")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .onChange(of: isSpeakerDiarizationEnabled) { _, _ in
                         HapticManager.selectionChanged()
                     }
 

--- a/VivaDictaTests/AppGroupCoordinatorSessionTests.swift
+++ b/VivaDictaTests/AppGroupCoordinatorSessionTests.swift
@@ -89,6 +89,7 @@ struct AppGroupCoordinatorSessionTests {
 
         #expect(coordinator.isSmartFormattingOnPasteEnabled == true)
         #expect(coordinator.isKeepTranscriptInClipboardEnabled == false)
+        #expect(coordinator.isSpeakerDiarizationEnabled == false)
         #expect(coordinator.isKeyboardHapticFeedbackEnabled == true)
         #expect(coordinator.isKeyboardSoundFeedbackEnabled == true)
     }
@@ -101,6 +102,9 @@ struct AppGroupCoordinatorSessionTests {
 
         coordinator.isKeepTranscriptInClipboardEnabled = true
         #expect(coordinator.isKeepTranscriptInClipboardEnabled == true)
+
+        coordinator.isSpeakerDiarizationEnabled = true
+        #expect(coordinator.isSpeakerDiarizationEnabled == true)
 
         coordinator.isKeyboardHapticFeedbackEnabled = false
         #expect(coordinator.isKeyboardHapticFeedbackEnabled == false)

--- a/VivaDictaTests/PromptsTemplatesTests.swift
+++ b/VivaDictaTests/PromptsTemplatesTests.swift
@@ -64,6 +64,13 @@ struct PromptsTemplatesTests {
         #expect(result.contains("em-dashes"))
     }
 
+    @Test func systemPrompt_containsSpeakerLabelPreservationRule() {
+        let result = PromptsTemplates.systemPrompt(with: "test")
+
+        #expect(result.contains("Speaker A:"))
+        #expect(result.contains("preserve every label"))
+    }
+
     // MARK: - Prompt Template Cases
 
     @Test func allCases_haveNonEmptyPrompts_exceptCustom() {

--- a/VivaDictaTests/SpeakerDiarizationFormatterTests.swift
+++ b/VivaDictaTests/SpeakerDiarizationFormatterTests.swift
@@ -1,0 +1,42 @@
+//
+//  SpeakerDiarizationFormatterTests.swift
+//  VivaDictaTests
+//
+//  Created by Anton Novoselov on 2026.04.14
+//
+
+import Foundation
+import Testing
+@testable import VivaDicta
+
+struct SpeakerDiarizationFormatterTests {
+
+    @Test func format_assignsStableAlphabeticLabelsInEncounterOrder() {
+        let result = SpeakerDiarizationFormatter.format([
+            SpeakerTurn(speakerID: "7", text: "Hello there."),
+            SpeakerTurn(speakerID: "3", text: "Hi.")
+        ])
+
+        #expect(result == "Speaker A: Hello there.\n\nSpeaker B: Hi.")
+    }
+
+    @Test func format_mergesConsecutiveTurnsFromSameSpeaker() {
+        let result = SpeakerDiarizationFormatter.format([
+            SpeakerTurn(speakerID: "0", text: "Hello"),
+            SpeakerTurn(speakerID: "0", text: "again"),
+            SpeakerTurn(speakerID: "1", text: "Hi")
+        ])
+
+        #expect(result == "Speaker A: Hello again\n\nSpeaker B: Hi")
+    }
+
+    @Test func format_reusesPreviousSpeakerWhenProviderOmitsLabel() {
+        let result = SpeakerDiarizationFormatter.format([
+            SpeakerTurn(speakerID: "speaker-1", text: "Hello there."),
+            SpeakerTurn(speakerID: nil, text: "Still me."),
+            SpeakerTurn(speakerID: "speaker-2", text: "Now me.")
+        ])
+
+        #expect(result == "Speaker A: Hello there. Still me.\n\nSpeaker B: Now me.")
+    }
+}

--- a/VivaDictaTests/TextProcessingFilterTests.swift
+++ b/VivaDictaTests/TextProcessingFilterTests.swift
@@ -106,6 +106,13 @@ struct TranscriptionOutputFilterTests {
         #expect(result == "Hello world")
     }
 
+    @Test func filter_preservesSpeakerParagraphBreaks() {
+        let input = "Speaker A: Hello there.\n\nSpeaker B: Hi."
+        let result = TranscriptionOutputFilter.filter(input)
+
+        #expect(result == input)
+    }
+
     // MARK: - filter Tests — Clean Input
 
     @Test func filter_cleanInput_returnsUnchanged() {

--- a/VivaDictaTests/TranscriptionManagerConfigTests.swift
+++ b/VivaDictaTests/TranscriptionManagerConfigTests.swift
@@ -102,3 +102,24 @@ struct TranscriptionManagerConfigTests {
         #expect(manager.allAvailableModels.count == countBefore)
     }
 }
+
+struct MistralTranscriptionServiceTests {
+
+    @Test func requestLanguage_keepsExplicitLanguageWhenDiarizationDisabled() {
+        let requestLanguage = MistralTranscriptionService.requestLanguage(
+            for: "en",
+            diarizationEnabled: false
+        )
+
+        #expect(requestLanguage == "en")
+    }
+
+    @Test func requestLanguage_skipsExplicitLanguageWhenDiarizationEnabled() {
+        let requestLanguage = MistralTranscriptionService.requestLanguage(
+            for: "en",
+            diarizationEnabled: true
+        )
+
+        #expect(requestLanguage == nil)
+    }
+}


### PR DESCRIPTION
## Summary
- add speaker diarization support to the transcription pipeline with speaker-attributed outputs
- enable local diarization for WhisperKit and cloud diarization for Deepgram and Mistral
- add a settings toggle, shared speaker formatting, and guard AI enhancement so speaker labels stay intact

## Testing
- `xcodebuild -scheme VivaDicta -configuration Debug -workspace ./VivaDicta.xcodeproj/project.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max,OS=26.4' build 2>&1 | xcsift`
- `xcodebuild -scheme VivaDicta -configuration Debug -workspace ./VivaDicta.xcodeproj/project.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max,OS=26.4' test 2>&1 | xcsift`

## Notes
- no SwiftData schema changes
- diarized output is currently stored as speaker-labeled plain text rather than structured speaker segments
- supported providers in app after this change: WhisperKit, Deepgram, and Mistral
