### PR TITLE
Expose transcribed notes as Shortcuts outputs

### DIFF
--- a/VivaDicta/AppIntents/CancelRecordIntent.swift
+++ b/VivaDicta/AppIntents/CancelRecordIntent.swift
@@ -1,0 +1,22 @@
+//
+//  CancelRecordIntent.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.18
+//
+
+import AppIntents
+
+struct CancelRecordIntent: AppIntent {
+    static let title: LocalizedStringResource = "Cancel Recording"
+    static let description = IntentDescription(
+        "Cancels the current VivaDicta recording without saving a transcription."
+    )
+
+    func perform() async throws -> some IntentResult {
+        await MainActor.run {
+            AppGroupCoordinator.shared.requestCancelRecording()
+        }
+        return .result()
+    }
+}

--- a/VivaDicta/AppIntents/CancelRecordIntent.swift
+++ b/VivaDicta/AppIntents/CancelRecordIntent.swift
@@ -13,6 +13,8 @@ struct CancelRecordIntent: AppIntent {
         "Cancels the current VivaDicta recording without saving a transcription."
     )
 
+    static let openAppWhenRun: Bool = true
+
     func perform() async throws -> some IntentResult {
         await MainActor.run {
             AppGroupCoordinator.shared.requestCancelRecording()

--- a/VivaDicta/AppIntents/GetLatestTranscriptionIntent.swift
+++ b/VivaDicta/AppIntents/GetLatestTranscriptionIntent.swift
@@ -1,0 +1,40 @@
+//
+//  GetLatestTranscriptionIntent.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.18
+//
+
+import AppIntents
+
+struct GetLatestTranscriptionIntent: AppIntent {
+    static let title: LocalizedStringResource = "Get Latest Note"
+    static let description = IntentDescription(
+        "Returns the most recently recorded note. Pipe its Text or Enhanced Text into other actions, like Copy to Clipboard or Open URL.",
+        categoryName: "Notes",
+        searchKeywords: ["latest", "recent", "last", "transcription", "note", "obsidian"],
+        resultValueName: "Latest Note"
+    )
+
+    @Dependency var dataController: DataController
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ReturnsValue<TranscriptionEntity> & ProvidesDialog {
+        let recent = try dataController.transcriptionEntities(limit: 1)
+
+        guard let latest = recent.first else {
+            throw NoTranscriptionsAvailableError()
+        }
+
+        return .result(
+            value: latest,
+            dialog: "\(latest.text(withPrefix: 80))"
+        )
+    }
+}
+
+struct NoTranscriptionsAvailableError: Error, CustomLocalizedStringResourceConvertible {
+    var localizedStringResource: LocalizedStringResource {
+        "You haven't recorded any notes yet."
+    }
+}

--- a/VivaDicta/AppIntents/RecordAndReturnTranscriptionIntent.swift
+++ b/VivaDicta/AppIntents/RecordAndReturnTranscriptionIntent.swift
@@ -1,0 +1,92 @@
+//
+//  RecordAndReturnTranscriptionIntent.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.18
+//
+
+import AppIntents
+import Foundation
+
+struct RecordAndReturnTranscriptionIntent: AppIntent {
+    static let title: LocalizedStringResource = "Record and Get Note"
+    static let description = IntentDescription(
+        "Starts recording in VivaDicta, waits for you to stop, and returns the transcribed note for use in other shortcut actions.",
+        categoryName: "Notes",
+        searchKeywords: ["record", "dictate", "transcribe", "note", "obsidian"],
+        resultValueName: "Recorded Note"
+    )
+
+    static let openAppWhenRun: Bool = true
+
+    /// Overall wait budget for the whole flow: user recording + transcription + optional AI enhancement.
+    private static let maxWaitSeconds: TimeInterval = 180
+
+    @Dependency var dataController: DataController
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ReturnsValue<TranscriptionEntity> & ProvidesDialog {
+        let coordinator = AppGroupCoordinator.shared
+        let startTime = Date()
+        let previousLatestId = try? dataController.transcriptions(limit: 1).first?.id
+
+        if !coordinator.isRecording && coordinator.transcriptionStatus == .idle {
+            coordinator.requestStartRecordingFromControl()
+        }
+
+        let entity = try await waitForNewTranscription(
+            after: startTime,
+            previousLatestId: previousLatestId,
+            coordinator: coordinator
+        )
+
+        return .result(
+            value: entity,
+            dialog: "\(entity.text(withPrefix: 80))"
+        )
+    }
+
+    @MainActor
+    private func waitForNewTranscription(
+        after startTime: Date,
+        previousLatestId: UUID?,
+        coordinator: AppGroupCoordinator
+    ) async throws -> TranscriptionEntity {
+        let deadline = Date().addingTimeInterval(Self.maxWaitSeconds)
+
+        while Date() < deadline {
+            try Task.checkCancellation()
+
+            if coordinator.transcriptionStatus == .error {
+                let message = coordinator.getAndConsumeTranscriptionErrorMessage()
+                    ?? String(localized: "Transcription failed.")
+                throw RecordAndReturnIntentError.failed(message)
+            }
+
+            if let latest = try dataController.transcriptions(limit: 1).first,
+               latest.id != previousLatestId,
+               latest.timestamp > startTime,
+               coordinator.transcriptionStatus == .completed || coordinator.transcriptionStatus == .idle {
+                return latest.entity
+            }
+
+            try await Task.sleep(for: .milliseconds(500))
+        }
+
+        throw RecordAndReturnIntentError.timedOut
+    }
+}
+
+enum RecordAndReturnIntentError: Error, CustomLocalizedStringResourceConvertible {
+    case failed(String)
+    case timedOut
+
+    var localizedStringResource: LocalizedStringResource {
+        switch self {
+        case .failed(let message):
+            "Recording failed: \(message)"
+        case .timedOut:
+            "Timed out waiting for the recording to finish."
+        }
+    }
+}

--- a/VivaDicta/AppIntents/RecordAndReturnTranscriptionIntent.swift
+++ b/VivaDicta/AppIntents/RecordAndReturnTranscriptionIntent.swift
@@ -35,10 +35,16 @@ struct RecordAndReturnTranscriptionIntent: AppIntent {
             // Another session is already mid-flight. Returning its result would
             // violate the intent's "starts recording ... and returns the note" contract.
             throw RecordAndReturnIntentError.alreadyInProgress
-        case .idle, .completed, .error:
-            // `.completed` / `.error` are stale leftovers from a previous in-app session
-            // (the main-app path never resets them; only the keyboard consumer does).
-            // Treat them as idle and kick off a new recording.
+        case .error:
+            // Drain the stale error message from the previous session before we
+            // start a new one - otherwise the poll loop's first tick would see
+            // `.error` and throw the old message as if it just happened.
+            _ = coordinator.getAndConsumeTranscriptionErrorMessage()
+            coordinator.requestStartRecordingFromControl()
+        case .idle, .completed:
+            // `.completed` is a stale leftover from a previous in-app session
+            // (the main-app path never resets it; only the keyboard consumer does).
+            // Treat it as idle and kick off a new recording.
             coordinator.requestStartRecordingFromControl()
         }
 
@@ -74,7 +80,11 @@ struct RecordAndReturnTranscriptionIntent: AppIntent {
                 throw RecordAndReturnIntentError.failed(message)
             }
 
-            if status == .recording || status == .transcribing || status == .enhancing {
+            // The main app never writes `.recording` to `transcriptionStatus`;
+            // it flips `isRecording` on the coordinator instead and only mutates
+            // the status when transcription begins. Check both so cancels during
+            // the recording phase itself still unblock the poll loop.
+            if coordinator.isRecording || status == .transcribing || status == .enhancing {
                 sawActiveSession = true
             }
 

--- a/VivaDicta/AppIntents/RecordAndReturnTranscriptionIntent.swift
+++ b/VivaDicta/AppIntents/RecordAndReturnTranscriptionIntent.swift
@@ -30,6 +30,14 @@ struct RecordAndReturnTranscriptionIntent: AppIntent {
         let startTime = Date()
         let previousLatestId = try dataController.transcriptions(limit: 1).first?.id
 
+        // `transcriptionStatus` stays `.idle` during the recording phase (the
+        // main app flips `isRecording` instead). Guard against that case too
+        // so starting this intent mid-recording doesn't silently latch onto
+        // the existing session and return its note.
+        if coordinator.isRecording {
+            throw RecordAndReturnIntentError.alreadyInProgress
+        }
+
         switch coordinator.transcriptionStatus {
         case .recording, .transcribing, .enhancing:
             // Another session is already mid-flight. Returning its result would
@@ -88,13 +96,17 @@ struct RecordAndReturnTranscriptionIntent: AppIntent {
                 sawActiveSession = true
             }
 
-            if let latest = try dataController.transcriptions(limit: 1).first,
+            if sawActiveSession,
+               let latest = try dataController.transcriptions(limit: 1).first,
                latest.id != previousLatestId,
                latest.timestamp > startTime,
                // `.idle` is accepted alongside `.completed` because the keyboard
                // consumer can race ahead and reset status to `.idle` between the
                // save and our poll tick. Don't "tighten" this to `.completed` only.
                status == .completed || status == .idle {
+                // `sawActiveSession` is required so a CloudKit-synced row from
+                // another device (VivaDictaMac) during the wait can't satisfy
+                // `timestamp > startTime` and be returned as this intent's result.
                 return latest.entity
             }
 

--- a/VivaDicta/AppIntents/RecordAndReturnTranscriptionIntent.swift
+++ b/VivaDicta/AppIntents/RecordAndReturnTranscriptionIntent.swift
@@ -28,9 +28,17 @@ struct RecordAndReturnTranscriptionIntent: AppIntent {
     func perform() async throws -> some IntentResult & ReturnsValue<TranscriptionEntity> & ProvidesDialog {
         let coordinator = AppGroupCoordinator.shared
         let startTime = Date()
-        let previousLatestId = try? dataController.transcriptions(limit: 1).first?.id
+        let previousLatestId = try dataController.transcriptions(limit: 1).first?.id
 
-        if !coordinator.isRecording && coordinator.transcriptionStatus == .idle {
+        switch coordinator.transcriptionStatus {
+        case .recording, .transcribing, .enhancing:
+            // Another session is already mid-flight. Returning its result would
+            // violate the intent's "starts recording ... and returns the note" contract.
+            throw RecordAndReturnIntentError.alreadyInProgress
+        case .idle, .completed, .error:
+            // `.completed` / `.error` are stale leftovers from a previous in-app session
+            // (the main-app path never resets them; only the keyboard consumer does).
+            // Treat them as idle and kick off a new recording.
             coordinator.requestStartRecordingFromControl()
         }
 
@@ -53,21 +61,37 @@ struct RecordAndReturnTranscriptionIntent: AppIntent {
         coordinator: AppGroupCoordinator
     ) async throws -> TranscriptionEntity {
         let deadline = Date().addingTimeInterval(Self.maxWaitSeconds)
+        var sawActiveSession = false
 
         while Date() < deadline {
             try Task.checkCancellation()
 
-            if coordinator.transcriptionStatus == .error {
+            let status = coordinator.transcriptionStatus
+
+            if status == .error {
                 let message = coordinator.getAndConsumeTranscriptionErrorMessage()
                     ?? String(localized: "Transcription failed.")
                 throw RecordAndReturnIntentError.failed(message)
             }
 
+            if status == .recording || status == .transcribing || status == .enhancing {
+                sawActiveSession = true
+            }
+
             if let latest = try dataController.transcriptions(limit: 1).first,
                latest.id != previousLatestId,
                latest.timestamp > startTime,
-               coordinator.transcriptionStatus == .completed || coordinator.transcriptionStatus == .idle {
+               // `.idle` is accepted alongside `.completed` because the keyboard
+               // consumer can race ahead and reset status to `.idle` between the
+               // save and our poll tick. Don't "tighten" this to `.completed` only.
+               status == .completed || status == .idle {
                 return latest.entity
+            }
+
+            // If we've observed an active session and it dropped back to `.idle`
+            // without producing a new row, the user cancelled.
+            if sawActiveSession && status == .idle {
+                throw RecordAndReturnIntentError.cancelled
             }
 
             try await Task.sleep(for: .milliseconds(500))
@@ -80,6 +104,8 @@ struct RecordAndReturnTranscriptionIntent: AppIntent {
 enum RecordAndReturnIntentError: Error, CustomLocalizedStringResourceConvertible {
     case failed(String)
     case timedOut
+    case cancelled
+    case alreadyInProgress
 
     var localizedStringResource: LocalizedStringResource {
         switch self {
@@ -87,6 +113,10 @@ enum RecordAndReturnIntentError: Error, CustomLocalizedStringResourceConvertible
             "Recording failed: \(message)"
         case .timedOut:
             "Timed out waiting for the recording to finish."
+        case .cancelled:
+            "Recording was cancelled."
+        case .alreadyInProgress:
+            "A recording is already in progress in VivaDicta. Stop it first, then try again."
         }
     }
 }

--- a/VivaDicta/AppIntents/RecordAndReturnTranscriptionIntent.swift
+++ b/VivaDicta/AppIntents/RecordAndReturnTranscriptionIntent.swift
@@ -43,16 +43,12 @@ struct RecordAndReturnTranscriptionIntent: AppIntent {
             // Another session is already mid-flight. Returning its result would
             // violate the intent's "starts recording ... and returns the note" contract.
             throw RecordAndReturnIntentError.alreadyInProgress
-        case .error:
-            // Drain the stale error message from the previous session before we
-            // start a new one - otherwise the poll loop's first tick would see
-            // `.error` and throw the old message as if it just happened.
-            _ = coordinator.getAndConsumeTranscriptionErrorMessage()
-            coordinator.requestStartRecordingFromControl()
-        case .idle, .completed:
-            // `.completed` is a stale leftover from a previous in-app session
-            // (the main-app path never resets it; only the keyboard consumer does).
-            // Treat it as idle and kick off a new recording.
+        case .idle, .completed, .error:
+            // `.completed` / `.error` are stale leftovers from a previous in-app
+            // session (the main-app path never resets them; only the keyboard
+            // consumer does). The poll loop only reacts to terminal states once
+            // it has observed an active session this run, so it's safe to leave
+            // the stale status alone here and kick off a new recording.
             coordinator.requestStartRecordingFromControl()
         }
 
@@ -82,18 +78,22 @@ struct RecordAndReturnTranscriptionIntent: AppIntent {
 
             let status = coordinator.transcriptionStatus
 
-            if status == .error {
-                let message = coordinator.getAndConsumeTranscriptionErrorMessage()
-                    ?? String(localized: "Transcription failed.")
-                throw RecordAndReturnIntentError.failed(message)
-            }
-
             // The main app never writes `.recording` to `transcriptionStatus`;
             // it flips `isRecording` on the coordinator instead and only mutates
             // the status when transcription begins. Check both so cancels during
             // the recording phase itself still unblock the poll loop.
             if coordinator.isRecording || status == .transcribing || status == .enhancing {
                 sawActiveSession = true
+            }
+
+            // Only treat `.error` as a failure once we've observed an active
+            // session this run - otherwise stale `.error` from a previous
+            // in-app failure would fire on the first poll tick before the main
+            // app has processed the Darwin start-request notification.
+            if sawActiveSession && status == .error {
+                let message = coordinator.getAndConsumeTranscriptionErrorMessage()
+                    ?? String(localized: "Transcription failed.")
+                throw RecordAndReturnIntentError.failed(message)
             }
 
             if sawActiveSession,

--- a/VivaDicta/AppIntents/ShortcutsProvider.swift
+++ b/VivaDicta/AppIntents/ShortcutsProvider.swift
@@ -70,5 +70,27 @@ final class ShortcutsProvider: AppShortcutsProvider {
             shortTitle: "Open a note",
             systemImageName: "document.viewfinder"
         )
+
+        AppShortcut(
+            intent: GetLatestTranscriptionIntent(),
+            phrases: [
+                "Get latest note from \(.applicationName)",
+                "Latest note in \(.applicationName)",
+                "My most recent note in \(.applicationName)"
+            ],
+            shortTitle: "Get Latest Note",
+            systemImageName: "text.quote"
+        )
+
+        AppShortcut(
+            intent: RecordAndReturnTranscriptionIntent(),
+            phrases: [
+                "Record and get note from \(.applicationName)",
+                "Dictate a note with \(.applicationName)",
+                "Record and transcribe in \(.applicationName)"
+            ],
+            shortTitle: "Record and Get Note",
+            systemImageName: "waveform.badge.plus"
+        )
     }
 }

--- a/VivaDicta/AppIntents/StartRecordIntent.swift
+++ b/VivaDicta/AppIntents/StartRecordIntent.swift
@@ -1,0 +1,24 @@
+//
+//  StartRecordIntent.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.18
+//
+
+import AppIntents
+
+struct StartRecordIntent: AppIntent {
+    static let title: LocalizedStringResource = "Start Recording"
+    static let description = IntentDescription(
+        "Starts a new recording in VivaDicta. Use with Stop Recording to control the session from a shortcut."
+    )
+
+    static let openAppWhenRun: Bool = true
+
+    func perform() async throws -> some IntentResult {
+        await MainActor.run {
+            AppGroupCoordinator.shared.requestStartRecordingFromControl()
+        }
+        return .result()
+    }
+}

--- a/VivaDicta/AppIntents/StopRecordIntent.swift
+++ b/VivaDicta/AppIntents/StopRecordIntent.swift
@@ -1,0 +1,22 @@
+//
+//  StopRecordIntent.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.18
+//
+
+import AppIntents
+
+struct StopRecordIntent: AppIntent {
+    static let title: LocalizedStringResource = "Stop Recording"
+    static let description = IntentDescription(
+        "Stops the current VivaDicta recording and begins transcription."
+    )
+
+    func perform() async throws -> some IntentResult {
+        await MainActor.run {
+            AppGroupCoordinator.shared.requestStopRecording()
+        }
+        return .result()
+    }
+}

--- a/VivaDicta/AppIntents/StopRecordIntent.swift
+++ b/VivaDicta/AppIntents/StopRecordIntent.swift
@@ -13,6 +13,8 @@ struct StopRecordIntent: AppIntent {
         "Stops the current VivaDicta recording and begins transcription."
     )
 
+    static let openAppWhenRun: Bool = true
+
     func perform() async throws -> some IntentResult {
         await MainActor.run {
             AppGroupCoordinator.shared.requestStopRecording()

--- a/VivaDicta/Shared/AppGroupCoordinator.swift
+++ b/VivaDicta/Shared/AppGroupCoordinator.swift
@@ -256,6 +256,12 @@ public final class AppGroupCoordinator {
     func updateAudioLevel(_ level: CGFloat) {
         let clamped = max(0, min(1, level))
         sharedDefaults?.set(Double(clamped), forKey: UserDefaultsKeys.audioLevel)
+        // Refresh the recording timestamp while audio is flowing so the 30s
+        // staleness check in `isRecording` doesn't trip during long main-app
+        // recordings (nothing else refreshes it until Stop fires the status
+        // transition). Readers that depend on `isRecording` - widget, live
+        // activity, keyboard, the record-and-return intent - all benefit.
+        sharedDefaults?.set(Date().timeIntervalSince1970, forKey: UserDefaultsKeys.lastRecordingTimestamp)
         postDarwinNotification(NotificationNames.audioLevelUpdated)
     }
 


### PR DESCRIPTION
## Summary
- Add `GetLatestTranscriptionIntent` - returns the most recent note as a chainable `TranscriptionEntity`, so users can pipe its `Text` or `Enhanced Text` into other Shortcuts actions.
- Add `RecordAndReturnTranscriptionIntent` - a single-step intent that starts recording via `AppGroupCoordinator`, waits for transcription to finish (polls SwiftData for a new `Transcription` with `timestamp > start`), and returns the resulting entity.
- Register both in `ShortcutsProvider` with Siri phrases (all include `\(.applicationName)`).

Polling reads SwiftData rather than installing a second listener on `AppGroupCoordinator.onTranscriptionCompleted`, because that callback is single-owner and already wired to `RecordViewModel`. `RecordViewModel` saves the `Transcription` before calling `shareTranscribedText`, so the DB is the correct source of truth.

Motivation: users want to use VivaDicta's transcription inside their own Shortcuts flows (e.g. append to Obsidian via `obsidian://new?file=<date>&clipboard&append=true`) without relying on a third-party OpenAI call.

## Test plan
- [x] Clean build succeeds (`xcodebuild` on iPhone 17 Pro Max sim, iOS 26.4, 0 errors).
- [ ] In Shortcuts, run `Get Latest Note` and verify it returns a note with `Text` / `Enhanced Text` fields.
- [ ] In Shortcuts, run `Record and Get Note`, dictate, tap stop, verify the returned entity matches the newly created transcription.
- [ ] Repro the friend's Obsidian flow: Record and Get Note -> Copy `Enhanced Text` to Clipboard -> Open `obsidian://new?file=<date>&clipboard&append=true`.
- [ ] Error path: start an intent, cancel the recording, verify it times out at 180s with a localized dialog instead of hanging.