### PR TITLE
Reset empty notes filter and glassify processing HUD

### DIFF
--- a/VivaDicta/Shared/NotesFilterResetPolicy.swift
+++ b/VivaDicta/Shared/NotesFilterResetPolicy.swift
@@ -13,12 +13,14 @@ enum NotesFilterResetPolicy {
         isSearching: Bool,
         oldTranscriptionCount: Int,
         newTranscriptionCount: Int,
+        previousFilteredCount: Int,
         remainingFilteredCount: Int
     ) -> Bool {
         guard hasActiveFilter else { return false }
         guard !isSearching else { return false }
         guard newTranscriptionCount < oldTranscriptionCount else { return false }
         guard newTranscriptionCount > 0 else { return false }
+        guard previousFilteredCount > 0 else { return false }
         return remainingFilteredCount == 0
     }
 }

--- a/VivaDicta/Shared/NotesFilterResetPolicy.swift
+++ b/VivaDicta/Shared/NotesFilterResetPolicy.swift
@@ -1,0 +1,24 @@
+//
+//  NotesFilterResetPolicy.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.15
+//
+
+import Foundation
+
+enum NotesFilterResetPolicy {
+    static func shouldResetToAllAfterDeletion(
+        hasActiveFilter: Bool,
+        isSearching: Bool,
+        oldTranscriptionCount: Int,
+        newTranscriptionCount: Int,
+        remainingFilteredCount: Int
+    ) -> Bool {
+        guard hasActiveFilter else { return false }
+        guard !isSearching else { return false }
+        guard newTranscriptionCount < oldTranscriptionCount else { return false }
+        guard newTranscriptionCount > 0 else { return false }
+        return remainingFilteredCount == 0
+    }
+}

