### PR TITLE
Support chat for OpenAI OAuth via Codex Responses API

### DIFF
--- a/VivaDicta/Services/AIEnhance/AIService+Chat.swift
+++ b/VivaDicta/Services/AIEnhance/AIService+Chat.swift
@@ -129,11 +129,34 @@ extension AIService {
                 onPartialResponse: onPartialResponse
             )
 
-        case nil:
-            // Check if this is an OAuth-only provider without chat support
-            if provider == .openAI && isOpenAISignedIn && provider.apiKey == nil {
-                throw EnhancementError.customError("Chat is not yet supported with OpenAI OAuth. Please add an OpenAI API key to use chat.")
+        case .openAIOAuth:
+            do {
+                let oauthProvider = OpenAIOAuthProvider()
+                let (token, accountId, _) = try await OAuthManager.shared.validAccessToken(for: oauthProvider)
+                let resolvedModel = OpenAIOAuthClient.resolveModel(model)
+                return try await OpenAIOAuthClient.chatStreaming(
+                    systemMessage: systemMessage,
+                    messages: messages,
+                    model: resolvedModel,
+                    accessToken: token,
+                    accountId: accountId,
+                    onPartialResponse: onPartialResponse
+                )
+            } catch let error as OAuthError {
+                if let apiKey = provider.apiKey {
+                    return try await makeOpenAIChatStreamingRequest(
+                        url: URL(string: provider.baseURL)!,
+                        model: model,
+                        systemMessage: systemMessage,
+                        messages: messages,
+                        headers: ["Authorization": "Bearer \(apiKey)"],
+                        onPartialResponse: onPartialResponse
+                    )
+                }
+                throw EnhancementError.customError(error.errorDescription ?? "OpenAI OAuth error")
             }
+
+        case nil:
             if provider == .gemini && isGeminiSignedIn && provider.apiKey == nil {
                 throw EnhancementError.customError("Chat is not yet supported with Gemini OAuth. Please add a Gemini API key to use chat.")
             }
@@ -169,6 +192,32 @@ extension AIService {
                 messages: messages,
                 apiKey: apiKey
             )
+
+        case .openAI where isOpenAISignedIn:
+            do {
+                let oauthProvider = OpenAIOAuthProvider()
+                let (token, accountId, _) = try await OAuthManager.shared.validAccessToken(for: oauthProvider)
+                let resolvedModel = OpenAIOAuthClient.resolveModel(model)
+                return try await OpenAIOAuthClient.chat(
+                    systemMessage: systemMessage,
+                    messages: messages,
+                    model: resolvedModel,
+                    accessToken: token,
+                    accountId: accountId
+                )
+            } catch let error as OAuthError {
+                if let apiKey = provider.apiKey {
+                    let (url, headers) = (URL(string: provider.baseURL)!, ["Authorization": "Bearer \(apiKey)"])
+                    return try await makeOpenAIChatNonStreamingRequest(
+                        url: url,
+                        model: model,
+                        systemMessage: systemMessage,
+                        messages: messages,
+                        headers: headers
+                    )
+                }
+                throw EnhancementError.customError(error.errorDescription ?? "OpenAI OAuth error")
+            }
 
         default:
             // OpenAI-compatible for all other providers
@@ -254,7 +303,7 @@ extension AIService {
     // MARK: - Private Helpers
 
     private enum ChatStreamingRoute {
-        case anthropic, openAICompatibleCloud, copilot, ollama, customOpenAI
+        case anthropic, openAICompatibleCloud, copilot, ollama, customOpenAI, openAIOAuth
     }
 
     private func chatStreamingRoute(for provider: AIProvider, model: String) -> ChatStreamingRoute? {
@@ -267,6 +316,14 @@ extension AIService {
             return .customOpenAI
         case .copilot:
             return isCopilotSignedIn ? .copilot : nil
+        case .openAI:
+            if isOpenAISignedIn {
+                return .openAIOAuth
+            }
+            if provider.supportsResponseStreaming(model: model), provider.apiKey != nil {
+                return .openAICompatibleCloud
+            }
+            return nil
         default:
             return provider.supportsResponseStreaming(model: model) && provider.apiKey != nil
                 ? .openAICompatibleCloud

--- a/VivaDicta/Services/AIEnhance/AIService+Chat.swift
+++ b/VivaDicta/Services/AIEnhance/AIService+Chat.swift
@@ -133,11 +133,10 @@ extension AIService {
             do {
                 let oauthProvider = OpenAIOAuthProvider()
                 let (token, accountId, _) = try await OAuthManager.shared.validAccessToken(for: oauthProvider)
-                let resolvedModel = OpenAIOAuthClient.resolveModel(model)
                 return try await OpenAIOAuthClient.chatStreaming(
                     systemMessage: systemMessage,
                     messages: messages,
-                    model: resolvedModel,
+                    model: model,
                     accessToken: token,
                     accountId: accountId,
                     onPartialResponse: onPartialResponse
@@ -197,11 +196,10 @@ extension AIService {
             do {
                 let oauthProvider = OpenAIOAuthProvider()
                 let (token, accountId, _) = try await OAuthManager.shared.validAccessToken(for: oauthProvider)
-                let resolvedModel = OpenAIOAuthClient.resolveModel(model)
                 return try await OpenAIOAuthClient.chat(
                     systemMessage: systemMessage,
                     messages: messages,
-                    model: resolvedModel,
+                    model: model,
                     accessToken: token,
                     accountId: accountId
                 )

--- a/VivaDicta/Services/OAuth/OpenAIOAuthClient.swift
+++ b/VivaDicta/Services/OAuth/OpenAIOAuthClient.swift
@@ -202,7 +202,20 @@ enum OpenAIOAuthClient {
             for try await byte in bytes { errorData.append(byte) }
             let errorBody = String(data: errorData, encoding: .utf8) ?? "Unknown error"
             logger.logError("OpenAI API error: HTTP \(httpResponse.statusCode) - \(errorBody)")
-            throw OAuthError.tokenExchangeFailed("HTTP \(httpResponse.statusCode): \(errorBody)")
+            // Only auth failures should trigger the API-key fallback in callers.
+            // Rate limits and server errors are transient - surface them directly
+            // so the user sees a meaningful message and their API key quota is
+            // not silently burned on unrelated backend blips.
+            switch httpResponse.statusCode {
+            case 401, 403:
+                throw OAuthError.tokenExchangeFailed("HTTP \(httpResponse.statusCode): \(errorBody)")
+            case 429:
+                throw EnhancementError.rateLimitExceeded
+            case 500...599:
+                throw EnhancementError.serverError
+            default:
+                throw EnhancementError.customError("OpenAI error (HTTP \(httpResponse.statusCode)): \(errorBody)")
+            }
         }
 
         var result = ""

--- a/VivaDicta/Services/OAuth/OpenAIOAuthClient.swift
+++ b/VivaDicta/Services/OAuth/OpenAIOAuthClient.swift
@@ -33,7 +33,7 @@ enum OpenAIOAuthClient {
         return defaultModel
     }
 
-    /// Sends an AI enhancement request via OpenAI's backend API.
+    /// Sends a single-turn AI enhancement request via OpenAI's backend API.
     static func enhance(
         text: String,
         systemPrompt: String,
@@ -42,21 +42,6 @@ enum OpenAIOAuthClient {
         accountId: String?,
         onPartialResult: (@MainActor (String) -> Void)? = nil
     ) async throws -> String {
-        guard let url = URL(string: OpenAIOAuthProvider.completionsEndpoint) else {
-            throw OAuthError.invalidResponse
-        }
-
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.addValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
-        request.addValue(originator, forHTTPHeaderField: "originator")
-        request.timeoutInterval = 60
-
-        if let accountId {
-            request.addValue(accountId, forHTTPHeaderField: "chatgpt-account-id")
-        }
-
         let effectiveModel = resolveModel(model)
         logger.logInfo("OpenAI OAuth: using model '\(effectiveModel)' (requested: '\(model)')")
 
@@ -70,9 +55,136 @@ enum OpenAIOAuthClient {
             "stream": true
         ]
 
-        request.addValue("text/event-stream", forHTTPHeaderField: "Accept")
-        request.httpBody = try? JSONSerialization.data(withJSONObject: requestBody)
+        let request = try buildResponsesRequest(
+            endpoint: OpenAIOAuthProvider.completionsEndpoint,
+            accessToken: accessToken,
+            accountId: accountId,
+            body: requestBody,
+            timeout: 60
+        )
 
+        return try await streamResponsesText(
+            request: request,
+            onPartialResult: onPartialResult
+        )
+    }
+
+    /// Multi-turn streaming chat over the Codex Responses backend.
+    ///
+    /// - Parameter messages: conversation turns as `[{"role": "user"|"assistant", "content": "..."}]`.
+    ///   System entries are ignored here; the system prompt goes into `instructions`.
+    static func chatStreaming(
+        systemMessage: String,
+        messages: [[String: String]],
+        model: String,
+        accessToken: String,
+        accountId: String?,
+        onPartialResponse: @escaping @MainActor (String) -> Void
+    ) async throws -> String {
+        let effectiveModel = resolveModel(model)
+        let inputItems = buildChatInputItems(messages: messages)
+        logger.logInfo(
+            "OpenAI OAuth chat: model='\(effectiveModel)' turns=\(inputItems.count) instructionsChars=\(systemMessage.count)"
+        )
+
+        let requestBody: [String: Any] = [
+            "model": effectiveModel,
+            "instructions": systemMessage,
+            "input": inputItems,
+            "store": false,
+            "stream": true
+        ]
+
+        let request = try buildResponsesRequest(
+            endpoint: OpenAIOAuthProvider.completionsEndpoint,
+            accessToken: accessToken,
+            accountId: accountId,
+            body: requestBody,
+            timeout: 300
+        )
+
+        return try await streamResponsesText(
+            request: request,
+            onPartialResult: onPartialResponse
+        )
+    }
+
+    /// Multi-turn non-streaming chat. Implemented by buffering the streaming helper.
+    static func chat(
+        systemMessage: String,
+        messages: [[String: String]],
+        model: String,
+        accessToken: String,
+        accountId: String?
+    ) async throws -> String {
+        try await chatStreaming(
+            systemMessage: systemMessage,
+            messages: messages,
+            model: model,
+            accessToken: accessToken,
+            accountId: accountId,
+            onPartialResponse: { _ in }
+        )
+    }
+
+    /// Fetches available models from OpenAI's backend.
+    static func fetchModels(accessToken: String) async throws -> [String] {
+        guard let url = URL(string: OpenAIOAuthProvider.modelsEndpoint) else {
+            return [defaultModel]
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.addValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.addValue(originator, forHTTPHeaderField: "originator")
+        request.timeoutInterval = 15
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            return [defaultModel]
+        }
+
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let models = json["models"] as? [[String: Any]] else {
+            return [defaultModel]
+        }
+
+        let modelIds = models.compactMap { $0["id"] as? String ?? $0["model"] as? String }
+        return modelIds.isEmpty ? [defaultModel] : modelIds
+    }
+
+    // MARK: - Private helpers
+
+    private static func buildResponsesRequest(
+        endpoint: String,
+        accessToken: String,
+        accountId: String?,
+        body: [String: Any],
+        timeout: TimeInterval
+    ) throws -> URLRequest {
+        guard let url = URL(string: endpoint) else {
+            throw OAuthError.invalidResponse
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.addValue(originator, forHTTPHeaderField: "originator")
+        request.addValue("text/event-stream", forHTTPHeaderField: "Accept")
+        if let accountId {
+            request.addValue(accountId, forHTTPHeaderField: "chatgpt-account-id")
+        }
+        request.timeoutInterval = timeout
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+        return request
+    }
+
+    private static func streamResponsesText(
+        request: URLRequest,
+        onPartialResult: (@MainActor (String) -> Void)?
+    ) async throws -> String {
         let (bytes, response) = try await URLSession.shared.bytes(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
@@ -80,17 +192,16 @@ enum OpenAIOAuthClient {
         }
 
         guard httpResponse.statusCode == 200 else {
-            // Collect error body from stream
             var errorData = Data()
             for try await byte in bytes { errorData.append(byte) }
             let errorBody = String(data: errorData, encoding: .utf8) ?? "Unknown error"
-            logger.logError("OpenAI API error: HTTP \(httpResponse.statusCode) — \(errorBody)")
+            logger.logError("OpenAI API error: HTTP \(httpResponse.statusCode) - \(errorBody)")
             throw OAuthError.tokenExchangeFailed("HTTP \(httpResponse.statusCode): \(errorBody)")
         }
 
-        // Parse SSE stream, collect output_text.delta events
         var result = ""
         for try await line in bytes.lines {
+            try Task.checkCancellation()
             guard line.hasPrefix("data: ") else { continue }
             let jsonStr = String(line.dropFirst(6))
             if jsonStr == "[DONE]" { break }
@@ -121,30 +232,28 @@ enum OpenAIOAuthClient {
         return finalResult
     }
 
-    /// Fetches available models from OpenAI's backend.
-    static func fetchModels(accessToken: String) async throws -> [String] {
-        guard let url = URL(string: OpenAIOAuthProvider.modelsEndpoint) else {
-            return [defaultModel]
+    /// Converts a flat `[{role, content}]` chat list into Codex-style `input` items.
+    /// System entries are dropped - the system prompt must be sent as `instructions`.
+    private static func buildChatInputItems(messages: [[String: String]]) -> [[String: Any]] {
+        var items: [[String: Any]] = []
+        for message in messages {
+            guard let role = message["role"],
+                  let content = message["content"],
+                  !content.isEmpty,
+                  role != "system" else {
+                continue
+            }
+
+            let contentType = (role == "assistant") ? "output_text" : "input_text"
+
+            items.append([
+                "type": "message",
+                "role": role,
+                "content": [
+                    ["type": contentType, "text": content]
+                ]
+            ])
         }
-
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.addValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
-        request.addValue(originator, forHTTPHeaderField: "originator")
-        request.timeoutInterval = 15
-
-        let (data, response) = try await URLSession.shared.data(for: request)
-
-        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
-            return [defaultModel]
-        }
-
-        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let models = json["models"] as? [[String: Any]] else {
-            return [defaultModel]
-        }
-
-        let modelIds = models.compactMap { $0["id"] as? String ?? $0["model"] as? String }
-        return modelIds.isEmpty ? [defaultModel] : modelIds
+        return items
     }
 }

--- a/VivaDicta/Services/OAuth/OpenAIOAuthClient.swift
+++ b/VivaDicta/Services/OAuth/OpenAIOAuthClient.swift
@@ -103,10 +103,16 @@ enum OpenAIOAuthClient {
             timeout: 300
         )
 
-        return try await streamResponsesText(
+        let raw = try await streamResponsesText(
             request: request,
             onPartialResult: onPartialResponse
         )
+
+        let filtered = AIEnhancementOutputFilter.filter(raw)
+        if filtered != raw {
+            await onPartialResponse(filtered)
+        }
+        return filtered
     }
 
     /// Multi-turn non-streaming chat. Implemented by buffering the streaming helper.

--- a/documentation/RAG/Tool-Provider-Support.md
+++ b/documentation/RAG/Tool-Provider-Support.md
@@ -101,7 +101,7 @@ Relevant code:
 | HuggingFace | Yes | Yes | Yes | Yes | Yes | No | Routed through shared OpenAI-compatible cloud path. |
 | Ollama | Yes | Yes | Yes | Yes | Yes | No | Routed through local OpenAI-compatible chat path. |
 | Custom OpenAI | Yes | Yes | Yes | Yes | Yes | No | Routed through custom OpenAI-compatible endpoint. |
-| OpenAI OAuth only | No | No | No | No | No | No | Chat is explicitly blocked today. |
+| OpenAI OAuth only | Yes | Yes (planner) | Yes (planner) | No | Yes | No | Routed through Codex Responses backend. Implicit tool-calling deferred. |
 | Gemini OAuth only | No | No | No | No | No | No | Chat is explicitly blocked today. |
 
 ## Providers Not Covered By Chat Tools
@@ -136,12 +136,14 @@ Apple has the richest tool integration:
 
 ### 3. OAuth is different from API key support
 
-OpenAI and Gemini both report as chat-ready when signed in, but OAuth-only chat is still blocked in the actual transport layer.
+OpenAI OAuth-only chat routes through the Codex Responses backend (`chatgpt.com/backend-api/codex/responses`) with a structured `input` body, not the standard Chat Completions `messages` body. Planner-based tool paths that call `makeChatRequest(...)` work because planners decode JSON from a plain text response. Implicit tool calling during normal chat (the `tools` + `tool_choice: "auto"` path) is not yet implemented for OAuth and is deferred.
+
+Gemini OAuth-only chat is still blocked in the transport layer.
 
 That means:
 
 - OpenAI API key chat tools: supported
-- OpenAI OAuth-only chat tools: not supported
+- OpenAI OAuth-only chat tools: planner-based tools supported, implicit chat tool-calling not yet supported
 - Gemini API key chat tools: supported
 - Gemini OAuth-only chat tools: not supported
 


### PR DESCRIPTION
## Summary

- OAuth-only OpenAI users can now chat in single-note, multi-note, and Smart Search surfaces without adding an API key
- Chat routes through the Codex Responses backend (`chatgpt.com/backend-api/codex/responses`) that the app already uses for transcription enhancement
- Request shape is the structured Codex form: system → `instructions`, turns → `input` items with `input_text`/`output_text` content blocks, `store: false`, `stream: true`
- Planner-based tools (Search other notes, Search web) work via `makeChatRequest(...)` automatically; implicit mid-chat tool-calling stays deferred

## Changes

- `OpenAIOAuthClient` gains `chatStreaming(...)` + `chat(...)` and extracts shared `buildResponsesRequest(...)` / `streamResponsesText(...)` helpers. `enhance(...)` behavior unchanged in terms of output.
- `AIService+Chat.swift` adds `.openAIOAuth` to `ChatStreamingRoute` and branches in both `makeChatStreamingRequest` and `makeChatRequest`. Removes the "Chat is not yet supported with OpenAI OAuth" error. Gemini OAuth gate kept.
- Auto-fallback to API key on `OAuthError` when both OAuth and API key are configured.
- Chat output runs through `AIEnhancementOutputFilter.filter(...)` to match the API-key path (strips `<thinking>` / XML wrappers if emitted).
- HTTP errors from the Codex backend are now classified: 401/403 → `OAuthError` (fallback fires), 429 → `EnhancementError.rateLimitExceeded`, 5xx → `EnhancementError.serverError`, other → `EnhancementError.customError`. Prevents silent API-key quota burn on transient server blips.
- `documentation/RAG/Tool-Provider-Support.md` updated to reflect the new OAuth chat capability and the deferred implicit tool-calling.

## Behavior change to note

Previously, a user with both OAuth *and* an API key got the API-key chat path. After this PR, they get OAuth chat. This matches how enhancement already behaves - if the user explicitly signed in with OAuth, that intent is respected. API key remains as an automatic fallback when OAuth errors out.

## Deferred

- Implicit mid-chat tool-calling for OAuth (`makeCrossNoteSearchToolDecision`, `makeWebSearchToolDecision`). The existing catch blocks in chat view models silently skip implicit tools on error, so OAuth users just don't get them - no user-visible breakage.
- Gemini OAuth chat - same structural pattern, will be a separate PR.
- Rare mid-stream token expiry edge case: if a token dies partway through a streaming response, the current fallback restarts the request and the UI would see the stream restart. Very rare (tokens valid for ~1h; we refresh proactively before dispatch).
- Unit tests for the new route - separate PR.

## Test plan

- [x] Build passes on iOS Simulator (iPhone 17 Pro Max, iOS 26.4)
- [x] Single-note chat with OpenAI OAuth
- [x] Cross-note search from chat with OpenAI OAuth
- [ ] Multi-note chat with OpenAI OAuth
- [ ] Smart Search chat with OpenAI OAuth
- [ ] Web search from chat with OpenAI OAuth
- [ ] Cancellation mid-stream
- [ ] Fallback to API key when OAuth token is invalid
- [ ] No regression for OpenAI API-key-only accounts
- [ ] No regression for single-turn transcription enhancement over OpenAI OAuth