### PR TITLE
Support chat for Gemini OAuth via Cloud Code Assist

### DIFF
--- a/VivaDicta/Services/AIEnhance/AIService+Chat.swift
+++ b/VivaDicta/Services/AIEnhance/AIService+Chat.swift
@@ -155,10 +155,33 @@ extension AIService {
                 throw EnhancementError.customError(error.errorDescription ?? "OpenAI OAuth error")
             }
 
-        case nil:
-            if provider == .gemini && isGeminiSignedIn && provider.apiKey == nil {
-                throw EnhancementError.customError("Chat is not yet supported with Gemini OAuth. Please add a Gemini API key to use chat.")
+        case .geminiOAuth:
+            do {
+                let oauthProvider = GeminiOAuthProvider()
+                let (token, _, projectId) = try await OAuthManager.shared.validAccessToken(for: oauthProvider)
+                return try await GeminiAPIClient.chatStreaming(
+                    systemMessage: systemMessage,
+                    messages: messages,
+                    model: model,
+                    accessToken: token,
+                    projectId: projectId,
+                    onPartialResponse: onPartialResponse
+                )
+            } catch let error as OAuthError {
+                if let apiKey = provider.apiKey {
+                    return try await makeOpenAIChatStreamingRequest(
+                        url: URL(string: provider.baseURL)!,
+                        model: model,
+                        systemMessage: systemMessage,
+                        messages: messages,
+                        headers: ["Authorization": "Bearer \(apiKey)"],
+                        onPartialResponse: onPartialResponse
+                    )
+                }
+                throw EnhancementError.customError(error.errorDescription ?? "Gemini OAuth error")
             }
+
+        case nil:
             // Fallback to non-streaming
             let result = try await makeChatRequest(
                 provider: provider,
@@ -215,6 +238,31 @@ extension AIService {
                     )
                 }
                 throw EnhancementError.customError(error.errorDescription ?? "OpenAI OAuth error")
+            }
+
+        case .gemini where isGeminiSignedIn:
+            do {
+                let oauthProvider = GeminiOAuthProvider()
+                let (token, _, projectId) = try await OAuthManager.shared.validAccessToken(for: oauthProvider)
+                return try await GeminiAPIClient.chat(
+                    systemMessage: systemMessage,
+                    messages: messages,
+                    model: model,
+                    accessToken: token,
+                    projectId: projectId
+                )
+            } catch let error as OAuthError {
+                if let apiKey = provider.apiKey {
+                    let (url, headers) = (URL(string: provider.baseURL)!, ["Authorization": "Bearer \(apiKey)"])
+                    return try await makeOpenAIChatNonStreamingRequest(
+                        url: url,
+                        model: model,
+                        systemMessage: systemMessage,
+                        messages: messages,
+                        headers: headers
+                    )
+                }
+                throw EnhancementError.customError(error.errorDescription ?? "Gemini OAuth error")
             }
 
         default:
