### PR TITLE
Drift widget record-pill mesh across the day

### DIFF
--- a/VivaDictaWidget/VivaDictaAskRecordWidget.swift
+++ b/VivaDictaWidget/VivaDictaAskRecordWidget.swift
@@ -18,13 +18,26 @@ struct AskRecordWidgetProvider: TimelineProvider {
     }
 
     func getTimeline(in context: Context, completion: @escaping (Timeline<AskRecordWidgetEntry>) -> Void) {
-        let entry = AskRecordWidgetEntry(date: Date())
-        completion(Timeline(entries: [entry], policy: .never))
+        let now = Date()
+        let entries = (0..<24).compactMap { hourOffset in
+            Calendar.current.date(byAdding: .hour, value: hourOffset, to: now)
+                .map { AskRecordWidgetEntry(date: $0) }
+        }
+        let reloadDate = Calendar.current.date(byAdding: .hour, value: 24, to: now) ?? now
+        completion(Timeline(entries: entries, policy: .after(reloadDate)))
     }
 }
 
 struct AskRecordWidgetEntry: TimelineEntry {
     let date: Date
+
+    /// Mesh-gradient time parameter: advances by 1 per hour, cycles through 0..24 across the day.
+    var t: Float {
+        let components = Calendar.current.dateComponents([.hour, .minute], from: date)
+        let hours = Float(components.hour ?? 0)
+        let minutes = Float(components.minute ?? 0)
+        return hours + minutes / 60
+    }
 }
 
 struct VivaDictaAskRecordWidgetEntryView: View {
@@ -146,7 +159,7 @@ struct VivaDictaAskRecordWidgetEntryView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background {
             if isFullColor {
-                WidgetRecordPillBackground(cornerRadius: 18, colorScheme: colorScheme)
+                WidgetRecordPillBackground(cornerRadius: 18, colorScheme: colorScheme, t: entry.t)
             } else {
                 recordFallbackBackground
             }
@@ -172,5 +185,8 @@ struct VivaDictaAskRecordWidget: Widget {
 #Preview(as: .systemSmall) {
     VivaDictaAskRecordWidget()
 } timeline: {
-    AskRecordWidgetEntry(date: .now)
+    AskRecordWidgetEntry(date: Calendar.current.date(bySettingHour: 0, minute: 0, second: 0, of: .now)!)
+    AskRecordWidgetEntry(date: Calendar.current.date(bySettingHour: 6, minute: 0, second: 0, of: .now)!)
+    AskRecordWidgetEntry(date: Calendar.current.date(bySettingHour: 12, minute: 0, second: 0, of: .now)!)
+    AskRecordWidgetEntry(date: Calendar.current.date(bySettingHour: 18, minute: 0, second: 0, of: .now)!)
 }

--- a/VivaDictaWidget/VivaDictaAskRecordWidget.swift
+++ b/VivaDictaWidget/VivaDictaAskRecordWidget.swift
@@ -10,34 +10,28 @@ import SwiftUI
 
 struct AskRecordWidgetProvider: TimelineProvider {
     func placeholder(in context: Context) -> AskRecordWidgetEntry {
-        AskRecordWidgetEntry(date: Date())
+        AskRecordWidgetEntry(date: Date(), t: 0)
     }
 
     func getSnapshot(in context: Context, completion: @escaping (AskRecordWidgetEntry) -> Void) {
-        completion(AskRecordWidgetEntry(date: Date()))
+        completion(AskRecordWidgetEntry(date: Date(), t: 0))
     }
 
     func getTimeline(in context: Context, completion: @escaping (Timeline<AskRecordWidgetEntry>) -> Void) {
         let now = Date()
         let entries = (0..<24).compactMap { hourOffset in
             Calendar.current.date(byAdding: .hour, value: hourOffset, to: now)
-                .map { AskRecordWidgetEntry(date: $0) }
+                .map { AskRecordWidgetEntry(date: $0, t: Float(hourOffset)) }
         }
-        let reloadDate = Calendar.current.date(byAdding: .hour, value: 24, to: now) ?? now
+        let reloadDate = now.addingTimeInterval(24 * 3600)
         completion(Timeline(entries: entries, policy: .after(reloadDate)))
     }
 }
 
 struct AskRecordWidgetEntry: TimelineEntry {
     let date: Date
-
-    /// Mesh-gradient time parameter: advances by 1 per hour, cycles through 0..24 across the day.
-    var t: Float {
-        let components = Calendar.current.dateComponents([.hour, .minute], from: date)
-        let hours = Float(components.hour ?? 0)
-        let minutes = Float(components.minute ?? 0)
-        return hours + minutes / 60
-    }
+    /// Mesh-gradient time parameter: monotonic hour-offset from timeline boot, so the mesh drifts without snapping at midnight.
+    let t: Float
 }
 
 struct VivaDictaAskRecordWidgetEntryView: View {
@@ -185,8 +179,8 @@ struct VivaDictaAskRecordWidget: Widget {
 #Preview(as: .systemSmall) {
     VivaDictaAskRecordWidget()
 } timeline: {
-    AskRecordWidgetEntry(date: Calendar.current.date(bySettingHour: 0, minute: 0, second: 0, of: .now)!)
-    AskRecordWidgetEntry(date: Calendar.current.date(bySettingHour: 6, minute: 0, second: 0, of: .now)!)
-    AskRecordWidgetEntry(date: Calendar.current.date(bySettingHour: 12, minute: 0, second: 0, of: .now)!)
-    AskRecordWidgetEntry(date: Calendar.current.date(bySettingHour: 18, minute: 0, second: 0, of: .now)!)
+    AskRecordWidgetEntry(date: .now, t: 0)
+    AskRecordWidgetEntry(date: .now, t: 6)
+    AskRecordWidgetEntry(date: .now, t: 12)
+    AskRecordWidgetEntry(date: .now, t: 18)
 }

--- a/VivaDictaWidget/VivaDictaQuickActionsWidget.swift
+++ b/VivaDictaWidget/VivaDictaQuickActionsWidget.swift
@@ -18,13 +18,26 @@ struct QuickActionsWidgetProvider: TimelineProvider {
     }
 
     func getTimeline(in context: Context, completion: @escaping (Timeline<QuickActionsWidgetEntry>) -> Void) {
-        let entry = QuickActionsWidgetEntry(date: Date())
-        completion(Timeline(entries: [entry], policy: .never))
+        let now = Date()
+        let entries = (0..<24).compactMap { hourOffset in
+            Calendar.current.date(byAdding: .hour, value: hourOffset, to: now)
+                .map { QuickActionsWidgetEntry(date: $0) }
+        }
+        let reloadDate = Calendar.current.date(byAdding: .hour, value: 24, to: now) ?? now
+        completion(Timeline(entries: entries, policy: .after(reloadDate)))
     }
 }
 
 struct QuickActionsWidgetEntry: TimelineEntry {
     let date: Date
+
+    /// Mesh-gradient time parameter: advances by 1 per hour, cycles through 0..24 across the day.
+    var t: Float {
+        let components = Calendar.current.dateComponents([.hour, .minute], from: date)
+        let hours = Float(components.hour ?? 0)
+        let minutes = Float(components.minute ?? 0)
+        return hours + minutes / 60
+    }
 }
 
 struct VivaDictaQuickActionsWidgetEntryView: View {
@@ -151,7 +164,7 @@ struct VivaDictaQuickActionsWidgetEntryView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background {
             if isFullColor {
-                WidgetRecordPillBackground(cornerRadius: 22, colorScheme: colorScheme)
+                WidgetRecordPillBackground(cornerRadius: 22, colorScheme: colorScheme, t: entry.t)
             } else {
                 recordFallbackBackground
             }
@@ -192,5 +205,8 @@ struct VivaDictaQuickActionsWidget: Widget {
 #Preview(as: .systemMedium) {
     VivaDictaQuickActionsWidget()
 } timeline: {
-    QuickActionsWidgetEntry(date: .now)
+    QuickActionsWidgetEntry(date: Calendar.current.date(bySettingHour: 0, minute: 0, second: 0, of: .now)!)
+    QuickActionsWidgetEntry(date: Calendar.current.date(bySettingHour: 6, minute: 0, second: 0, of: .now)!)
+    QuickActionsWidgetEntry(date: Calendar.current.date(bySettingHour: 12, minute: 0, second: 0, of: .now)!)
+    QuickActionsWidgetEntry(date: Calendar.current.date(bySettingHour: 18, minute: 0, second: 0, of: .now)!)
 }

--- a/VivaDictaWidget/VivaDictaQuickActionsWidget.swift
+++ b/VivaDictaWidget/VivaDictaQuickActionsWidget.swift
@@ -10,34 +10,28 @@ import SwiftUI
 
 struct QuickActionsWidgetProvider: TimelineProvider {
     func placeholder(in context: Context) -> QuickActionsWidgetEntry {
-        QuickActionsWidgetEntry(date: Date())
+        QuickActionsWidgetEntry(date: Date(), t: 0)
     }
 
     func getSnapshot(in context: Context, completion: @escaping (QuickActionsWidgetEntry) -> Void) {
-        completion(QuickActionsWidgetEntry(date: Date()))
+        completion(QuickActionsWidgetEntry(date: Date(), t: 0))
     }
 
     func getTimeline(in context: Context, completion: @escaping (Timeline<QuickActionsWidgetEntry>) -> Void) {
         let now = Date()
         let entries = (0..<24).compactMap { hourOffset in
             Calendar.current.date(byAdding: .hour, value: hourOffset, to: now)
-                .map { QuickActionsWidgetEntry(date: $0) }
+                .map { QuickActionsWidgetEntry(date: $0, t: Float(hourOffset)) }
         }
-        let reloadDate = Calendar.current.date(byAdding: .hour, value: 24, to: now) ?? now
+        let reloadDate = now.addingTimeInterval(24 * 3600)
         completion(Timeline(entries: entries, policy: .after(reloadDate)))
     }
 }
 
 struct QuickActionsWidgetEntry: TimelineEntry {
     let date: Date
-
-    /// Mesh-gradient time parameter: advances by 1 per hour, cycles through 0..24 across the day.
-    var t: Float {
-        let components = Calendar.current.dateComponents([.hour, .minute], from: date)
-        let hours = Float(components.hour ?? 0)
-        let minutes = Float(components.minute ?? 0)
-        return hours + minutes / 60
-    }
+    /// Mesh-gradient time parameter: monotonic hour-offset from timeline boot, so the mesh drifts without snapping at midnight.
+    let t: Float
 }
 
 struct VivaDictaQuickActionsWidgetEntryView: View {
@@ -205,8 +199,8 @@ struct VivaDictaQuickActionsWidget: Widget {
 #Preview(as: .systemMedium) {
     VivaDictaQuickActionsWidget()
 } timeline: {
-    QuickActionsWidgetEntry(date: Calendar.current.date(bySettingHour: 0, minute: 0, second: 0, of: .now)!)
-    QuickActionsWidgetEntry(date: Calendar.current.date(bySettingHour: 6, minute: 0, second: 0, of: .now)!)
-    QuickActionsWidgetEntry(date: Calendar.current.date(bySettingHour: 12, minute: 0, second: 0, of: .now)!)
-    QuickActionsWidgetEntry(date: Calendar.current.date(bySettingHour: 18, minute: 0, second: 0, of: .now)!)
+    QuickActionsWidgetEntry(date: .now, t: 0)
+    QuickActionsWidgetEntry(date: .now, t: 6)
+    QuickActionsWidgetEntry(date: .now, t: 12)
+    QuickActionsWidgetEntry(date: .now, t: 18)
 }

--- a/VivaDictaWidget/WidgetRecordPillBackground.swift
+++ b/VivaDictaWidget/WidgetRecordPillBackground.swift
@@ -7,17 +7,19 @@
 
 import SwiftUI
 
-/// Static mesh-gradient pill that mirrors the main screen mic button's
-/// AnimatedMeshGradient background. Widgets can't animate, so the mesh
-/// uses a fixed `t` value instead of a TimelineView.
+/// Mesh-gradient pill that mirrors the main screen mic button's
+/// AnimatedMeshGradient background. Widgets can't run TimelineView,
+/// so `t` is driven by the widget's timeline entry — the background
+/// shifts subtly across the day as entries refresh hourly.
 struct WidgetRecordPillBackground: View {
     let cornerRadius: CGFloat
     let colorScheme: ColorScheme
+    let t: Float
 
     var body: some View {
         let shape = RoundedRectangle(cornerRadius: cornerRadius)
 
-        let gradient = StaticWidgetMeshGradient(colors: meshColors)
+        let gradient = StaticWidgetMeshGradient(colors: meshColors, t: t)
             .mask(
                 shape
                     .stroke(lineWidth: 26)
@@ -84,7 +86,7 @@ struct WidgetRecordPillBackground: View {
 
 private struct StaticWidgetMeshGradient: View {
     let colors: [Color]
-    let t: Float = 3.5
+    let t: Float
 
     var body: some View {
         MeshGradient(width: 3, height: 3, points: [


### PR DESCRIPTION
## Summary
- Record pill background in both widgets (Ask/Record small, Quick Actions medium) now mirrors the main-screen mic button's mesh - but drifts subtly across the day via the widget timeline system (widgets can't run `TimelineView`, so we fake "aliveness" with hourly entries).
- `WidgetRecordPillBackground` takes a `t: Float` parameter (was hardcoded `3.5`). Mesh points are still computed from the same `sinInRange` formulas as `AnimatedMeshGradient`/`AnimatedMeshGradient2`.
- Both widget providers emit 24 hourly `TimelineEntry`s with `policy: .after(reloadDate)` to refresh the next day. Each entry derives `t = hours + minutes/60`, so slow mesh points barely move between adjacent hours (~3° rotation) while faster ones clearly shift (~56°). Feels alive without being jumpy.
- Also slightly darkens the light-theme Ask AI / Search notes pill background (`white: 0.92` → `0.84`) for better contrast against the widget's off-white gradient.
- Previews updated to cycle through 0/6/12/18h so the drift is visible in Xcode preview.

## Test plan
- [ ] Add the Ask/Record small widget to the home screen in both light and dark mode. Confirm the Record pill mesh matches the main-screen mic button look.
- [ ] Add the Quick Actions medium widget; confirm same.
- [ ] Let the device sit for >1h (or scrub system time forward) and confirm the mesh shifts between hours without re-adding the widget.
- [ ] Verify the Ask AI and Search notes pills look slightly darker in light mode.
- [ ] Verify accented (non-full-color) rendering mode still falls back to the solid background.