### PR TITLE
Add home screen quick actions: Search, Ask AI, Continue chat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,8 @@ fastlane/.env
 
 # Code coverage
 *.xccoverage
+*.profraw
+*.profdata
 
 # Asset catalog compiler cache
 *.assetcatalog

--- a/VivaDicta/AppDelegate.swift
+++ b/VivaDicta/AppDelegate.swift
@@ -97,9 +97,24 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             appState.shouldFocusSearch = true
         case QuickActionType.askAI.rawValue:
             appState.shouldShowChats = true
+        case QuickActionType.continueChat.rawValue:
+            if let route = pendingChatRoute(from: shortcutItem) {
+                appState.pendingChatRoute = route
+                appState.shouldShowChats = true
+            }
         default:
             break
         }
+    }
+
+    private func pendingChatRoute(from shortcutItem: UIApplicationShortcutItem) -> PendingChatRoute? {
+        guard
+            let idString = shortcutItem.userInfo?["chatID"] as? String,
+            let id = UUID(uuidString: idString),
+            let kindString = shortcutItem.userInfo?["chatKind"] as? String,
+            let kind = PendingChatKind(rawValue: kindString)
+        else { return nil }
+        return PendingChatRoute(id: id, kind: kind)
     }
 }
 

--- a/VivaDicta/AppDelegate.swift
+++ b/VivaDicta/AppDelegate.swift
@@ -88,12 +88,17 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func handleShortcutItem(_ shortcutItem: UIApplicationShortcutItem) {
-        if shortcutItem.type == QuickActionType.startRecord.rawValue {
-            // Trigger recording through AppState
-            if let appState = SceneDelegate.appState {
-                // Set flag to trigger recording when the app finishes launching
-                appState.shouldStartRecording = true
-            }
+        guard let appState = SceneDelegate.appState else { return }
+
+        switch shortcutItem.type {
+        case QuickActionType.startRecord.rawValue:
+            appState.shouldStartRecording = true
+        case QuickActionType.search.rawValue:
+            appState.shouldFocusSearch = true
+        case QuickActionType.askAI.rawValue:
+            appState.shouldShowChats = true
+        default:
+            break
         }
     }
 }

--- a/VivaDicta/AppState.swift
+++ b/VivaDicta/AppState.swift
@@ -95,6 +95,9 @@ class AppState {
     /// Requests that the Ask AI / chats screen be presented (from a quick action).
     var shouldShowChats: Bool = false
 
+    /// Deep-link target for the Chats screen when a quick action requests a specific conversation.
+    var pendingChatRoute: PendingChatRoute?
+
     /// Describes what the next recording should do after transcription finishes.
     var pendingRecordingDestination: RecordingDestination = .newNote
 
@@ -390,6 +393,19 @@ class AppState {
 
         return activity
     }
+}
+
+/// Identifies the kind of chat a "Continue chat" quick action should open.
+enum PendingChatKind: String {
+    case multiNote
+    case allNotes
+    case singleNote
+}
+
+/// Deep-link descriptor for resuming a specific chat from a Home Screen quick action.
+struct PendingChatRoute: Equatable {
+    let id: UUID
+    let kind: PendingChatKind
 }
 
 #if DEBUG

--- a/VivaDicta/AppState.swift
+++ b/VivaDicta/AppState.swift
@@ -89,6 +89,12 @@ class AppState {
     /// Triggers the start of a new recording.
     var shouldStartRecording: Bool = false
 
+    /// Requests that the main list's search field be focused (from a quick action).
+    var shouldFocusSearch: Bool = false
+
+    /// Requests that the Ask AI / chats screen be presented (from a quick action).
+    var shouldShowChats: Bool = false
+
     /// Describes what the next recording should do after transcription finishes.
     var pendingRecordingDestination: RecordingDestination = .newNote
 

--- a/VivaDicta/Views/MainView.swift
+++ b/VivaDicta/Views/MainView.swift
@@ -23,6 +23,7 @@ struct MainView: View {
     @State private var showingNotesFilter = false
     @State private var showingFileImport = false
     @State private var searchText = ""
+    @FocusState private var isSearchFocused: Bool
 
     // Selection mode state
     @State private var isSelectionMode = false
@@ -129,6 +130,27 @@ struct MainView: View {
                     appState.shouldStartRecording = false
                 }
             }
+            .onChange(of: appState.shouldFocusSearch) { _, newValue in
+                if newValue {
+                    showingSettings = false
+                    showingRecordingSheet = false
+                    showMultiNoteChats = false
+                    router.popToRoot()
+                    isSearchFocused = true
+                    appState.shouldFocusSearch = false
+                }
+            }
+            .onChange(of: appState.shouldShowChats) { _, newValue in
+                if newValue {
+                    showingSettings = false
+                    showingRecordingSheet = false
+                    router.popToRoot()
+                    HapticManager.lightImpact()
+                    showMultiNoteChats = true
+                    Task { await ChatsDiscoveryTip.chatsOpenedEvent.donate() }
+                    appState.shouldShowChats = false
+                }
+            }
             .onChange(of: appState.shouldNavigateToModels) { _, newValue in
                 if newValue { showingSettings = true }
             }
@@ -180,6 +202,7 @@ struct MainView: View {
             )
         )
         .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always), prompt: "Search notes")
