### PR TITLE
Replace Continue chat quick action with Need help?

### DIFF
--- a/VivaDicta/AppDelegate.swift
+++ b/VivaDicta/AppDelegate.swift
@@ -97,24 +97,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             appState.shouldFocusSearch = true
         case QuickActionType.askAI.rawValue:
             appState.shouldShowChats = true
-        case QuickActionType.continueChat.rawValue:
-            if let route = pendingChatRoute(from: shortcutItem) {
-                appState.pendingChatRoute = route
-                appState.shouldShowChats = true
-            }
+        case QuickActionType.needHelp.rawValue:
+            appState.shouldShowHelpDocs = true
         default:
             break
         }
-    }
-
-    private func pendingChatRoute(from shortcutItem: UIApplicationShortcutItem) -> PendingChatRoute? {
-        guard
-            let idString = shortcutItem.userInfo?["chatID"] as? String,
-            let id = UUID(uuidString: idString),
-            let kindString = shortcutItem.userInfo?["chatKind"] as? String,
-            let kind = PendingChatKind(rawValue: kindString)
-        else { return nil }
-        return PendingChatRoute(id: id, kind: kind)
     }
 }
 

--- a/VivaDicta/AppDelegate.swift
+++ b/VivaDicta/AppDelegate.swift
@@ -99,6 +99,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             appState.shouldShowChats = true
         case QuickActionType.needHelp.rawValue:
             appState.shouldShowHelpDocs = true
+        case "continueChat":
+            // Compat: users upgrading from the previous build still have the old
+            // Continue chat shortcut cached by iOS until updateShortcutItems()
+            // runs on next background. Route the stale tap to chats so it isn't
+            // a silent noop. Safe to remove after one release cycle.
+            appState.shouldShowChats = true
         default:
             break
         }

--- a/VivaDicta/AppState.swift
+++ b/VivaDicta/AppState.swift
@@ -95,8 +95,8 @@ class AppState {
     /// Requests that the Ask AI / chats screen be presented (from a quick action).
     var shouldShowChats: Bool = false
 
-    /// Deep-link target for the Chats screen when a quick action requests a specific conversation.
-    var pendingChatRoute: PendingChatRoute?
+    /// Requests the in-app documentation browser (from the Need help? quick action).
+    var shouldShowHelpDocs: Bool = false
 
     /// Describes what the next recording should do after transcription finishes.
     var pendingRecordingDestination: RecordingDestination = .newNote
@@ -393,19 +393,6 @@ class AppState {
 
         return activity
     }
-}
-
-/// Identifies the kind of chat a "Continue chat" quick action should open.
-enum PendingChatKind: String {
-    case multiNote
-    case allNotes
-    case singleNote
-}
-
-/// Deep-link descriptor for resuming a specific chat from a Home Screen quick action.
-struct PendingChatRoute: Equatable {
-    let id: UUID
-    let kind: PendingChatKind
 }
 
 #if DEBUG

--- a/VivaDicta/Views/MainView.swift
+++ b/VivaDicta/Views/MainView.swift
@@ -24,6 +24,9 @@ struct MainView: View {
     @State private var showingFileImport = false
     @State private var searchText = ""
     @FocusState private var isSearchFocused: Bool
+    @State private var showingHelpDocs = false
+
+    private let helpDocsURL = URL(string: "https://vivadicta.com/ios/docs")!
 
     // Selection mode state
     @State private var isSelectionMode = false
@@ -113,6 +116,10 @@ struct MainView: View {
                 }
                 .navigationTransition(.zoom(sourceID: "NotesFilterSheetTransition", in: sheetTransitions))
             }
+            .sheet(isPresented: $showingHelpDocs) {
+                SafariView(url: helpDocsURL)
+                    .ignoresSafeArea()
+            }
     }
 
     @ViewBuilder
