### PR TITLE
Add per-mode Obsidian append integration

### DIFF
--- a/VivaDicta.xcodeproj/project.pbxproj
+++ b/VivaDicta.xcodeproj/project.pbxproj
@@ -335,6 +335,7 @@
 				Shared/AppGroupCoordinator.swift,
 				Shared/KeyboardLayoutStyle.swift,
 				Shared/MicButton.swift,
+				Shared/ObsidianURLBuilder.swift,
 				Shared/RecentNotesCache.swift,
 				Shared/RecordingState.swift,
 				Shared/RippleEffect.metal,

--- a/VivaDicta/Services/AIEnhance/VivaMode.swift
+++ b/VivaDicta/Services/AIEnhance/VivaMode.swift
@@ -82,14 +82,8 @@ struct VivaMode: Identifiable, Hashable, Codable {
     /// Whether to append the transcription to an Obsidian note after completion.
     var obsidianEnabled: Bool
 
-    /// Optional Obsidian vault name. Empty = use last-opened vault.
-    var obsidianVault: String
-
-    /// Template for the Obsidian note filename. Placeholders: {date}, {yyyy}, {MM}, {dd}, {preset}, {mode}.
+    /// Template for the Obsidian note filename. Placeholders: {date}, {yyyy}, {MM}, {dd}, {HH}, {mm}, {ss}, {preset}, {mode}.
     var obsidianNoteTemplate: String
-
-    /// Prefix prepended to each appended line. Placeholders: {time}, {date}, {preset}.
-    var obsidianLinePrefix: String
 
     /// Creates a new VivaMode with the specified settings.
     init(id: UUID,
@@ -107,9 +101,7 @@ struct VivaMode: Identifiable, Hashable, Codable {
          isAutoTextFormattingEnabled: Bool = false,
          isSmartInsertEnabled: Bool = false,
          obsidianEnabled: Bool = false,
-         obsidianVault: String = "",
-         obsidianNoteTemplate: String = "VD {date} {HH}-{mm}-{ss}",
-         obsidianLinePrefix: String = "") {
+         obsidianNoteTemplate: String = "VD {date} {HH}-{mm}-{ss}") {
         self.id = id
         self.name = name
         self.transcriptionProvider = transcriptionProvider
@@ -125,9 +117,7 @@ struct VivaMode: Identifiable, Hashable, Codable {
         self.isAutoTextFormattingEnabled = isAutoTextFormattingEnabled
         self.isSmartInsertEnabled = isSmartInsertEnabled
         self.obsidianEnabled = obsidianEnabled
-        self.obsidianVault = obsidianVault
         self.obsidianNoteTemplate = obsidianNoteTemplate
-        self.obsidianLinePrefix = obsidianLinePrefix
     }
 
     // MARK: - Backward-Compatible Decoding
@@ -149,9 +139,7 @@ struct VivaMode: Identifiable, Hashable, Codable {
         isAutoTextFormattingEnabled = try container.decodeIfPresent(Bool.self, forKey: .isAutoTextFormattingEnabled) ?? true
         isSmartInsertEnabled = try container.decodeIfPresent(Bool.self, forKey: .isSmartInsertEnabled) ?? true
         obsidianEnabled = try container.decodeIfPresent(Bool.self, forKey: .obsidianEnabled) ?? false
-        obsidianVault = try container.decodeIfPresent(String.self, forKey: .obsidianVault) ?? ""
         obsidianNoteTemplate = try container.decodeIfPresent(String.self, forKey: .obsidianNoteTemplate) ?? "VD {date} {HH}-{mm}-{ss}"
-        obsidianLinePrefix = try container.decodeIfPresent(String.self, forKey: .obsidianLinePrefix) ?? ""
 
         // Try new format first
         if let preset = try container.decodeIfPresent(String.self, forKey: .presetId) {
@@ -173,7 +161,7 @@ struct VivaMode: Identifiable, Hashable, Codable {
         case aiProvider, aiModel, reminderExtractorProvider, reminderExtractorModel, aiEnhanceEnabled
         case useClipboardContext
         case isAutoTextFormattingEnabled, isSmartInsertEnabled
-        case obsidianEnabled, obsidianVault, obsidianNoteTemplate, obsidianLinePrefix
+        case obsidianEnabled, obsidianNoteTemplate
     }
 
     /// Encodes using the new format only (presetId).
@@ -194,9 +182,7 @@ struct VivaMode: Identifiable, Hashable, Codable {
         try container.encode(isAutoTextFormattingEnabled, forKey: .isAutoTextFormattingEnabled)
         try container.encode(isSmartInsertEnabled, forKey: .isSmartInsertEnabled)
         try container.encode(obsidianEnabled, forKey: .obsidianEnabled)
-        try container.encode(obsidianVault, forKey: .obsidianVault)
         try container.encode(obsidianNoteTemplate, forKey: .obsidianNoteTemplate)
-        try container.encode(obsidianLinePrefix, forKey: .obsidianLinePrefix)
     }
 
     /// The default mode used when no custom mode is configured.

--- a/VivaDicta/Services/AIEnhance/VivaMode.swift
+++ b/VivaDicta/Services/AIEnhance/VivaMode.swift
@@ -108,8 +108,8 @@ struct VivaMode: Identifiable, Hashable, Codable {
          isSmartInsertEnabled: Bool = false,
          obsidianEnabled: Bool = false,
          obsidianVault: String = "",
-         obsidianNoteTemplate: String = "{date}",
-         obsidianLinePrefix: String = "- {time} ") {
+         obsidianNoteTemplate: String = "VD {date} {HH}-{mm}-{ss}",
+         obsidianLinePrefix: String = "") {
         self.id = id
         self.name = name
         self.transcriptionProvider = transcriptionProvider
@@ -150,8 +150,8 @@ struct VivaMode: Identifiable, Hashable, Codable {
         isSmartInsertEnabled = try container.decodeIfPresent(Bool.self, forKey: .isSmartInsertEnabled) ?? true
         obsidianEnabled = try container.decodeIfPresent(Bool.self, forKey: .obsidianEnabled) ?? false
         obsidianVault = try container.decodeIfPresent(String.self, forKey: .obsidianVault) ?? ""
-        obsidianNoteTemplate = try container.decodeIfPresent(String.self, forKey: .obsidianNoteTemplate) ?? "{date}"
-        obsidianLinePrefix = try container.decodeIfPresent(String.self, forKey: .obsidianLinePrefix) ?? "- {time} "
+        obsidianNoteTemplate = try container.decodeIfPresent(String.self, forKey: .obsidianNoteTemplate) ?? "VD {date} {HH}-{mm}-{ss}"
+        obsidianLinePrefix = try container.decodeIfPresent(String.self, forKey: .obsidianLinePrefix) ?? ""
 
         // Try new format first
         if let preset = try container.decodeIfPresent(String.self, forKey: .presetId) {

--- a/VivaDicta/Services/AIEnhance/VivaMode.swift
+++ b/VivaDicta/Services/AIEnhance/VivaMode.swift
@@ -79,6 +79,18 @@ struct VivaMode: Identifiable, Hashable, Codable {
     /// Whether smart insert (auto-adjust spacing and capitalization) is applied when inserting text via keyboard.
     let isSmartInsertEnabled: Bool
 
+    /// Whether to append the transcription to an Obsidian note after completion.
+    var obsidianEnabled: Bool
+
+    /// Optional Obsidian vault name. Empty = use last-opened vault.
+    var obsidianVault: String
+
+    /// Template for the Obsidian note filename. Placeholders: {date}, {yyyy}, {MM}, {dd}, {preset}, {mode}.
+    var obsidianNoteTemplate: String
+
+    /// Prefix prepended to each appended line. Placeholders: {time}, {date}, {preset}.
+    var obsidianLinePrefix: String
+
     /// Creates a new VivaMode with the specified settings.
     init(id: UUID,
          name: String,
@@ -93,7 +105,11 @@ struct VivaMode: Identifiable, Hashable, Codable {
          aiEnhanceEnabled: Bool,
          useClipboardContext: Bool = false,
          isAutoTextFormattingEnabled: Bool = false,
-         isSmartInsertEnabled: Bool = false) {
+         isSmartInsertEnabled: Bool = false,
+         obsidianEnabled: Bool = false,
+         obsidianVault: String = "",
+         obsidianNoteTemplate: String = "{date}",
+         obsidianLinePrefix: String = "- {time} ") {
         self.id = id
         self.name = name
         self.transcriptionProvider = transcriptionProvider
@@ -108,6 +124,10 @@ struct VivaMode: Identifiable, Hashable, Codable {
         self.useClipboardContext = useClipboardContext
         self.isAutoTextFormattingEnabled = isAutoTextFormattingEnabled
         self.isSmartInsertEnabled = isSmartInsertEnabled
+        self.obsidianEnabled = obsidianEnabled
+        self.obsidianVault = obsidianVault
+        self.obsidianNoteTemplate = obsidianNoteTemplate
+        self.obsidianLinePrefix = obsidianLinePrefix
     }
 
     // MARK: - Backward-Compatible Decoding
@@ -128,6 +148,10 @@ struct VivaMode: Identifiable, Hashable, Codable {
         useClipboardContext = try container.decodeIfPresent(Bool.self, forKey: .useClipboardContext) ?? false
         isAutoTextFormattingEnabled = try container.decodeIfPresent(Bool.self, forKey: .isAutoTextFormattingEnabled) ?? true
         isSmartInsertEnabled = try container.decodeIfPresent(Bool.self, forKey: .isSmartInsertEnabled) ?? true
+        obsidianEnabled = try container.decodeIfPresent(Bool.self, forKey: .obsidianEnabled) ?? false
+        obsidianVault = try container.decodeIfPresent(String.self, forKey: .obsidianVault) ?? ""
+        obsidianNoteTemplate = try container.decodeIfPresent(String.self, forKey: .obsidianNoteTemplate) ?? "{date}"
+        obsidianLinePrefix = try container.decodeIfPresent(String.self, forKey: .obsidianLinePrefix) ?? "- {time} "
 
         // Try new format first
         if let preset = try container.decodeIfPresent(String.self, forKey: .presetId) {
@@ -149,6 +173,7 @@ struct VivaMode: Identifiable, Hashable, Codable {
         case aiProvider, aiModel, reminderExtractorProvider, reminderExtractorModel, aiEnhanceEnabled
         case useClipboardContext
         case isAutoTextFormattingEnabled, isSmartInsertEnabled
+        case obsidianEnabled, obsidianVault, obsidianNoteTemplate, obsidianLinePrefix
     }
 
     /// Encodes using the new format only (presetId).
@@ -168,6 +193,10 @@ struct VivaMode: Identifiable, Hashable, Codable {
         try container.encode(useClipboardContext, forKey: .useClipboardContext)
         try container.encode(isAutoTextFormattingEnabled, forKey: .isAutoTextFormattingEnabled)
         try container.encode(isSmartInsertEnabled, forKey: .isSmartInsertEnabled)
+        try container.encode(obsidianEnabled, forKey: .obsidianEnabled)
+        try container.encode(obsidianVault, forKey: .obsidianVault)
+        try container.encode(obsidianNoteTemplate, forKey: .obsidianNoteTemplate)
+        try container.encode(obsidianLinePrefix, forKey: .obsidianLinePrefix)
     }
 
     /// The default mode used when no custom mode is configured.

--- a/VivaDicta/Shared/ObsidianURLBuilder.swift
+++ b/VivaDicta/Shared/ObsidianURLBuilder.swift
@@ -1,0 +1,98 @@
+//
+//  ObsidianURLBuilder.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.24
+//
+
+import Foundation
+
+/// Builds the clipboard payload and `obsidian://new` URL used to append a
+/// transcription to an Obsidian note. Shared between the main app and the
+/// keyboard extension so both hand-off paths produce identical behaviour.
+enum ObsidianURLBuilder {
+
+    struct Output {
+        /// Text to place on the pasteboard before opening Obsidian. Includes
+        /// the line prefix + trailing newline so repeated appends stack as
+        /// separate lines.
+        let clipboardText: String
+
+        /// The fully-formed `obsidian://new?...` URL.
+        let url: URL
+    }
+
+    /// Build the clipboard text + Obsidian URL for a transcription.
+    ///
+    /// - Parameters:
+    ///   - text: The final transcription text (enhanced if AI ran, else raw).
+    ///   - mode: The active `VivaMode` carrying the Obsidian configuration.
+    ///   - presetName: Human-readable preset name for the `{preset}` placeholder.
+    ///   - date: The moment the transcription completed. Parameterised for testability.
+    /// - Returns: `nil` if the resulting note name is empty or the URL cannot
+    ///   be constructed. Callers should treat `nil` as a no-op.
+    static func build(text: String,
+                      mode: VivaMode,
+                      presetName: String?,
+                      date: Date = Date()) -> Output? {
+        let noteName = expand(template: mode.obsidianNoteTemplate,
+                              date: date,
+                              presetName: presetName,
+                              modeName: mode.name,
+                              includeTime: false)
+        guard !noteName.isEmpty else { return nil }
+
+        let prefix = expand(template: mode.obsidianLinePrefix,
+                            date: date,
+                            presetName: presetName,
+                            modeName: mode.name,
+                            includeTime: true)
+
+        let clipboardText = prefix + text + "\n"
+
+        var components = URLComponents()
+        components.scheme = "obsidian"
+        components.host = "new"
+        var items: [URLQueryItem] = [
+            URLQueryItem(name: "file", value: noteName),
+            URLQueryItem(name: "clipboard", value: nil),
+            URLQueryItem(name: "append", value: "true")
+        ]
+        let vault = mode.obsidianVault.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !vault.isEmpty {
+            items.append(URLQueryItem(name: "vault", value: vault))
+        }
+        components.queryItems = items
+
+        guard let url = components.url else { return nil }
+        return Output(clipboardText: clipboardText, url: url)
+    }
+
+    private static func expand(template: String,
+                               date: Date,
+                               presetName: String?,
+                               modeName: String,
+                               includeTime: Bool) -> String {
+        var result = template
+        let calendar = Calendar.current
+        let components = calendar.dateComponents([.year, .month, .day, .hour, .minute], from: date)
+        let year = String(format: "%04d", components.year ?? 0)
+        let month = String(format: "%02d", components.month ?? 0)
+        let day = String(format: "%02d", components.day ?? 0)
+        let hour = String(format: "%02d", components.hour ?? 0)
+        let minute = String(format: "%02d", components.minute ?? 0)
+
+        result = result.replacing("{date}", with: "\(year)-\(month)-\(day)")
+        result = result.replacing("{yyyy}", with: year)
+        result = result.replacing("{MM}", with: month)
+        result = result.replacing("{dd}", with: day)
+        if includeTime {
+            result = result.replacing("{time}", with: "\(hour):\(minute)")
+            result = result.replacing("{HH}", with: hour)
+            result = result.replacing("{mm}", with: minute)
+        }
+        result = result.replacing("{preset}", with: presetName ?? "")
+        result = result.replacing("{mode}", with: modeName)
+        return result
+    }
+}

--- a/VivaDicta/Shared/ObsidianURLBuilder.swift
+++ b/VivaDicta/Shared/ObsidianURLBuilder.swift
@@ -60,16 +60,20 @@ enum ObsidianURLBuilder {
                                date: Date,
                                presetName: String?,
                                modeName: String) -> String {
-        var result = template
-        let calendar = Calendar.current
-        let components = calendar.dateComponents([.year, .month, .day, .hour, .minute, .second], from: date)
-        let year = String(format: "%04d", components.year ?? 0)
-        let month = String(format: "%02d", components.month ?? 0)
-        let day = String(format: "%02d", components.day ?? 0)
-        let hour = String(format: "%02d", components.hour ?? 0)
-        let minute = String(format: "%02d", components.minute ?? 0)
-        let second = String(format: "%02d", components.second ?? 0)
+        // Force Gregorian so `{date}` is always YYYY-MM-DD regardless of the
+        // user's iOS calendar setting (Buddhist, Hebrew, etc. would otherwise
+        // shift the year value).
+        let gregorian = Calendar(identifier: .gregorian)
+        let components = gregorian.dateComponents([.year, .month, .day, .hour, .minute, .second], from: date)
+        let year = (components.year ?? 0).formatted(.number.grouping(.never).precision(.integerLength(4...)))
+        let twoDigits = IntegerFormatStyle<Int>.number.grouping(.never).precision(.integerLength(2...))
+        let month = (components.month ?? 0).formatted(twoDigits)
+        let day = (components.day ?? 0).formatted(twoDigits)
+        let hour = (components.hour ?? 0).formatted(twoDigits)
+        let minute = (components.minute ?? 0).formatted(twoDigits)
+        let second = (components.second ?? 0).formatted(twoDigits)
 
+        var result = template
         result = result.replacing("{date}", with: "\(year)-\(month)-\(day)")
         result = result.replacing("{yyyy}", with: year)
         result = result.replacing("{MM}", with: month)

--- a/VivaDicta/Shared/ObsidianURLBuilder.swift
+++ b/VivaDicta/Shared/ObsidianURLBuilder.swift
@@ -13,9 +13,9 @@ import Foundation
 enum ObsidianURLBuilder {
 
     struct Output {
-        /// Text to place on the pasteboard before opening Obsidian. Includes
-        /// the line prefix + trailing newline so repeated appends stack as
-        /// separate lines.
+        /// Text to place on the pasteboard before opening Obsidian. Trailing
+        /// newline ensures that if the user configures a repeating note name
+        /// (e.g. `{date}`), repeated appends stack as separate lines.
         let clipboardText: String
 
         /// The fully-formed `obsidian://new?...` URL.
@@ -38,31 +38,19 @@ enum ObsidianURLBuilder {
         let noteName = expand(template: mode.obsidianNoteTemplate,
                               date: date,
                               presetName: presetName,
-                              modeName: mode.name,
-                              includeTime: false)
+                              modeName: mode.name)
         guard !noteName.isEmpty else { return nil }
 
-        let prefix = expand(template: mode.obsidianLinePrefix,
-                            date: date,
-                            presetName: presetName,
-                            modeName: mode.name,
-                            includeTime: true)
-
-        let clipboardText = prefix + text + "\n"
+        let clipboardText = text + "\n"
 
         var components = URLComponents()
         components.scheme = "obsidian"
         components.host = "new"
-        var items: [URLQueryItem] = [
+        components.queryItems = [
             URLQueryItem(name: "file", value: noteName),
             URLQueryItem(name: "clipboard", value: nil),
             URLQueryItem(name: "append", value: "true")
         ]
-        let vault = mode.obsidianVault.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !vault.isEmpty {
-            items.append(URLQueryItem(name: "vault", value: vault))
-        }
-        components.queryItems = items
 
         guard let url = components.url else { return nil }
         return Output(clipboardText: clipboardText, url: url)
@@ -71,8 +59,7 @@ enum ObsidianURLBuilder {
     private static func expand(template: String,
                                date: Date,
                                presetName: String?,
-                               modeName: String,
-                               includeTime: Bool) -> String {
+                               modeName: String) -> String {
         var result = template
         let calendar = Calendar.current
         let components = calendar.dateComponents([.year, .month, .day, .hour, .minute, .second], from: date)
@@ -90,9 +77,6 @@ enum ObsidianURLBuilder {
         result = result.replacing("{HH}", with: hour)
         result = result.replacing("{mm}", with: minute)
         result = result.replacing("{ss}", with: second)
-        if includeTime {
-            result = result.replacing("{time}", with: "\(hour):\(minute)")
-        }
         result = result.replacing("{preset}", with: presetName ?? "")
         result = result.replacing("{mode}", with: modeName)
         return result

--- a/VivaDicta/Shared/ObsidianURLBuilder.swift
+++ b/VivaDicta/Shared/ObsidianURLBuilder.swift
@@ -75,21 +75,23 @@ enum ObsidianURLBuilder {
                                includeTime: Bool) -> String {
         var result = template
         let calendar = Calendar.current
-        let components = calendar.dateComponents([.year, .month, .day, .hour, .minute], from: date)
+        let components = calendar.dateComponents([.year, .month, .day, .hour, .minute, .second], from: date)
         let year = String(format: "%04d", components.year ?? 0)
         let month = String(format: "%02d", components.month ?? 0)
         let day = String(format: "%02d", components.day ?? 0)
         let hour = String(format: "%02d", components.hour ?? 0)
         let minute = String(format: "%02d", components.minute ?? 0)
+        let second = String(format: "%02d", components.second ?? 0)
 
         result = result.replacing("{date}", with: "\(year)-\(month)-\(day)")
         result = result.replacing("{yyyy}", with: year)
         result = result.replacing("{MM}", with: month)
         result = result.replacing("{dd}", with: day)
+        result = result.replacing("{HH}", with: hour)
+        result = result.replacing("{mm}", with: minute)
+        result = result.replacing("{ss}", with: second)
         if includeTime {
             result = result.replacing("{time}", with: "\(hour):\(minute)")
-            result = result.replacing("{HH}", with: hour)
-            result = result.replacing("{mm}", with: minute)
         }
         result = result.replacing("{preset}", with: presetName ?? "")
         result = result.replacing("{mode}", with: modeName)

--- a/VivaDicta/Views/RecordViewModel.swift
+++ b/VivaDicta/Views/RecordViewModel.swift
@@ -614,6 +614,8 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
                     ClipboardManager.copyToClipboard(textToShare)
                 }
 
+                self.openObsidianIfEnabled(text: textToShare, presetName: promptName)
+
                 HapticManager.heartbeat()
                 self.recordingState = .idle
                 self.aiService.clearCapturedClipboard()
@@ -778,6 +780,8 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
                         ClipboardManager.copyToClipboard(pending.text)
                     }
 
+                    self.openObsidianIfEnabled(text: pending.text, presetName: nil)
+
                     // Request app rating after successful transcription
                     RateAppManager.requestReviewIfAppropriate()
                 } catch {
@@ -800,6 +804,21 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
             // For other states, just use regular cancel (which also reschedules timeout)
             cancelTranscribe()
         }
+    }
+
+    /// If the active mode has Obsidian append enabled, copy the final text to
+    /// the clipboard and open `obsidian://new?...&clipboard&append=true` so
+    /// Obsidian appends it to the configured note.
+    private func openObsidianIfEnabled(text: String, presetName: String?) {
+        let mode = aiService.selectedMode
+        guard mode.obsidianEnabled else { return }
+        guard let output = ObsidianURLBuilder.build(text: text, mode: mode, presetName: presetName) else {
+            logger.logError("📱 Obsidian: failed to build URL for mode '\(mode.name)'")
+            return
+        }
+        ClipboardManager.copyToClipboard(output.clipboardText)
+        logger.logInfo("📱 Obsidian: opening \(output.url.absoluteString)")
+        UIApplication.shared.open(output.url)
     }
 
     private func saveNewTranscription(

--- a/VivaDicta/Views/SettingsScreen/ModeEditView.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditView.swift
@@ -756,10 +756,55 @@ struct ModeEditView: View {
                 }
             }
 
+            Section(header: obsidianSectionHeader,
+                    footer: obsidianSectionFooter) {
+                Toggle(isOn: $viewModel.obsidianEnabled) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Append to Obsidian")
+                            .font(.body)
+                        Text("After each transcription, open Obsidian and append the text to a note.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .onChange(of: viewModel.obsidianEnabled) { _, _ in
+                    HapticManager.selectionChanged()
+                }
+
+                if viewModel.obsidianEnabled {
+                    HStack {
+                        Text("Vault")
+                        Spacer()
+                        TextField("Default", text: $viewModel.obsidianVault)
+                            .multilineTextAlignment(.trailing)
+                            .autocorrectionDisabled()
+                            .textInputAutocapitalization(.never)
+                    }
+
+                    HStack {
+                        Text("Note name")
+                        Spacer()
+                        TextField("{date}", text: $viewModel.obsidianNoteTemplate)
+                            .multilineTextAlignment(.trailing)
+                            .autocorrectionDisabled()
+                            .textInputAutocapitalization(.never)
+                    }
+
+                    HStack {
+                        Text("Line prefix")
+                        Spacer()
+                        TextField("- {time} ", text: $viewModel.obsidianLinePrefix)
+                            .multilineTextAlignment(.trailing)
+                            .autocorrectionDisabled()
+                            .textInputAutocapitalization(.never)
+                    }
+                }
+            }
+
             if viewModel.isEditing {
                 if viewModel.isValid {
                     Section {
-                        
+
                         Button {
                             duplicateMode()
                         } label: {
@@ -917,6 +962,14 @@ struct ModeEditView: View {
                     }
             }
         }
+    }
+
+    private var obsidianSectionHeader: some View {
+        Text("Obsidian")
+    }
+
+    private var obsidianSectionFooter: some View {
+        Text("Placeholders: {date}, {yyyy}, {MM}, {dd}, {preset}, {mode} for the note name; {time}, {HH}, {mm} for the line prefix. The clipboard will be overwritten each time.")
     }
 
     private var reminderSuggestionsSectionHeader: some View {

--- a/VivaDicta/Views/SettingsScreen/ModeEditView.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditView.swift
@@ -784,7 +784,7 @@ struct ModeEditView: View {
                     HStack {
                         Text("Note name")
                         Spacer()
-                        TextField("{date}", text: $viewModel.obsidianNoteTemplate)
+                        TextField("VD {date} {HH}-{mm}-{ss}", text: $viewModel.obsidianNoteTemplate)
                             .multilineTextAlignment(.trailing)
                             .autocorrectionDisabled()
                             .textInputAutocapitalization(.never)
@@ -793,7 +793,7 @@ struct ModeEditView: View {
                     HStack {
                         Text("Line prefix")
                         Spacer()
-                        TextField("- {time} ", text: $viewModel.obsidianLinePrefix)
+                        TextField("Optional", text: $viewModel.obsidianLinePrefix)
                             .multilineTextAlignment(.trailing)
                             .autocorrectionDisabled()
                             .textInputAutocapitalization(.never)
@@ -969,7 +969,7 @@ struct ModeEditView: View {
     }
 
     private var obsidianSectionFooter: some View {
-        Text("Placeholders: {date}, {yyyy}, {MM}, {dd}, {preset}, {mode} for the note name; {time}, {HH}, {mm} for the line prefix. The clipboard will be overwritten each time.")
+        Text("A new Obsidian note is created for each transcription. Use {date}, {yyyy}, {MM}, {dd}, {HH}, {mm}, {ss}, {preset}, {mode} in the note name or line prefix. To instead append to a daily note, set the name to just {date}. The clipboard is overwritten each time.")
     }
 
     private var reminderSuggestionsSectionHeader: some View {

--- a/VivaDicta/Views/SettingsScreen/ModeEditView.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditView.swift
@@ -950,8 +950,11 @@ struct ModeEditView: View {
         Text("Obsidian")
     }
 
+    @ViewBuilder
     private var obsidianSectionFooter: some View {
-        Text("A new Obsidian note is created for each transcription. Placeholders: {date}, {yyyy}, {MM}, {dd}, {HH}, {mm}, {ss}, {preset}, {mode}. To instead append to a daily note, set the name to just {date}. The clipboard is overwritten each time.")
+        if viewModel.obsidianEnabled {
+            Text("A new Obsidian note is created for each transcription. Placeholders: {date}, {yyyy}, {MM}, {dd}, {HH}, {mm}, {ss}, {preset}, {mode}. To instead append to a daily note, set the name to just {date}. The clipboard is overwritten each time.")
+        }
     }
 
     private var reminderSuggestionsSectionHeader: some View {

--- a/VivaDicta/Views/SettingsScreen/ModeEditView.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditView.swift
@@ -773,27 +773,9 @@ struct ModeEditView: View {
 
                 if viewModel.obsidianEnabled {
                     HStack {
-                        Text("Vault")
-                        Spacer()
-                        TextField("Default", text: $viewModel.obsidianVault)
-                            .multilineTextAlignment(.trailing)
-                            .autocorrectionDisabled()
-                            .textInputAutocapitalization(.never)
-                    }
-
-                    HStack {
                         Text("Note name")
                         Spacer()
                         TextField("VD {date} {HH}-{mm}-{ss}", text: $viewModel.obsidianNoteTemplate)
-                            .multilineTextAlignment(.trailing)
-                            .autocorrectionDisabled()
-                            .textInputAutocapitalization(.never)
-                    }
-
-                    HStack {
-                        Text("Line prefix")
-                        Spacer()
-                        TextField("Optional", text: $viewModel.obsidianLinePrefix)
                             .multilineTextAlignment(.trailing)
                             .autocorrectionDisabled()
                             .textInputAutocapitalization(.never)
@@ -969,7 +951,7 @@ struct ModeEditView: View {
     }
 
     private var obsidianSectionFooter: some View {
-        Text("A new Obsidian note is created for each transcription. Use {date}, {yyyy}, {MM}, {dd}, {HH}, {mm}, {ss}, {preset}, {mode} in the note name or line prefix. To instead append to a daily note, set the name to just {date}. The clipboard is overwritten each time.")
+        Text("A new Obsidian note is created for each transcription. Placeholders: {date}, {yyyy}, {MM}, {dd}, {HH}, {mm}, {ss}, {preset}, {mode}. To instead append to a daily note, set the name to just {date}. The clipboard is overwritten each time.")
     }
 
     private var reminderSuggestionsSectionHeader: some View {

--- a/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
@@ -29,6 +29,11 @@ class ModeEditViewModel {
     var isAutoTextFormattingEnabled: Bool = false
     var isSmartInsertEnabled: Bool = false
 
+    var obsidianEnabled: Bool = false
+    var obsidianVault: String = ""
+    var obsidianNoteTemplate: String = "{date}"
+    var obsidianLinePrefix: String = "- {time} "
+
     let aiService: AIService
     private let transcriptionManager: TranscriptionManager
     let presetManager: PresetManager
@@ -185,6 +190,10 @@ class ModeEditViewModel {
             useClipboardContext = existingMode.useClipboardContext
             isAutoTextFormattingEnabled = existingMode.isAutoTextFormattingEnabled
             isSmartInsertEnabled = existingMode.isSmartInsertEnabled
+            obsidianEnabled = existingMode.obsidianEnabled
+            obsidianVault = existingMode.obsidianVault
+            obsidianNoteTemplate = existingMode.obsidianNoteTemplate
+            obsidianLinePrefix = existingMode.obsidianLinePrefix
 
             validateLanguageSelection()
             validateAIModelSelection()
@@ -225,7 +234,11 @@ class ModeEditViewModel {
             aiEnhanceEnabled: aiEnhanceEnabled,
             useClipboardContext: aiEnhanceEnabled ? useClipboardContext : false,
             isAutoTextFormattingEnabled: isAutoTextFormattingEnabled,
-            isSmartInsertEnabled: isSmartInsertEnabled
+            isSmartInsertEnabled: isSmartInsertEnabled,
+            obsidianEnabled: obsidianEnabled,
+            obsidianVault: obsidianVault.trimmingCharacters(in: .whitespacesAndNewlines),
+            obsidianNoteTemplate: obsidianNoteTemplate.trimmingCharacters(in: .whitespacesAndNewlines),
+            obsidianLinePrefix: obsidianLinePrefix
         )
     }
 

--- a/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
@@ -31,8 +31,8 @@ class ModeEditViewModel {
 
     var obsidianEnabled: Bool = false
     var obsidianVault: String = ""
-    var obsidianNoteTemplate: String = "{date}"
-    var obsidianLinePrefix: String = "- {time} "
+    var obsidianNoteTemplate: String = "VD {date} {HH}-{mm}-{ss}"
+    var obsidianLinePrefix: String = ""
 
     let aiService: AIService
     private let transcriptionManager: TranscriptionManager

--- a/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
@@ -30,9 +30,7 @@ class ModeEditViewModel {
     var isSmartInsertEnabled: Bool = false
 
     var obsidianEnabled: Bool = false
-    var obsidianVault: String = ""
     var obsidianNoteTemplate: String = "VD {date} {HH}-{mm}-{ss}"
-    var obsidianLinePrefix: String = ""
 
     let aiService: AIService
     private let transcriptionManager: TranscriptionManager
@@ -191,9 +189,7 @@ class ModeEditViewModel {
             isAutoTextFormattingEnabled = existingMode.isAutoTextFormattingEnabled
             isSmartInsertEnabled = existingMode.isSmartInsertEnabled
             obsidianEnabled = existingMode.obsidianEnabled
-            obsidianVault = existingMode.obsidianVault
             obsidianNoteTemplate = existingMode.obsidianNoteTemplate
-            obsidianLinePrefix = existingMode.obsidianLinePrefix
 
             validateLanguageSelection()
             validateAIModelSelection()
@@ -236,9 +232,7 @@ class ModeEditViewModel {
             isAutoTextFormattingEnabled: isAutoTextFormattingEnabled,
             isSmartInsertEnabled: isSmartInsertEnabled,
             obsidianEnabled: obsidianEnabled,
-            obsidianVault: obsidianVault.trimmingCharacters(in: .whitespacesAndNewlines),
-            obsidianNoteTemplate: obsidianNoteTemplate.trimmingCharacters(in: .whitespacesAndNewlines),
-            obsidianLinePrefix: obsidianLinePrefix
+            obsidianNoteTemplate: obsidianNoteTemplate.trimmingCharacters(in: .whitespacesAndNewlines)
         )
     }
 

--- a/VivaDictaKeyboard/KeyboardCustomView.swift
+++ b/VivaDictaKeyboard/KeyboardCustomView.swift
@@ -196,6 +196,11 @@ struct KeyboardCustomView: View {
                 .zIndex(1)
             }
         }
+        .onChange(of: dictationState.pendingObsidianURL) { _, newURL in
+            guard let url = newURL else { return }
+            openURL(url)
+            dictationState.pendingObsidianURL = nil
+        }
     }
 
     private func deleteWordBeforeCursor() {

--- a/VivaDictaKeyboard/KeyboardDictationState.swift
+++ b/VivaDictaKeyboard/KeyboardDictationState.swift
@@ -64,6 +64,12 @@ final class KeyboardDictationState {
     // Callback called when transcription text is ready to be pasted to user's input field. Called by KeyboardViewController
     var onTranscriptionReady: ((String) -> Void)?
 
+    /// Set by `KeyboardViewController` when a transcription completes in a mode
+    /// with Obsidian append enabled. `KeyboardCustomView` observes this and
+    /// fires `openURL` via the SwiftUI environment (the only API that can open
+    /// URLs from a keyboard extension), then clears it back to nil.
+    var pendingObsidianURL: URL?
+
     // MARK: - Auto-dismiss
     private var errorDismissTask: Task<Void, Never>?
 

--- a/VivaDictaKeyboard/KeyboardViewController.swift
+++ b/VivaDictaKeyboard/KeyboardViewController.swift
@@ -33,6 +33,14 @@ class KeyboardViewController: KeyboardInputViewController {
         if AppGroupCoordinator.shared.isKeepTranscriptInClipboardEnabled {
             ClipboardManager.copyToClipboard(finalText)
         }
+
+        let mode = dictationState.vivaModeManager.selectedVivaMode
+        if mode.obsidianEnabled,
+           let output = ObsidianURLBuilder.build(text: finalText, mode: mode, presetName: nil) {
+            ClipboardManager.copyToClipboard(output.clipboardText)
+            logger.logInfo("⌨️ Obsidian: queueing \(output.url.absoluteString)")
+            dictationState.pendingObsidianURL = output.url
+        }
     }
     
     
@@ -233,12 +241,35 @@ struct VivaDictaKeyboardToolbarView: View {
 
             Spacer()
 
+            // TEMP: Obsidian URL-open test button (remove after probe)
+            Button(action: testObsidianURLOpen) {
+                Image(systemName: "flask.fill")
+                    .font(.system(size: 20))
+                    .foregroundStyle(.purple)
+                    .frame(width: 36, height: 36)
+            }
+            .accessibilityLabel("Test Obsidian")
+            .padding(.trailing, 12)
+
             // Always show MicButton - it handles notReady state by opening main app
             KeyboardMicButton(onTapAction: handleMic)
         }
         .padding(.horizontal, 16)
         .padding(.top, 6)
         .padding(.bottom, 8)
+    }
+
+    // TEMP: probe whether the keyboard extension can open arbitrary external
+    // URL schemes via SwiftUI's openURL. Remove once the answer is known.
+    private func testObsidianURLOpen() {
+        HapticManager.lightImpact()
+        let timestamp = Date().formatted(.iso8601)
+        let testText = "vd-keyboard-test \(timestamp)"
+        UIPasteboard.general.string = testText
+        controller?.logger.logInfo("🧪 Obsidian probe: pasteboard=\(testText)")
+        guard let url = URL(string: "obsidian://new?file=VD-Test&clipboard&append=true") else { return }
+        controller?.logger.logInfo("🧪 Obsidian probe: opening \(url.absoluteString)")
+        openURL(url)
     }
 
     private func handleMic() {

--- a/VivaDictaKeyboard/KeyboardViewController.swift
+++ b/VivaDictaKeyboard/KeyboardViewController.swift
@@ -241,35 +241,12 @@ struct VivaDictaKeyboardToolbarView: View {
 
             Spacer()
 
-            // TEMP: Obsidian URL-open test button (remove after probe)
-            Button(action: testObsidianURLOpen) {
-                Image(systemName: "flask.fill")
-                    .font(.system(size: 20))
-                    .foregroundStyle(.purple)
-                    .frame(width: 36, height: 36)
-            }
-            .accessibilityLabel("Test Obsidian")
-            .padding(.trailing, 12)
-
             // Always show MicButton - it handles notReady state by opening main app
             KeyboardMicButton(onTapAction: handleMic)
         }
         .padding(.horizontal, 16)
         .padding(.top, 6)
         .padding(.bottom, 8)
-    }
-
-    // TEMP: probe whether the keyboard extension can open arbitrary external
-    // URL schemes via SwiftUI's openURL. Remove once the answer is known.
-    private func testObsidianURLOpen() {
-        HapticManager.lightImpact()
-        let timestamp = Date().formatted(.iso8601)
-        let testText = "vd-keyboard-test \(timestamp)"
-        UIPasteboard.general.string = testText
-        controller?.logger.logInfo("🧪 Obsidian probe: pasteboard=\(testText)")
-        guard let url = URL(string: "obsidian://new?file=VD-Test&clipboard&append=true") else { return }
-        controller?.logger.logInfo("🧪 Obsidian probe: opening \(url.absoluteString)")
-        openURL(url)
     }
 
     private func handleMic() {


### PR DESCRIPTION
## Summary

Adds an opt-in per-mode setting to append each transcription to an Obsidian note via the `obsidian://new?file=...&clipboard&append=true` URL scheme. Works from both the main app (post-transcription hook in `RecordViewModel`) and the keyboard extension (verified that SwiftUI's `@Environment(\.openURL)` can open external schemes from a keyboard extension, same mechanism used by the existing `vivadicta://` deep link).

- New \"Obsidian\" section in the mode editor with a toggle + note name template (defaults to one note per transcription: \`VD {date} {HH}-{mm}-{ss}\`).
- Shared \`ObsidianURLBuilder\` helper consumed by both the main app and the keyboard target (added to keyboard membership exceptions in pbxproj).
- Placeholders: \`{date}\`, \`{yyyy}\`, \`{MM}\`, \`{dd}\`, \`{HH}\`, \`{mm}\`, \`{ss}\`, \`{preset}\`, \`{mode}\`. Set the template to just \`{date}\` to get daily-note append behaviour instead.
- Date placeholders are forced to Gregorian so \`{date}\` always resolves to \`YYYY-MM-DD\` regardless of the user's iOS calendar setting; formatted with \`IntegerFormatStyle\` (no \`String(format:)\`).
- Backward-compatible decoding on \`VivaMode\` - existing saved modes load with the toggle off.

Feature is opt-in. There is a temporary purple flask probe button in the keyboard toolbar that was used to validate the extension URL-open path; it can be removed once end-to-end device testing confirms the real hook works.

## Test plan

- [ ] Build & run on a physical device (simulator cannot hand off to Obsidian).
- [ ] Install Obsidian on the device and open any vault.
- [ ] Enable \`Append to Obsidian\` on a mode with defaults.
- [ ] Main app: record + enhance -> VivaDicta backgrounds and a new note appears in Obsidian.
- [ ] Keyboard: swap to VivaDicta keyboard in a text field, tap mic -> text inserts AND Obsidian foregrounds with a new note.
- [ ] Flip template to \`{date}\`, record twice -> both entries land in the same daily note.
- [ ] Turn the toggle off -> footer hides, no Obsidian hand-off happens.
- [ ] Open an existing pre-upgrade mode -> Obsidian section renders with toggle off, no behaviour change.
- [ ] Remove the temp flask probe button once happy with behaviour.