### PR TITLE
Add Search and Ask AI app shortcuts to Spotlight

### DIFF
--- a/VivaDicta/AppIntents/OpenAskAIIntent.swift
+++ b/VivaDicta/AppIntents/OpenAskAIIntent.swift
@@ -1,0 +1,28 @@
+//
+//  OpenAskAIIntent.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.19
+//
+
+import AppIntents
+
+struct OpenAskAIIntent: AppIntent {
+    static let title: LocalizedStringResource = "Ask AI"
+    static let description = IntentDescription(
+        "Opens VivaDicta and shows the Ask AI chats screen.",
+        categoryName: "Navigation",
+        searchKeywords: ["ask", "ai", "chat", "assistant", "notes"]
+    )
+
+    static let openAppWhenRun: Bool = true
+
+    func perform() async throws -> some IntentResult {
+#if !os(macOS)
+        await MainActor.run {
+            PendingAppIntentAction.shared.enqueue(.askAI)
+        }
+#endif
+        return .result()
+    }
+}

--- a/VivaDicta/AppIntents/OpenSearchIntent.swift
+++ b/VivaDicta/AppIntents/OpenSearchIntent.swift
@@ -1,0 +1,28 @@
+//
+//  OpenSearchIntent.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.19
+//
+
+import AppIntents
+
+struct OpenSearchIntent: AppIntent {
+    static let title: LocalizedStringResource = "Search"
+    static let description = IntentDescription(
+        "Opens VivaDicta and focuses the notes search field.",
+        categoryName: "Navigation",
+        searchKeywords: ["search", "find", "filter", "notes", "lookup"]
+    )
+
+    static let openAppWhenRun: Bool = true
+
+    func perform() async throws -> some IntentResult {
+#if !os(macOS)
+        await MainActor.run {
+            PendingAppIntentAction.shared.enqueue(.search)
+        }
+#endif
+        return .result()
+    }
+}

--- a/VivaDicta/AppIntents/PendingAppIntentAction.swift
+++ b/VivaDicta/AppIntents/PendingAppIntentAction.swift
@@ -1,0 +1,39 @@
+//
+//  PendingAppIntentAction.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.19
+//
+
+#if !os(macOS)
+import Foundation
+
+@MainActor
+final class PendingAppIntentAction {
+    static let shared = PendingAppIntentAction()
+    private init() {}
+
+    enum Action {
+        case search
+        case askAI
+    }
+
+    var pending: Action?
+
+    func enqueue(_ action: Action) {
+        pending = action
+        drain()
+    }
+
+    func drain() {
+        guard let appState = SceneDelegate.appState, let action = pending else { return }
+        switch action {
+        case .search:
+            appState.shouldFocusSearch = true
+        case .askAI:
+            appState.shouldShowChats = true
+        }
+        pending = nil
+    }
+}
+#endif

--- a/VivaDicta/AppIntents/ShortcutsProvider.swift
+++ b/VivaDicta/AppIntents/ShortcutsProvider.swift
@@ -34,7 +34,55 @@ final class ShortcutsProvider: AppShortcutsProvider {
             shortTitle: LocalizedStringResource("Record Note"),
             systemImageName: "microphone.circle.fill"
         )