@@ -149,6 +156,16 @@ struct MainView: View {
                     showMultiNoteChats = true
                     Task { await ChatsDiscoveryTip.chatsOpenedEvent.donate() }
                     appState.shouldShowChats = false
+                }
+            }
+            .onChange(of: appState.shouldShowHelpDocs) { _, newValue in
+                if newValue {
+                    showingSettings = false
+                    showingRecordingSheet = false
+                    showMultiNoteChats = false
+                    router.popToRoot()
+                    showingHelpDocs = true
+                    appState.shouldShowHelpDocs = false
                 }
             }
             .onChange(of: appState.shouldNavigateToModels) { _, newValue in

--- a/VivaDicta/Views/MultiNoteChat/MultiNoteChatsListView.swift
+++ b/VivaDicta/Views/MultiNoteChat/MultiNoteChatsListView.swift
@@ -138,10 +138,6 @@ struct MultiNoteChatsListView: View {
                 if viewModel == nil {
                     viewModel = ChatsListViewModel(modelContext: modelContext)
                 }
-                consumePendingChatRouteIfNeeded()
-            }
-            .onChange(of: appState.pendingChatRoute) { _, _ in
-                consumePendingChatRouteIfNeeded()
             }
             .onChange(of: navigationPath.count) {
                 if navigationPath.isEmpty {
@@ -162,21 +158,6 @@ struct MultiNoteChatsListView: View {
         case creation
         case multiNoteChat(UUID)
         case singleNoteChat(UUID)
-    }
-
-    private func consumePendingChatRouteIfNeeded() {
-        guard let route = appState.pendingChatRoute else { return }
-        if viewModel == nil {
-            viewModel = ChatsListViewModel(modelContext: modelContext)
-        }
-        navigationPath = NavigationPath()
-        switch route.kind {
-        case .multiNote, .allNotes:
-            navigationPath.append(NavigationTarget.multiNoteChat(route.id))
-        case .singleNote:
-            navigationPath.append(NavigationTarget.singleNoteChat(route.id))
-        }
-        appState.pendingChatRoute = nil
     }
 
     // MARK: - ViewModel Caching

--- a/VivaDicta/Views/Shared/SafariView.swift
+++ b/VivaDicta/Views/Shared/SafariView.swift
@@ -1,0 +1,19 @@
+//
+//  SafariView.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.19
+//
+
+import SwiftUI
+import SafariServices
+
+struct SafariView: UIViewControllerRepresentable {
+    let url: URL
+
+    func makeUIViewController(context: Context) -> SFSafariViewController {
+        SFSafariViewController(url: url)
+    }
+
+    func updateUIViewController(_ uiViewController: SFSafariViewController, context: Context) {}
+}

--- a/VivaDicta/VivaDictaApp.swift
+++ b/VivaDicta/VivaDictaApp.swift
@@ -606,94 +606,32 @@ struct VivaDictaApp: App {
     }
     
     func updateShortcutItems() {
-        var items: [UIApplicationShortcutItem] = []
-
-        if let continueAction = mostRecentChatShortcut(modelContext: modelContainer.mainContext) {
-            items.append(continueAction)
-        }
-
-        items.append(UIApplicationShortcutItem(
+        let needHelpAction = UIApplicationShortcutItem(
+            type: QuickActionType.needHelp.rawValue,
+            localizedTitle: "Need help?",
+            localizedSubtitle: "Open the documentation",
+            icon: UIApplicationShortcutIcon(systemImageName: "questionmark.circle"),
+            userInfo: [:])
+        let searchAction = UIApplicationShortcutItem(
             type: QuickActionType.search.rawValue,
             localizedTitle: "Search",
             localizedSubtitle: "Find notes instantly",
             icon: UIApplicationShortcutIcon(systemImageName: "magnifyingglass"),
-            userInfo: [:]))
-        items.append(UIApplicationShortcutItem(
+            userInfo: [:])
+        let askAIAction = UIApplicationShortcutItem(
             type: QuickActionType.askAI.rawValue,
             localizedTitle: "Ask AI",
             localizedSubtitle: "Chat with your notes",
             icon: UIApplicationShortcutIcon(systemImageName: "bubble.left.and.bubble.right.fill"),
-            userInfo: [:]))
-        items.append(UIApplicationShortcutItem(
+            userInfo: [:])
+        let recordAction = UIApplicationShortcutItem(
             type: QuickActionType.startRecord.rawValue,
             localizedTitle: "Record",
             localizedSubtitle: "Turn your voice into text",
             icon: UIApplicationShortcutIcon(systemImageName: "microphone.circle.fill"),
-            userInfo: [:]))
+            userInfo: [:])
 
-        UIApplication.shared.shortcutItems = items
-    }
-
-    @MainActor
-    private func mostRecentChatShortcut(modelContext: ModelContext) -> UIApplicationShortcutItem? {
-        var multiDescriptor = FetchDescriptor<MultiNoteConversation>(
-            sortBy: [SortDescriptor(\.lastInteractionAt, order: .reverse)]
-        )
-        multiDescriptor.fetchLimit = 1
-        let latestMulti = (try? modelContext.fetch(multiDescriptor))?.first
-
-        let singleDescriptor = FetchDescriptor<ChatConversation>(
-            sortBy: [SortDescriptor(\.lastInteractionAt, order: .reverse)]
-        )
-        let latestSingle = (try? modelContext.fetch(singleDescriptor))?.first { conversation in
-            conversation.transcription != nil && !(conversation.messages ?? []).isEmpty
-        }
-
-        switch (latestMulti, latestSingle) {
-        case (let multi?, let single?):
-            return multi.lastInteractionAt >= single.lastInteractionAt
-                ? continueChatItem(for: multi)
-                : continueChatItem(for: single)
-        case (let multi?, nil):
-            return continueChatItem(for: multi)
-        case (nil, let single?):
-            return continueChatItem(for: single)
-        case (nil, nil):
-            return nil
-        }
-    }
-
-    private func continueChatItem(for conversation: MultiNoteConversation) -> UIApplicationShortcutItem {
-        let subtitle = conversation.title.isEmpty ? "Untitled chat" : conversation.title
-        let kind: PendingChatKind = conversation.isAllNotes ? .allNotes : .multiNote
-        return UIApplicationShortcutItem(
-            type: QuickActionType.continueChat.rawValue,
-            localizedTitle: "Continue chat",
-            localizedSubtitle: subtitle,
-            icon: UIApplicationShortcutIcon(systemImageName: "bubble.left.fill"),
-            userInfo: [
-                "chatID": conversation.id.uuidString as NSString,
-                "chatKind": kind.rawValue as NSString
-            ])
-    }
-
-    private func continueChatItem(for conversation: ChatConversation) -> UIApplicationShortcutItem {
-        let snippet: String
-        if let transcription = conversation.transcription {
-            let trimmed = transcription.text.trimmingCharacters(in: .whitespacesAndNewlines)
-            snippet = trimmed.isEmpty ? "Note chat" : String(trimmed.prefix(60))
-        } else {
-            snippet = "Note chat"
-        }
-        return UIApplicationShortcutItem(
-            type: QuickActionType.continueChat.rawValue,
-            localizedTitle: "Continue chat",
-            localizedSubtitle: snippet,
-            icon: UIApplicationShortcutIcon(systemImageName: "bubble.left.fill"),
-            userInfo: [
-                "chatID": conversation.id.uuidString as NSString,
-                "chatKind": PendingChatKind.singleNote.rawValue as NSString
-            ])
+        UIApplication.shared.shortcutItems = [needHelpAction, searchAction, askAIAction, recordAction]
     }
     
     @MainActor
@@ -717,5 +655,5 @@ enum QuickActionType: String {
     case startRecord
     case search
     case askAI
-    case continueChat
+    case needHelp
 }


### PR DESCRIPTION
## Summary

Follow-up to #215. Swaps the dynamic **Continue chat** home screen quick action for a static **Need help?** action that opens the documentation inside an in-app \`SFSafariViewController\` sheet.

### Why
- **Discoverability**: the previous Continue chat shortcut was invisible to new users (no chats yet) and marginally useful to power users. Need help? is always there and genuinely helps onboarding / confused users.
- **Code savings**: removes ~90 lines of dynamic fetching, \`userInfo\` decoding, \`PendingChatRoute\` plumbing, and the route consumer in \`MultiNoteChatsListView\`. Net -71 LOC.
- **Closes both Codex P2 issues from #215** (stack routing, \`fetchLimit\` edge case) by removing the surface entirely.
- **Matches a pattern users recognize** from competitor apps (e.g. Spokenly).

### Long-press order (matches Spokenly-style ordering)
\`Need help? -> Search -> Ask AI -> Record\`

### URL & presentation
- Same URL as the existing Settings > Support > Documentation link: \`https://vivadicta.com/ios/docs\`.
- Presented as \`SFSafariViewController\` inside a SwiftUI sheet (stays in-app, has native Done button) via a new 15-line \`SafariView\` wrapper in \`Views/Shared/\`.

### Files
- \`VivaDictaApp.swift\` - 4 static shortcut items; \`.continueChat\` -> \`.needHelp\` in QuickActionType.
- \`AppState.swift\` - removed \`PendingChatKind\` / \`PendingChatRoute\` / \`pendingChatRoute\`; added \`shouldShowHelpDocs\`.
- \`AppDelegate.swift\` - replaced \`.continueChat\` branch + userInfo decoder with a single \`.needHelp\` branch.
- \`Views/MultiNoteChat/MultiNoteChatsListView.swift\` - removed \`consumePendingChatRouteIfNeeded()\` and its two observer hooks.
- \`Views/MainView.swift\` - new \`showingHelpDocs\` state + \`.sheet\` presenting \`SafariView\`; \`onChange\` on \`shouldShowHelpDocs\`.
- \`Views/Shared/SafariView.swift\` - new \`UIViewControllerRepresentable\` wrapping \`SFSafariViewController\`.

## Test plan

- [ ] Cold-launch via long-press -> Need help?: docs sheet appears in-app, Done button closes it.
- [ ] Warm launch (app already foregrounded) -> Need help?: sheet presents over the current screen.
- [ ] Search / Ask AI / Record still work (regression check for #215).
- [ ] Long-press menu visibly shows 4 items in the documented order.