### PR TITLE
Add All Notes chat mode

### DIFF
--- a/VivaDicta/Models/MultiNoteConversation.swift
+++ b/VivaDicta/Models/MultiNoteConversation.swift
@@ -29,6 +29,11 @@ final class MultiNoteConversation {
     /// Number of source notes included at creation time.
     var sourceNoteCount: Int = 0
 
+    /// True when this conversation was created from the "All Notes" shortcut,
+    /// which auto-picks the most recent notes that fit the provider's budget.
+    /// False for regular multi-note chats where the user hand-picked notes.
+    var isAllNotes: Bool = false
+
     /// Chat messages in this conversation.
     @Relationship(deleteRule: .cascade)
     var messages: [ChatMessage]? = []

--- a/VivaDicta/Services/AIEnhance/MultiNoteContextManager.swift
+++ b/VivaDicta/Services/AIEnhance/MultiNoteContextManager.swift
@@ -60,8 +60,13 @@ struct MultiNoteContextManager {
         let limit = ChatContextManager.contextLimit(for: provider, model: model)
         let systemTokens = ChatContextManager.estimateTokens(systemPrompt)
         let responseReserve = min(4_096, limit / 4)
+        // Cap to avoid Int overflow in the headroom math - every cloud provider
+        // returns .max from contextLimit, and multiplying near-Int.max traps.
+        // 10M tokens is far above any real model context (Gemini 2.5 Pro ~2M).
+        let maxReasonableBudget = 10_000_000
+        let rawBudget = min(limit - systemTokens - responseReserve, maxReasonableBudget)
         // Leave ~30% of the budget for the conversation itself.
-        let packBudget = max(0, limit - systemTokens - responseReserve) * 7 / 10
+        let packBudget = max(0, rawBudget) * 7 / 10
 
         var selected: [Transcription] = []
         var usedTokens = 0

--- a/VivaDicta/Services/AIEnhance/MultiNoteContextManager.swift
+++ b/VivaDicta/Services/AIEnhance/MultiNoteContextManager.swift
@@ -34,6 +34,49 @@ struct MultiNoteContextManager {
     - Only use web search when the user explicitly asks to look something up online or asks about current events, news, or real-time information not covered in the notes.
     """
 
+    // MARK: - All Notes Pack Selection
+
+    /// Default target count for the "All Notes" chat shortcut.
+    static let allNotesDefaultTargetCount = 20
+
+    /// Picks the most recent notes for an "All Notes" chat, stopping when either
+    /// the count cap or the provider's token budget is reached.
+    ///
+    /// Cloud providers return `.max` from `ChatContextManager.contextLimit`, so
+    /// the count cap is what bounds them. Apple FM has a real budget, so the
+    /// token cap will usually hit first and the chat will include fewer notes.
+    ///
+    /// Notes are expected to be sorted newest-first. At least one note is always
+    /// returned if `notes` is non-empty, even if that note alone exceeds the
+    /// estimated budget - matches existing single-note-too-large behavior.
+    static func selectRecentNotesForAllNotesPack(
+        from notes: [Transcription],
+        provider: AIProvider,
+        model: String,
+        targetCount: Int = allNotesDefaultTargetCount
+    ) -> [Transcription] {
+        guard !notes.isEmpty else { return [] }
+
+        let limit = ChatContextManager.contextLimit(for: provider, model: model)
+        let systemTokens = ChatContextManager.estimateTokens(systemPrompt)
+        let responseReserve = min(4_096, limit / 4)
+        // Leave ~30% of the budget for the conversation itself.
+        let packBudget = max(0, limit - systemTokens - responseReserve) * 7 / 10
+
+        var selected: [Transcription] = []
+        var usedTokens = 0
+        let wrapperOverhead = 50
+
+        for note in notes.prefix(targetCount) {
+            let tokens = ChatContextManager.estimateTokens(note.text) + wrapperOverhead
+            if !selected.isEmpty, usedTokens + tokens > packBudget { break }
+            selected.append(note)
+            usedTokens += tokens
+        }
+
+        return selected
+    }
+
     // MARK: - Note Assembly (used at creation time)
 
     /// Wraps multiple transcriptions in XML tags for AI disambiguation.

--- a/VivaDicta/Views/MultiNoteChat/MultiNoteChatsListView.swift
+++ b/VivaDicta/Views/MultiNoteChat/MultiNoteChatsListView.swift
@@ -26,6 +26,7 @@ struct MultiNoteChatsListView: View {
     enum ChatTab: String, CaseIterable {
         case multiNote = "Multi-Note"
         case singleNote = "Single-Note"
+        case allNotes = "All Notes"
         case smartSearch = "Smart Search"
     }
 
@@ -34,10 +35,11 @@ struct MultiNoteChatsListView: View {
     }
 
     private var availableTabs: [ChatTab] {
+        var tabs: [ChatTab] = [.multiNote, .singleNote, .allNotes]
         if isSmartSearchEnabled {
-            return ChatTab.allCases
+            tabs.append(.smartSearch)
         }
-        return [.multiNote, .singleNote]
+        return tabs
     }
 
     var body: some View {
@@ -72,6 +74,8 @@ struct MultiNoteChatsListView: View {
                         multiNoteContent
                     case .singleNote:
                         singleNoteContent
+                    case .allNotes:
+                        allNotesContent
                     case .smartSearch:
                         smartSearchContent
                     }
@@ -96,6 +100,14 @@ struct MultiNoteChatsListView: View {
                         .disabled(!isAIConfigured)
                     }
                 }
+                if selectedTab == .allNotes {
+                    ToolbarItem(placement: .primaryAction) {
+                        Button("New Chat", systemImage: "plus") {
+                            startNewAllNotesChat()
+                        }
+                        .disabled(!isAIConfigured)
+                    }
+                }
             }
             .navigationDestination(for: NavigationTarget.self) { target in
                 switch target {
@@ -106,7 +118,8 @@ struct MultiNoteChatsListView: View {
                         navigationPath.append(NavigationTarget.multiNoteChat(conversation.id))
                     }
                 case .multiNoteChat(let conversationId):
-                    if let conversation = viewModel?.multiNoteConversations.first(where: { $0.id == conversationId }) {
+                    if let conversation = viewModel?.multiNoteConversations.first(where: { $0.id == conversationId })
+                        ?? viewModel?.allNotesConversations.first(where: { $0.id == conversationId }) {
                         MultiNoteChatView(
                             viewModel: multiNoteChatVM(for: conversation)
                         )
@@ -236,6 +249,46 @@ struct MultiNoteChatsListView: View {
                 )
             }
         }
+    }
+
+    // MARK: - All Notes Content
+
+    private var allNotesContent: some View {
+        Group {
+            if let viewModel, !viewModel.allNotesConversations.isEmpty {
+                List {
+                    ForEach(viewModel.allNotesConversations, id: \.id) { conversation in
+                        Button {
+                            navigationPath.append(NavigationTarget.multiNoteChat(conversation.id))
+                        } label: {
+                            multiNoteRow(conversation)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                    .onDelete { indexSet in
+                        for index in indexSet {
+                            let conversation = viewModel.allNotesConversations[index]
+                            cachedMultiNoteVMs.removeValue(forKey: conversation.id)
+                            viewModel.deleteMultiNoteConversation(conversation)
+                        }
+                    }
+                }
+            } else {
+                ContentUnavailableView(
+                    "No All-Notes Chats",
+                    systemImage: "bubble.left.and.bubble.right.fill",
+                    description: Text("Start a chat that automatically includes your most recent notes.")
+                )
+            }
+        }
+    }
+
+    private func startNewAllNotesChat() {
+        guard let viewModel else { return }
+        guard let conversation = viewModel.createAllNotesConversation(aiService: appState.aiService) else {
+            return
+        }
+        navigationPath.append(NavigationTarget.multiNoteChat(conversation.id))
     }
 
     // MARK: - Smart Search Content

--- a/VivaDicta/Views/MultiNoteChat/MultiNoteChatsListView.swift
+++ b/VivaDicta/Views/MultiNoteChat/MultiNoteChatsListView.swift
@@ -24,9 +24,9 @@ struct MultiNoteChatsListView: View {
     @State private var cachedSmartSearchVM: SmartSearchChatViewModel?
 
     enum ChatTab: String, CaseIterable {
+        case allNotes = "Recent Notes"
         case multiNote = "Multi-Note"
         case singleNote = "Single-Note"
-        case allNotes = "All Notes"
         case smartSearch = "Smart Search"
     }
 
@@ -35,7 +35,7 @@ struct MultiNoteChatsListView: View {
     }
 
     private var availableTabs: [ChatTab] {
-        var tabs: [ChatTab] = [.multiNote, .singleNote, .allNotes]
+        var tabs: [ChatTab] = [.allNotes, .multiNote, .singleNote]
         if isSmartSearchEnabled {
             tabs.append(.smartSearch)
         }
@@ -275,7 +275,7 @@ struct MultiNoteChatsListView: View {
                 }
             } else {
                 ContentUnavailableView(
-                    "No All-Notes Chats",
+                    "No Recent Notes Chats",
                     systemImage: "bubble.left.and.bubble.right.fill",
                     description: Text("Start a chat that automatically includes your most recent notes.")
                 )

--- a/VivaDicta/Views/MultiNoteChat/MultiNoteChatsListViewModel.swift
+++ b/VivaDicta/Views/MultiNoteChat/MultiNoteChatsListViewModel.swift
@@ -90,8 +90,8 @@ final class ChatsListViewModel {
         let conversation = MultiNoteConversation()
         conversation.isAllNotes = true
         conversation.title = selected.count == totalCount
-            ? "All Notes (\(selected.count))"
-            : "All Notes - \(selected.count) of \(totalCount) recent"
+            ? "Recent Notes (\(selected.count))"
+            : "Recent Notes - \(selected.count) of \(totalCount)"
         conversation.noteContext = MultiNoteContextManager.assembleNoteText(from: selected)
         conversation.sourceNoteCount = selected.count
         conversation.transcriptions = selected

--- a/VivaDicta/Views/MultiNoteChat/MultiNoteChatsListViewModel.swift
+++ b/VivaDicta/Views/MultiNoteChat/MultiNoteChatsListViewModel.swift
@@ -12,7 +12,10 @@ import SwiftData
 @Observable
 @MainActor
 final class ChatsListViewModel {
+    /// User-picked multi-note conversations (isAllNotes == false).
     var multiNoteConversations: [MultiNoteConversation] = []
+    /// Conversations created from the "All Notes" shortcut (isAllNotes == true).
+    var allNotesConversations: [MultiNoteConversation] = []
     var singleNoteConversations: [ChatConversation] = []
     var smartSearchConversation: SmartSearchConversation?
     private let modelContext: ModelContext
@@ -32,7 +35,9 @@ final class ChatsListViewModel {
         let descriptor = FetchDescriptor<MultiNoteConversation>(
             sortBy: [SortDescriptor(\.lastInteractionAt, order: .reverse)]
         )
-        multiNoteConversations = (try? modelContext.fetch(descriptor)) ?? []
+        let all = (try? modelContext.fetch(descriptor)) ?? []
+        multiNoteConversations = all.filter { !$0.isAllNotes }
+        allNotesConversations = all.filter { $0.isAllNotes }
     }
 
     func loadSingleNote() {
@@ -51,6 +56,50 @@ final class ChatsListViewModel {
         modelContext.delete(conversation)
         try? modelContext.save()
         loadMultiNote()
+    }
+
+    /// Creates an "All Notes" conversation pre-populated with the most recent
+    /// notes that fit the current provider/model budget.
+    ///
+    /// Returns nil if the user has no notes yet.
+    func createAllNotesConversation(
+        aiService: AIService,
+        targetCount: Int = MultiNoteContextManager.allNotesDefaultTargetCount
+    ) -> MultiNoteConversation? {
+        let provider = aiService.selectedMode.aiProvider ?? .apple
+        let model = aiService.selectedMode.aiModel
+
+        var fetchDescriptor = FetchDescriptor<Transcription>(
+            sortBy: [SortDescriptor(\.timestamp, order: .reverse)]
+        )
+        fetchDescriptor.fetchLimit = targetCount
+        let recentNotes = (try? modelContext.fetch(fetchDescriptor)) ?? []
+
+        guard !recentNotes.isEmpty else { return nil }
+
+        let selected = MultiNoteContextManager.selectRecentNotesForAllNotesPack(
+            from: recentNotes,
+            provider: provider,
+            model: model,
+            targetCount: targetCount
+        )
+        guard !selected.isEmpty else { return nil }
+
+        let totalCount = (try? modelContext.fetchCount(FetchDescriptor<Transcription>())) ?? selected.count
+
+        let conversation = MultiNoteConversation()
+        conversation.isAllNotes = true
+        conversation.title = selected.count == totalCount
+            ? "All Notes (\(selected.count))"
+            : "All Notes - \(selected.count) of \(totalCount) recent"
+        conversation.noteContext = MultiNoteContextManager.assembleNoteText(from: selected)
+        conversation.sourceNoteCount = selected.count
+        conversation.transcriptions = selected
+        modelContext.insert(conversation)
+        try? modelContext.save()
+
+        loadMultiNote()
+        return conversation
     }
 
     func deleteSingleNoteConversation(_ conversation: ChatConversation) {


### PR DESCRIPTION
## Summary

Adds a 4th chat tab - **All Notes** - that starts a conversation pre-populated with the user's most recent notes. Tap the tab, tap **New Chat**, talk to the model about whatever you've been writing. No note-picking, no RAG.

### Motivation

Users without much LLM context often expect \"why can't I just chat with all my notes?\" - the existing modes don't quite answer that:
- **Multi-Note**: user picks notes up-front (friction)
- **Single-Note**: one note only
- **Smart Search**: zero notes at open, RAG per turn; answers vague/greeting questions with deterministic \"no evidence\" replies since there's nothing in context yet

All Notes fills the gap: baseline note context from turn 1, for casual \"what have I been thinking about\" questions.

## How it works

`MultiNoteContextManager.selectRecentNotesForAllNotesPack` picks the newest 20 notes and packs them until either:
- the count cap hits (20), or
- ~70% of the provider's token budget would be consumed

**Cloud providers** return `.max` from `contextLimit` (per last week's refactor), so the count cap always wins - all 20 notes fit, the server enforces its own window.

**Apple FM** has a real on-device budget, so the token cap usually hits first. The chat title reflects this: `All Notes (20)` when everything fits, `All Notes - 5 of 147 recent` when truncated.

The first note is always included even if it alone exceeds the budget - matches existing single-note-too-large behavior.

## What's new on disk

`MultiNoteConversation` gains an `isAllNotes: Bool = false` field:
- distinguishes auto-packed conversations from user-picked Multi-Note ones in the list
- CloudKit schema change - needs Development -> Production deployment via CloudKit Dashboard before the next App Store submission (`$release-prepare` Step 8).

## What was reused

- `MultiNoteChatView` / `MultiNoteChatViewModel` - zero changes; the new conversation type is just a `MultiNoteConversation` with a flag
- `MultiNoteContextManager.assembleNoteText` - same XML `<NOTE>` wrapper format
- All navigation, message handling, compaction, tool use, error paths

## Files changed (4)

- `VivaDicta/Models/MultiNoteConversation.swift` - new `isAllNotes` field
- `VivaDicta/Services/AIEnhance/MultiNoteContextManager.swift` - new packing helper
- `VivaDicta/Views/MultiNoteChat/MultiNoteChatsListViewModel.swift` - split conversations by flag, new creation method
- `VivaDicta/Views/MultiNoteChat/MultiNoteChatsListView.swift` - 4th tab, toolbar button, content view

## Test plan

- [x] Clean build passes on iPhone 17 Pro Max simulator, iOS 26.4 (0 errors)
- [ ] Smoke: tap All Notes tab, tap New Chat with 20+ notes on a cloud provider -> conversation opens with all 20 packed
- [ ] Smoke: same on Apple FM -> title reads \"N of M recent\", packing stops before overflow
- [ ] Smoke: ask \"what have I been working on\" -> model grounds from recent notes
- [ ] Smoke: empty state when user has zero notes (entry still renders the \"No All-Notes Chats\" content unavailable view)
- [ ] Smoke: swipe-to-delete works on an All Notes conversation
- [ ] Regression: Multi-Note tab only shows user-picked conversations, not polluted by All Notes ones

## Notes

- CloudKit schema deployment required before App Store submission.