### PR TITLE
Add Find Notes shortcut and searchable note picker

### DIFF
--- a/VivaDicta/AppIntents/SearchNotesIntent.swift
+++ b/VivaDicta/AppIntents/SearchNotesIntent.swift
@@ -1,0 +1,46 @@
+//
+//  SearchNotesIntent.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.19
+//
+
+import AppIntents
+
+struct SearchNotesIntent: AppIntent {
+    static let title: LocalizedStringResource = "Find Notes"
+    static let description = IntentDescription(
+        "Searches your notes for the query and returns matching entries. Chain with Copy to Clipboard, Open URL, or Repeat with Each to build multi-step shortcuts.",
+        categoryName: "Notes",
+        searchKeywords: ["find", "search", "filter", "query", "lookup", "notes"],
+        resultValueName: "Matching Notes"
+    )
+
+    @Parameter(
+        title: "Query",
+        description: "Text to search for in the original or AI-enhanced transcription."
+    )
+    var query: String
+
+    @Dependency var dataController: DataController
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ReturnsValue<[TranscriptionEntity]> & ProvidesDialog {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !trimmed.isEmpty else {
+            return .result(value: [], dialog: "Please provide a search query.")
+        }
+
+        let matches = try dataController.transcriptionEntities(matching: #Predicate { transcription in
+            transcription.text.localizedStandardContains(trimmed) ||
+            (transcription.enhancedText?.localizedStandardContains(trimmed) ?? false)
+        })
+
+        let dialog = AttributedString(
+            localized: "Found ^[\(matches.count) note](inflect: true) matching \"\(trimmed)\"."
+        )
+
+        return .result(value: matches, dialog: "\(dialog)")
+    }
+}

--- a/VivaDicta/AppIntents/SearchNotesIntent.swift
+++ b/VivaDicta/AppIntents/SearchNotesIntent.swift
@@ -24,23 +24,34 @@ struct SearchNotesIntent: AppIntent {
 
     @Dependency var dataController: DataController
 
+    /// Cap at 200 so a broad query (e.g. "the") doesn't hand thousands of entities to
+    /// a downstream `Repeat with Each` - both slow and destructive for actions like
+    /// "Append to Obsidian" that mutate external state per iteration.
+    private static let maxMatches = 200
+
     @MainActor
     func perform() async throws -> some IntentResult & ReturnsValue<[TranscriptionEntity]> & ProvidesDialog {
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
 
         guard !trimmed.isEmpty else {
-            return .result(value: [], dialog: "Please provide a search query.")
+            throw SearchNotesQueryEmptyError()
         }
 
-        let matches = try dataController.transcriptionEntities(matching: #Predicate { transcription in
-            transcription.text.localizedStandardContains(trimmed) ||
-            (transcription.enhancedText?.localizedStandardContains(trimmed) ?? false)
-        })
+        let matches = try dataController.transcriptionEntities(
+            searching: trimmed,
+            limit: Self.maxMatches
+        )
 
         let dialog = AttributedString(
             localized: "Found ^[\(matches.count) note](inflect: true) matching \"\(trimmed)\"."
         )
 
         return .result(value: matches, dialog: "\(dialog)")
+    }
+}
+
+struct SearchNotesQueryEmptyError: Error, CustomLocalizedStringResourceConvertible {
+    var localizedStringResource: LocalizedStringResource {
+        "Please provide a search query."
     }
 }

--- a/VivaDicta/AppIntents/ShortcutsProvider.swift
+++ b/VivaDicta/AppIntents/ShortcutsProvider.swift
@@ -40,8 +40,7 @@ final class ShortcutsProvider: AppShortcutsProvider {
             phrases: [
                 "Search in \(.applicationName)",
                 "Search notes in \(.applicationName)",
-                "Find notes in \(.applicationName)",
-                "Find a note in \(.applicationName)",
+                "Open \(.applicationName) search",
                 "Search my \(.applicationName) notes"
             ],
             shortTitle: LocalizedStringResource("Search"),
@@ -70,6 +69,17 @@ final class ShortcutsProvider: AppShortcutsProvider {
             ],
             shortTitle: "Get Latest Note",
             systemImageName: "text.quote"
+        )
+
+        AppShortcut(
+            intent: SearchNotesIntent(),
+            phrases: [
+                "Find notes in \(.applicationName)",
+                "Find a note in \(.applicationName)",
+                "Look up a note in \(.applicationName)"
+            ],
+            shortTitle: "Find Notes",
+            systemImageName: "text.magnifyingglass"
         )
 
         AppShortcut(

--- a/VivaDicta/AppIntents/ShortcutsProvider.swift
+++ b/VivaDicta/AppIntents/ShortcutsProvider.swift
@@ -81,18 +81,7 @@ final class ShortcutsProvider: AppShortcutsProvider {
             shortTitle: "Find Notes",
             systemImageName: "text.magnifyingglass"
         )
-
-        AppShortcut(
-            intent: RecordAndReturnTranscriptionIntent(),
-            phrases: [
-                "Record and get note from \(.applicationName)",
-                "Dictate a note with \(.applicationName)",
-                "Record and transcribe in \(.applicationName)"
-            ],
-            shortTitle: "Record and Get Note",
-            systemImageName: "waveform.badge.plus"
-        )
-
+        
         AppShortcut(
             intent: CountRecentTranscriptionsIntent(),
             phrases: [

--- a/VivaDicta/DataController.swift
+++ b/VivaDicta/DataController.swift
@@ -112,4 +112,21 @@ class DataController {
         let transcriptionsDescriptor = FetchDescriptor<Transcription>(predicate: predicate)
         return try modelContext.fetchCount(transcriptionsDescriptor)
     }
+
+    /// Searches transcriptions whose original text or AI-enhanced text matches the query.
+    ///
+    /// Callers should guard against empty queries before calling - `localizedStandardContains("")`
+    /// is true for every row, which would return the entire table.
+    func transcriptionEntities(
+        searching query: String,
+        limit: Int? = nil
+    ) throws -> [TranscriptionEntity] {
+        try transcriptionEntities(
+            matching: #Predicate { transcription in
+                transcription.text.localizedStandardContains(query) ||
+                (transcription.enhancedText?.localizedStandardContains(query) ?? false)
+            },
+            limit: limit
+        )
+    }
 }

--- a/VivaDicta/Models/TranscriptionEntity.swift
+++ b/VivaDicta/Models/TranscriptionEntity.swift
@@ -144,7 +144,7 @@ struct TranscriptionEntity: IndexedEntity {
     }
 }
 
