### PR TITLE
Adjust Apple FM sampling by preset intent

### DIFF
--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -777,13 +777,15 @@ class AIService {
                 text: text,
                 systemMessage: systemMessage,
                 preFormattedUserMessage: formattedText,
+                appleFMPresetID: preset.id,
                 onPartialResponse: onPartialResult
             )
         } else {
             requestResult = try await makeRequest(
                 text: text,
                 systemMessage: systemMessage,
-                preFormattedUserMessage: formattedText
+                preFormattedUserMessage: formattedText,
+                appleFMPresetID: preset.id
             )
         }
 
@@ -1133,6 +1135,7 @@ class AIService {
         text: String,
         systemMessage: String? = nil,
         preFormattedUserMessage: String? = nil,
+        appleFMPresetID: String? = nil,
         onPartialResponse: @escaping @MainActor (String) -> Void
     ) async throws -> String {
         guard let aiProvider = self.selectedMode.aiProvider else {
@@ -1152,12 +1155,16 @@ class AIService {
         switch resolvedStreamingRoute(for: aiProvider) {
         case .apple:
             if #available(iOS 26, *) {
+                let samplingProfile = AppleFoundationModelSamplingProfile.profile(
+                    for: appleFMPresetID ?? selectedMode.presetId
+                )
                 logger.logDebug("AI Processing - Using Apple Foundation Model streaming")
                 logger.logDebug("AI Processing - System Message: \(sysMsg)")
                 logger.logDebug("AI Processing - User Message: \(userMsg)")
                 return try await appleFoundationModelService.enhanceStreaming(
                     systemMessage: sysMsg,
                     userMessage: userMsg,
+                    samplingProfile: samplingProfile,
                     onPartialResponse: onPartialResponse
                 )
             } else {
@@ -1321,7 +1328,12 @@ class AIService {
         return result
     }
 
-    private func makeRequest(text: String, systemMessage: String? = nil, preFormattedUserMessage: String? = nil) async throws -> String {
+    private func makeRequest(
+        text: String,
+        systemMessage: String? = nil,
+        preFormattedUserMessage: String? = nil,
+        appleFMPresetID: String? = nil
+    ) async throws -> String {
         guard let aiProvider = self.selectedMode.aiProvider else {
             throw EnhancementError.notConfigured
         }
@@ -1335,12 +1347,19 @@ class AIService {
             if #available(iOS 26, *) {
                 let sysMsg = systemMessage ?? getSystemMessage()
                 let userMsg = preFormattedUserMessage ?? formatTranscriptForLLM(text)
+                let samplingProfile = AppleFoundationModelSamplingProfile.profile(
+                    for: appleFMPresetID ?? selectedMode.presetId
+                )
                 logger.logDebug("AI Processing - Using Apple Foundation Model")
                 logger.logDebug("AI Processing - System Message: \(sysMsg)")
                 logger.logDebug("AI Processing - User Message: \(userMsg)")
                 lastSystemMessageSent = sysMsg
                 lastUserMessageSent = userMsg
-                return try await appleFoundationModelService.enhance(systemMessage: sysMsg, userMessage: userMsg)
+                return try await appleFoundationModelService.enhance(
+                    systemMessage: sysMsg,
+                    userMessage: userMsg,
+                    samplingProfile: samplingProfile
+                )
             } else {
                 throw EnhancementError.notConfigured
             }

--- a/VivaDicta/Services/AIEnhance/AppleFoundationModelService.swift
+++ b/VivaDicta/Services/AIEnhance/AppleFoundationModelService.swift
@@ -9,7 +9,7 @@ import Foundation
 import FoundationModels
 import os
 
-enum AppleFoundationModelSamplingProfile: String, Equatable {
+enum AppleFoundationModelSamplingProfile: Equatable {
     case extractive
     case balanced
     case conversational
@@ -17,7 +17,7 @@ enum AppleFoundationModelSamplingProfile: String, Equatable {
 
     static func profile(for presetID: String?) -> Self {
         switch presetID {
-        case "summary", "action_points", "key_points":
+        case "summary", "action_points", "key_points", "takeaways", "mind_map":
             .extractive
         case "regular", "proofreading", "rewrite":
             .balanced

--- a/VivaDicta/Services/AIEnhance/AppleFoundationModelService.swift
+++ b/VivaDicta/Services/AIEnhance/AppleFoundationModelService.swift
@@ -9,6 +9,51 @@ import Foundation
 import FoundationModels
 import os
 
+enum AppleFoundationModelSamplingProfile: String, Equatable {
+    case extractive
+    case balanced
+    case conversational
+    case creative
+
+    static func profile(for presetID: String?) -> Self {
+        switch presetID {
+        case "summary", "action_points", "key_points":
+            .extractive
+        case "regular", "proofreading", "rewrite":
+            .balanced
+        case "chat", "casual":
+            .conversational
+        case "philosophical", "blog", "instagram", "new_ideas":
+            .creative
+        default:
+            .balanced
+        }
+    }
+
+    @available(iOS 26, *)
+    var generationOptions: GenerationOptions {
+        switch self {
+        case .extractive:
+            GenerationOptions(sampling: .greedy)
+        case .balanced:
+            GenerationOptions(
+                sampling: .random(probabilityThreshold: 0.8),
+                temperature: 0.3
+            )
+        case .conversational:
+            GenerationOptions(
+                sampling: .random(probabilityThreshold: 0.9),
+                temperature: 0.5
+            )
+        case .creative:
+            GenerationOptions(
+                sampling: .random(probabilityThreshold: 0.95),
+                temperature: 0.7
+            )
+        }
+    }
+}
+
 // MARK: - Service
 
 /// Service for AI text enhancement using Apple's on-device Foundation Models.
@@ -24,8 +69,13 @@ final class AppleFoundationModelService {
     /// - Parameters:
     ///   - systemMessage: The system message (same as cloud providers)
     ///   - userMessage: The formatted user message (transcript, optionally wrapped in tags)
+    ///   - samplingProfile: Sampling profile chosen for the current preset goal
     /// - Returns: The enhanced text
-    func enhance(systemMessage: String, userMessage: String) async throws -> String {
+    func enhance(
+        systemMessage: String,
+        userMessage: String,
+        samplingProfile: AppleFoundationModelSamplingProfile = .balanced
+    ) async throws -> String {
         guard AppleFoundationModelAvailability.isAvailable else {
             throw AppleFoundationModelError.notAvailable
         }
@@ -42,8 +92,7 @@ final class AppleFoundationModelService {
         let prompt = Prompt { userMessage }
 
         do {
-            // Use greedy sampling for deterministic, consistent transcript cleaning
-            let options = GenerationOptions(sampling: .greedy)
+            let options = samplingProfile.generationOptions
             let response = try await session.respond(to: prompt, options: options)
             let enhancedText = response.content.trimmingCharacters(in: .whitespacesAndNewlines)
             let filteredText = AIEnhancementOutputFilter.filter(enhancedText)
@@ -79,11 +128,13 @@ final class AppleFoundationModelService {
     /// - Parameters:
     ///   - systemMessage: The system message (same as cloud providers)
     ///   - userMessage: The formatted user message (transcript, optionally wrapped in tags)
+    ///   - samplingProfile: Sampling profile chosen for the current preset goal
     ///   - onPartialResponse: Called with the latest partial response snapshot.
     /// - Returns: The final enhanced text
     func enhanceStreaming(
         systemMessage: String,
         userMessage: String,
+        samplingProfile: AppleFoundationModelSamplingProfile = .balanced,
         onPartialResponse: @escaping @MainActor (String) -> Void
     ) async throws -> String {
         guard AppleFoundationModelAvailability.isAvailable else {
@@ -102,7 +153,7 @@ final class AppleFoundationModelService {
         let prompt = Prompt { userMessage }
 
         do {
-            let options = GenerationOptions(sampling: .greedy)
+            let options = samplingProfile.generationOptions
             let stream = session.streamResponse(to: prompt, options: options)
 
             for try await partialResponse in stream {

--- a/VivaDictaTests/AIServiceConfigurationTests.swift
+++ b/VivaDictaTests/AIServiceConfigurationTests.swift
@@ -240,8 +240,18 @@ struct AIServiceConfigurationTests {
 
     // MARK: - Apple FM Sampling Profiles
 
-    @Test func appleFMSamplingProfile_summaryUsesExtractive() {
-        #expect(AppleFoundationModelSamplingProfile.profile(for: "summary") == .extractive)
+    @Test func appleFMSamplingProfile_extractivePresetsUseExtractive() {
+        let extractivePresetIDs = [
+            "summary",
+            "action_points",
+            "key_points",
+            "takeaways",
+            "mind_map"
+        ]
+
+        for presetID in extractivePresetIDs {
+            #expect(AppleFoundationModelSamplingProfile.profile(for: presetID) == .extractive)
+        }
     }
 
     @Test func appleFMSamplingProfile_regularUsesBalanced() {

--- a/VivaDictaTests/AIServiceConfigurationTests.swift
+++ b/VivaDictaTests/AIServiceConfigurationTests.swift
@@ -238,6 +238,29 @@ struct AIServiceConfigurationTests {
         #expect(service.currentModeSupportsResponseStreaming == true)
     }
 
+    // MARK: - Apple FM Sampling Profiles
+
+    @Test func appleFMSamplingProfile_summaryUsesExtractive() {
+        #expect(AppleFoundationModelSamplingProfile.profile(for: "summary") == .extractive)
+    }
+
+    @Test func appleFMSamplingProfile_regularUsesBalanced() {
+        #expect(AppleFoundationModelSamplingProfile.profile(for: "regular") == .balanced)
+    }
+
+    @Test func appleFMSamplingProfile_chatUsesConversational() {
+        #expect(AppleFoundationModelSamplingProfile.profile(for: "chat") == .conversational)
+    }
+
+    @Test func appleFMSamplingProfile_philosophicalUsesCreative() {
+        #expect(AppleFoundationModelSamplingProfile.profile(for: "philosophical") == .creative)
+    }
+
+    @Test func appleFMSamplingProfile_unknownPresetFallsBackToBalanced() {
+        #expect(AppleFoundationModelSamplingProfile.profile(for: "custom_123") == .balanced)
+        #expect(AppleFoundationModelSamplingProfile.profile(for: nil) == .balanced)
+    }
+
     // MARK: - Disable Modes by Provider Tests
 
     @Test func disableAIForModesUsingProvider_onlyAffectsMatchingModes() {


### PR DESCRIPTION
## Summary
- add Apple Foundation Model sampling profiles keyed by preset intent instead of using one generation setting for every preset
- route Apple FM enhancement, streaming, and variation generation through the preset-specific sampling profile
- keep summarize presets (`summary`, `action_points`, `key_points`, `takeaways`, `mind_map`) deterministic with the extractive profile
- add focused tests for the preset-to-profile mapping

## Testing
- xcodebuild -quiet -derivedDataPath <temp> -scheme VivaDicta -configuration Debug -workspace ./VivaDicta.xcodeproj/project.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max,OS=26.4' test -only-testing:VivaDictaTests/AIServiceConfigurationTests\n\n## Notes\n- intentional behavior change: `regular`, `proofreading`, and `rewrite` now use light random sampling instead of greedy for Apple FM\n- custom and unknown presets currently fall back to the balanced Apple FM profile\n- no API, persistence, or schema changes