@@ -301,7 +349,7 @@ extension AIService {
     // MARK: - Private Helpers
 
     private enum ChatStreamingRoute {
-        case anthropic, openAICompatibleCloud, copilot, ollama, customOpenAI, openAIOAuth
+        case anthropic, openAICompatibleCloud, copilot, ollama, customOpenAI, openAIOAuth, geminiOAuth
     }
 
     private func chatStreamingRoute(for provider: AIProvider, model: String) -> ChatStreamingRoute? {
@@ -317,6 +365,14 @@ extension AIService {
         case .openAI:
             if isOpenAISignedIn {
                 return .openAIOAuth
+            }
+            if provider.supportsResponseStreaming(model: model), provider.apiKey != nil {
+                return .openAICompatibleCloud
+            }
+            return nil
+        case .gemini:
+            if isGeminiSignedIn {
+                return .geminiOAuth
             }
             if provider.supportsResponseStreaming(model: model), provider.apiKey != nil {
                 return .openAICompatibleCloud

--- a/VivaDicta/Services/OAuth/GeminiAPIClient.swift
+++ b/VivaDicta/Services/OAuth/GeminiAPIClient.swift
@@ -392,6 +392,9 @@ enum GeminiAPIClient {
 
         var aggregatedText = ""
         var bufferedDataLines: [String] = []
+        var eventCount = 0
+        var firstEventLogged = false
+        var lastEventPayload: String?
 
         for try await line in bytes.lines {
             try Task.checkCancellation()
@@ -405,12 +408,32 @@ enum GeminiAPIClient {
                 continue
             }
 
+            if !bufferedDataLines.isEmpty {
+                eventCount += 1
+                let payload = bufferedDataLines.joined(separator: "\n")
+                if !firstEventLogged {
+                    logger.logInfo("Gemini OAuth chat: first SSE event: \(payload.prefix(500))")
+                    firstEventLogged = true
+                }
+                lastEventPayload = payload
+            }
+
             aggregatedText = try await processStreamChunk(
                 bufferedDataLines,
                 currentAggregatedText: aggregatedText,
                 onPartialResult: onPartialResponse
             )
             bufferedDataLines.removeAll(keepingCapacity: true)
+        }
+
+        if !bufferedDataLines.isEmpty {
+            eventCount += 1
+            let payload = bufferedDataLines.joined(separator: "\n")
+            if !firstEventLogged {
+                logger.logInfo("Gemini OAuth chat: first SSE event: \(payload.prefix(500))")
+                firstEventLogged = true
+            }
+            lastEventPayload = payload
         }
 
         aggregatedText = try await processStreamChunk(
@@ -420,6 +443,7 @@ enum GeminiAPIClient {
         )
 
         guard !aggregatedText.isEmpty else {
+            logger.logError("Gemini OAuth chat: empty aggregated text after \(eventCount) event(s). Last event: \(lastEventPayload?.prefix(1000) ?? "none")")
             throw OAuthError.invalidResponse
         }
 

--- a/VivaDicta/Services/OAuth/GeminiAPIClient.swift
+++ b/VivaDicta/Services/OAuth/GeminiAPIClient.swift
@@ -391,56 +391,52 @@ enum GeminiAPIClient {
         }
 
         var aggregatedText = ""
-        var bufferedDataLines: [String] = []
         var eventCount = 0
         var firstEventLogged = false
         var lastEventPayload: String?
 
+        // Cloud Code Assist streams each SSE event as one complete JSON object
+        // on its own `data:` line, without always emitting the blank-line
+        // separators SSE uses to demarcate events. Observed on
+        // gemini-3-flash-preview: many `data:` lines arrive back-to-back with
+        // no blanks, each a self-contained JSON delta. Parsing each line
+        // immediately (rather than buffering until a blank line) handles both
+        // the well-separated and the no-blank-line cases, and also gives
+        // proper token-by-token streaming in the UI.
         for try await line in bytes.lines {
             try Task.checkCancellation()
 
-            if line.hasPrefix("data: ") {
-                bufferedDataLines.append(String(line.dropFirst(6)))
-                continue
-            }
+            guard line.hasPrefix("data: ") else { continue }
 
-            guard line.isEmpty else {
-                continue
-            }
+            let payload = String(line.dropFirst(6)).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !payload.isEmpty else { continue }
 
-            if !bufferedDataLines.isEmpty {
-                eventCount += 1
-                let payload = bufferedDataLines.joined(separator: "\n")
-                if !firstEventLogged {
-                    logger.logInfo("Gemini OAuth chat: first SSE event: \(payload.prefix(500))")
-                    firstEventLogged = true
-                }
-                lastEventPayload = payload
-            }
-
-            aggregatedText = try await processStreamChunk(
-                bufferedDataLines,
-                currentAggregatedText: aggregatedText,
-                onPartialResult: onPartialResponse
-            )
-            bufferedDataLines.removeAll(keepingCapacity: true)
-        }
-
-        if !bufferedDataLines.isEmpty {
             eventCount += 1
-            let payload = bufferedDataLines.joined(separator: "\n")
             if !firstEventLogged {
                 logger.logInfo("Gemini OAuth chat: first SSE event: \(payload.prefix(500))")
                 firstEventLogged = true
             }
             lastEventPayload = payload
-        }
 
-        aggregatedText = try await processStreamChunk(
-            bufferedDataLines,
-            currentAggregatedText: aggregatedText,
-            onPartialResult: onPartialResponse
-        )
+            guard let data = payload.data(using: .utf8),
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                continue
+            }
+
+            if let error = json["error"] as? [String: Any],
+               let message = error["message"] as? String {
+                throw EnhancementError.customError(message)
+            }
+
+            if let chunkText = streamingText(from: json) {
+                if chunkText.hasPrefix(aggregatedText) {
+                    aggregatedText = chunkText
+                } else {
+                    aggregatedText += chunkText
+                }
+                await onPartialResponse(aggregatedText)
+            }
+        }
 
         guard !aggregatedText.isEmpty else {
             logger.logError("Gemini OAuth chat: empty aggregated text after \(eventCount) event(s). Last event: \(lastEventPayload?.prefix(1000) ?? "none")")

--- a/VivaDicta/Services/OAuth/GeminiAPIClient.swift
+++ b/VivaDicta/Services/OAuth/GeminiAPIClient.swift
@@ -297,4 +297,178 @@ enum GeminiAPIClient {
         let text = parts.compactMap { $0["text"] as? String }.joined()
         return text.isEmpty ? nil : text
     }
+
+    // MARK: - Multi-turn chat
+
+    /// Multi-turn streaming chat over the Cloud Code Assist backend.
+    ///
+    /// - Parameter messages: conversation turns as `[{"role": "user"|"assistant", "content": "..."}]`.
+    ///   System entries are ignored; the system prompt goes into `systemInstruction`.
+    ///   The `assistant` role is translated to Gemini's `model` role.
+    static func chatStreaming(
+        systemMessage: String,
+        messages: [[String: String]],
+        model: String,
+        accessToken: String,
+        projectId: String?,
+        onPartialResponse: @escaping @MainActor (String) -> Void
+    ) async throws -> String {
+        guard let url = URL(string: streamingEndpoint) else {
+            throw OAuthError.invalidResponse
+        }
+
+        let effectiveModel = resolveModel(model)
+        let contents = buildChatContents(messages: messages)
+        logger.logInfo(
+            "Gemini OAuth chat: model='\(effectiveModel)' turns=\(contents.count) instructionsChars=\(systemMessage.count) projectId=\(projectId ?? "none")"
+        )
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addValue("text/event-stream", forHTTPHeaderField: "Accept")
+        request.addValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.addValue("google-cloud-sdk vscode_cloudshelleditor/0.1", forHTTPHeaderField: "User-Agent")
+        request.addValue("gl-node/22.17.0", forHTTPHeaderField: "X-Goog-Api-Client")
+        request.timeoutInterval = 300
+
+        var requestBody: [String: Any] = [
+            "model": effectiveModel,
+            "userAgent": "vivadicta",
+            "request": [
+                "contents": contents,
+                "systemInstruction": [
+                    "parts": [["text": systemMessage]]
+                ],
+                "generationConfig": [
+                    "maxOutputTokens": 8192
+                ]
+            ]
+        ]
+
+        if let projectId {
+            requestBody["project"] = projectId
+        }
+
+        request.httpBody = try? JSONSerialization.data(withJSONObject: requestBody)
+
+        try Task.checkCancellation()
+
+        let (bytes, response) = try await URLSession.shared.bytes(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw OAuthError.invalidResponse
+        }
+
+        guard httpResponse.statusCode == 200 else {
+            var errorData = Data()
+            for try await byte in bytes {
+                errorData.append(byte)
+            }
+            let errorBody = String(data: errorData, encoding: .utf8) ?? "Unknown error"
+            logger.logError("Gemini OAuth chat error: HTTP \(httpResponse.statusCode) - \(errorBody)")
+
+            // Only auth failures should trigger the API-key fallback in callers.
+            // Rate limits and server errors are transient - surface them directly
+            // so the user sees a meaningful message and their API key quota is
+            // not silently burned on unrelated backend blips.
+            switch httpResponse.statusCode {
+            case 401, 403:
+                throw OAuthError.tokenExchangeFailed("HTTP \(httpResponse.statusCode): \(errorBody)")
+            case 429:
+                if let errorData = errorBody.data(using: .utf8),
+                   let errorJson = try? JSONSerialization.jsonObject(with: errorData) as? [String: Any],
+                   let error = errorJson["error"] as? [String: Any],
+                   let message = error["message"] as? String {
+                    throw EnhancementError.customError("Gemini rate limit reached. \(message)")
+                }
+                throw EnhancementError.rateLimitExceeded
+            case 500...599:
+                throw EnhancementError.serverError
+            default:
+                throw EnhancementError.customError("Gemini error (HTTP \(httpResponse.statusCode)): \(errorBody)")
+            }
+        }
+
+        var aggregatedText = ""
+        var bufferedDataLines: [String] = []
+
+        for try await line in bytes.lines {
+            try Task.checkCancellation()
+
+            if line.hasPrefix("data: ") {
+                bufferedDataLines.append(String(line.dropFirst(6)))
+                continue
+            }
+
+            guard line.isEmpty else {
+                continue
+            }
+
+            aggregatedText = try await processStreamChunk(
+                bufferedDataLines,
+                currentAggregatedText: aggregatedText,
+                onPartialResult: onPartialResponse
+            )
+            bufferedDataLines.removeAll(keepingCapacity: true)
+        }
+
+        aggregatedText = try await processStreamChunk(
+            bufferedDataLines,
+            currentAggregatedText: aggregatedText,
+            onPartialResult: onPartialResponse
+        )
+
+        guard !aggregatedText.isEmpty else {
+            throw OAuthError.invalidResponse
+        }
+
+        let trimmed = aggregatedText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let filtered = AIEnhancementOutputFilter.filter(trimmed)
+        if filtered != aggregatedText {
+            await onPartialResponse(filtered)
+        }
+        return filtered
+    }
+
+    /// Multi-turn non-streaming chat. Implemented by buffering the streaming helper.
+    static func chat(
+        systemMessage: String,
+        messages: [[String: String]],
+        model: String,
+        accessToken: String,
+        projectId: String?
+    ) async throws -> String {
+        try await chatStreaming(
+            systemMessage: systemMessage,
+            messages: messages,
+            model: model,
+            accessToken: accessToken,
+            projectId: projectId,
+            onPartialResponse: { _ in }
+        )
+    }
+
+    /// Converts a flat `[{role, content}]` chat list into Gemini `contents` items.
+    /// System entries are dropped - the system prompt must be sent as `systemInstruction`.
+    /// Gemini uses `"model"` for the assistant role (not `"assistant"`).
+    private static func buildChatContents(messages: [[String: String]]) -> [[String: Any]] {
+        var items: [[String: Any]] = []
+        for message in messages {
+            guard let role = message["role"],
+                  let content = message["content"],
+                  !content.isEmpty,
+                  role != "system" else {
+                continue
+            }
+
+            let geminiRole = (role == "assistant") ? "model" : role
+
+            items.append([
+                "role": geminiRole,
+                "parts": [["text": content]]
+            ])
+        }
+        return items
+    }
 }

--- a/documentation/RAG/Tool-Provider-Support.md
+++ b/documentation/RAG/Tool-Provider-Support.md
@@ -102,7 +102,7 @@ Relevant code:
 | Ollama | Yes | Yes | Yes | Yes | Yes | No | Routed through local OpenAI-compatible chat path. |
 | Custom OpenAI | Yes | Yes | Yes | Yes | Yes | No | Routed through custom OpenAI-compatible endpoint. |
 | OpenAI OAuth only | Yes | Yes (planner) | Yes (planner) | No | Yes | No | Routed through Codex Responses backend. Implicit tool-calling deferred. |
-| Gemini OAuth only | No | No | No | No | No | No | Chat is explicitly blocked today. |
+| Gemini OAuth only | Yes | Yes (planner) | Yes (planner) | No | Yes | No | Routed through Cloud Code Assist backend. Implicit tool-calling deferred. |
 
 ## Providers Not Covered By Chat Tools
 
@@ -136,16 +136,18 @@ Apple has the richest tool integration:
 
 ### 3. OAuth is different from API key support
 
-OpenAI OAuth-only chat routes through the Codex Responses backend (`chatgpt.com/backend-api/codex/responses`) with a structured `input` body, not the standard Chat Completions `messages` body. Planner-based tool paths that call `makeChatRequest(...)` work because planners decode JSON from a plain text response. Implicit tool calling during normal chat (the `tools` + `tool_choice: "auto"` path) is not yet implemented for OAuth and is deferred.
+OpenAI OAuth-only chat routes through the Codex Responses backend (`chatgpt.com/backend-api/codex/responses`) with a structured `input` body, not the standard Chat Completions `messages` body.
 
-Gemini OAuth-only chat is still blocked in the transport layer.
+Gemini OAuth-only chat routes through the Cloud Code Assist backend (`cloudcode-pa.googleapis.com/v1internal:streamGenerateContent`) with Gemini-native `contents` + `systemInstruction`, not the OpenAI-compatible shim.
+
+Planner-based tool paths that call `makeChatRequest(...)` work on both because planners decode JSON from a plain text response. Implicit tool calling during normal chat (the `tools` + `tool_choice: "auto"` path) is not yet implemented for either OAuth path and is deferred.
 
 That means:
 
 - OpenAI API key chat tools: supported
 - OpenAI OAuth-only chat tools: planner-based tools supported, implicit chat tool-calling not yet supported
 - Gemini API key chat tools: supported
-- Gemini OAuth-only chat tools: not supported
+- Gemini OAuth-only chat tools: planner-based tools supported, implicit chat tool-calling not yet supported
 
 ## Key Source Files
 


### PR DESCRIPTION
## Summary

- Gemini-OAuth-only users can now chat in single-note, multi-note, and Smart Search surfaces without adding an API key
- Chat routes through the Cloud Code Assist backend (`cloudcode-pa.googleapis.com/v1internal:streamGenerateContent`) that the app already uses for transcription enhancement over Gemini OAuth
- Request body is Gemini-native: `contents` + `systemInstruction` + `generationConfig`, wrapped in the Cloud Code Assist `request` envelope with `project` when a project ID is available
- Mirrors the OpenAI OAuth chat PR (#223) in architecture and error handling

## Changes

- `GeminiAPIClient` gains `chatStreaming(...)`, `chat(...)`, and a private `buildChatContents(...)` helper. Existing `enhance(...)` / `enhanceStreaming(...)` behavior unchanged.
- Role mapping: `assistant` → `model` (Gemini's convention). System entries dropped from `contents` - system prompt goes into top-level `systemInstruction`.
- `AIService+Chat.swift` adds `.geminiOAuth` to `ChatStreamingRoute` and branches in both `makeChatStreamingRequest` and `makeChatRequest`. Removes the "Chat is not yet supported with Gemini OAuth" error.
- HTTP errors are classified: 401/403 → `OAuthError` (fallback fires), 429 → `EnhancementError.rateLimitExceeded` (preserves Google's error message when available), 5xx → `EnhancementError.serverError`, other → `EnhancementError.customError`. Same pattern as the OpenAI OAuth PR.
- Auto-fallback to API key on `OAuthError` when both OAuth and an API key are configured.
- Chat output runs through `AIEnhancementOutputFilter.filter(...)` to match the API-key path.
- `documentation/RAG/Tool-Provider-Support.md` updated to reflect the new Gemini OAuth chat capability.

## Behavior change to note

Previously, a user with both Gemini OAuth and an API key got the API-key chat path. After this PR, they get OAuth chat. Matches how enhancement already behaves and how OpenAI OAuth chat shipped in #223. API key remains the automatic fallback when OAuth errors out.

## Deferred

- Implicit mid-chat tool-calling for Gemini OAuth (`makeCrossNoteSearchToolDecision`, `makeWebSearchToolDecision`). The existing catch blocks in chat view models silently skip implicit tools on error, so OAuth users just don't get them - no user-visible breakage.
- Unit tests for the new route - separate PR.

## Test plan

- [x] Build passes on iOS Simulator (iPhone 17 Pro Max, iOS 26.4)
- [ ] Single-note chat with Gemini OAuth
- [ ] Multi-note chat with Gemini OAuth
- [ ] Smart Search chat with Gemini OAuth
- [ ] Cross-note search from chat with Gemini OAuth
- [ ] Web search from chat with Gemini OAuth
- [ ] Cancellation mid-stream
- [ ] Fallback to API key when OAuth token is invalid
- [ ] No regression for Gemini API-key-only accounts
- [ ] No regression for single-turn transcription enhancement over Gemini OAuth