### PR TITLE
Add Ask & Record and Quick Actions home screen widgets

### DIFF
--- a/VivaDicta/VivaDictaApp.swift
+++ b/VivaDicta/VivaDictaApp.swift
@@ -489,6 +489,10 @@ struct VivaDictaApp: App {
             // Start recording
             appState.shouldStartRecording = true
             logger.logInfo("🎙️ Starting recording from widget deeplink")
+        } else if url.absoluteString == "openAskFromWidget" {
+            logger.logInfo("📱 Recognized as widget Ask AI request")
+
+            appState.shouldShowChats = true
         } else if url.absoluteString.starts(with: "vivadicta://transcribe-shared") {
             logger.logInfo("📱 Recognized as share extension transcription request")
 

--- a/VivaDicta/VivaDictaApp.swift
+++ b/VivaDicta/VivaDictaApp.swift
@@ -493,6 +493,10 @@ struct VivaDictaApp: App {
             logger.logInfo("📱 Recognized as widget Ask AI request")
 
             appState.shouldShowChats = true
+        } else if url.absoluteString == "openSearchFromWidget" {
+            logger.logInfo("📱 Recognized as widget Search request")
+
+            appState.shouldFocusSearch = true
         } else if url.absoluteString.starts(with: "vivadicta://transcribe-shared") {
             logger.logInfo("📱 Recognized as share extension transcription request")
 

--- a/VivaDictaWidget/VivaDictaAskRecordWidget.swift
+++ b/VivaDictaWidget/VivaDictaAskRecordWidget.swift
@@ -19,8 +19,7 @@ struct AskRecordWidgetProvider: TimelineProvider {
 
     func getTimeline(in context: Context, completion: @escaping (Timeline<AskRecordWidgetEntry>) -> Void) {
         let entry = AskRecordWidgetEntry(date: Date())
-        let reloadDate = Calendar.current.date(byAdding: .hour, value: 24, to: entry.date)!
-        completion(Timeline(entries: [entry], policy: .after(reloadDate)))
+        completion(Timeline(entries: [entry], policy: .never))
     }
 }
 
@@ -123,9 +122,11 @@ struct VivaDictaAskRecordWidgetEntryView: View {
             Image(systemName: "bubble.left.and.bubble.right.fill")
                 .font(.title3)
                 .foregroundStyle(askForeground)
+                .widgetAccentable()
             Text("Ask AI")
                 .font(.headline)
                 .foregroundStyle(askForeground)
+                .widgetAccentable()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(askBackground, in: .rect(cornerRadius: 18))

--- a/VivaDictaWidget/VivaDictaAskRecordWidget.swift
+++ b/VivaDictaWidget/VivaDictaAskRecordWidget.swift
@@ -92,8 +92,29 @@ struct VivaDictaAskRecordWidgetEntryView: View {
         }
         .padding(20)
         .containerBackground(for: .widget) {
-            
-//            colorScheme == .dark ? Color.black : Color.white
+            backgroundGradient
+        }
+    }
+    
+    private var backgroundGradient: LinearGradient {
+        if colorScheme == .dark {
+            LinearGradient(
+                colors: [
+                    Color(red: 0.08, green: 0.06, blue: 0.12),
+                    Color(red: 0.18, green: 0.12, blue: 0.28)
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+        } else {
+            LinearGradient(
+                colors: [
+                    .white,
+                    Color(red: 0.88, green: 0.85, blue: 0.95)
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
         }
     }
 

--- a/VivaDictaWidget/VivaDictaAskRecordWidget.swift
+++ b/VivaDictaWidget/VivaDictaAskRecordWidget.swift
@@ -49,7 +49,13 @@ struct VivaDictaAskRecordWidgetEntryView: View {
     }
 
     private var recordBackground: Color {
-        isFullColor ? .black : .clear
+        if !isFullColor {
+            .clear
+        } else if colorScheme == .dark {
+            Color(red: 0.32, green: 0.06, blue: 0.08)
+        } else {
+            .black
+        }
     }
 
     private var askForeground: Color {

--- a/VivaDictaWidget/VivaDictaAskRecordWidget.swift
+++ b/VivaDictaWidget/VivaDictaAskRecordWidget.swift
@@ -1,0 +1,129 @@
+//
+//  VivaDictaAskRecordWidget.swift
+//  VivaDictaWidget
+//
+//  Created by Anton Novoselov on 2026.04.19
+//
+
+import WidgetKit
+import SwiftUI
+
+struct AskRecordWidgetProvider: TimelineProvider {
+    func placeholder(in context: Context) -> AskRecordWidgetEntry {
+        AskRecordWidgetEntry(date: Date())
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (AskRecordWidgetEntry) -> Void) {
+        completion(AskRecordWidgetEntry(date: Date()))
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<AskRecordWidgetEntry>) -> Void) {
+        let entry = AskRecordWidgetEntry(date: Date())
+        let reloadDate = Calendar.current.date(byAdding: .hour, value: 24, to: entry.date)!
+        completion(Timeline(entries: [entry], policy: .after(reloadDate)))
+    }
+}
+
+struct AskRecordWidgetEntry: TimelineEntry {
+    let date: Date
+}
+
+struct VivaDictaAskRecordWidgetEntryView: View {
+    @Environment(\.widgetRenderingMode) private var renderingMode
+    @Environment(\.colorScheme) private var colorScheme
+
+    var entry: AskRecordWidgetProvider.Entry
+
+    private var isFullColor: Bool {
+        renderingMode == .fullColor
+    }
+
+    private var askBackground: Color {
+        if !isFullColor {
+            .clear
+        } else if colorScheme == .dark {
+            Color(white: 0.18)
+        } else {
+            Color(white: 0.92)
+        }
+    }
+
+    private var recordBackground: Color {
+        isFullColor ? .black : .clear
+    }
+
+    private var askForeground: Color {
+        if !isFullColor {
+            .white
+        } else if colorScheme == .dark {
+            .white
+        } else {
+            .black
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 8) {
+            Link(destination: URL(string: "openAskFromWidget")!) {
+                askButton
+            }
+            .frame(maxWidth: .infinity)
+
+            Link(destination: URL(string: "startRecordFromWidget")!) {
+                recordButton
+            }
+            .frame(maxWidth: .infinity)
+        }
+        .padding(20)
+        .containerBackground(for: .widget) {
+            
+//            colorScheme == .dark ? Color.black : Color.white
+        }
+    }
+
+    private var askButton: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "bubble.left.and.bubble.right.fill")
+                .font(.title3)
+                .foregroundStyle(askForeground)
+            Text("Ask AI")
+                .font(.headline)
+                .foregroundStyle(askForeground)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(askBackground, in: .rect(cornerRadius: 18))
+    }
+
+    private var recordButton: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "record.circle.fill")
+                .font(.title2)
+                .foregroundStyle(.red)
+            Text("Record")
+                .font(.headline)
+                .foregroundStyle(.white)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(recordBackground, in: .rect(cornerRadius: 18))
+    }
+}
+
+struct VivaDictaAskRecordWidget: Widget {
+    let kind: String = "VivaDictaAskRecordWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: AskRecordWidgetProvider()) { entry in
+            VivaDictaAskRecordWidgetEntryView(entry: entry)
+        }
+        .configurationDisplayName("Ask & Record")
+        .description("Quickly open Ask AI or start a new recording.")
+        .supportedFamilies([.systemSmall])
+        .contentMarginsDisabled()
+    }
+}
+
+#Preview(as: .systemSmall) {
+    VivaDictaAskRecordWidget()
+} timeline: {
+    AskRecordWidgetEntry(date: .now)
+}

