### PR TITLE
Read raw isRecording flag from the intent's poll loop

### DIFF
--- a/VivaDicta/AppIntents/RecordAndReturnTranscriptionIntent.swift
+++ b/VivaDicta/AppIntents/RecordAndReturnTranscriptionIntent.swift
@@ -34,7 +34,7 @@ struct RecordAndReturnTranscriptionIntent: AppIntent {
         // main app flips `isRecording` instead). Guard against that case too
         // so starting this intent mid-recording doesn't silently latch onto
         // the existing session and return its note.
-        if coordinator.isRecording {
+        if coordinator.isRecordingRaw {
             throw RecordAndReturnIntentError.alreadyInProgress
         }
 
@@ -83,7 +83,7 @@ struct RecordAndReturnTranscriptionIntent: AppIntent {
             // it flips `isRecording` on the coordinator instead and only mutates
             // the status when transcription begins. Check both so cancels during
             // the recording phase itself still unblock the poll loop.
-            if coordinator.isRecording || status == .transcribing || status == .enhancing {
+            if coordinator.isRecordingRaw || status == .transcribing || status == .enhancing {
                 sawActiveSession = true
             }
 
@@ -118,7 +118,7 @@ struct RecordAndReturnTranscriptionIntent: AppIntent {
             // off an async task that writes `.transcribing` to status - so for
             // one to two poll ticks we legitimately observe `!isRecording &&
             // status == .idle`. Real cancels persist indefinitely.
-            if sawActiveSession && !coordinator.isRecording && status == .idle {
+            if sawActiveSession && !coordinator.isRecordingRaw && status == .idle {
                 consecutiveIdleTicks += 1
                 if consecutiveIdleTicks >= 6 {
                     throw RecordAndReturnIntentError.cancelled

--- a/VivaDicta/Shared/AppGroupCoordinator.swift
+++ b/VivaDicta/Shared/AppGroupCoordinator.swift
@@ -243,6 +243,15 @@ public final class AppGroupCoordinator {
         return storedState
     }
 
+    /// Raw `isRecording` flag without the 30-second staleness check.
+    /// Use when you need the stored value as-is - e.g. from a polling loop
+    /// where the getter's side-effect of clearing the flag mid-recording
+    /// would corrupt state. Only the default `isRecording` getter (with
+    /// its crash-recovery semantics) should be used by UI-level callers.
+    var isRecordingRaw: Bool {
+        sharedDefaults?.bool(forKey: UserDefaultsKeys.isRecording) ?? false
+    }
+
     // MARK: - Public Interface for Main App
 
     func updateRecordingState(_ isRecording: Bool) {
@@ -256,12 +265,6 @@ public final class AppGroupCoordinator {
     func updateAudioLevel(_ level: CGFloat) {
         let clamped = max(0, min(1, level))
         sharedDefaults?.set(Double(clamped), forKey: UserDefaultsKeys.audioLevel)
-        // Refresh the recording timestamp while audio is flowing so the 30s
-        // staleness check in `isRecording` doesn't trip during long main-app
-        // recordings (nothing else refreshes it until Stop fires the status
-        // transition). Readers that depend on `isRecording` - widget, live
-        // activity, keyboard, the record-and-return intent - all benefit.
-        sharedDefaults?.set(Date().timeIntervalSince1970, forKey: UserDefaultsKeys.lastRecordingTimestamp)
         postDarwinNotification(NotificationNames.audioLevelUpdated)
     }
 


### PR DESCRIPTION
## Summary
Narrow-scope follow-up to #211/#212. Reverts the `updateAudioLevel` behavior change, since no existing UI callers actually exercised the 30s staleness bug (Control Center widget reads on demand, not in a tight loop), and changing coordinator behavior for everyone to accommodate a single new caller isn't justified.

Instead, add `AppGroupCoordinator.isRecordingRaw` - a side-effect-free accessor that returns the stored flag without the 30s staleness check - and use it in the three `coordinator.isRecording` reads inside `RecordAndReturnTranscriptionIntent` (preflight, active-session detector, cancel guard).

## Test plan
- [x] Build succeeds (0 errors).
- [ ] Option A shortcut with a >30s recording: dictate 60s in VivaDicta, tap Stop, confirm the shortcut completes with the transcribed text instead of throwing `cancelled`.
- [ ] Option A with <30s recording (regression check).
- [ ] Control Center widget unchanged (still reads `coordinator.isRecording` with staleness semantics).