### PR TITLE
Fix incorrect keyboard tags when audio prewarm is active

### DIFF
--- a/VivaDicta/Views/MainView.swift
+++ b/VivaDicta/Views/MainView.swift
@@ -796,7 +796,10 @@ struct MainView: View {
         }
 
         // Start recording directly
-        vm.startCaptureAudio(destination: destination)
+        vm.startCaptureAudio(
+            destination: destination,
+            sourceTag: SourceTag.app
+        )
     }
 
     private func handleFileImport(_ result: Result<[URL], any Error>) {
@@ -837,7 +840,8 @@ struct MainView: View {
                 // Start transcription
                 vm.transcribingSpeechTask = vm.transcribeSpeechTask(
                     recordURL: destinationURL,
-                    modelContext: modelContext
+                    modelContext: modelContext,
+                    sourceTag: SourceTag.app
                 )
             } catch {
                 logger.logError("Failed to copy imported file: \(error.localizedDescription)")

--- a/VivaDicta/Views/RecordViewModel.swift
+++ b/VivaDicta/Views/RecordViewModel.swift
@@ -122,6 +122,7 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
     // Pending transcription data for saving when enhancement is cancelled
     private var pendingTranscription: PendingTranscriptionData?
     private var activeRecordingDestination: RecordingDestination = .newNote
+    private var activeSourceTag: String = SourceTag.app
 
     var captureURL: URL {
         FileManager.appDirectory(for: .audio).appendingPathComponent("recording.wav")
@@ -177,13 +178,18 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
     ///
     /// If a keyboard prewarm session is active, uses the prewarmed audio engine.
     /// Otherwise, configures and starts a standard AVAudioRecorder.
-    func startCaptureAudio(destination: RecordingDestination = .newNote) {
+    func startCaptureAudio(
+        destination: RecordingDestination = .newNote,
+        sourceTag: String = SourceTag.app
+    ) {
         Task { @MainActor in
             // Guard against duplicate starts
             guard recordingState != .recording else {
                 logger.logInfo("📱 Already recording, ignoring duplicate start request")
                 return
             }
+
+            activeSourceTag = sourceTag
 
             // Check if prewarm session is active (keyboard recording)
             if prewarmManager.isSessionActive {
@@ -290,7 +296,9 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
     func stopCaptureAudio(modelContext: ModelContext) {
         HapticManager.mediumImpact()
         let destination = activeRecordingDestination
+        let sourceTag = activeSourceTag
         activeRecordingDestination = .newNote
+        activeSourceTag = SourceTag.app
 
         // Stop real recorder if in prewarm mode (dummy continues running)
         if prewarmManager.isSessionActive {
@@ -313,6 +321,7 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
                     transcribingSpeechTask = transcribeSpeechTask(
                         recordURL: finalURL,
                         modelContext: modelContext,
+                        sourceTag: sourceTag,
                         destination: destination
                     )
                 } catch {
@@ -332,6 +341,7 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
                 transcribingSpeechTask = transcribeSpeechTask(
                     recordURL: finalURL,
                     modelContext: modelContext,
+                    sourceTag: sourceTag,
                     destination: destination
                 )
             } catch {
@@ -493,7 +503,7 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
                 var enhancedText: String? = nil
                 var promptName: String? = nil
                 var enhancementDur: TimeInterval? = nil
-                let resolvedSourceTag = sourceTag ?? (prewarmManager.isSessionActive ? SourceTag.keyboard : SourceTag.app)
+                let resolvedSourceTag = sourceTag ?? SourceTag.app
                 let shouldEnhance = destination == .newNote && aiService.isProperlyConfigured()
 
                 // Check if AI Processing is properly configured
@@ -661,6 +671,7 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
         transcribingSpeechTask = nil
         pendingTranscription = nil
         activeRecordingDestination = .newNote
+        activeSourceTag = SourceTag.app
 
         // Stop real capture if still recording
         if prewarmManager.isSessionActive && prewarmManager.audioEngine?.isRunning == true {
@@ -983,7 +994,7 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
                     self.appState?.transcriptionManager.setCurrentMode(selectedMode)
                 }
 
-                self.startCaptureAudio()
+                self.startCaptureAudio(sourceTag: SourceTag.keyboard)
             }
         }
 

--- a/VivaDicta/VivaDictaApp.swift
+++ b/VivaDicta/VivaDictaApp.swift
@@ -314,7 +314,7 @@ struct VivaDictaApp: App {
                     }
                     
                     // Start the actual recording
-                    vm.startCaptureAudio()
+                    vm.startCaptureAudio(sourceTag: SourceTag.keyboard)
                     
                     // Small delay to ensure recording is fully started
                     try? await Task.sleep(for: .milliseconds(200))
@@ -342,7 +342,7 @@ struct VivaDictaApp: App {
                 if let vm = appState.recordViewModel,
                    vm.transcriptionManager.getCurrentTranscriptionModel() != nil {
                     logger.logInfo("🎙️ Starting recording before showing manual switch sheet")
-                    vm.startCaptureAudio()
+                    vm.startCaptureAudio(sourceTag: SourceTag.keyboard)
                 }
                 appState.showKeyboardFlowToast = true
             }
@@ -436,7 +436,7 @@ struct VivaDictaApp: App {
                         if let vm = appState.recordViewModel,
                            vm.transcriptionManager.getCurrentTranscriptionModel() != nil {
                             logger.logInfo("🎙️ Starting recording before showing manual switch toast (no hostId)")
-                            vm.startCaptureAudio()
+                            vm.startCaptureAudio(sourceTag: SourceTag.keyboard)
                         }
                         appState.showKeyboardFlowToast = true
                     }


### PR DESCRIPTION
## Summary
- make recording source explicit when capture starts instead of inferring it from audio prewarm state later
- keep keyboard recordings tagged as `keyboard` only for actual keyboard-triggered flows
- keep in-app recording and imported audio tagged as `app` even when audio prewarm is active

## Testing
- `xcodebuild -scheme VivaDicta -configuration Debug -workspace ./VivaDicta.xcodeproj/project.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max,OS=26.4' build 2>&1 | xcsift`

## Notes
- No breaking changes expected