### PR TITLE
Improve Parakeet transcription flow and add opt-in vocabulary boosting

### DIFF
--- a/VivaDicta/Models/ParakeetModel.swift
+++ b/VivaDicta/Models/ParakeetModel.swift
@@ -62,14 +62,17 @@ extension ParakeetModel {
         AsrModels.defaultCacheDirectory(for: version)
     }
 
-    var isDownloaded: Bool {
+    private var hasCachedModelDirectory: Bool {
         FileManager.default.fileExists(atPath: modelsDirectory.path)
     }
 
+    var isDownloaded: Bool {
+        AsrModels.modelsExist(at: modelsDirectory, version: version)
+    }
+
     func deleteModel() throws {
-        if isDownloaded {
+        if hasCachedModelDirectory {
             try FileManager.default.removeItem(at: modelsDirectory)
         }
     }
 }
-

--- a/VivaDicta/Services/ModelDownloadManager.swift
+++ b/VivaDicta/Services/ModelDownloadManager.swift
@@ -76,7 +76,6 @@ class ModelDownloadManager: @unchecked Sendable {
     /// Current download status per model, keyed by model name.
     public var downloadStatuses: [String: DownloadStatus] = [:]
 
-    private var observations: [String: NSKeyValueObservation] = [:]
     private var downloadTasks: [String: Task<Void, any Error>] = [:]
     private let logger = Logger(category: .modelDownloadManager)
 
@@ -493,49 +492,6 @@ class ModelDownloadManager: @unchecked Sendable {
 
             // Update every 0.5 seconds for smooth animation
             try? await Task.sleep(for: .milliseconds(500))
-        }
-    }
-
-    // MARK: - Common Download Utilities
-
-    private func downloadFileWithProgress(from url: URL, progressKey: String) async throws -> Data {
-        let destinationURL = FileManager.appDirectory(for: .models).appendingPathComponent(UUID().uuidString)
-
-        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Data, Error>) in
-            let task = URLSession.shared.downloadTask(with: url) { tempURL, response, error in
-                if let error = error {
-                    continuation.resume(throwing: error)
-                    return
-                }
-
-                guard let httpResponse = response as? HTTPURLResponse,
-                      (200...299).contains(httpResponse.statusCode),
-                      let tempURL = tempURL else {
-                    continuation.resume(throwing: URLError(.badServerResponse))
-                    return
-                }
-
-                do {
-                    try FileManager.default.moveItem(at: tempURL, to: destinationURL)
-                    let data = try Data(contentsOf: destinationURL, options: .mappedIfSafe)
-                    continuation.resume(returning: data)
-                    try? FileManager.default.removeItem(at: destinationURL)
-                } catch {
-                    continuation.resume(throwing: error)
-                }
-            }
-
-            task.resume()
-
-            let observation = task.progress.observe(\.fractionCompleted) { [weak self] progress, _ in
-                let currentProgress = round(progress.fractionCompleted * 100) / 100
-                Task { @MainActor in
-                    self?.downloadProgress[progressKey] = currentProgress
-                }
-            }
-
-            // Store observation for potential cleanup
-            observations[progressKey] = observation
         }
     }
 }