-        
+
+        AppShortcut(
+            intent: OpenSearchIntent(),
+            phrases: [
+                "Search in \(.applicationName)",
+                "Search notes in \(.applicationName)",
+                "Find notes in \(.applicationName)",
+                "Find a note in \(.applicationName)",
+                "Search my \(.applicationName) notes"
+            ],
+            shortTitle: LocalizedStringResource("Search"),
+            systemImageName: "magnifyingglass"
+        )
+
+        AppShortcut(
+            intent: OpenAskAIIntent(),
+            phrases: [
+                "Ask AI in \(.applicationName)",
+                "Ask the AI in \(.applicationName)",
+                "Open \(.applicationName) chats",
+                "Ask \(.applicationName) AI",
+                "Ask AI about my \(.applicationName) notes"
+            ],
+            shortTitle: LocalizedStringResource("Ask AI"),
+            systemImageName: "bubble.left.and.bubble.right.fill"
+        )
+
+        AppShortcut(
+            intent: GetLatestTranscriptionIntent(),
+            phrases: [
+                "Get latest note from \(.applicationName)",
+                "Latest note in \(.applicationName)",
+                "My most recent note in \(.applicationName)"
+            ],
+            shortTitle: "Get Latest Note",
+            systemImageName: "text.quote"
+        )
+
+        AppShortcut(
+            intent: RecordAndReturnTranscriptionIntent(),
+            phrases: [
+                "Record and get note from \(.applicationName)",
+                "Dictate a note with \(.applicationName)",
+                "Record and transcribe in \(.applicationName)"
+            ],
+            shortTitle: "Record and Get Note",
+            systemImageName: "waveform.badge.plus"
+        )
+
         AppShortcut(
             intent: CountRecentTranscriptionsIntent(),
             phrases: [
@@ -69,28 +117,6 @@ final class ShortcutsProvider: AppShortcutsProvider {
             ],
             shortTitle: "Open a note",
             systemImageName: "document.viewfinder"
-        )
-
-        AppShortcut(
-            intent: GetLatestTranscriptionIntent(),
-            phrases: [
-                "Get latest note from \(.applicationName)",
-                "Latest note in \(.applicationName)",
-                "My most recent note in \(.applicationName)"
-            ],
-            shortTitle: "Get Latest Note",
-            systemImageName: "text.quote"
-        )
-
-        AppShortcut(
-            intent: RecordAndReturnTranscriptionIntent(),
-            phrases: [
-                "Record and get note from \(.applicationName)",
-                "Dictate a note with \(.applicationName)",
-                "Record and transcribe in \(.applicationName)"
-            ],
-            shortTitle: "Record and Get Note",
-            systemImageName: "waveform.badge.plus"
         )
     }
 }

--- a/VivaDicta/VivaDictaApp.swift
+++ b/VivaDicta/VivaDictaApp.swift
@@ -153,6 +153,7 @@ struct VivaDictaApp: App {
                         // Set the AppState reference for quick actions
 #if !os(macOS)
                         SceneDelegate.appState = appState
+                        PendingAppIntentAction.shared.drain()
 #endif
 
                         // Migrate dictionary data from UserDefaults to SwiftData (one-time)

--- a/VivaDicta/VivaDictaApp.swift
+++ b/VivaDicta/VivaDictaApp.swift
@@ -118,8 +118,10 @@ struct VivaDictaApp: App {
         AppGroupCoordinator.shared.resetSessionStateOnAppLaunch()
         
         ShortcutsProvider.updateAppShortcutParameters()
-        IntentDonationManager.shared.donate(intent: ToggleRecordIntent())
-        
+//        IntentDonationManager.shared.donate(intent: ToggleRecordIntent())
+//        IntentDonationManager.shared.donate(intent: OpenSearchIntent())
+//        IntentDonationManager.shared.donate(intent: OpenAskAIIntent())
+
         // TODO: - It's not working, keeping for reference. It was presumed to work with ToggleKeyboardFlowIntent.
         // Set up handler for keyboard session activation from intent
         AppGroupCoordinator.shared.onKeyboardSessionActivated = {


### PR DESCRIPTION
## Summary

- Introduce `OpenSearchIntent` and `OpenAskAIIntent` so Spotlight/Siri can open VivaDicta directly to the notes search field or the Ask AI chats screen.
- Back both intents with a shared `PendingAppIntentAction` queue, drained right after `SceneDelegate.appState` is assigned. This handles the cold-launch timing window where `perform()` fires before `MainView.onAppear` wires up the AppState reference.
- Reorder `ShortcutsProvider` so the first five tiles surface as Record Note -> Search -> Ask AI -> Get Latest Note -> Record and Get Note.
- Add `categoryName: "Navigation"` and `searchKeywords` on both new intents for better Shortcuts-library findability.

Stays under the 10-shortcut cap (9 registered).

## Test plan

- [ ] Build succeeds (`xcodebuild ... build`)
- [ ] Spotlight shows Record Note, Search, Ask AI as the top 3 tiles under VivaDicta
- [ ] Tapping the Search tile opens the app and focuses the notes search field
- [ ] Tapping the Ask AI tile opens the app and shows the chats screen
- [ ] Cold-launch flow: force-quit the app, tap Search / Ask AI tile - UI still lands correctly (queue + drain path)
- [ ] Siri voice: "Search in VivaDicta" and "Ask the AI in VivaDicta" both route to the right screen
- [ ] Existing Record Note, Get Latest Note, Record and Get Note shortcuts still work