--- a/VivaDictaWidget/VivaDictaAskRecordWidget.swift
+++ b/VivaDictaWidget/VivaDictaAskRecordWidget.swift
@@ -48,7 +48,17 @@ struct VivaDictaAskRecordWidgetEntryView: View {
         }
     }
 
-    private var recordBackground: Color {
+    private var recordForeground: Color {
+        if !isFullColor {
+            .white
+        } else if colorScheme == .dark {
+            .white
+        } else {
+            .black
+        }
+    }
+
+    private var recordFallbackBackground: Color {
         if !isFullColor {
             .clear
         } else if colorScheme == .dark {
@@ -105,12 +115,21 @@ struct VivaDictaAskRecordWidgetEntryView: View {
             Image(systemName: "record.circle.fill")
                 .font(.title2)
                 .foregroundStyle(.red)
+                .widgetAccentable()
             Text("Record")
                 .font(.headline)
-                .foregroundStyle(.white)
+                .foregroundStyle(recordForeground)
+                .widgetAccentable()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(recordBackground, in: .rect(cornerRadius: 18))
+        .background {
+            if isFullColor {
+                WidgetRecordPillBackground(cornerRadius: 18, colorScheme: colorScheme)
+            } else {
+                recordFallbackBackground
+            }
+        }
+        .clipShape(.rect(cornerRadius: 18))
     }
 }
 

--- a/VivaDictaWidget/VivaDictaQuickActionsWidget.swift
+++ b/VivaDictaWidget/VivaDictaQuickActionsWidget.swift
@@ -19,8 +19,7 @@ struct QuickActionsWidgetProvider: TimelineProvider {
 
     func getTimeline(in context: Context, completion: @escaping (Timeline<QuickActionsWidgetEntry>) -> Void) {
         let entry = QuickActionsWidgetEntry(date: Date())
-        let reloadDate = Calendar.current.date(byAdding: .hour, value: 24, to: entry.date)!
-        completion(Timeline(entries: [entry], policy: .after(reloadDate)))
+        completion(Timeline(entries: [entry], policy: .never))
     }
 }
 

--- a/VivaDictaWidget/VivaDictaQuickActionsWidget.swift
+++ b/VivaDictaWidget/VivaDictaQuickActionsWidget.swift
@@ -98,7 +98,29 @@ struct VivaDictaQuickActionsWidgetEntryView: View {
             }
         }
         .padding(12)
-        .containerBackground(for: .widget) { }
+        .containerBackground(for: .widget) {backgroundGradient}
+    }
+    
+    private var backgroundGradient: LinearGradient {
+        if colorScheme == .dark {
+            LinearGradient(
+                colors: [
+                    Color(red: 0.08, green: 0.06, blue: 0.12),
+                    Color(red: 0.18, green: 0.12, blue: 0.28)
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+        } else {
+            LinearGradient(
+                colors: [
+                    .white,
+                    Color(red: 0.88, green: 0.85, blue: 0.95)
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+        }
     }
 
     private var searchPill: some View {

--- a/VivaDictaWidget/VivaDictaQuickActionsWidget.swift
+++ b/VivaDictaWidget/VivaDictaQuickActionsWidget.swift
@@ -1,0 +1,157 @@
+//
+//  VivaDictaQuickActionsWidget.swift
+//  VivaDictaWidget
+//
+//  Created by Anton Novoselov on 2026.04.19
+//
+
+import WidgetKit
+import SwiftUI
+
+struct QuickActionsWidgetProvider: TimelineProvider {
+    func placeholder(in context: Context) -> QuickActionsWidgetEntry {
+        QuickActionsWidgetEntry(date: Date())
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (QuickActionsWidgetEntry) -> Void) {
+        completion(QuickActionsWidgetEntry(date: Date()))
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<QuickActionsWidgetEntry>) -> Void) {
+        let entry = QuickActionsWidgetEntry(date: Date())
+        let reloadDate = Calendar.current.date(byAdding: .hour, value: 24, to: entry.date)!
+        completion(Timeline(entries: [entry], policy: .after(reloadDate)))
+    }
+}
+
+struct QuickActionsWidgetEntry: TimelineEntry {
+    let date: Date
+}
+
+struct VivaDictaQuickActionsWidgetEntryView: View {
+    @Environment(\.widgetRenderingMode) private var renderingMode
+    @Environment(\.colorScheme) private var colorScheme
+
+    var entry: QuickActionsWidgetProvider.Entry
+
+    private var isFullColor: Bool {
+        renderingMode == .fullColor
+    }
+
+    private var lightPillBackground: Color {
+        if !isFullColor {
+            .clear
+        } else if colorScheme == .dark {
+            Color(white: 0.18)
+        } else {
+            Color(white: 0.92)
+        }
+    }
+
+    private var darkPillBackground: Color {
+        if !isFullColor {
+            .clear
+        } else if colorScheme == .dark {
+            Color(red: 0.32, green: 0.06, blue: 0.08)
+        } else {
+            .black
+        }
+    }
+
+    private var lightPillForeground: Color {
+        if !isFullColor {
+            .white
+        } else if colorScheme == .dark {
+            .white
+        } else {
+            .black
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 8) {
+            Link(destination: URL(string: "openSearchFromWidget")!) {
+                searchPill
+            }
+            .frame(maxWidth: .infinity)
+
+            HStack(spacing: 8) {
+                Link(destination: URL(string: "startRecordFromWidget")!) {
+                    recordPill
+                }
+                .frame(maxWidth: .infinity)
+
+                Link(destination: URL(string: "openAskFromWidget")!) {
+                    askPill
+                }
+                .frame(maxWidth: .infinity)
+            }
+        }
+        .padding(12)
+        .containerBackground(for: .widget) { }
+    }
+
+    private var searchPill: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .font(.headline)
+                .foregroundStyle(lightPillForeground)
+                .widgetAccentable()
+            Text("Search notes")
+                .font(.headline)
+                .foregroundStyle(lightPillForeground)
+                .widgetAccentable()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(lightPillBackground, in: .rect(cornerRadius: 22))
+    }
+
+    private var recordPill: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "record.circle.fill")
+                .font(.title3)
+                .foregroundStyle(.red)
+            Text("Record")
+                .font(.headline)
+                .foregroundStyle(.white)
+                .widgetAccentable()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(darkPillBackground, in: .rect(cornerRadius: 22))
+    }
+
+    private var askPill: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "bubble.left.and.bubble.right.fill")
+                .font(.headline)
+                .foregroundStyle(lightPillForeground)
+                .widgetAccentable()
+            Text("Ask AI")
+                .font(.headline)
+                .foregroundStyle(lightPillForeground)
+                .widgetAccentable()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(lightPillBackground, in: .rect(cornerRadius: 22))
+    }
+}
+
+struct VivaDictaQuickActionsWidget: Widget {
+    let kind: String = "VivaDictaQuickActionsWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: QuickActionsWidgetProvider()) { entry in
+            VivaDictaQuickActionsWidgetEntryView(entry: entry)
+        }
+        .configurationDisplayName("Quick Actions")
+        .description("Search notes, start a recording, or open Ask AI.")
+        .supportedFamilies([.systemMedium])
+        .contentMarginsDisabled()
+    }
+}
+
+#Preview(as: .systemMedium) {
+    VivaDictaQuickActionsWidget()
+} timeline: {
+    QuickActionsWidgetEntry(date: .now)
+}

