### PR TITLE
Drop preemptive context budgeting for cloud providers

### DIFF
--- a/VivaDicta/Services/AIEnhance/ChatContextManager.swift
+++ b/VivaDicta/Services/AIEnhance/ChatContextManager.swift
@@ -69,50 +69,23 @@ struct ChatContextManager {
 
     // MARK: - Context Limits
 
-    /// Known context window sizes per provider/model prefix.
-    /// Returns token limit for the given provider and model.
+    /// Context window in tokens for the given provider and model.
+    ///
+    /// Only Apple Foundation Models has a real, knowable, and actionable limit:
+    /// the model runs on-device and we must pre-flight budget before sending.
+    /// For every cloud provider the window varies by model and evolves faster
+    /// than our hardcoded table can track, and the server already enforces its
+    /// own limit and returns a clean error if we overshoot. Returning `.max`
+    /// disables preemptive trimming and auto-compaction for cloud.
     static func contextLimit(for provider: AIProvider, model: String) -> Int {
-        let modelLower = model.lowercased()
-
         switch provider {
         case .apple:
             if #available(iOS 26, *) {
                 return SystemLanguageModel.default.contextSize
             }
             return 4_096
-
-        case .anthropic:
-            return 200_000
-
-        case .openAI:
-            return 128_000
-
-        case .gemini:
-            if modelLower.contains("2.5") || modelLower.contains("3.") {
-                return 1_000_000
-            }
-            return 128_000
-
-        case .groq:
-            if modelLower.contains("llama-4") {
-                return 128_000
-            }
-            return 8_192
-
-        case .mistral:
-            return 128_000
-
-        case .grok:
-            return 128_000
-
-        case .ollama:
-            return 4_096
-
-        case .openRouter, .vercelAIGateway, .huggingFace:
-            return 32_000
-
         default:
-            return 8_000
+            return .max
         }
     }
 
@@ -134,16 +107,6 @@ struct ChatContextManager {
         let total = systemTokens + noteTokens + messageTokens
 
         return min(Double(total) / Double(limit), 1.0)
-    }
-
-    /// Whether auto-compaction should trigger (fill > 70%).
-    static func shouldAutoCompact(
-        noteText: String,
-        messages: [ChatMessage],
-        provider: AIProvider,
-        model: String
-    ) -> Bool {
-        fillRatio(noteText: noteText, messages: messages, provider: provider, model: model) > 0.7
     }
 
     // MARK: - Message Assembly

--- a/VivaDicta/Services/AIEnhance/MultiNoteContextManager.swift
+++ b/VivaDicta/Services/AIEnhance/MultiNoteContextManager.swift
@@ -70,15 +70,6 @@ struct MultiNoteContextManager {
         return min(Double(total) / Double(limit), 1.0)
     }
 
-    static func shouldAutoCompact(
-        noteText: String,
-        messages: [ChatMessage],
-        provider: AIProvider,
-        model: String
-    ) -> Bool {
-        fillRatio(noteText: noteText, messages: messages, provider: provider, model: model) > 0.7
-    }
-
     // MARK: - Message Assembly
 
     /// Builds the messages array for cloud AI API calls.

--- a/VivaDicta/Views/Chat/ChatView.swift
+++ b/VivaDicta/Views/Chat/ChatView.swift
@@ -312,15 +312,17 @@ struct ChatView: View {
                     .glassCapsule(fallback: Color.secondary.opacity(0.1))
             }
 
-            Text("\(percentage)%")
-                .font(.caption2)
-                .foregroundStyle(ratio > 0.7 ? .orange : .secondary)
-                .padding(.horizontal, 8)
-                .padding(.vertical, 3)
-                .glassCapsule(
-                    tint: ratio > 0.7 ? Color.orange.opacity(0.35) : nil,
-                    fallback: (ratio > 0.7 ? Color.orange : Color.secondary).opacity(0.1)
-                )
+            if ratio > 0 {
+                Text("\(percentage)%")
+                    .font(.caption2)
+                    .foregroundStyle(ratio > 0.7 ? .orange : .secondary)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 3)
+                    .glassCapsule(
+                        tint: ratio > 0.7 ? Color.orange.opacity(0.35) : nil,
+                        fallback: (ratio > 0.7 ? Color.orange : Color.secondary).opacity(0.1)
+                    )
+            }
         }
     }
 

