### PR TITLE
Add Markdown export content setting and single-note export entry points

### DIFF
--- a/VivaDicta/Services/MarkdownExportContent.swift
+++ b/VivaDicta/Services/MarkdownExportContent.swift
@@ -14,6 +14,7 @@ enum MarkdownExportContent: String, CaseIterable, Identifiable, Sendable {
     case lastVariationOnly
 
     nonisolated static let `default`: MarkdownExportContent = .allVariations
+    nonisolated static let userDefaultsKey = "markdownExportContent"
 
     var id: String { rawValue }
 
@@ -28,7 +29,7 @@ enum MarkdownExportContent: String, CaseIterable, Identifiable, Sendable {
 
     nonisolated static var current: MarkdownExportContent {
         guard
-            let raw = UserDefaults.standard.string(forKey: "markdownExportContent"),
+            let raw = UserDefaults.standard.string(forKey: Self.userDefaultsKey),
             let value = MarkdownExportContent(rawValue: raw)
         else {
             return .default

--- a/VivaDicta/Services/MarkdownExportContent.swift
+++ b/VivaDicta/Services/MarkdownExportContent.swift
@@ -1,0 +1,38 @@
+//
+//  MarkdownExportContent.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.18
+//
+
+import Foundation
+
+enum MarkdownExportContent: String, CaseIterable, Identifiable, Sendable {
+    case allVariations
+    case originalOnly
+    case originalAndLastVariation
+    case lastVariationOnly
+
+    nonisolated static let `default`: MarkdownExportContent = .allVariations
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .allVariations: "Original + All Variations"
+        case .originalOnly: "Original Only"
+        case .originalAndLastVariation: "Original + Last Variation"
+        case .lastVariationOnly: "Last Variation Only"
+        }
+    }
+
+    nonisolated static var current: MarkdownExportContent {
+        guard
+            let raw = UserDefaults.standard.string(forKey: "markdownExportContent"),
+            let value = MarkdownExportContent(rawValue: raw)
+        else {
+            return .default
+        }
+        return value
+    }
+}

--- a/VivaDicta/Services/TranscriptionMarkdownExportService.swift
+++ b/VivaDicta/Services/TranscriptionMarkdownExportService.swift
@@ -103,16 +103,42 @@ enum TranscriptionMarkdownExportService {
             lines.append("")
         }
 
-        lines.append("## Original")
-        lines.append("")
-        lines.append(snapshot.text.trimmingCharacters(in: .whitespacesAndNewlines))
-        lines.append("")
+        let sorted = sortedVariations(for: snapshot)
+        let lastVariation = sorted.last
 
-        for variation in sortedVariations(for: snapshot) {
+        func appendOriginal() {
+            lines.append("## Original")
+            lines.append("")
+            lines.append(snapshot.text.trimmingCharacters(in: .whitespacesAndNewlines))
+            lines.append("")
+        }
+
+        func appendVariation(_ variation: VariationSnapshot) {
             lines.append("## \(variation.title)")
             lines.append("")
             lines.append(variation.text.trimmingCharacters(in: .whitespacesAndNewlines))
             lines.append("")
+        }
+
+        switch MarkdownExportContent.current {
+        case .allVariations:
+            appendOriginal()
+            for variation in sorted {
+                appendVariation(variation)
+            }
+        case .originalOnly:
+            appendOriginal()
+        case .originalAndLastVariation:
+            appendOriginal()
+            if let lastVariation {
+                appendVariation(lastVariation)
+            }
+        case .lastVariationOnly:
+            if let lastVariation {
+                appendVariation(lastVariation)
+            } else {
+                appendOriginal()
+            }
         }
 
         return lines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines) + "\n"

--- a/VivaDicta/Services/TranscriptionMarkdownExportService.swift
+++ b/VivaDicta/Services/TranscriptionMarkdownExportService.swift
@@ -25,20 +25,12 @@ enum TranscriptionMarkdownExportService {
         let createdAt: Date
     }
 
-    @MainActor static func item(for transcription: Transcription) -> MarkdownExportItem {
-        item(forSnapshot: snapshot(for: transcription))
-    }
-
     @MainActor static func items(for transcriptions: [Transcription]) -> [MarkdownExportItem] {
         items(forSnapshots: snapshots(for: transcriptions))
     }
 
     @MainActor static func snapshots(for transcriptions: [Transcription]) -> [Snapshot] {
         transcriptions.map(snapshot(for:))
-    }
-
-    nonisolated static func item(forSnapshot snapshot: Snapshot) -> MarkdownExportItem {
-        markdownItem(for: snapshot, filename: markdownFilename(for: snapshot))
     }
 
     nonisolated static func items(forSnapshots snapshots: [Snapshot]) -> [MarkdownExportItem] {

--- a/VivaDicta/Shared/UserDefaultsStorage.swift
+++ b/VivaDicta/Shared/UserDefaultsStorage.swift
@@ -79,8 +79,5 @@ enum UserDefaultsStorage {
         // Notes filter
         static let savedNotesFilterSourceTags = "savedNotesFilterSourceTags"
         static let savedNotesFilterUserTagIds = "savedNotesFilterUserTagIds"
-
-        // Export
-        static let markdownExportContent = "markdownExportContent"
     }
 }

--- a/VivaDicta/Shared/UserDefaultsStorage.swift
+++ b/VivaDicta/Shared/UserDefaultsStorage.swift
@@ -79,5 +79,8 @@ enum UserDefaultsStorage {
         // Notes filter
         static let savedNotesFilterSourceTags = "savedNotesFilterSourceTags"
         static let savedNotesFilterUserTagIds = "savedNotesFilterUserTagIds"
+
+        // Export
+        static let markdownExportContent = "markdownExportContent"
     }
 }

--- a/VivaDicta/Views/MainView.swift
+++ b/VivaDicta/Views/MainView.swift
@@ -40,7 +40,6 @@ struct MainView: View {
     @State private var showFileErrorAlert = false
     @State private var fileErrorMessage = ""
     @State private var savedNotesFilter = SavedNotesFilterStorage.load()
-    @State private var exportItem: MarkdownExportItem?
     @State private var exportItems: [MarkdownExportItem] = []
     @State private var zipShareFile: ExportedShareFile?
     @State private var isPreparingZipShare = false
@@ -225,16 +224,6 @@ struct MainView: View {
             allowsMultipleSelection: false
         ) { result in
             handleFileImport(result)
-        }
-        .fileExporter(
-            isPresented: singleExportSheetBinding,
-            item: exportItem,
-            contentTypes: [MarkdownExportItem.contentType],
-            defaultFilename: exportItem?.filename
-        ) { result in
-            handleSingleExportCompletion(result)
-        } onCancellation: {
-            clearExportState()
         }
         .fileExporter(
             isPresented: multipleExportSheetBinding,
@@ -587,17 +576,6 @@ struct MainView: View {
         !displayedTranscriptionIDs.isEmpty && displayedTranscriptionIDs.isSubset(of: selectedTranscriptionIDs)
     }
 
-    private var singleExportSheetBinding: Binding<Bool> {
-        Binding(
-            get: { exportItem != nil },
-            set: { isPresented in
-                if !isPresented {
-                    clearExportState()
-                }
-            }
-        )
-    }
-
     private var multipleExportSheetBinding: Binding<Bool> {
         Binding(
             get: { !exportItems.isEmpty },
@@ -689,11 +667,7 @@ struct MainView: View {
 
         clearExportState()
 
-        if selected.count == 1, let transcription = selected.first {
-            exportItem = TranscriptionMarkdownExportService.item(for: transcription)
-        } else {
-            exportItems = TranscriptionMarkdownExportService.items(for: selected)
-        }
+        exportItems = TranscriptionMarkdownExportService.items(for: selected)
     }
 
     private func prepareZipShare() {
@@ -719,17 +693,6 @@ struct MainView: View {
         }
     }
 
-    private func handleSingleExportCompletion(_ result: Result<URL, any Error>) {
-        switch result {
-        case .success:
-            HapticManager.success()
-        case .failure(let error):
-            presentExportErrorIfNeeded(error)
-        }
-
-        clearExportState()
-    }
-
     private func handleMultipleExportCompletion(_ result: Result<[URL], any Error>) {
         switch result {
         case .success:
@@ -750,7 +713,6 @@ struct MainView: View {
     }
 
     private func clearExportState() {
-        exportItem = nil
         exportItems = []
     }
 

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -54,7 +54,7 @@ struct SettingsView: View {
 
     @AppStorage(UserDefaultsStorage.Keys.isICloudSyncEnabled)
     private var isICloudSyncEnabled = true
-    @AppStorage(UserDefaultsStorage.Keys.markdownExportContent)
+    @AppStorage(MarkdownExportContent.userDefaultsKey)
     private var markdownExportContent: MarkdownExportContent = .default
     @State private var showRestartAlert = false
     @AppStorage(AppGroupCoordinator.isHapticsEnabled, store: UserDefaultsStorage.shared)

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -54,6 +54,8 @@ struct SettingsView: View {
 
     @AppStorage(UserDefaultsStorage.Keys.isICloudSyncEnabled)
     private var isICloudSyncEnabled = true
+    @AppStorage(UserDefaultsStorage.Keys.markdownExportContent)
+    private var markdownExportContent: MarkdownExportContent = .default
     @State private var showRestartAlert = false
     @AppStorage(AppGroupCoordinator.isHapticsEnabled, store: UserDefaultsStorage.shared)
     private var isHapticsEnabled = true
@@ -362,6 +364,26 @@ struct SettingsView: View {
                                 .foregroundStyle(.secondary)
                         }
                     }
+                }
+
+                Section {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Picker("Markdown Export", selection: $markdownExportContent) {
+                            ForEach(MarkdownExportContent.allCases) { option in
+                                Text(option.displayName).tag(option)
+                            }
+                        }
+                        .pickerStyle(.menu)
+                        .tint(.primary)
+                        Text("Choose what to include when exporting notes as Markdown.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .onChange(of: markdownExportContent) { _, _ in
+                        HapticManager.selectionChanged()
+                    }
+                } header: {
+                    Text("Export")
                 }
 
                 Section("Storage") {

--- a/VivaDicta/Views/TranscriptionDetailView.swift
+++ b/VivaDicta/Views/TranscriptionDetailView.swift
@@ -38,6 +38,9 @@ struct TranscriptionDetailView: View {
     @State private var showTagPicker: Bool = false
     @State private var showChat: Bool = false
     @State private var chatViewModel: ChatViewModel?
+    @State private var exportItems: [MarkdownExportItem] = []
+    @State private var showExportErrorAlert: Bool = false
+    @State private var exportErrorMessage: String = ""
 
     // Ripple effect state for processing animations
     @State private var rippleEffectTimer: Timer?
@@ -579,6 +582,48 @@ struct TranscriptionDetailView: View {
         } message: {
             Text(enhancementErrorMessage)
         }
+        .fileExporter(
+            isPresented: exportSheetBinding,
+            items: exportItems,
+            contentTypes: [MarkdownExportItem.contentType]
+        ) { result in
+            handleMarkdownExportCompletion(result)
+        } onCancellation: {
+            exportItems = []
+        }
+        .alert("Export Failed", isPresented: $showExportErrorAlert) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(exportErrorMessage)
+        }
+    }
+
+    private var exportSheetBinding: Binding<Bool> {
+        Binding(
+            get: { !exportItems.isEmpty },
+            set: { isPresented in
+                if !isPresented {
+                    exportItems = []
+                }
+            }
+        )
+    }
+
+    private func exportTranscriptionAsMarkdown() {
+        exportItems = TranscriptionMarkdownExportService.items(for: [transcription])
+    }
+
+    private func handleMarkdownExportCompletion(_ result: Result<[URL], any Error>) {
+        switch result {
+        case .success:
+            HapticManager.success()
+        case .failure(let error):
+            if !(error is CancellationError) {
+                exportErrorMessage = error.localizedDescription
+                showExportErrorAlert = true
+            }
+        }
+        exportItems = []
     }
 
     private var textContentView: some View {
@@ -777,6 +822,15 @@ struct TranscriptionDetailView: View {
                     ) {
                         Label("Audio Recording", systemImage: "waveform")
                     }
+                }
+            }
+
+            Section("Export") {
+                Button {
+                    HapticManager.lightImpact()
+                    exportTranscriptionAsMarkdown()
+                } label: {
+                    Label("Export as Markdown", systemImage: "doc.text")
                 }
             }
         } label: {


### PR DESCRIPTION
## Summary
- New Settings option (Export section) to choose what Markdown export includes: Original + All Variations (default), Original Only, Original + Last Variation, or Last Variation Only. Applies to both bulk and single-note exports.
- Fix: single-note Markdown export from the main screen was a no-op because two stacked `.fileExporter` modifiers conflicted. All exports now route through the `items:` variant.
- New "Export as Markdown" action in the note detail share menu, under an "Export" section.

## Test plan
- [ ] Open Settings, change "Markdown Export" to each of the 4 options, export a note with variations, verify content.
- [ ] In main screen selection mode, select one note, tap Export -> Markdown Files, confirm Save dialog appears (regression fix).
- [ ] In main screen selection mode, select multiple notes, verify folder-picker export still works.
- [ ] In note detail, open share menu, tap Export as Markdown, confirm Save dialog appears and file contents honor the Settings preference.
- [ ] Confirm the original share items (current variation, Original Text, Audio Recording) still work.