--- a/VivaDictaWidget/VivaDictaQuickActionsWidget.swift
+++ b/VivaDictaWidget/VivaDictaQuickActionsWidget.swift
@@ -48,7 +48,17 @@ struct VivaDictaQuickActionsWidgetEntryView: View {
         }
     }
 
-    private var darkPillBackground: Color {
+    private var recordForeground: Color {
+        if !isFullColor {
+            .white
+        } else if colorScheme == .dark {
+            .white
+        } else {
+            .black
+        }
+    }
+
+    private var recordFallbackBackground: Color {
         if !isFullColor {
             .clear
         } else if colorScheme == .dark {
@@ -111,13 +121,21 @@ struct VivaDictaQuickActionsWidgetEntryView: View {
             Image(systemName: "record.circle.fill")
                 .font(.title3)
                 .foregroundStyle(.red)
+                .widgetAccentable()
             Text("Record")
                 .font(.headline)
-                .foregroundStyle(.white)
+                .foregroundStyle(recordForeground)
                 .widgetAccentable()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(darkPillBackground, in: .rect(cornerRadius: 22))
+        .background {
+            if isFullColor {
+                WidgetRecordPillBackground(cornerRadius: 22, colorScheme: colorScheme)
+            } else {
+                recordFallbackBackground
+            }
+        }
+        .clipShape(.rect(cornerRadius: 22))
     }
 
     private var askPill: some View {

--- a/VivaDictaWidget/VivaDictaWidgetBundle.swift
+++ b/VivaDictaWidget/VivaDictaWidgetBundle.swift
@@ -12,6 +12,7 @@ import SwiftUI
 struct VivaDictaWidgetBundle: WidgetBundle {
     var body: some Widget {
         VivaDictaIconWidget()
+        VivaDictaAskRecordWidget()
         VivaDictaWidgetControl()
         VivaDictaLiveActivity()
     }

--- a/VivaDictaWidget/VivaDictaWidgetBundle.swift
+++ b/VivaDictaWidget/VivaDictaWidgetBundle.swift
@@ -13,6 +13,7 @@ struct VivaDictaWidgetBundle: WidgetBundle {
     var body: some Widget {
         VivaDictaIconWidget()
         VivaDictaAskRecordWidget()
+        VivaDictaQuickActionsWidget()
         VivaDictaWidgetControl()
         VivaDictaLiveActivity()
     }

--- a/VivaDictaWidget/WidgetRecordPillBackground.swift
+++ b/VivaDictaWidget/WidgetRecordPillBackground.swift
@@ -1,0 +1,112 @@
+//
+//  WidgetRecordPillBackground.swift
+//  VivaDictaWidget
+//
+//  Created by Anton Novoselov on 2026.04.19
+//
+
+import SwiftUI
+
+/// Static mesh-gradient pill that mirrors the main screen mic button's
+/// AnimatedMeshGradient background. Widgets can't animate, so the mesh
+/// uses a fixed `t` value instead of a TimelineView.
+struct WidgetRecordPillBackground: View {
+    let cornerRadius: CGFloat
+    let colorScheme: ColorScheme
+
+    var body: some View {
+        let shape = RoundedRectangle(cornerRadius: cornerRadius)
+
+        let gradient = StaticWidgetMeshGradient(colors: meshColors)
+            .mask(
+                shape
+                    .stroke(lineWidth: 26)
+                    .blur(radius: 6)
+            )
+            .blendMode(colorScheme == .dark ? .lighten : .normal)
+
+        Group {
+            if colorScheme == .dark {
+                gradient
+                    .overlay(
+                        shape
+                            .stroke(lineWidth: 3)
+                            .fill(Color.white)
+                            .blur(radius: 2)
+                            .blendMode(.overlay)
+                    )
+                    .overlay(
+                        shape
+                            .stroke(lineWidth: 1)
+                            .fill(Color.white)
+                            .blur(radius: 1)
+                            .blendMode(.overlay)
+                    )
+                    .background(Color.black)
+            } else {
+                gradient
+                    .overlay(
+                        shape
+                            .stroke(lineWidth: 3)
+                            .fill(Color.black.opacity(0.7))
+                            .blur(radius: 2)
+                            .blendMode(.overlay)
+                    )
+                    .overlay(
+                        shape
+                            .stroke(lineWidth: 1)
+                            .fill(Color.black)
+                            .blur(radius: 1)
+                            .blendMode(.overlay)
+                    )
+                    .background(Color.white)
+            }
+        }
+        .clipShape(shape)
+    }
+
+    private var meshColors: [Color] {
+        if colorScheme == .dark {
+            [
+                .red, .purple, .indigo,
+                .orange, .white, .blue,
+                .yellow, .black, .mint
+            ]
+        } else {
+            [
+                .blue, .red, .orange,
+                .orange, .indigo, .red,
+                .cyan, .purple, .mint
+            ]
+        }
+    }
+}
+
+private struct StaticWidgetMeshGradient: View {
+    let colors: [Color]
+    let t: Float = 3.5
+
+    var body: some View {
+        MeshGradient(width: 3, height: 3, points: [
+            .init(0, 0), .init(0.5, 0), .init(1, 0),
+            [sinInRange(-0.8...(-0.2), offset: 0.439, timeScale: 0.342, t: t),
+             sinInRange(0.3...0.7, offset: 3.42, timeScale: 0.984, t: t)],
+            [sinInRange(0.1...0.8, offset: 0.239, timeScale: 0.084, t: t),
+             sinInRange(0.2...0.8, offset: 5.21, timeScale: 0.242, t: t)],
+            [sinInRange(1.0...1.5, offset: 0.939, timeScale: 0.084, t: t),
+             sinInRange(0.4...0.8, offset: 0.25, timeScale: 0.642, t: t)],
+            [sinInRange(-0.8...0.0, offset: 1.439, timeScale: 0.442, t: t),
+             sinInRange(1.4...1.9, offset: 3.42, timeScale: 0.984, t: t)],
+            [sinInRange(0.3...0.6, offset: 0.339, timeScale: 0.784, t: t),
+             sinInRange(1.0...1.2, offset: 1.22, timeScale: 0.772, t: t)],
+            [sinInRange(1.0...1.5, offset: 0.939, timeScale: 0.056, t: t),
+             sinInRange(1.3...1.7, offset: 0.47, timeScale: 0.342, t: t)]
+        ], colors: colors)
+    }
+
+    private func sinInRange(_ range: ClosedRange<Float>, offset: Float, timeScale: Float, t: Float) -> Float {
+        let amplitude = (range.upperBound - range.lowerBound) / 2
+        let midPoint = (range.upperBound + range.lowerBound) / 2
+        return midPoint + amplitude * sin(timeScale * t + offset)
+    }
+}


### PR DESCRIPTION
## Summary
- New `VivaDictaAskRecordWidget` (systemSmall): stacked Ask AI + Record pills
- New `VivaDictaQuickActionsWidget` (systemMedium): Search notes + Record + Ask pills
- Record pill styled to match the main-screen mic button (static port of `AnimatedMeshGradient` with a ring-stroke glow), adapted to a rounded pill
- Deep links reused/added: `startRecordFromWidget`, `openAskFromWidget` (new), `openSearchFromWidget` (new), routed in `VivaDictaApp.handleDeepLink` to the existing `shouldStartRecording` / `shouldShowChats` / `shouldFocusSearch` app-state flags
- Uses `Link` (not `Button(intent:)`) so the widget target's file membership doesn't need to grow

## Test plan
- [ ] Add Ask & Record widget from the gallery, tap Ask → chats screen opens
- [ ] Tap Record on Ask & Record widget → recording starts
- [ ] Add Quick Actions widget, tap Search notes → search focuses in main list
- [ ] Tap Record on Quick Actions widget → recording starts
- [ ] Tap Ask on Quick Actions widget → chats screen opens
- [ ] Verify Record pill visual in light and dark mode (text legible in both)
- [ ] Verify widget renders correctly in Tinted / Clear Home Screen appearance