--- a/VivaDicta/Views/Chat/ChatViewModel.swift
+++ b/VivaDicta/Views/Chat/ChatViewModel.swift
@@ -90,10 +90,11 @@ final class ChatViewModel {
 
     var contextFillRatio: Double = 0
 
-    /// Updates the context fill ratio. Uses real token count for Apple FM on iOS 26.4+,
-    /// falls back to character-based estimation for cloud providers and older iOS.
+    /// Updates the context fill ratio. Only tracked for Apple Foundation Models,
+    /// where the on-device context is known and actionable. Cloud providers rely
+    /// on the server to enforce their own limits.
     func updateContextFillRatio() {
-        guard let provider = selectedProvider, let model = selectedModel else {
+        guard let provider = selectedProvider, selectedModel != nil else {
             contextFillRatio = 0
             return
         }
@@ -101,12 +102,7 @@ final class ChatViewModel {
         if provider == .apple {
             Task { await updateAppleFMFillRatio() }
         } else {
-            contextFillRatio = ChatContextManager.fillRatio(
-                noteText: assembledNoteText,
-                messages: messages,
-                provider: provider,
-                model: model
-            )
+            contextFillRatio = 0
         }
     }
 
@@ -802,16 +798,6 @@ final class ChatViewModel {
         allowImplicitCrossNoteTool: Bool,
         allowImplicitWebTool: Bool
     ) async throws -> CloudSendResult {
-        if ChatContextManager.shouldAutoCompact(
-            noteText: assembledNoteText,
-            messages: messages,
-            provider: provider,
-            model: model
-        ) {
-            logger.logInfo("Chat - Auto-compacting context")
-            try await performCompaction()
-        }
-
         let baseChatMessages = cloudChatMessages(for: promptText)
         let (baseSystemMessage, baseAPIMessages) = ChatContextManager.assembleMessages(
             noteText: assembledNoteText,

--- a/VivaDicta/Views/MultiNoteChat/MultiNoteChatView.swift
+++ b/VivaDicta/Views/MultiNoteChat/MultiNoteChatView.swift
@@ -294,15 +294,17 @@ struct MultiNoteChatView: View {
                     .glassCapsule(fallback: Color.secondary.opacity(0.1))
             }
 
-            Text("\(percentage)%")
-                .font(.caption2)
-                .foregroundStyle(ratio > 0.7 ? .orange : .secondary)
-                .padding(.horizontal, 8)
-                .padding(.vertical, 3)
-                .glassCapsule(
-                    tint: ratio > 0.7 ? Color.orange.opacity(0.35) : nil,
-                    fallback: (ratio > 0.7 ? Color.orange : Color.secondary).opacity(0.1)
-                )
+            if ratio > 0 {
+                Text("\(percentage)%")
+                    .font(.caption2)
+                    .foregroundStyle(ratio > 0.7 ? .orange : .secondary)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 3)
+                    .glassCapsule(
+                        tint: ratio > 0.7 ? Color.orange.opacity(0.35) : nil,
+                        fallback: (ratio > 0.7 ? Color.orange : Color.secondary).opacity(0.1)
+                    )
+            }
         }
     }
 

--- a/VivaDicta/Views/MultiNoteChat/MultiNoteChatViewModel.swift
+++ b/VivaDicta/Views/MultiNoteChat/MultiNoteChatViewModel.swift
@@ -87,7 +87,7 @@ final class MultiNoteChatViewModel {
     var contextFillRatio: Double = 0
 
     func updateContextFillRatio() {
-        guard let provider = selectedProvider, let model = selectedModel else {
+        guard let provider = selectedProvider, selectedModel != nil else {
             contextFillRatio = 0
             return
         }
@@ -95,12 +95,7 @@ final class MultiNoteChatViewModel {
         if provider == .apple {
             Task { await updateAppleFMFillRatio() }
         } else {
-            contextFillRatio = MultiNoteContextManager.fillRatio(
-                noteText: assembledNoteText,
-                messages: messages,
-                provider: provider,
-                model: model
-            )
+            contextFillRatio = 0
         }
     }
 
@@ -788,16 +783,6 @@ final class MultiNoteChatViewModel {
         allowImplicitCrossNoteTool: Bool,
         allowImplicitWebTool: Bool
     ) async throws -> CloudSendResult {
-        if MultiNoteContextManager.shouldAutoCompact(
-            noteText: assembledNoteText,
-            messages: messages,
-            provider: provider,
-            model: model
-        ) {
-            logger.logInfo("Multi-note chat - Auto-compacting context")
-            try await performCompaction()
-        }
-
         let baseChatMessages = cloudChatMessages(for: promptText)
         let (baseSystemMessage, baseAPIMessages) = MultiNoteContextManager.assembleMessages(
             noteText: assembledNoteText,

--- a/VivaDicta/Views/SmartSearch/SmartSearchChatView.swift
+++ b/VivaDicta/Views/SmartSearch/SmartSearchChatView.swift
@@ -366,13 +366,15 @@ struct SmartSearchChatView: View {
 
                 let ratio = viewModel.contextFillRatio
                 let percentage = Int(ratio * 100)
-                Text("\(percentage)%")
-                    .font(.caption2)
-                    .foregroundStyle(ratio > 0.7 ? .orange : .secondary)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 3)
-                    .background((ratio > 0.7 ? Color.orange : Color.secondary).opacity(0.1))
-                    .clipShape(.capsule)
+                if ratio > 0 {
+                    Text("\(percentage)%")
+                        .font(.caption2)
+                        .foregroundStyle(ratio > 0.7 ? .orange : .secondary)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 3)
+                        .background((ratio > 0.7 ? Color.orange : Color.secondary).opacity(0.1))
+                        .clipShape(.capsule)
+                }
             }
             .padding(.horizontal)
             .padding(.vertical, 8)

--- a/VivaDicta/Views/SmartSearch/SmartSearchChatViewModel.swift
+++ b/VivaDicta/Views/SmartSearch/SmartSearchChatViewModel.swift
@@ -65,7 +65,7 @@ final class SmartSearchChatViewModel {
     var contextFillRatio: Double = 0
 
     func updateContextFillRatio() {
-        guard let provider = selectedProvider, let model = selectedModel else {
+        guard let provider = selectedProvider, selectedModel != nil else {
             contextFillRatio = 0
             return
         }
@@ -73,11 +73,7 @@ final class SmartSearchChatViewModel {
         if provider == .apple {
             Task { await updateAppleFMFillRatio() }
         } else {
-            contextFillRatio = SmartSearchContextManager.fillRatio(
-                messages: messages,
-                provider: provider,
-                model: model
-            )
+            contextFillRatio = 0
         }
     }
 
@@ -619,15 +615,6 @@ final class SmartSearchChatViewModel {
     }
 
     private func sendCloudMessage(_ augmentedPrompt: String, provider: AIProvider, model: String) async throws -> String {
-        if SmartSearchContextManager.shouldAutoCompact(
-            messages: messages,
-            provider: provider,
-            model: model
-        ) {
-            logger.logInfo("Smart Search - Auto-compacting context")
-            try await performCompaction()
-        }
-
         // Build messages with augmented prompt as the latest user message
         var chatMessages = messages.dropLast() // Exclude the pending user message
         let augmentedUserMessage = ChatMessage(

--- a/VivaDicta/Views/SmartSearch/SmartSearchContextManager.swift
+++ b/VivaDicta/Views/SmartSearch/SmartSearchContextManager.swift
@@ -169,14 +169,6 @@ struct SmartSearchContextManager {
         return min(Double(total) / Double(limit), 1.0)
     }
 
-    static func shouldAutoCompact(
-        messages: [ChatMessage],
-        provider: AIProvider,
-        model: String
-    ) -> Bool {
-        fillRatio(messages: messages, provider: provider, model: model) > 0.7
-    }
-
     // MARK: - Message Assembly
 
     /// Builds the messages array for cloud AI API calls.


### PR DESCRIPTION
## Summary

Stop pretending we know every cloud provider's context window. `ChatContextManager.contextLimit` now returns a real value only for Apple Foundation Models; every cloud provider returns `.max`, which disables preemptive trimming and auto-compaction.

### Why
- The old hardcoded table was lossy and stale: Claude 200K hardcoded while 1M beta exists, OpenAI variants differ, xAI Grok 4 is 256K, etc.
- A too-small entry caused real false positives: Custom OpenAI fell through to the 8K default, so any note above ~5K tokens triggered compaction on open, **even when the configured endpoint was a 200K or 1M model**.
- Preemptive compaction is destructive - we summarize history/context that didn't need summarizing. Being wrong here is worse than doing nothing.
- Cloud providers already return clean `context_length_exceeded` errors. Users can compact manually via the existing **Compact** button if a conversation grows too long.

### What changes
- `ChatContextManager.contextLimit` collapses to Apple + default `.max`.
- Preemptive `shouldAutoCompact` calls removed from `ChatViewModel.sendCloudMessage`, `MultiNoteChatViewModel.sendCloudMessage`, `SmartSearchChatViewModel.sendCloudMessage`.
- `shouldAutoCompact` helpers deleted from `ChatContextManager`, `MultiNoteContextManager`, `SmartSearchContextManager` (no more callers).
- Cloud branch of `updateContextFillRatio` removed in all three view models - cloud just sets ratio to 0.
- `%` pill in the three chat views is hidden when ratio is 0, so cloud conversations no longer show a misleading `0%`.

### What does not change
- Apple FM still uses real `SystemLanguageModel.default.contextSize`, still shows the fill pill, still auto-compacts at 70%, still has reactive compaction on `exceededContextWindowSize`.
- `assembleMessages` still exists; with `limit = .max` it simply packs everything (no note truncation, no message drop).
- The manual **Compact** button works as before for cloud.

### Net
9 files, -139 / +49 lines.

## Test plan
- [x] Clean build passes on iPhone 17 Pro Max simulator, iOS 26.4 (0 errors, 29 pre-existing warnings).
- [ ] Smoke: open a long single-note chat on a cloud provider; confirm no "auto-compacting" log line fires at open and the % pill is hidden.
- [ ] Smoke: same on multi-note chat and Smart Search chat.
- [ ] Smoke: Apple FM path still shows the % pill and still auto-compacts past 70%.
- [ ] Smoke: Custom OpenAI against a local endpoint - open a note that previously triggered preemptive compaction; confirm it no longer does.