-struct TranscriptionEntityDefaultQuery: EnumerableEntityQuery {
+struct TranscriptionEntityDefaultQuery: EnumerableEntityQuery, EntityStringQuery {
     @Dependency var dataController: DataController
 
     @MainActor
@@ -157,6 +157,15 @@ struct TranscriptionEntityDefaultQuery: EnumerableEntityQuery {
     func entities(for identifiers: [UUID]) async throws -> [TranscriptionEntity] {
         try dataController.transcriptionEntities(matching: #Predicate {
             identifiers.contains($0.id)
+        })
+    }
+
+    @MainActor
+    func entities(matching string: String) async throws -> [TranscriptionEntity] {
+        let query = string
+        return try dataController.transcriptionEntities(matching: #Predicate { transcription in
+            transcription.text.localizedStandardContains(query) ||
+            (transcription.enhancedText?.localizedStandardContains(query) ?? false)
         })
     }
 }

--- a/VivaDicta/Models/TranscriptionEntity.swift
+++ b/VivaDicta/Models/TranscriptionEntity.swift
@@ -162,10 +162,10 @@ struct TranscriptionEntityDefaultQuery: EnumerableEntityQuery, EntityStringQuery
 
     @MainActor
     func entities(matching string: String) async throws -> [TranscriptionEntity] {
-        let query = string
-        return try dataController.transcriptionEntities(matching: #Predicate { transcription in
-            transcription.text.localizedStandardContains(query) ||
-            (transcription.enhancedText?.localizedStandardContains(query) ?? false)
-        })
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        // localizedStandardContains("") is true for every row, so a blank query would
+        // return the entire table - undo the 100-item cap that allEntities() enforces.
+        guard !trimmed.isEmpty else { return [] }
+        return try dataController.transcriptionEntities(searching: trimmed, limit: 100)
     }
 }


### PR DESCRIPTION
## Summary

- **EntityStringQuery conformance** on `TranscriptionEntityDefaultQuery` - when any existing intent takes a `TranscriptionEntity` parameter (Open a Note, Remind me of a Note, Open a Note Snippet), users can now type a query in the Shortcuts picker instead of scrolling through the 100 most recent.
- **New `SearchNotesIntent(query: String) -> [TranscriptionEntity]`** - a chainable Find action. Use cases: "Find grocery -> Copy to Clipboard", "Find meeting notes -> Repeat with Each -> Append to Obsidian." Returns matches filtered by `localizedStandardContains` on both the original and AI-enhanced text.
- **Registered in `ShortcutsProvider`** (10th slot, at the cap). Split phrase families so Siri voice doesn't collide: `Search*` phrases go to `OpenSearchIntent` (opens in-app search UI), `Find*` phrases go to `SearchNotesIntent` (returns matching notes for composition).

**Note:** `String` parameters can't be interpolated into `AppShortcut` phrase key paths (only `AppEntity`/`AppEnum` are allowed), so `SearchNotesIntent` uses static phrases. When invoked by voice or tile, Shortcuts prompts for the query value automatically.

## Test plan

- [ ] Build succeeds (verified locally, 0 errors)
- [ ] Open Shortcuts -> Add Action -> VivaDicta -> "Find Notes" - typing a query returns matching notes
- [ ] Chain "Find Notes" -> "Copy to Clipboard" in a shortcut, run it with a known query, verify clipboard content
- [ ] Long-press Spotlight "Find Notes" tile - Shortcuts prompts for the query
- [ ] Siri: "Find notes in VivaDicta" - prompts for query, returns results
- [ ] Existing `TranscriptionEntity` parameter pickers (e.g., "Remind me of a Note" action) now accept typed search text
- [ ] Regression: "Search in VivaDicta" still opens the in-app search field via `OpenSearchIntent`