+        .searchFocused($isSearchFocused)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar { trailingToolbarContent }
         .toolbar { principalToolbarContent }

--- a/VivaDicta/Views/MultiNoteChat/MultiNoteChatsListView.swift
+++ b/VivaDicta/Views/MultiNoteChat/MultiNoteChatsListView.swift
@@ -169,15 +169,11 @@ struct MultiNoteChatsListView: View {
         if viewModel == nil {
             viewModel = ChatsListViewModel(modelContext: modelContext)
         }
+        navigationPath = NavigationPath()
         switch route.kind {
-        case .multiNote:
-            selectedTab = .multiNote
-            navigationPath.append(NavigationTarget.multiNoteChat(route.id))
-        case .allNotes:
-            selectedTab = .allNotes
+        case .multiNote, .allNotes:
             navigationPath.append(NavigationTarget.multiNoteChat(route.id))
         case .singleNote:
-            selectedTab = .singleNote
             navigationPath.append(NavigationTarget.singleNoteChat(route.id))
         }
         appState.pendingChatRoute = nil

--- a/VivaDicta/Views/MultiNoteChat/MultiNoteChatsListView.swift
+++ b/VivaDicta/Views/MultiNoteChat/MultiNoteChatsListView.swift
@@ -138,6 +138,10 @@ struct MultiNoteChatsListView: View {
                 if viewModel == nil {
                     viewModel = ChatsListViewModel(modelContext: modelContext)
                 }
+                consumePendingChatRouteIfNeeded()
+            }
+            .onChange(of: appState.pendingChatRoute) { _, _ in
+                consumePendingChatRouteIfNeeded()
             }
             .onChange(of: navigationPath.count) {
                 if navigationPath.isEmpty {
@@ -158,6 +162,25 @@ struct MultiNoteChatsListView: View {
         case creation
         case multiNoteChat(UUID)
         case singleNoteChat(UUID)
+    }
+
+    private func consumePendingChatRouteIfNeeded() {
+        guard let route = appState.pendingChatRoute else { return }
+        if viewModel == nil {
+            viewModel = ChatsListViewModel(modelContext: modelContext)
+        }
+        switch route.kind {
+        case .multiNote:
+            selectedTab = .multiNote
+            navigationPath.append(NavigationTarget.multiNoteChat(route.id))
+        case .allNotes:
+            selectedTab = .allNotes
+            navigationPath.append(NavigationTarget.multiNoteChat(route.id))
+        case .singleNote:
+            selectedTab = .singleNote
+            navigationPath.append(NavigationTarget.singleNoteChat(route.id))
+        }
+        appState.pendingChatRoute = nil
     }
 
     // MARK: - ViewModel Caching

--- a/VivaDicta/VivaDictaApp.swift
+++ b/VivaDicta/VivaDictaApp.swift
@@ -606,13 +606,25 @@ struct VivaDictaApp: App {
     }
     
     func updateShortcutItems() {
+        let searchAction = UIApplicationShortcutItem(
+            type: QuickActionType.search.rawValue,
+            localizedTitle: "Search",
+            localizedSubtitle: "Find notes instantly",
+            icon: UIApplicationShortcutIcon(systemImageName: "magnifyingglass"),
+            userInfo: [:])
+        let askAIAction = UIApplicationShortcutItem(
+            type: QuickActionType.askAI.rawValue,
+            localizedTitle: "Ask AI",
+            localizedSubtitle: "Chat with your notes",
+            icon: UIApplicationShortcutIcon(systemImageName: "bubble.left.and.bubble.right.fill"),
+            userInfo: [:])
         let recordAction = UIApplicationShortcutItem(
             type: QuickActionType.startRecord.rawValue,
-            localizedTitle: "Start recording",
+            localizedTitle: "Record",
             localizedSubtitle: "Turn your voice into text",
             icon: UIApplicationShortcutIcon(systemImageName: "microphone.circle.fill"),
             userInfo: [:])
-        UIApplication.shared.shortcutItems = [recordAction]
+        UIApplication.shared.shortcutItems = [searchAction, askAIAction, recordAction]
     }
     
     @MainActor
@@ -634,4 +646,6 @@ struct VivaDictaApp: App {
 
 enum QuickActionType: String {
     case startRecord
+    case search
+    case askAI
 }

--- a/VivaDicta/VivaDictaApp.swift
+++ b/VivaDicta/VivaDictaApp.swift
@@ -642,10 +642,9 @@ struct VivaDictaApp: App {
         multiDescriptor.fetchLimit = 1
         let latestMulti = (try? modelContext.fetch(multiDescriptor))?.first
 
-        var singleDescriptor = FetchDescriptor<ChatConversation>(
+        let singleDescriptor = FetchDescriptor<ChatConversation>(
             sortBy: [SortDescriptor(\.lastInteractionAt, order: .reverse)]
         )
-        singleDescriptor.fetchLimit = 20
         let latestSingle = (try? modelContext.fetch(singleDescriptor))?.first { conversation in
             conversation.transcription != nil && !(conversation.messages ?? []).isEmpty
         }

--- a/VivaDicta/VivaDictaApp.swift
+++ b/VivaDicta/VivaDictaApp.swift
@@ -606,25 +606,95 @@ struct VivaDictaApp: App {
     }
     
     func updateShortcutItems() {
-        let searchAction = UIApplicationShortcutItem(
+        var items: [UIApplicationShortcutItem] = []
+
+        if let continueAction = mostRecentChatShortcut(modelContext: modelContainer.mainContext) {
+            items.append(continueAction)
+        }
+
+        items.append(UIApplicationShortcutItem(
             type: QuickActionType.search.rawValue,
             localizedTitle: "Search",
             localizedSubtitle: "Find notes instantly",
             icon: UIApplicationShortcutIcon(systemImageName: "magnifyingglass"),
-            userInfo: [:])
-        let askAIAction = UIApplicationShortcutItem(
+            userInfo: [:]))
+        items.append(UIApplicationShortcutItem(
             type: QuickActionType.askAI.rawValue,
             localizedTitle: "Ask AI",
             localizedSubtitle: "Chat with your notes",
             icon: UIApplicationShortcutIcon(systemImageName: "bubble.left.and.bubble.right.fill"),
-            userInfo: [:])
-        let recordAction = UIApplicationShortcutItem(
+            userInfo: [:]))
+        items.append(UIApplicationShortcutItem(
             type: QuickActionType.startRecord.rawValue,
             localizedTitle: "Record",
             localizedSubtitle: "Turn your voice into text",
             icon: UIApplicationShortcutIcon(systemImageName: "microphone.circle.fill"),
-            userInfo: [:])
-        UIApplication.shared.shortcutItems = [searchAction, askAIAction, recordAction]
+            userInfo: [:]))
+
+        UIApplication.shared.shortcutItems = items
+    }
+
+    @MainActor
+    private func mostRecentChatShortcut(modelContext: ModelContext) -> UIApplicationShortcutItem? {
+        var multiDescriptor = FetchDescriptor<MultiNoteConversation>(
+            sortBy: [SortDescriptor(\.lastInteractionAt, order: .reverse)]
+        )
+        multiDescriptor.fetchLimit = 1
+        let latestMulti = (try? modelContext.fetch(multiDescriptor))?.first
+
+        var singleDescriptor = FetchDescriptor<ChatConversation>(
+            sortBy: [SortDescriptor(\.lastInteractionAt, order: .reverse)]
+        )
+        singleDescriptor.fetchLimit = 20
+        let latestSingle = (try? modelContext.fetch(singleDescriptor))?.first { conversation in
+            conversation.transcription != nil && !(conversation.messages ?? []).isEmpty
+        }
+
+        switch (latestMulti, latestSingle) {
+        case (let multi?, let single?):
+            return multi.lastInteractionAt >= single.lastInteractionAt
+                ? continueChatItem(for: multi)
+                : continueChatItem(for: single)
+        case (let multi?, nil):
+            return continueChatItem(for: multi)
+        case (nil, let single?):
+            return continueChatItem(for: single)
+        case (nil, nil):
+            return nil
+        }
+    }
+
+    private func continueChatItem(for conversation: MultiNoteConversation) -> UIApplicationShortcutItem {
+        let subtitle = conversation.title.isEmpty ? "Untitled chat" : conversation.title
+        let kind: PendingChatKind = conversation.isAllNotes ? .allNotes : .multiNote
+        return UIApplicationShortcutItem(
+            type: QuickActionType.continueChat.rawValue,
+            localizedTitle: "Continue chat",
+            localizedSubtitle: subtitle,
+            icon: UIApplicationShortcutIcon(systemImageName: "bubble.left.fill"),
+            userInfo: [
+                "chatID": conversation.id.uuidString as NSString,
+                "chatKind": kind.rawValue as NSString
+            ])
+    }
+
+    private func continueChatItem(for conversation: ChatConversation) -> UIApplicationShortcutItem {
+        let snippet: String
+        if let transcription = conversation.transcription {
+            let trimmed = transcription.text.trimmingCharacters(in: .whitespacesAndNewlines)
+            snippet = trimmed.isEmpty ? "Note chat" : String(trimmed.prefix(60))
+        } else {
+            snippet = "Note chat"
+        }
+        return UIApplicationShortcutItem(
+            type: QuickActionType.continueChat.rawValue,
+            localizedTitle: "Continue chat",
+            localizedSubtitle: snippet,
+            icon: UIApplicationShortcutIcon(systemImageName: "bubble.left.fill"),
+            userInfo: [
+                "chatID": conversation.id.uuidString as NSString,
+                "chatKind": PendingChatKind.singleNote.rawValue as NSString
+            ])
     }
     
     @MainActor
@@ -648,4 +718,5 @@ enum QuickActionType: String {
     case startRecord
     case search
     case askAI
+    case continueChat
 }


### PR DESCRIPTION
## Summary

Adds three new home screen quick actions (long-press the app icon) alongside the existing Record action:

- **Search** - pops to root and focuses the notes list search field.
- **Ask AI** - opens the chats screen (same entry point as the in-app chats button).
- **Continue chat** - dynamic action that resumes the most recently used multi-note or single-note chat. Uses the conversation title (or a note snippet for single-note) as the subtitle. Only shown when at least one chat exists.

The three static actions are registered in `updateShortcutItems()`; the dynamic "Continue chat" is rebuilt on every `.background` transition by fetching the newest `MultiNoteConversation` / `ChatConversation` (by `lastInteractionAt`) and embedding `{chatID, chatKind}` in the shortcut's `userInfo`. `SceneDelegate` decodes that into a `PendingChatRoute` on `AppState`, and `MultiNoteChatsListView` consumes it to switch to the correct tab and push the conversation onto its navigation stack.

Also gitignores LLVM profile artifacts (`*.profraw`, `*.profdata`).

### Scope notes
- Smart Search conversations are intentionally excluded from "Continue chat" - they're a single persistent global session with no meaningful title.
- Dynamic item only refreshes on backgrounding (same cadence as the existing `updateShortcutItems()` call site).

## Test plan

- [ ] Cold-launch via Home Screen long-press -> Search: main list appears, search field is focused.
- [ ] Cold-launch via long-press -> Ask AI: chats screen opens.
- [ ] Cold-launch via long-press -> Record: recording starts (regression check).
- [ ] With no chats yet: long-press shows only Search / Ask AI / Record.
- [ ] After creating a multi-note chat and backgrounding the app: long-press shows "Continue chat" with that title as the subtitle, and tapping it lands on that conversation.
- [ ] Same flow for a single-note chat: subtitle shows the note snippet, tap lands on the single-note chat.
- [ ] "All Notes" conversation case: tapping "Continue chat" lands in the Recent Notes tab on that conversation.
- [ ] Warm launch (app already in memory, route still pops/pushes correctly).