--- a/VivaDicta/Services/ModelDownloadManager.swift
+++ b/VivaDicta/Services/ModelDownloadManager.swift
@@ -220,28 +220,32 @@ class ModelDownloadManager: @unchecked Sendable {
 
         logger.logNotice("📥 Starting download of \(model.displayName)")
 
-        // Start progress simulation - declare outside do block to ensure cleanup
-        let progressTask = Task { @MainActor in
-            while !Task.isCancelled && self.downloadStatuses[model.name] == .downloading {
-                if let currentProgress = self.downloadProgress[model.name], currentProgress < 0.9 {
-                    self.downloadProgress[model.name] = min(currentProgress + 0.02, 0.9)
-                }
-                try? await Task.sleep(for: .seconds(1))
-            }
-        }
-        
-        defer {
-            progressTask.cancel()
-        }
-
         do {
-            // Download to FluidAudio's default cache directory
-            async let asrDownload = AsrModels.downloadAndLoad(version: model.version)
-            // Initialize VAD manager to download VAD models to default cache
-            async let vadDownload = VadManager()
+            let modelName = model.name
 
-            _ = try await (asrDownload, vadDownload)
-            
+            _ = try await AsrModels.downloadAndLoad(
+                version: model.version,
+                progressHandler: { progress in
+                    self.updateParakeetDownloadProgress(
+                        for: modelName,
+                        progress: progress,
+                        within: 0.0 ... 0.85
+                    )
+                }
+            )
+
+            try Task.checkCancellation()
+
+            _ = try await VadManager(
+                progressHandler: { progress in
+                    self.updateParakeetDownloadProgress(
+                        for: modelName,
+                        progress: progress,
+                        within: 0.85 ... 1.0
+                    )
+                }
+            )
+
             try Task.checkCancellation()
 
             await MainActor.run {
@@ -274,6 +278,21 @@ class ModelDownloadManager: @unchecked Sendable {
 
             logger.logError("❌ Failed to download \(model.displayName): \(error.localizedDescription)")
             throw error
+        }
+    }
+
+    nonisolated private func updateParakeetDownloadProgress(
+        for modelName: String,
+        progress: DownloadUtils.DownloadProgress,
+        within range: ClosedRange<Double>
+    ) {
+        let boundedProgress =
+            range.lowerBound
+            + ((range.upperBound - range.lowerBound) * progress.fractionCompleted)
+
+        Task { @MainActor in
+            guard self.downloadStatuses[modelName] == .downloading else { return }
+            self.downloadProgress[modelName] = boundedProgress
         }
     }
 

--- a/VivaDicta/Services/Transcription/CloudTranscription/GroqTranscriptionService.swift
+++ b/VivaDicta/Services/Transcription/CloudTranscription/GroqTranscriptionService.swift
@@ -10,6 +10,7 @@ import os
 
 struct GroqTranscriptionService {
     private let logger = Logger(category: .groqTranscriptionService)
+    private let maxVocabularyPromptTerms = 25
 
     func transcribe(audioURL: URL, model: any TranscriptionModel) async throws -> TranscriptionServiceResult {
         let text = try await NetworkRetry.withRetry(logger: logger) {
@@ -130,10 +131,11 @@ struct GroqTranscriptionService {
         }
     }
     
-    /// Use custom vocabulary words as prompt
+    /// Provide Groq with a concise spelling hint for custom vocabulary terms.
     private func buildPromptWithVocabulary() -> String {
-        let vocabularyWords = CustomVocabulary.getTerms()
+        let vocabularyWords = CustomVocabulary.getTerms(maxTerms: maxVocabularyPromptTerms)
         guard !vocabularyWords.isEmpty else { return "" }
-        return vocabularyWords.joined(separator: ", ")
+        let preferredSpellings = vocabularyWords.joined(separator: ", ")
+        return "Prefer these spellings if they are heard in the audio: \(preferredSpellings)."
     }
 }

--- a/VivaDicta/Services/Transcription/ParakeetTranscriptionService.swift
+++ b/VivaDicta/Services/Transcription/ParakeetTranscriptionService.swift
@@ -5,6 +5,7 @@
 //  Created by Anton Novoselov on 2025.09.27
 //
 
+import AVFoundation
 import Foundation
 @preconcurrency import FluidAudio
 import os
@@ -56,24 +57,31 @@ class ParakeetTranscriptionService: TranscriptionService {
         
         logger.logNotice("🦜 Starting Parakeet transcription with model: \(parakeetModel.displayName)")
 
-        // Read and convert audio to 16kHz mono Float32
-        let audioSamples = try await readAndConvertAudio(from: audioURL)
-        let durationSeconds = Double(audioSamples.count) / 16000.0
-
+        let audioFile = try AVAudioFile(forReading: audioURL)
+        let durationSeconds = Double(audioFile.length) / audioFile.processingFormat.sampleRate
         logger.logNotice("📊 Audio duration: \(durationSeconds.formatted(.number.precision(.fractionLength(2)))) seconds")
 
         // Apply VAD for recordings longer than 20 seconds
         // VAD setting should be shared with keyboard extension
         let isVADEnabled = UserDefaultsStorage.shared.object(forKey: AppGroupCoordinator.kIsVADEnabled) as? Bool ?? true
-        
-        var speechAudio: [Float]
-        
+
         if durationSeconds < 20.0 || !isVADEnabled {
-            speechAudio = audioSamples
-        } else {
-            logger.logNotice("🎙️ Applying VAD for long audio (> 20s)")
-            speechAudio = try await applyVAD(to: audioSamples)
+            logger.logNotice("🎙️ Using direct file transcription for Parakeet")
+            let result = try await asrManager.transcribe(audioURL, source: .system)
+
+            await asrManager.cleanup()
+            self.asrManager = nil
+            self.vadManager = nil
+            logger.logNotice("🦜 Parakeet ASR models cleaned up from memory")
+            logger.logNotice("✅ Parakeet transcription completed successfully")
+            return result.text
         }
+
+        logger.logNotice("🎙️ Applying VAD for long audio (> 20s)")
+
+        // VAD segmentation still requires 16kHz mono Float32 samples.
+        var speechAudio = try await readAndConvertAudio(from: audioURL)
+        speechAudio = try await applyVAD(to: speechAudio)
 
         // Add trailing silence to improve final word punctuation detection
         let trailingSilenceSamples = 16_000 // 1 second at 16kHz
@@ -83,7 +91,7 @@ class ParakeetTranscriptionService: TranscriptionService {
         }
 
         // Transcribe the audio
-        let result = try await asrManager.transcribe(speechAudio)
+        let result = try await asrManager.transcribe(speechAudio, source: .system)
 
         // Clean up models after transcription to minimize RAM usage
         await asrManager.cleanup()

--- a/VivaDicta/Services/Transcription/ParakeetTranscriptionService.swift
+++ b/VivaDicta/Services/Transcription/ParakeetTranscriptionService.swift
@@ -14,6 +14,7 @@ class ParakeetTranscriptionService: TranscriptionService {
     private var asrManager: AsrManager?
     private var vadManager: VadManager?
     private let logger = Logger(category: .parakeetTranscriptionService)
+    private let boostedStreamingConfig = SlidingWindowAsrConfig.default
 
     init() {}
 
@@ -23,16 +24,8 @@ class ParakeetTranscriptionService: TranscriptionService {
         }
 
         do {
-            // Validate models before loading
-            let isValid = try await AsrModels.isModelValid(version: model.version)
-            if !isValid {
-                logger.error("Model validation failed for \(model.version == .v2 ? "v2" : "v3"). Models are corrupted.")
-                throw ParakeetTranscriptionError.modelValidationFailed("Parakeet models are corrupted. Please delete and re-download the model.")
-            }
-
             let manager = AsrManager(config: .default)
-            // Load from FluidAudio's default cache directory
-            let models = try await AsrModels.loadFromCache(configuration: nil, version: model.version)
+            let models = try await loadAsrModels(for: model)
             try await manager.loadModels(models)
 
             self.asrManager = manager
@@ -56,13 +49,6 @@ class ParakeetTranscriptionService: TranscriptionService {
             throw TranscriptionError.unsupportedModel
         }
 
-        try await loadModel(model: parakeetModel)
-
-        guard let asrManager = asrManager else {
-            logger.logNotice("🦜 ASR manager not initialized, cannot transcribe")
-            throw TranscriptionError.modelLoadFailed
-        }
-
         logger.logNotice("🦜 Starting Parakeet transcription with model: \(parakeetModel.displayName)")
 
         await reportProgress(.init(stage: .preparingAudio), to: progressHandler)
@@ -74,6 +60,23 @@ class ParakeetTranscriptionService: TranscriptionService {
         // Apply VAD for recordings longer than 20 seconds
         // VAD setting should be shared with keyboard extension
         let isVADEnabled = UserDefaultsStorage.shared.object(forKey: AppGroupCoordinator.kIsVADEnabled) as? Bool ?? true
+
+        if let boostedText = try await transcribeWithVocabularyBoostingIfEnabled(
+            audioURL: audioURL,
+            model: parakeetModel,
+            durationSeconds: durationSeconds,
+            isVADEnabled: isVADEnabled,
+            progressHandler: progressHandler
+        ) {
+            return boostedText
+        }
+
+        try await loadModel(model: parakeetModel)
+
+        guard let asrManager = asrManager else {
+            logger.logNotice("🦜 ASR manager not initialized, cannot transcribe")
+            throw TranscriptionError.modelLoadFailed
+        }
 
         if durationSeconds < 20.0 || !isVADEnabled {
             logger.logNotice("🎙️ Using direct file transcription for Parakeet")
@@ -129,6 +132,16 @@ class ParakeetTranscriptionService: TranscriptionService {
         return try converter.resampleAudioFile(path: url.path)
     }
 
+    private func loadAsrModels(for model: ParakeetModel) async throws -> AsrModels {
+        let isValid = try await AsrModels.isModelValid(version: model.version)
+        if !isValid {
+            logger.error("Model validation failed for \(model.version == .v2 ? "v2" : "v3"). Models are corrupted.")
+            throw ParakeetTranscriptionError.modelValidationFailed("Parakeet models are corrupted. Please delete and re-download the model.")
+        }
+
+        return try await AsrModels.loadFromCache(configuration: nil, version: model.version)
+    }
+
     private func applyVAD(to audioSamples: [Float]) async throws -> [Float] {
         let vadConfig = VadConfig(defaultThreshold: 0.7)
 
@@ -164,6 +177,207 @@ class ParakeetTranscriptionService: TranscriptionService {
         } catch {
             logger.logWarning("⚠️ VAD processing failed: \(error.localizedDescription), using full audio")
             return audioSamples
+        }
+    }
+
+    private var isVocabularyBoostingEnabled: Bool {
+        UserDefaultsStorage.appPrivate.bool(forKey: UserDefaultsStorage.Keys.isParakeetVocabularyBoostingEnabled)
+    }
+
+    private func transcribeWithVocabularyBoostingIfEnabled(
+        audioURL: URL,
+        model: ParakeetModel,
+        durationSeconds: Double,
+        isVADEnabled: Bool,
+        progressHandler: TranscriptionProgressHandler?
+    ) async throws -> String? {
+        guard isVocabularyBoostingEnabled else {
+            return nil
+        }
+
+        do {
+            guard let (vocabulary, ctcModels) = try await loadVocabularyBoostingResources() else {
+                logger.logInfo("🦜 Vocabulary boosting enabled but no usable vocabulary terms found - falling back to standard Parakeet transcription")
+                return nil
+            }
+
+            logger.logNotice("🦜 Using Parakeet custom vocabulary boosting with \(vocabulary.terms.count) terms")
+            return try await transcribeWithVocabularyBoosting(
+                audioURL: audioURL,
+                model: model,
+                vocabulary: vocabulary,
+                ctcModels: ctcModels,
+                durationSeconds: durationSeconds,
+                isVADEnabled: isVADEnabled,
+                progressHandler: progressHandler
+            )
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            logger.logWarning("⚠️ Parakeet vocabulary boosting failed, falling back to standard transcription: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    private func loadVocabularyBoostingResources() async throws -> (vocabulary: CustomVocabularyContext, ctcModels: CtcModels)? {
+        let terms = CustomVocabulary.getTerms()
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+
+        guard !terms.isEmpty else {
+            return nil
+        }
+
+        let ctcModels = try await CtcModels.downloadAndLoad(variant: .ctc110m)
+        let tokenizer = try await CtcTokenizer.load(
+            from: CtcModels.defaultCacheDirectory(for: ctcModels.variant)
+        )
+
+        let tokenizedTerms = terms.compactMap { term -> CustomVocabularyTerm? in
+            let tokenIds = tokenizer.encode(term)
+            guard !tokenIds.isEmpty else { return nil }
+
+            return CustomVocabularyTerm(
+                text: term,
+                weight: 10.0,
+                aliases: nil,
+                tokenIds: nil,
+                ctcTokenIds: tokenIds
+            )
+        }
+
+        guard !tokenizedTerms.isEmpty else {
+            return nil
+        }
+
+        return (CustomVocabularyContext(terms: tokenizedTerms), ctcModels)
+    }
+
+    private func transcribeWithVocabularyBoosting(
+        audioURL: URL,
+        model: ParakeetModel,
+        vocabulary: CustomVocabularyContext,
+        ctcModels: CtcModels,
+        durationSeconds: Double,
+        isVADEnabled: Bool,
+        progressHandler: TranscriptionProgressHandler?
+    ) async throws -> String {
+        defer {
+            vadManager = nil
+        }
+
+        let models = try await loadAsrModels(for: model)
+        let slidingManager = SlidingWindowAsrManager(config: boostedStreamingConfig)
+
+        do {
+            try await slidingManager.configureVocabularyBoosting(
+                vocabulary: vocabulary,
+                ctcModels: ctcModels
+            )
+            try await slidingManager.start(models: models, source: .system)
+
+            if durationSeconds < 20.0 || !isVADEnabled {
+                logger.logNotice("🎙️ Using vocabulary-boosted file transcription for Parakeet")
+                await reportProgress(.init(stage: .transcribing), to: progressHandler)
+                try await streamAudioFile(
+                    at: audioURL,
+                    to: slidingManager,
+                    progressHandler: progressHandler
+                )
+            } else {
+                logger.logNotice("🎙️ Applying VAD before vocabulary-boosted Parakeet transcription")
+                await reportProgress(.init(stage: .detectingSpeech), to: progressHandler)
+
+                var speechAudio = try await readAndConvertAudio(from: audioURL)
+                speechAudio = try await applyVAD(to: speechAudio)
+
+                let trailingSilenceSamples = 16_000
+                let maxSingleChunkSamples = 240_000
+                if speechAudio.count + trailingSilenceSamples <= maxSingleChunkSamples {
+                    speechAudio += [Float](repeating: 0, count: trailingSilenceSamples)
+                }
+
+                await reportProgress(.init(stage: .transcribing), to: progressHandler)
+                try await streamAudioSamples(
+                    speechAudio,
+                    to: slidingManager,
+                    progressHandler: progressHandler
+                )
+            }
+
+            let text = try await slidingManager.finish()
+            await slidingManager.cleanup()
+            logger.logNotice("✅ Parakeet transcription with custom vocabulary completed successfully")
+            return text
+        } catch {
+            await slidingManager.cleanup()
+            throw error
+        }
+    }
+
+    private func streamAudioFile(
+        at audioURL: URL,
+        to slidingManager: SlidingWindowAsrManager,
+        progressHandler: TranscriptionProgressHandler?
+    ) async throws {
+        let audioFile = try AVAudioFile(forReading: audioURL)
+        let converter = AudioConverter()
+        let totalFrames = max(audioFile.length, 1)
+        let framesPerBuffer: AVAudioFrameCount = 32_768
+        var framesRead: AVAudioFramePosition = 0
+
+        while true {
+            try Task.checkCancellation()
+
+            guard let buffer = AVAudioPCMBuffer(
+                pcmFormat: audioFile.processingFormat,
+                frameCapacity: framesPerBuffer
+            ) else {
+                throw TranscriptionError.audioConversionFailed
+            }
+
+            try audioFile.read(into: buffer)
+            if buffer.frameLength == 0 {
+                break
+            }
+
+            let samples = try converter.resampleBuffer(buffer)
+            if !samples.isEmpty {
+                try await slidingManager.streamFloatSamples(samples)
+            }
+            framesRead += AVAudioFramePosition(buffer.frameLength)
+
+            let fractionCompleted = min(Double(framesRead) / Double(totalFrames), 0.99)
+            await reportProgress(
+                .init(stage: .transcribing, fractionCompleted: fractionCompleted),
+                to: progressHandler
+            )
+        }
+    }
+
+    private func streamAudioSamples(
+        _ audioSamples: [Float],
+        to slidingManager: SlidingWindowAsrManager,
+        progressHandler: TranscriptionProgressHandler?
+    ) async throws {
+        let chunkSize = 16_000
+        let totalSamples = max(audioSamples.count, 1)
+        var startIndex = 0
+
+        while startIndex < audioSamples.count {
+            try Task.checkCancellation()
+
+            let endIndex = min(startIndex + chunkSize, audioSamples.count)
+            let chunk = Array(audioSamples[startIndex..<endIndex])
+            try await slidingManager.streamFloatSamples(chunk)
+
+            let fractionCompleted = min(Double(endIndex) / Double(totalSamples), 0.99)
+            await reportProgress(
+                .init(stage: .transcribing, fractionCompleted: fractionCompleted),
+                to: progressHandler
+            )
+
+            startIndex = endIndex
         }
     }
 

--- a/VivaDicta/Services/Transcription/ParakeetTranscriptionService.swift
+++ b/VivaDicta/Services/Transcription/ParakeetTranscriptionService.swift
@@ -13,6 +13,10 @@ import os
 class ParakeetTranscriptionService: TranscriptionService {
     private var asrManager: AsrManager?
     private var vadManager: VadManager?
+    private var cachedVocabularyTerms: [String] = []
+    private var cachedVocabularyContext: CustomVocabularyContext?
+    private var cachedCtcModels: CtcModels?
+    private var cachedCtcTokenizer: CtcTokenizer?
     private let logger = Logger(category: .parakeetTranscriptionService)
     private let boostedStreamingConfig = SlidingWindowAsrConfig.default
 
@@ -99,16 +103,7 @@ class ParakeetTranscriptionService: TranscriptionService {
         logger.logNotice("🎙️ Applying VAD for long audio (> 20s)")
         await reportProgress(.init(stage: .detectingSpeech), to: progressHandler)
 
-        // VAD segmentation still requires 16kHz mono Float32 samples.
-        var speechAudio = try await readAndConvertAudio(from: audioURL)
-        speechAudio = try await applyVAD(to: speechAudio)
-
-        // Add trailing silence to improve final word punctuation detection
-        let trailingSilenceSamples = 16_000 // 1 second at 16kHz
-        let maxSingleChunkSamples = 240_000
-        if speechAudio.count + trailingSilenceSamples <= maxSingleChunkSamples {
-            speechAudio += [Float](repeating: 0, count: trailingSilenceSamples)
-        }
+        let speechAudio = try await prepareSpeechAudio(from: audioURL)
 
         await reportProgress(.init(stage: .transcribing), to: progressHandler)
 
@@ -130,6 +125,23 @@ class ParakeetTranscriptionService: TranscriptionService {
         // Use AudioConverter from FluidAudio to properly convert audio to 16kHz mono
         let converter = AudioConverter()
         return try converter.resampleAudioFile(path: url.path)
+    }
+
+    private func prepareSpeechAudio(from audioURL: URL) async throws -> [Float] {
+        var speechAudio = try await readAndConvertAudio(from: audioURL)
+        speechAudio = try await applyVAD(to: speechAudio)
+        return addTrailingSilenceIfNeeded(to: speechAudio)
+    }
+
+    private func addTrailingSilenceIfNeeded(to audioSamples: [Float]) -> [Float] {
+        let trailingSilenceSamples = 16_000 // 1 second at 16kHz
+        let maxSingleChunkSamples = 240_000
+
+        guard audioSamples.count + trailingSilenceSamples <= maxSingleChunkSamples else {
+            return audioSamples
+        }
+
+        return audioSamples + [Float](repeating: 0, count: trailingSilenceSamples)
     }
 
     private func loadAsrModels(for model: ParakeetModel) async throws -> AsrModels {
@@ -181,7 +193,15 @@ class ParakeetTranscriptionService: TranscriptionService {
     }
 
     private var isVocabularyBoostingEnabled: Bool {
-        UserDefaultsStorage.appPrivate.bool(forKey: UserDefaultsStorage.Keys.isParakeetVocabularyBoostingEnabled)
+        let isSpellingCorrectionsEnabled =
+            UserDefaultsStorage.appPrivate.object(
+                forKey: UserDefaultsStorage.Keys.isSpellingCorrectionsEnabled
+            ) as? Bool ?? true
+
+        return isSpellingCorrectionsEnabled
+            && UserDefaultsStorage.appPrivate.bool(
+                forKey: UserDefaultsStorage.Keys.isParakeetVocabularyBoostingEnabled
+            )
     }
 
     private func transcribeWithVocabularyBoostingIfEnabled(
@@ -228,10 +248,13 @@ class ParakeetTranscriptionService: TranscriptionService {
             return nil
         }
 
-        let ctcModels = try await CtcModels.downloadAndLoad(variant: .ctc110m)
-        let tokenizer = try await CtcTokenizer.load(
-            from: CtcModels.defaultCacheDirectory(for: ctcModels.variant)
-        )
+        let ctcModels = try await loadCachedCtcModels()
+
+        if cachedVocabularyTerms == terms, let cachedVocabularyContext {
+            return (cachedVocabularyContext, ctcModels)
+        }
+
+        let tokenizer = try await loadCachedCtcTokenizer(for: ctcModels)
 
         let tokenizedTerms = terms.compactMap { term -> CustomVocabularyTerm? in
             let tokenIds = tokenizer.encode(term)
@@ -250,7 +273,33 @@ class ParakeetTranscriptionService: TranscriptionService {
             return nil
         }
 
-        return (CustomVocabularyContext(terms: tokenizedTerms), ctcModels)
+        let vocabularyContext = CustomVocabularyContext(terms: tokenizedTerms)
+        cachedVocabularyTerms = terms
+        cachedVocabularyContext = vocabularyContext
+
+        return (vocabularyContext, ctcModels)
+    }
+
+    private func loadCachedCtcModels() async throws -> CtcModels {
+        if let cachedCtcModels {
+            return cachedCtcModels
+        }
+
+        let ctcModels = try await CtcModels.downloadAndLoad(variant: .ctc110m)
+        cachedCtcModels = ctcModels
+        return ctcModels
+    }
+
+    private func loadCachedCtcTokenizer(for ctcModels: CtcModels) async throws -> CtcTokenizer {
+        if let cachedCtcTokenizer {
+            return cachedCtcTokenizer
+        }
+
+        let tokenizer = try await CtcTokenizer.load(
+            from: CtcModels.defaultCacheDirectory(for: ctcModels.variant)
+        )
+        cachedCtcTokenizer = tokenizer
+        return tokenizer
     }
 
     private func transcribeWithVocabularyBoosting(
@@ -288,14 +337,7 @@ class ParakeetTranscriptionService: TranscriptionService {
                 logger.logNotice("🎙️ Applying VAD before vocabulary-boosted Parakeet transcription")
                 await reportProgress(.init(stage: .detectingSpeech), to: progressHandler)
 
-                var speechAudio = try await readAndConvertAudio(from: audioURL)
-                speechAudio = try await applyVAD(to: speechAudio)
-
-                let trailingSilenceSamples = 16_000
-                let maxSingleChunkSamples = 240_000
-                if speechAudio.count + trailingSilenceSamples <= maxSingleChunkSamples {
-                    speechAudio += [Float](repeating: 0, count: trailingSilenceSamples)
-                }
+                let speechAudio = try await prepareSpeechAudio(from: audioURL)
 
                 await reportProgress(.init(stage: .transcribing), to: progressHandler)
                 try await streamAudioSamples(

--- a/VivaDicta/Services/Transcription/ParakeetTranscriptionService.swift
+++ b/VivaDicta/Services/Transcription/ParakeetTranscriptionService.swift
@@ -68,7 +68,7 @@ class ParakeetTranscriptionService: TranscriptionService {
             isVADEnabled: isVADEnabled,
             progressHandler: progressHandler
         ) {
-            return boostedText
+            return .plain(boostedText)
         }
 
         try await loadModel(model: parakeetModel)
@@ -93,7 +93,7 @@ class ParakeetTranscriptionService: TranscriptionService {
 
             await cleanupAfterTranscription(using: asrManager)
             logger.logNotice("✅ Parakeet transcription completed successfully")
-            return result.text
+            return .plain(result.text)
         }
 
         logger.logNotice("🎙️ Applying VAD for long audio (> 20s)")

--- a/VivaDicta/Services/Transcription/ParakeetTranscriptionService.swift
+++ b/VivaDicta/Services/Transcription/ParakeetTranscriptionService.swift
@@ -44,18 +44,28 @@ class ParakeetTranscriptionService: TranscriptionService {
     }
  
     func transcribe(audioURL: URL, model: any TranscriptionModel) async throws -> TranscriptionServiceResult {
+        try await transcribe(audioURL: audioURL, model: model, progressHandler: nil)
+    }
+
+    func transcribe(
+        audioURL: URL,
+        model: any TranscriptionModel,
+        progressHandler: TranscriptionProgressHandler?
+    ) async throws -> TranscriptionServiceResult {
         guard let parakeetModel = model as? ParakeetModel else {
             throw TranscriptionError.unsupportedModel
         }
-        
+
         try await loadModel(model: parakeetModel)
-        
+
         guard let asrManager = asrManager else {
             logger.logNotice("🦜 ASR manager not initialized, cannot transcribe")
             throw TranscriptionError.modelLoadFailed
         }
-        
+
         logger.logNotice("🦜 Starting Parakeet transcription with model: \(parakeetModel.displayName)")
+
+        await reportProgress(.init(stage: .preparingAudio), to: progressHandler)
 
         let audioFile = try AVAudioFile(forReading: audioURL)
         let durationSeconds = Double(audioFile.length) / audioFile.processingFormat.sampleRate
@@ -67,17 +77,24 @@ class ParakeetTranscriptionService: TranscriptionService {
 
         if durationSeconds < 20.0 || !isVADEnabled {
             logger.logNotice("🎙️ Using direct file transcription for Parakeet")
-            let result = try await asrManager.transcribe(audioURL, source: .system)
+            await reportProgress(.init(stage: .transcribing), to: progressHandler)
 
-            await asrManager.cleanup()
-            self.asrManager = nil
-            self.vadManager = nil
-            logger.logNotice("🦜 Parakeet ASR models cleaned up from memory")
+            let shouldObserveProgress = durationSeconds > 15.0
+            let result = try await transcribeWithProgressObservation(
+                using: asrManager,
+                shouldObserveProgress: shouldObserveProgress,
+                progressHandler: progressHandler
+            ) {
+                try await asrManager.transcribe(audioURL, source: .system)
+            }
+
+            await cleanupAfterTranscription(using: asrManager)
             logger.logNotice("✅ Parakeet transcription completed successfully")
             return result.text
         }
 
         logger.logNotice("🎙️ Applying VAD for long audio (> 20s)")
+        await reportProgress(.init(stage: .detectingSpeech), to: progressHandler)
 
         // VAD segmentation still requires 16kHz mono Float32 samples.
         var speechAudio = try await readAndConvertAudio(from: audioURL)
@@ -90,16 +107,18 @@ class ParakeetTranscriptionService: TranscriptionService {
             speechAudio += [Float](repeating: 0, count: trailingSilenceSamples)
         }
 
-        // Transcribe the audio
-        let result = try await asrManager.transcribe(speechAudio, source: .system)
+        await reportProgress(.init(stage: .transcribing), to: progressHandler)
 
-        // Clean up models after transcription to minimize RAM usage
-        await asrManager.cleanup()
-        
-        self.asrManager = nil
-        self.vadManager = nil
-        logger.logNotice("🦜 Parakeet ASR models cleaned up from memory")
-        
+        let shouldObserveProgress = speechAudio.count > 240_000
+        let result = try await transcribeWithProgressObservation(
+            using: asrManager,
+            shouldObserveProgress: shouldObserveProgress,
+            progressHandler: progressHandler
+        ) {
+            try await asrManager.transcribe(speechAudio, source: .system)
+        }
+
+        await cleanupAfterTranscription(using: asrManager)
         logger.logNotice("✅ Parakeet transcription completed successfully")
         return .plain(result.text)
     }
@@ -145,6 +164,62 @@ class ParakeetTranscriptionService: TranscriptionService {
         } catch {
             logger.logWarning("⚠️ VAD processing failed: \(error.localizedDescription), using full audio")
             return audioSamples
+        }
+    }
+
+    private func reportProgress(
+        _ progress: TranscriptionProgressInfo,
+        to progressHandler: TranscriptionProgressHandler?
+    ) async {
+        guard let progressHandler else { return }
+        await progressHandler(progress)
+    }
+
+    private func cleanupAfterTranscription(using asrManager: AsrManager) async {
+        await asrManager.cleanup()
+        self.asrManager = nil
+        self.vadManager = nil
+        logger.logNotice("🦜 Parakeet ASR models cleaned up from memory")
+    }
+
+    private func transcribeWithProgressObservation(
+        using asrManager: AsrManager,
+        shouldObserveProgress: Bool,
+        progressHandler: TranscriptionProgressHandler?,
+        operation: () async throws -> ASRResult
+    ) async throws -> ASRResult {
+        let observationTask = await makeProgressObservationTask(
+            using: asrManager,
+            shouldObserveProgress: shouldObserveProgress,
+            progressHandler: progressHandler
+        )
+        defer {
+            observationTask?.cancel()
+        }
+
+        return try await operation()
+    }
+
+    private func makeProgressObservationTask(
+        using asrManager: AsrManager,
+        shouldObserveProgress: Bool,
+        progressHandler: TranscriptionProgressHandler?
+    ) async -> Task<Void, Never>? {
+        guard shouldObserveProgress, let progressHandler else {
+            return nil
+        }
+
+        let progressStream = await asrManager.transcriptionProgressStream
+        return Task {
+            do {
+                for try await progress in progressStream {
+                    await progressHandler(
+                        .init(stage: .transcribing, fractionCompleted: progress)
+                    )
+                }
+            } catch {
+                return
+            }
         }
     }
 }

--- a/VivaDicta/Services/Transcription/SlidingWindowAsrManager+VivaDicta.swift
+++ b/VivaDicta/Services/Transcription/SlidingWindowAsrManager+VivaDicta.swift
@@ -10,6 +10,8 @@ import AVFoundation
 
 extension SlidingWindowAsrManager {
     func streamFloatSamples(_ audioSamples: [Float]) throws {
+        guard !audioSamples.isEmpty else { return }
+
         guard let format = AVAudioFormat(
             commonFormat: .pcmFormatFloat32,
             sampleRate: 16_000,

--- a/VivaDicta/Services/Transcription/SlidingWindowAsrManager+VivaDicta.swift
+++ b/VivaDicta/Services/Transcription/SlidingWindowAsrManager+VivaDicta.swift
@@ -1,0 +1,41 @@
+//
+//  SlidingWindowAsrManager+VivaDicta.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.14
+//
+
+import AVFoundation
+@preconcurrency import FluidAudio
+
+extension SlidingWindowAsrManager {
+    func streamFloatSamples(_ audioSamples: [Float]) throws {
+        guard let format = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: 16_000,
+            channels: 1,
+            interleaved: false
+        ) else {
+            throw TranscriptionError.audioConversionFailed
+        }
+
+        guard let buffer = AVAudioPCMBuffer(
+            pcmFormat: format,
+            frameCapacity: AVAudioFrameCount(audioSamples.count)
+        ) else {
+            throw TranscriptionError.audioConversionFailed
+        }
+
+        buffer.frameLength = AVAudioFrameCount(audioSamples.count)
+
+        guard let channelData = buffer.floatChannelData?[0] else {
+            throw TranscriptionError.audioConversionFailed
+        }
+
+        audioSamples.withUnsafeBufferPointer { samplesPointer in
+            channelData.update(from: samplesPointer.baseAddress!, count: audioSamples.count)
+        }
+
+        streamAudio(buffer)
+    }
+}

--- a/VivaDicta/Services/Transcription/TranscriptionManager.swift
+++ b/VivaDicta/Services/Transcription/TranscriptionManager.swift
@@ -183,21 +183,27 @@ class TranscriptionManager {
     ///
     /// - Throws: ``TranscriptionError/transcriptionFailed`` if no valid model is configured,
     ///   or any error thrown by the underlying transcription service.
-    public func transcribe(audioURL: URL) async throws -> String {
+    public func transcribe(
+        audioURL: URL,
+        progressHandler: TranscriptionProgressHandler? = nil
+    ) async throws -> String {
         guard let model = getCurrentTranscriptionModel() else {
             throw TranscriptionError.transcriptionFailed
         }
 
-        let transcriptionService: any TranscriptionService
+        let transcriptionResult: TranscriptionServiceResult
         switch model.provider {
         case .parakeet:
-            transcriptionService = parakeetTranscriptionService
+            transcriptionResult = try await parakeetTranscriptionService.transcribe(
+                audioURL: audioURL,
+                model: model,
+                progressHandler: progressHandler
+            )
         case .whisperKit:
-            transcriptionService = whisperKitTranscriptionService
+            transcriptionResult = try await whisperKitTranscriptionService.transcribe(audioURL: audioURL, model: model)
         default:
-            transcriptionService = cloudTranscriptionService
+            transcriptionResult = try await cloudTranscriptionService.transcribe(audioURL: audioURL, model: model)
         }
-        let transcriptionResult = try await transcriptionService.transcribe(audioURL: audioURL, model: model)
 
         var result = TranscriptionOutputFilter.filter(transcriptionResult.text)
 

--- a/VivaDicta/Services/Transcription/TranscriptionProgressInfo.swift
+++ b/VivaDicta/Services/Transcription/TranscriptionProgressInfo.swift
@@ -1,0 +1,49 @@
+//
+//  TranscriptionProgressInfo.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.14.
+//
+
+import Foundation
+
+enum TranscriptionProgressStage: Sendable, Equatable {
+    case preparingAudio
+    case detectingSpeech
+    case transcribing
+
+    var detailText: String {
+        switch self {
+        case .preparingAudio:
+            return "Preparing audio..."
+        case .detectingSpeech:
+            return "Detecting speech..."
+        case .transcribing:
+            return "Transcribing..."
+        }
+    }
+}
+
+struct TranscriptionProgressInfo: Sendable, Equatable {
+    let stage: TranscriptionProgressStage
+    let fractionCompleted: Double?
+
+    init(stage: TranscriptionProgressStage, fractionCompleted: Double? = nil) {
+        self.stage = stage
+        self.fractionCompleted = fractionCompleted.map { min(max($0, 0), 1) }
+    }
+
+    var detailText: String {
+        switch stage {
+        case .transcribing:
+            if let fractionCompleted {
+                return "\(fractionCompleted.formatted(.percent.precision(.fractionLength(0)))) complete"
+            }
+            return stage.detailText
+        default:
+            return stage.detailText
+        }
+    }
+}
+
+typealias TranscriptionProgressHandler = @Sendable (TranscriptionProgressInfo) async -> Void

--- a/VivaDicta/Services/Transcription/TranscriptionProgressInfo.swift
+++ b/VivaDicta/Services/Transcription/TranscriptionProgressInfo.swift
@@ -33,13 +33,13 @@ struct TranscriptionProgressInfo: Sendable, Equatable {
         self.fractionCompleted = fractionCompleted.map { min(max($0, 0), 1) }
     }
 
-    var detailText: String {
+    var detailText: String? {
         switch stage {
         case .transcribing:
             if let fractionCompleted {
                 return "\(fractionCompleted.formatted(.percent.precision(.fractionLength(0)))) complete"
             }
-            return stage.detailText
+            return nil
         default:
             return stage.detailText
         }

--- a/VivaDicta/Shared/UserDefaultsStorage.swift
+++ b/VivaDicta/Shared/UserDefaultsStorage.swift
@@ -43,6 +43,7 @@ enum UserDefaultsStorage {
         static let textReplacements = "textReplacements"
         static let isReplacementsEnabled = "isReplacementsEnabled"
         static let isSpellingCorrectionsEnabled = "isSpellingCorrectionsEnabled"
+        static let isParakeetVocabularyBoostingEnabled = "isParakeetVocabularyBoostingEnabled"
         static let isAutoAudioCleanupEnabled = "isAutoAudioCleanupEnabled"
         static let audioRetentionDays = "audioRetentionDays"
         static let isAutoNoteCleanupEnabled = "isAutoNoteCleanupEnabled"

--- a/VivaDicta/Views/HudView.swift
+++ b/VivaDicta/Views/HudView.swift
@@ -6,6 +6,8 @@ struct HudView: View {
     @Environment(\.colorScheme) var colorScheme
 
     var state: RecordingState
+    var detailText: String? = nil
+    var progress: Double? = nil
     var onCancel: (() -> Void)?
 
     var statusIcon: String {
@@ -33,9 +35,21 @@ struct HudView: View {
     var body: some View {
 
         if colorScheme == .light {
-            HudViewLight(statusIcon: statusIcon, statusText: statusText, onCancel: onCancel)
+            HudViewLight(
+                statusIcon: statusIcon,
+                statusText: statusText,
+                detailText: detailText,
+                progress: progress,
+                onCancel: onCancel
+            )
         } else {
-            HudViewDark(statusIcon: statusIcon, statusText: statusText, onCancel: onCancel)
+            HudViewDark(
+                statusIcon: statusIcon,
+                statusText: statusText,
+                detailText: detailText,
+                progress: progress,
+                onCancel: onCancel
+            )
         }
     }
 
@@ -45,6 +59,8 @@ struct HudContentView: View {
 
     var statusIcon: String
     var statusText: String
+    var detailText: String?
+    var progress: Double?
     var onCancel: (() -> Void)?
 
     @State private var isSymbolAnimating = false
@@ -98,6 +114,21 @@ struct HudContentView: View {
                 Rectangle()
                     .fill(.clear)
                     .frame(width: 140, height: 24)
+            }
+
+            if let detailText {
+                Text(detailText)
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 180, height: 20)
+                    .transition(.opacity.combined(with: .move(edge: .bottom)))
+            }
+
+            if let progress {
+                ProgressView(value: progress)
+                    .tint(.white.opacity(0.85))
+                    .frame(width: 180)
+                    .transition(.opacity.combined(with: .move(edge: .bottom)))
             }
 
             // Cancel button - appears after 1 second
@@ -170,10 +201,18 @@ struct HudViewDark: View {
 
     var statusIcon: String
     var statusText: String
+    var detailText: String?
+    var progress: Double?
     var onCancel: (() -> Void)?
 
     var body: some View {
-        HudContentView(statusIcon: statusIcon, statusText: statusText, onCancel: onCancel)
+        HudContentView(
+            statusIcon: statusIcon,
+            statusText: statusText,
+            detailText: detailText,
+            progress: progress,
+            onCancel: onCancel
+        )
             .background(
             AnimatedMeshGradient()
                 .mask(
@@ -208,10 +247,18 @@ struct HudViewLight: View {
 
     var statusIcon: String
     var statusText: String
+    var detailText: String?
+    var progress: Double?
     var onCancel: (() -> Void)?
 
     var body: some View {
-        HudContentView(statusIcon: statusIcon, statusText: statusText, onCancel: onCancel)
+        HudContentView(
+            statusIcon: statusIcon,
+            statusText: statusText,
+            detailText: detailText,
+            progress: progress,
+            onCancel: onCancel
+        )
             .background(
             ZStack {
                 AnimatedMeshGradient()

--- a/VivaDicta/Views/MainView.swift
+++ b/VivaDicta/Views/MainView.swift
@@ -348,6 +348,8 @@ struct MainView: View {
             appState.recordViewModel?.recordingState == .enhancing {
             HudView(
                 state: appState.recordViewModel?.recordingState ?? .idle,
+                detailText: appState.recordViewModel?.transcriptionProgress?.detailText,
+                progress: appState.recordViewModel?.transcriptionProgress?.fractionCompleted,
                 onCancel: {
                     appState.recordViewModel?.cancelProcessing()
                 }

--- a/VivaDicta/Views/RecordViewModel.swift
+++ b/VivaDicta/Views/RecordViewModel.swift
@@ -117,6 +117,7 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
     // removing old observers before adding new ones (see AppGroupCoordinator.addObserver)
     
     var transcribingSpeechTask: Task<Void, Never>?
+    var transcriptionProgress: TranscriptionProgressInfo?
 
     // Pending transcription data for saving when enhancement is cancelled
     private var pendingTranscription: PendingTranscriptionData?
@@ -409,6 +410,7 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
 
             do {
                 self.recordingState = .transcribing
+                self.transcriptionProgress = nil
 
                 // Notify keyboard that transcription has started
                 AppGroupCoordinator.shared.updateTranscriptionStatus(.transcribing)
@@ -456,7 +458,14 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
                 try Task.checkCancellation()
 
                 let transcriptionStart = Date()
-                let transcribedText = try await transcriptionManager.transcribe(audioURL: audioURLToTranscribe)
+                let transcribedText = try await transcriptionManager.transcribe(
+                    audioURL: audioURLToTranscribe,
+                    progressHandler: { progress in
+                        await MainActor.run {
+                            self.transcriptionProgress = progress
+                        }
+                    }
+                )
                 let transcriptionDuration = Date().timeIntervalSince(transcriptionStart)
 
                 // Check for cancellation after transcription
@@ -506,6 +515,7 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
                     )
 
                     // Update state to show enhancing animation
+                    self.transcriptionProgress = nil
                     self.recordingState = .enhancing
                     HapticManager.lightImpact()
 
@@ -926,6 +936,7 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
 
     func resetValues() {
         audioPower = 0
+        transcriptionProgress = nil
         AppGroupCoordinator.shared.updateAudioLevel(0)
 
         audioRecorder?.stop()

--- a/VivaDicta/Views/RecordViewModel.swift
+++ b/VivaDicta/Views/RecordViewModel.swift
@@ -413,39 +413,42 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
                 // Notify keyboard that transcription has started
                 AppGroupCoordinator.shared.updateTranscriptionStatus(.transcribing)
 
-                // Check if file needs downsampling (keyboard recordings are 48kHz)
                 var audioURLToTranscribe = recordURL
 
-                // Detect sample rate
-                let tempFile = try AVAudioFile(forReading: recordURL)
-                let sampleRate = tempFile.processingFormat.sampleRate
+                if transcriptionManager.currentMode.transcriptionProvider == .parakeet {
+                    logger.logInfo("🎙️ Skipping pre-downsampling for Parakeet because FluidAudio handles file conversion internally")
+                } else {
+                    // Check if file needs downsampling (keyboard recordings are 48kHz)
+                    let tempFile = try AVAudioFile(forReading: recordURL)
+                    let sampleRate = tempFile.processingFormat.sampleRate
 
-                if sampleRate > 16000 {
-                    logger.logInfo("🎙️ Detected high sample rate (\(Int(sampleRate))Hz), downsampling to 16kHz")
-                    // Use .wav extension for cross-platform PCM support
-                    let downsampledURL = recordURL.deletingPathExtension().appendingPathExtension("16k.wav")
+                    if sampleRate > 16000 {
+                        logger.logInfo("🎙️ Detected high sample rate (\(Int(sampleRate))Hz), downsampling to 16kHz")
+                        // Use .wav extension for cross-platform PCM support
+                        let downsampledURL = recordURL.deletingPathExtension().appendingPathExtension("16k.wav")
 
-                    do {
-                        try await downsampleTo16kHzMono(inputURL: recordURL, outputURL: downsampledURL)
+                        do {
+                            try await downsampleTo16kHzMono(inputURL: recordURL, outputURL: downsampledURL)
 
-                        // Verify the output file was created and has content
-                        let attributes = try FileManager.default.attributesOfItem(atPath: downsampledURL.path)
-                        let fileSize = attributes[.size] as? Int64 ?? 0
+                            // Verify the output file was created and has content
+                            let attributes = try FileManager.default.attributesOfItem(atPath: downsampledURL.path)
+                            let fileSize = attributes[.size] as? Int64 ?? 0
 
-                        if fileSize > 1000 {  // At least 1KB
-                            // Delete original high-rate file to save space
-                            try? FileManager.default.removeItem(at: recordURL)
+                            if fileSize > 1000 {  // At least 1KB
+                                // Delete original high-rate file to save space
+                                try? FileManager.default.removeItem(at: recordURL)
 
-                            // Use downsampled file for transcription
-                            audioURLToTranscribe = downsampledURL
-                            logger.logInfo("🎙️ Downsampling complete, file size: \(fileSize) bytes, saved ~\(Int((1.0 - 16000.0/sampleRate) * 100))% space")
-                        } else {
-                            logger.logWarning("🎙️ Downsampled file too small (\(fileSize) bytes), using original")
-                            try? FileManager.default.removeItem(at: downsampledURL)
+                                // Use downsampled file for transcription
+                                audioURLToTranscribe = downsampledURL
+                                logger.logInfo("🎙️ Downsampling complete, file size: \(fileSize) bytes, saved ~\(Int((1.0 - 16000.0/sampleRate) * 100))% space")
+                            } else {
+                                logger.logWarning("🎙️ Downsampled file too small (\(fileSize) bytes), using original")
+                                try? FileManager.default.removeItem(at: downsampledURL)
+                            }
+                        } catch {
+                            logger.logWarning("🎙️ Downsampling failed, using original file: \(error.localizedDescription)")
+                            // Continue with original file if downsampling fails
                         }
-                    } catch {
-                        logger.logWarning("🎙️ Downsampling failed, using original file: \(error.localizedDescription)")
-                        // Continue with original file if downsampling fails
                     }
                 }
 

--- a/VivaDicta/Views/SettingsScreen/DictionaryView.swift
+++ b/VivaDicta/Views/SettingsScreen/DictionaryView.swift
@@ -20,10 +20,13 @@ struct WordsDictionaryView: View {
 
     @AppStorage(UserDefaultsStorage.Keys.isSpellingCorrectionsEnabled)
     private var isSpellingCorrectionsEnabled: Bool = true
+    @AppStorage(UserDefaultsStorage.Keys.isParakeetVocabularyBoostingEnabled)
+    private var isParakeetVocabularyBoostingEnabled: Bool = false
 
     var body: some View {
         VStack(spacing: 0) {
             enableToggle
+            parakeetVocabularyToggle
 
             if words.isEmpty {
                 emptyStateView
@@ -88,6 +91,22 @@ struct WordsDictionaryView: View {
             .onChange(of: isSpellingCorrectionsEnabled) { _, _ in
                 HapticManager.selectionChanged()
             }
+    }
+
+    private var parakeetVocabularyToggle: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Toggle("Use with Parakeet Transcription", isOn: $isParakeetVocabularyBoostingEnabled)
+                .disabled(!isSpellingCorrectionsEnabled)
+                .onChange(of: isParakeetVocabularyBoostingEnabled) { _, _ in
+                    HapticManager.selectionChanged()
+                }
+
+            Text("Experimental. Uses the words from this list as custom vocabulary for local Parakeet transcription. May download extra model files and use more memory. Off by default.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal)
+        .padding(.bottom, 8)
     }
 
     private var emptyStateView: some View {

--- a/VivaDicta/Views/SettingsScreen/DictionaryView.swift
+++ b/VivaDicta/Views/SettingsScreen/DictionaryView.swift
@@ -88,7 +88,10 @@ struct WordsDictionaryView: View {
         Toggle("Enable Spelling Corrections", isOn: $isSpellingCorrectionsEnabled)
             .padding(.horizontal)
             .padding(.vertical, 8)
-            .onChange(of: isSpellingCorrectionsEnabled) { _, _ in
+            .onChange(of: isSpellingCorrectionsEnabled) { _, isEnabled in
+                if !isEnabled {
+                    isParakeetVocabularyBoostingEnabled = false
+                }
                 HapticManager.selectionChanged()
             }
     }

--- a/documentation/Text-Processing-Pipeline-Architecture.md
+++ b/documentation/Text-Processing-Pipeline-Architecture.md
@@ -47,6 +47,15 @@ VivaDicta applies a multi-stage text processing pipeline to transform raw audio 
 │  │  • Only enabled replacements applied                                │   │
 │  └──────────────────────────────────────────────────────────────────────┘   │
 │                                              │                               │
+│                                              ▼                               │
+│  ┌──────────────────────────────────────────────────────────────────────┐   │
+│  │  Gate: TranscriptionOutputFilter.hasMeaningfulContent() [ALWAYS]    │   │
+│  │                                                                      │   │
+│  │  • Runs after filter, formatting, and replacements                  │   │
+│  │  • Rejects empty / whitespace-only / punctuation-only text          │   │
+│  │  • Used before saving the transcription                             │   │
+│  └──────────────────────────────────────────────────────────────────────┘   │
+│                                              │                               │
 │                            ┌─────────────────┴─────────────────┐            │
 │                            │                                    │            │
 │                   AI Processing enabled?                        │            │
@@ -117,7 +126,7 @@ Removes common speech-to-text artifacts. Applied unconditionally to all transcri
 Also removes trailing comma/period after filler words.
 
 **Meaningful Content Check:**
-`hasMeaningfulContent(_:)` returns `false` for strings that are empty, whitespace-only, or contain only punctuation. Used to skip saving empty transcriptions.
+`hasMeaningfulContent(_:)` returns `false` for strings that are empty, whitespace-only, or contain only punctuation. In the current code path, this gate runs after Stage 1, optional Stage 2, and optional Stage 3, and is used to skip saving empty transcriptions.
 
 ### Stage 2: TextFormatter
 

--- a/documentation/Transcription-System-Architecture.md
+++ b/documentation/Transcription-System-Architecture.md
@@ -44,6 +44,9 @@ The transcription system routes audio files to the appropriate speech-to-text pr
 │  │       │  • Case-insensitive regex matching                         │    │
 │  │       │  • Word boundary aware (CJK/Thai exempted)                 │    │
 │  │       ▼                                                             │    │
+│  │  TranscriptionOutputFilter.hasMeaningfulContent() ← Before save     │    │
+│  │       │  • Reject empty / punctuation-only text                     │    │
+│  │       ▼                                                             │    │
 │  │  Final transcribed text                                             │    │
 │  └─────────────────────────────────────────────────────────────────────┘    │
 └──────────────────────────────────────────────────────────────────────────────┘

--- a/documentation/text-processing-pipeline.md
+++ b/documentation/text-processing-pipeline.md
@@ -12,13 +12,13 @@ Transcription Service (WhisperKit / Parakeet / Cloud)
 TranscriptionOutputFilter.filter()              -- Stage 1: Clean raw transcription
     |
     v
-TranscriptionOutputFilter.hasMeaningfulContent() -- Gate: discard empty/punctuation-only
-    |
-    v
 TextFormatter.format()                           -- Stage 2: Paragraph formatting (if enabled)
     |
     v
 ReplacementsService.applyReplacements()          -- Stage 3: User word replacements (if enabled)
+    |
+    v
+TranscriptionOutputFilter.hasMeaningfulContent() -- Gate: discard empty/punctuation-only before save
     |
     v
 [Transcribed text stored]
@@ -63,10 +63,13 @@ Cleans raw transcription output from any provider.
 Returns `true` if text contains at least one alphanumeric character. Rejects pure punctuation, whitespace, or empty strings.
 
 **Called from:**
-- `TranscriptionManager.transcribe()` -- immediately after receiving raw text
-- `RecordViewModel` -- gates whether to save transcription
+- `RecordViewModel` -- gates whether to save transcription after local formatting and replacements
+- `WatchAudioProcessor` -- gates whether to save watch transcriptions
+- Pending transcription recovery paths before save
 
 **Always active** -- not configurable.
+
+**Important:** In the current code path, this gate runs after `TranscriptionOutputFilter.filter()`, optional `TextFormatter.format()`, and optional `ReplacementsService.applyReplacements()`. It is not performed inside `TranscriptionManager.transcribe()`.
 
 ---
 
@@ -190,9 +193,9 @@ Smart formatting when inserting transcribed text from the keyboard extension.
 | # | Component | Stage | Always Active | Setting |
 |---|-----------|-------|---------------|---------|
 | 1 | `TranscriptionOutputFilter.filter()` | After transcription | Yes | -- |
-| 2 | `TranscriptionOutputFilter.hasMeaningfulContent()` | Gate check | Yes | -- |
-| 3 | `TextFormatter.format()` | Paragraph formatting | No | `VivaMode.isAutoTextFormattingEnabled` |
-| 4 | `ReplacementsService.applyReplacements()` | Word replacements | No | `isReplacementsEnabled` |
+| 2 | `TextFormatter.format()` | Paragraph formatting | No | `VivaMode.isAutoTextFormattingEnabled` |
+| 3 | `ReplacementsService.applyReplacements()` | Word replacements | No | `isReplacementsEnabled` |
+| 4 | `TranscriptionOutputFilter.hasMeaningfulContent()` | Gate check before save | Yes | -- |
 | 5 | `CustomVocabulary.getTerms()` | AI prompt injection | No | `isSpellingCorrectionsEnabled` |
 | 6 | `PromptsTemplates.systemPrompt()` | AI system message | When `useSystemTemplate=true` | -- |
 | 7 | `formatTranscriptForLLM()` | AI user message | When `wrapInTranscriptTags=true` | -- |


### PR DESCRIPTION
## Summary

- simplify the Parakeet audio path by using direct file transcription when VAD is not needed
- replace simulated Parakeet model download progress with real progress and surface long transcription progress in the recording HUD
- add an opt-in Parakeet custom vocabulary boosting path backed by FluidAudio CTC models, disabled by default
- harden local Parakeet model detection and tighten the Groq vocabulary hint prompt

## Testing

- `xcodebuild -scheme VivaDicta -configuration Debug -workspace ./VivaDicta.xcodeproj/project.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max,OS=26.4' build 2>&1 | xcsift`

## Notes

- Parakeet vocabulary boosting stays off by default and falls back to the current path if no usable terms are available or the CTC flow fails.
- Enabling vocabulary boosting may trigger extra model downloads and use more memory.
- No manual runtime testing has been performed yet.
