### PR TITLE
Add Chinese script preference for AI-enhanced output

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,7 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          model: claude-opus-4-6
+          claude_args: '--model claude-opus-4-7'
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
@@ -43,9 +43,4 @@ jobs:
 
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'
-
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
 

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -830,7 +830,7 @@ class AIService {
             customVocabularySection = "\n\n<CUSTOM_VOCABULARY>Important Vocabulary: \(vocabularyString)\n</CUSTOM_VOCABULARY>"
         }
 
-        let scriptSuffix = ChineseScriptPreferenceStore.current.systemMessageSuffix ?? ""
+        let scriptSuffix = resolvedChineseScriptSuffix()
 
         let systemMessage: String
         if preset.useSystemTemplate {
@@ -1671,6 +1671,16 @@ class AIService {
     
     // MARK: - System Message (Cloud Providers)
 
+    /// Returns the Chinese script hint that should be appended to system messages,
+    /// or an empty string. The preference is only honored while the user has an
+    /// active Chinese signal (same condition that surfaces the Settings picker).
+    /// This keeps stored preferences in sync with the user's visible controls - no
+    /// ghost suffix when the picker is hidden.
+    private func resolvedChineseScriptSuffix() -> String {
+        guard ChineseScriptPreferenceStore.shouldShowSetting(modes: modes) else { return "" }
+        return ChineseScriptPreferenceStore.current.systemMessageSuffix ?? ""
+    }
+
     private func getSystemMessage() -> String {
         var customVocabularySection = ""
         let customVocabularyWords = CustomVocabulary.getTerms()
@@ -1694,7 +1704,7 @@ class AIService {
         let promptInstructions = preset?.promptInstructions ?? ""
         let useSystemTemplate = preset?.useSystemTemplate ?? true
 
-        let scriptSuffix = ChineseScriptPreferenceStore.current.systemMessageSuffix ?? ""
+        let scriptSuffix = resolvedChineseScriptSuffix()
         let contextSections = customVocabularySection + clipboardContextSection + scriptSuffix
 
         if useSystemTemplate {

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -830,11 +830,13 @@ class AIService {
             customVocabularySection = "\n\n<CUSTOM_VOCABULARY>Important Vocabulary: \(vocabularyString)\n</CUSTOM_VOCABULARY>"
         }
 
+        let scriptSuffix = ChineseScriptPreferenceStore.current.systemMessageSuffix ?? ""
+
         let systemMessage: String
         if preset.useSystemTemplate {
-            systemMessage = PromptsTemplates.systemPrompt(with: preset.promptInstructions) + customVocabularySection
+            systemMessage = PromptsTemplates.systemPrompt(with: preset.promptInstructions) + customVocabularySection + scriptSuffix
         } else {
-            systemMessage = preset.promptInstructions + customVocabularySection
+            systemMessage = preset.promptInstructions + customVocabularySection + scriptSuffix
         }
 
         let userMessage: String
@@ -1692,7 +1694,8 @@ class AIService {
         let promptInstructions = preset?.promptInstructions ?? ""
         let useSystemTemplate = preset?.useSystemTemplate ?? true
 
-        let contextSections = customVocabularySection + clipboardContextSection
+        let scriptSuffix = ChineseScriptPreferenceStore.current.systemMessageSuffix ?? ""
+        let contextSections = customVocabularySection + clipboardContextSection + scriptSuffix
 
         if useSystemTemplate {
             return PromptsTemplates.systemPrompt(with: promptInstructions) + contextSections

--- a/VivaDicta/Services/AIEnhance/ChineseScriptPreference.swift
+++ b/VivaDicta/Services/AIEnhance/ChineseScriptPreference.swift
@@ -1,0 +1,79 @@
+//
+//  ChineseScriptPreference.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.17
+//
+
+import Foundation
+
+/// User preference for the Chinese script used in AI-enhanced output.
+/// The preference is appended as a short hint to the AI system message, so it
+/// only affects text that the model is already producing in Chinese. Non-Chinese
+/// output is untouched regardless of this setting.
+enum ChineseScriptPreference: String, CaseIterable, Identifiable, Sendable {
+    case auto
+    case simplified
+    case traditional
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .auto: return "Auto"
+        case .simplified: return "Simplified (简体)"
+        case .traditional: return "Traditional (繁體)"
+        }
+    }
+
+    /// Instruction appended to the AI system message. `nil` for `.auto` so the
+    /// prompt stays untouched for users who never configured this.
+    var systemMessageSuffix: String? {
+        switch self {
+        case .auto:
+            return nil
+        case .simplified:
+            return "\n\nWhen the output is in Chinese, use Simplified Chinese characters (简体中文)."
+        case .traditional:
+            return "\n\nWhen the output is in Chinese, use Traditional Chinese characters (繁體中文)."
+        }
+    }
+}
+
+enum ChineseScriptPreferenceStore {
+    private static let userDefaultsKey = "preferredChineseScript"
+
+    static var current: ChineseScriptPreference {
+        get {
+            guard let raw = UserDefaults.standard.string(forKey: userDefaultsKey),
+                  let preference = ChineseScriptPreference(rawValue: raw) else {
+                return .auto
+            }
+            return preference
+        }
+        set {
+            if newValue == .auto {
+                UserDefaults.standard.removeObject(forKey: userDefaultsKey)
+            } else {
+                UserDefaults.standard.set(newValue.rawValue, forKey: userDefaultsKey)
+            }
+        }
+    }
+
+    /// Whether to surface the preference row in Settings. True when the user
+    /// has signaled Chinese usage in any of: device preferred languages, any
+    /// mode's transcription language, or the global selected language.
+    static func shouldShowSetting(modes: [VivaMode]) -> Bool {
+        if Locale.preferredLanguages.contains(where: { $0.hasPrefix("zh") }) {
+            return true
+        }
+        if modes.contains(where: { ($0.transcriptionLanguage ?? "").hasPrefix("zh") }) {
+            return true
+        }
+        if let selected = UserDefaultsStorage.shared.string(forKey: AppGroupCoordinator.kSelectedLanguageKey),
+           selected.hasPrefix("zh") {
+            return true
+        }
+        return false
+    }
+}

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -233,6 +233,7 @@ struct SettingsView: View {
                                 }
                             }
                             .pickerStyle(.menu)
+                            .tint(.primary)
                             Text("Applied to AI-enhanced output when it's in Chinese.")
                                 .font(.caption)
                                 .foregroundStyle(.secondary)

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -25,6 +25,7 @@ struct SettingsView: View {
     private var isAutoCopyAfterRecordingEnabled = false
     @AppStorage(UserDefaultsStorage.Keys.isAutoReminderExtractionEnabled, store: UserDefaultsStorage.appPrivate)
     private var isAutoReminderExtractionEnabled = false
+    @State private var chineseScriptPreference: ChineseScriptPreference = ChineseScriptPreferenceStore.current
     @AppStorage(UserDefaultsStorage.Keys.audioSessionTimeout)
     private var audioSessionTimeout: Int = 180
     private let prewarmManager = AudioPrewarmManager.shared
@@ -223,6 +224,22 @@ struct SettingsView: View {
                     }
                     .onChange(of: isAutoReminderExtractionEnabled) { _, _ in
                         HapticManager.selectionChanged()
+                    }
+                    if ChineseScriptPreferenceStore.shouldShowSetting(modes: appState.aiService.modes) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Picker("Chinese Script", selection: $chineseScriptPreference) {
+                                ForEach(ChineseScriptPreference.allCases) { option in
+                                    Text(option.displayName).tag(option)
+                                }
+                            }
+                            Text("Applied to AI-enhanced output when it's in Chinese.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        .onChange(of: chineseScriptPreference) { _, newValue in
+                            ChineseScriptPreferenceStore.current = newValue
+                            HapticManager.selectionChanged()
+                        }
                     }
                     NavigationLink(value: SettingsDestination.chatTools) {
                         HStack {

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -25,7 +25,7 @@ struct SettingsView: View {
     private var isAutoCopyAfterRecordingEnabled = false
     @AppStorage(UserDefaultsStorage.Keys.isAutoReminderExtractionEnabled, store: UserDefaultsStorage.appPrivate)
     private var isAutoReminderExtractionEnabled = false
-    @State private var chineseScriptPreference: ChineseScriptPreference = ChineseScriptPreferenceStore.current
+    @AppStorage("preferredChineseScript") private var chineseScriptPreference: ChineseScriptPreference = .auto
     @AppStorage(UserDefaultsStorage.Keys.audioSessionTimeout)
     private var audioSessionTimeout: Int = 180
     private let prewarmManager = AudioPrewarmManager.shared
@@ -232,12 +232,12 @@ struct SettingsView: View {
                                     Text(option.displayName).tag(option)
                                 }
                             }
+                            .pickerStyle(.menu)
                             Text("Applied to AI-enhanced output when it's in Chinese.")
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                         }
-                        .onChange(of: chineseScriptPreference) { _, newValue in
-                            ChineseScriptPreferenceStore.current = newValue
+                        .onChange(of: chineseScriptPreference) { _, _ in
                             HapticManager.selectionChanged()
                         }
                     }


### PR DESCRIPTION
## Summary

- Adds a Settings → AI Settings row letting users choose Simplified or Traditional Chinese for AI-enhanced output
- Preference is appended as a short hint to the AI system message, so it applies across all presets and providers (OpenAI, Anthropic, Gemini, Groq, Apple Foundation Model, etc.)
- Row is locale-conditional: visible only when the device's preferred languages contain Chinese, any mode's transcription language starts with \`zh\`, or the global selected language starts with \`zh\` — no clutter for other users
- When set to the default (\`auto\`), no text is appended — zero behavior change for non-Chinese users

## Motivation

A user reported that Whisper outputs a mix of Simplified and Traditional Chinese characters, and they need consistent Simplified output. Rather than biasing the ASR (Whisper \`promptTokens\` trick is flaky on \`large-v3-turbo\` per WhisperKit #285/#372 and not officially supported), this handles script consistency at the AI stage where LLMs follow instructions reliably. Works equally well with Apple Foundation Model (which distinguishes Simplified/Traditional natively) and cloud LLMs.

## Test plan

- [x] Build passes on iOS 26.4 Simulator
- [x] \`TranscriptionManagerConfigTests\`, \`MistralTranscriptionServiceTests\`, \`PromptsTemplatesTests\` pass (29/29)
- [ ] Manual: device with \`zh-Hans\` preferred language shows the picker; device with only English does not
- [ ] Manual: after creating a mode with Chinese as transcription language on an English device, picker appears
- [ ] Manual: with preference = Simplified, AI enhancement of a Chinese transcription produces Simplified characters (tested across OpenAI + Apple FM)
- [ ] Manual: with preference = Auto, no change to system message vs. main