### PR TITLE
Debounce record-and-return cancel detection

### DIFF
--- a/VivaDicta/AppIntents/RecordAndReturnTranscriptionIntent.swift
+++ b/VivaDicta/AppIntents/RecordAndReturnTranscriptionIntent.swift
@@ -72,6 +72,7 @@ struct RecordAndReturnTranscriptionIntent: AppIntent {
     ) async throws -> TranscriptionEntity {
         let deadline = Date().addingTimeInterval(Self.maxWaitSeconds)
         var sawActiveSession = false
+        var consecutiveIdleTicks = 0
 
         while Date() < deadline {
             try Task.checkCancellation()
@@ -111,9 +112,19 @@ struct RecordAndReturnTranscriptionIntent: AppIntent {
             }
 
             // If we've observed an active session and it dropped back to `.idle`
-            // without producing a new row, the user cancelled.
-            if sawActiveSession && status == .idle {
-                throw RecordAndReturnIntentError.cancelled
+            // without producing a new row, the user cancelled. Debounce across a
+            // few consecutive ticks: when the user taps Stop in-app, the main
+            // app synchronously flips `isRecording = false` and only then kicks
+            // off an async task that writes `.transcribing` to status - so for
+            // one to two poll ticks we legitimately observe `!isRecording &&
+            // status == .idle`. Real cancels persist indefinitely.
+            if sawActiveSession && !coordinator.isRecording && status == .idle {
+                consecutiveIdleTicks += 1
+                if consecutiveIdleTicks >= 6 {
+                    throw RecordAndReturnIntentError.cancelled
+                }
+            } else {
+                consecutiveIdleTicks = 0
             }
 
             try await Task.sleep(for: .milliseconds(500))


### PR DESCRIPTION
## Summary
Fixes Option A of the Obsidian/Shortcuts flow introduced in #211 falsely throwing "Recording was cancelled." when the user taps Stop inside VivaDicta.

Root cause: `RecordViewModel` synchronously calls `AppGroupCoordinator.updateRecordingState(false)` on Stop, but only later (inside an async `Task { @MainActor }`) writes `transcriptionStatus = .transcribing`. The intent's 500ms poll loop catches that one-to-two-tick window where `!isRecording && status == .idle` and trips the cancel detector.

Fix: debounce - require six consecutive idle ticks (~3s) before throwing `.cancelled`. Real cancels persist indefinitely; the stop-transition gap is at most one or two ticks.

## Test plan
- [x] Build succeeds (xcodebuild iPhone 17 Pro Max sim iOS 26.4, 0 errors).
- [ ] Option A shortcut: Record and Get Note -> Copy Enhanced Text -> Open Obsidian URL. Dictate 5s, tap Stop in VivaDicta, confirm the shortcut proceeds with the new text.
- [ ] Option B shortcut still works (Start -> Alert -> Stop -> Wait -> Get Latest).
- [ ] User cancels recording in-app: shortcut still throws Recording was cancelled within ~3s instead of hanging 180s.