--- a/VivaDicta/Views/HudView.swift
+++ b/VivaDicta/Views/HudView.swift
@@ -206,14 +206,14 @@ struct HudViewDark: View {
     var onCancel: (() -> Void)?
 
     var body: some View {
-        HudContentView(
+        return HudContentView(
             statusIcon: statusIcon,
             statusText: statusText,
             detailText: detailText,
             progress: progress,
             onCancel: onCancel
         )
-            .background(
+        .background(
             AnimatedMeshGradient()
                 .mask(
                     RoundedRectangle(cornerRadius: 30)
@@ -229,7 +229,6 @@ struct HudViewDark: View {
                 .blur(radius: 2)
                 .blendMode(.overlay)
         )
-        
         .overlay(
             RoundedRectangle(cornerRadius: 30)
                 .stroke(lineWidth: 1)
@@ -238,8 +237,8 @@ struct HudViewDark: View {
                 .blendMode(.overlay)
         )
         .background(.black)
-        .mask(RoundedRectangle(cornerRadius: 30, style: .continuous))
-        
+        .clipShape(.rect(cornerRadius: 30))
+        .applyHudGlassEffect(cornerRadius: 30, isInteractive: onCancel != nil)
     }
 }
 
@@ -252,14 +251,14 @@ struct HudViewLight: View {
     var onCancel: (() -> Void)?
 
     var body: some View {
-        HudContentView(
+        return HudContentView(
             statusIcon: statusIcon,
             statusText: statusText,
             detailText: detailText,
             progress: progress,
             onCancel: onCancel
         )
-            .background(
+        .background(
             ZStack {
                 AnimatedMeshGradient()
                     .mask(
@@ -300,6 +299,27 @@ struct HudViewLight: View {
         )
         .shadow(color: .black.opacity(0.15), radius: 20, x: 0, y: 20)
         .shadow(color: .black.opacity(0.1), radius: 15, x: 0, y: 15)
+        .applyHudGlassEffect(cornerRadius: 16, isInteractive: onCancel != nil)
+    }
+}
+
+private struct HudGlassEffectModifier: ViewModifier {
+    let cornerRadius: CGFloat
+    let isInteractive: Bool
+
+    func body(content: Content) -> some View {
+        if #available(iOS 26, *) {
+            content
+                .glassEffect(.clear.interactive(isInteractive), in: .rect(cornerRadius: cornerRadius))
+        } else {
+            content
+        }
+    }
+}
+
+extension View {
+    fileprivate func applyHudGlassEffect(cornerRadius: CGFloat, isInteractive: Bool) -> some View {
+        modifier(HudGlassEffectModifier(cornerRadius: cornerRadius, isInteractive: isInteractive))
     }
 }
 

--- a/VivaDicta/Views/TranscriptionsContentView.swift
+++ b/VivaDicta/Views/TranscriptionsContentView.swift
@@ -154,6 +154,14 @@ struct TranscriptionsContentView: View {
             performDebouncedSearch(with: newValue)
         }
         .onChange(of: allTranscriptions) { oldValue, newValue in
+            let shouldResetTagFilter = NotesFilterResetPolicy.shouldResetToAllAfterDeletion(
+                hasActiveFilter: hasActiveTagFilter,
+                isSearching: !searchText.isEmpty,
+                oldTranscriptionCount: oldValue.count,
+                newTranscriptionCount: newValue.count,
+                remainingFilteredCount: filterTranscriptionsByActiveTags(newValue).count
+            )
+
             // Detect newly inserted transcriptions
             if newValue.count > previousTranscriptionCount {
                 // Find the newly added transcription(s)
@@ -181,6 +189,12 @@ struct TranscriptionsContentView: View {
             } else {
                 performDebouncedSearch(with: searchText)
             }
+
+            if shouldResetTagFilter {
+                selectedSourceTags.removeAll()
+                selectedUserTagIds.removeAll()
+            }
+
             syncDisplayedIDs()
         }
         .onChange(of: filteredTranscriptions) {

--- a/VivaDicta/Views/TranscriptionsContentView.swift
+++ b/VivaDicta/Views/TranscriptionsContentView.swift
@@ -159,6 +159,7 @@ struct TranscriptionsContentView: View {
                 isSearching: !searchText.isEmpty,
                 oldTranscriptionCount: oldValue.count,
                 newTranscriptionCount: newValue.count,
+                previousFilteredCount: filterTranscriptionsByActiveTags(oldValue).count,
                 remainingFilteredCount: filterTranscriptionsByActiveTags(newValue).count
             )
 

--- a/VivaDictaTests/NotesFilterResetPolicyTests.swift
+++ b/VivaDictaTests/NotesFilterResetPolicyTests.swift
@@ -15,6 +15,7 @@ struct NotesFilterResetPolicyTests {
             isSearching: false,
             oldTranscriptionCount: 4,
             newTranscriptionCount: 2,
+            previousFilteredCount: 2,
             remainingFilteredCount: 0
         )
 
@@ -27,6 +28,7 @@ struct NotesFilterResetPolicyTests {
             isSearching: false,
             oldTranscriptionCount: 4,
             newTranscriptionCount: 3,
+            previousFilteredCount: 2,
             remainingFilteredCount: 1
         )
 
@@ -39,6 +41,7 @@ struct NotesFilterResetPolicyTests {
             isSearching: true,
             oldTranscriptionCount: 4,
             newTranscriptionCount: 2,
+            previousFilteredCount: 2,
             remainingFilteredCount: 0
         )
 
@@ -51,6 +54,20 @@ struct NotesFilterResetPolicyTests {
             isSearching: false,
             oldTranscriptionCount: 2,
             newTranscriptionCount: 0,
+            previousFilteredCount: 2,
+            remainingFilteredCount: 0
+        )
+
+        #expect(!shouldReset)
+    }
+
+    @Test func keepsFilterWhenDeletionDoesNotRemoveAnyVisibleMatches() {
+        let shouldReset = NotesFilterResetPolicy.shouldResetToAllAfterDeletion(
+            hasActiveFilter: true,
+            isSearching: false,
+            oldTranscriptionCount: 4,
+            newTranscriptionCount: 3,
+            previousFilteredCount: 0,
             remainingFilteredCount: 0
         )
 

--- a/VivaDictaTests/NotesFilterResetPolicyTests.swift
+++ b/VivaDictaTests/NotesFilterResetPolicyTests.swift
@@ -1,0 +1,59 @@
+//
+//  NotesFilterResetPolicyTests.swift
+//  VivaDictaTests
+//
+//  Created by Anton Novoselov on 2026.04.15
+//
+
+import Testing
+@testable import VivaDicta
+
+struct NotesFilterResetPolicyTests {
+    @Test func resetsToAllAfterDeletionRemovesLastFilteredResult() {
+        let shouldReset = NotesFilterResetPolicy.shouldResetToAllAfterDeletion(
+            hasActiveFilter: true,
+            isSearching: false,
+            oldTranscriptionCount: 4,
+            newTranscriptionCount: 2,
+            remainingFilteredCount: 0
+        )
+
+        #expect(shouldReset)
+    }
+
+    @Test func keepsFilterWhenMatchingNotesStillRemain() {
+        let shouldReset = NotesFilterResetPolicy.shouldResetToAllAfterDeletion(
+            hasActiveFilter: true,
+            isSearching: false,
+            oldTranscriptionCount: 4,
+            newTranscriptionCount: 3,
+            remainingFilteredCount: 1
+        )
+
+        #expect(!shouldReset)
+    }
+
+    @Test func keepsFilterWhenSearchIsActive() {
+        let shouldReset = NotesFilterResetPolicy.shouldResetToAllAfterDeletion(
+            hasActiveFilter: true,
+            isSearching: true,
+            oldTranscriptionCount: 4,
+            newTranscriptionCount: 2,
+            remainingFilteredCount: 0
+        )
+
+        #expect(!shouldReset)
+    }
+
+    @Test func keepsFilterWhenEverythingWasDeleted() {
+        let shouldReset = NotesFilterResetPolicy.shouldResetToAllAfterDeletion(
+            hasActiveFilter: true,
+            isSearching: false,
+            oldTranscriptionCount: 2,
+            newTranscriptionCount: 0,
+            remainingFilteredCount: 0
+        )
+
+        #expect(!shouldReset)
+    }
+}


### PR DESCRIPTION
## Summary
- reset the active notes chip filter to `All` after deleting the last matching notes while other notes still exist
- add a focused reset policy and test coverage for the deletion flow
- apply a clear glass effect over the existing processing HUD to match the main screen mic button treatment

## Testing
- `xcodebuild -scheme VivaDicta -configuration Debug -workspace ./VivaDicta.xcodeproj/project.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max,OS=26.4' test -only-testing:VivaDictaTests/NotesFilterResetPolicyTests 2>&1 | xcsift`
- `xcodebuild -scheme VivaDicta -configuration Debug -workspace ./VivaDicta.xcodeproj/project.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max,OS=26.4' build 2>&1 | xcsift`

## Notes
- no breaking changes expected
