### PR TITLE
Add Settings → Integrations with global Obsidian toggle

### DIFF
--- a/VivaDicta/Services/AIEnhance/VivaMode.swift
+++ b/VivaDicta/Services/AIEnhance/VivaMode.swift
@@ -79,11 +79,10 @@ struct VivaMode: Identifiable, Hashable, Codable {
     /// Whether smart insert (auto-adjust spacing and capitalization) is applied when inserting text via keyboard.
     let isSmartInsertEnabled: Bool
 
-    /// Whether to append the transcription to an Obsidian note after completion.
+    /// Whether this mode opts in to saving transcriptions to Obsidian.
+    /// Only effective when the global Obsidian integration is enabled in
+    /// Settings → Integrations.
     var obsidianEnabled: Bool
-
-    /// Template for the Obsidian note filename. Placeholders: {date}, {yyyy}, {MM}, {dd}, {HH}, {mm}, {ss}, {preset}, {mode}.
-    var obsidianNoteTemplate: String
 
     /// Creates a new VivaMode with the specified settings.
     init(id: UUID,
@@ -100,8 +99,7 @@ struct VivaMode: Identifiable, Hashable, Codable {
          useClipboardContext: Bool = false,
          isAutoTextFormattingEnabled: Bool = false,
          isSmartInsertEnabled: Bool = false,
-         obsidianEnabled: Bool = false,
-         obsidianNoteTemplate: String = "VD {date} {HH}-{mm}-{ss}") {
+         obsidianEnabled: Bool = true) {
         self.id = id
         self.name = name
         self.transcriptionProvider = transcriptionProvider
@@ -117,7 +115,6 @@ struct VivaMode: Identifiable, Hashable, Codable {
         self.isAutoTextFormattingEnabled = isAutoTextFormattingEnabled
         self.isSmartInsertEnabled = isSmartInsertEnabled
         self.obsidianEnabled = obsidianEnabled
-        self.obsidianNoteTemplate = obsidianNoteTemplate
     }
 
     // MARK: - Backward-Compatible Decoding
@@ -138,8 +135,7 @@ struct VivaMode: Identifiable, Hashable, Codable {
         useClipboardContext = try container.decodeIfPresent(Bool.self, forKey: .useClipboardContext) ?? false
         isAutoTextFormattingEnabled = try container.decodeIfPresent(Bool.self, forKey: .isAutoTextFormattingEnabled) ?? true
         isSmartInsertEnabled = try container.decodeIfPresent(Bool.self, forKey: .isSmartInsertEnabled) ?? true
-        obsidianEnabled = try container.decodeIfPresent(Bool.self, forKey: .obsidianEnabled) ?? false
-        obsidianNoteTemplate = try container.decodeIfPresent(String.self, forKey: .obsidianNoteTemplate) ?? "VD {date} {HH}-{mm}-{ss}"
+        obsidianEnabled = try container.decodeIfPresent(Bool.self, forKey: .obsidianEnabled) ?? true
 
         // Try new format first
         if let preset = try container.decodeIfPresent(String.self, forKey: .presetId) {
@@ -161,7 +157,7 @@ struct VivaMode: Identifiable, Hashable, Codable {
         case aiProvider, aiModel, reminderExtractorProvider, reminderExtractorModel, aiEnhanceEnabled
         case useClipboardContext
         case isAutoTextFormattingEnabled, isSmartInsertEnabled
-        case obsidianEnabled, obsidianNoteTemplate
+        case obsidianEnabled
     }
 
     /// Encodes using the new format only (presetId).
@@ -182,7 +178,6 @@ struct VivaMode: Identifiable, Hashable, Codable {
         try container.encode(isAutoTextFormattingEnabled, forKey: .isAutoTextFormattingEnabled)
         try container.encode(isSmartInsertEnabled, forKey: .isSmartInsertEnabled)
         try container.encode(obsidianEnabled, forKey: .obsidianEnabled)
-        try container.encode(obsidianNoteTemplate, forKey: .obsidianNoteTemplate)
     }
 
     /// The default mode used when no custom mode is configured.

--- a/VivaDicta/Shared/ObsidianURLBuilder.swift
+++ b/VivaDicta/Shared/ObsidianURLBuilder.swift
@@ -26,19 +26,22 @@ enum ObsidianURLBuilder {
     ///
     /// - Parameters:
     ///   - text: The final transcription text (enhanced if AI ran, else raw).
-    ///   - mode: The active `VivaMode` carrying the Obsidian configuration.
+    ///   - template: Note-name template carrying placeholders like `{date}`.
+    ///     Stored globally in Settings → Integrations.
+    ///   - modeName: Human-readable mode name for the `{mode}` placeholder.
     ///   - presetName: Human-readable preset name for the `{preset}` placeholder.
     ///   - date: The moment the transcription completed. Parameterised for testability.
     /// - Returns: `nil` if the resulting note name is empty or the URL cannot
     ///   be constructed. Callers should treat `nil` as a no-op.
     static func build(text: String,
-                      mode: VivaMode,
+                      template: String,
+                      modeName: String,
                       presetName: String?,
                       date: Date = Date()) -> Output? {
-        let noteName = expand(template: mode.obsidianNoteTemplate,
+        let noteName = expand(template: template,
                               date: date,
                               presetName: presetName,
-                              modeName: mode.name)
+                              modeName: modeName)
         guard !noteName.isEmpty else { return nil }
 
         let clipboardText = text + "\n"

--- a/VivaDicta/Shared/UserDefaultsStorage.swift
+++ b/VivaDicta/Shared/UserDefaultsStorage.swift
@@ -79,5 +79,13 @@ enum UserDefaultsStorage {
         // Notes filter
         static let savedNotesFilterSourceTags = "savedNotesFilterSourceTags"
         static let savedNotesFilterUserTagIds = "savedNotesFilterUserTagIds"
+
+        // Integrations - Obsidian
+        static let isObsidianGloballyEnabled = "isObsidianGloballyEnabled"
+        static let obsidianNoteTemplate = "obsidianNoteTemplate"
     }
+
+    // MARK: - Integrations defaults
+
+    static let defaultObsidianNoteTemplate = "VD {date} {HH}-{mm}-{ss}"
 }

--- a/VivaDicta/Views/RecordViewModel.swift
+++ b/VivaDicta/Views/RecordViewModel.swift
@@ -839,8 +839,11 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
         guard UserDefaultsStorage.appPrivate.bool(forKey: UserDefaultsStorage.Keys.isObsidianGloballyEnabled) else { return }
         let mode = aiService.selectedMode
         guard mode.obsidianEnabled else { return }
-        let template = UserDefaultsStorage.appPrivate.string(forKey: UserDefaultsStorage.Keys.obsidianNoteTemplate)
-            ?? UserDefaultsStorage.defaultObsidianNoteTemplate
+        // Trim and fall back to the default if the user cleared the field -
+        // an empty note name would silently fail to build a URL.
+        let trimmedTemplate = (UserDefaultsStorage.appPrivate.string(forKey: UserDefaultsStorage.Keys.obsidianNoteTemplate) ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let template = trimmedTemplate.isEmpty ? UserDefaultsStorage.defaultObsidianNoteTemplate : trimmedTemplate
         guard let output = ObsidianURLBuilder.build(text: text, template: template, modeName: mode.name, presetName: presetName) else {
             logger.logError("📱 Obsidian: failed to build URL for mode '\(mode.name)'")
             return

--- a/VivaDicta/Views/RecordViewModel.swift
+++ b/VivaDicta/Views/RecordViewModel.swift
@@ -836,9 +836,12 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
     /// latter posts a Darwin notification that wakes the keyboard's
     /// `handleTranscription` - which needs the App Group payload in place.
     private func openObsidianIfEnabled(text: String, presetName: String?, sourceTag: String) {
+        guard UserDefaultsStorage.appPrivate.bool(forKey: UserDefaultsStorage.Keys.isObsidianGloballyEnabled) else { return }
         let mode = aiService.selectedMode
         guard mode.obsidianEnabled else { return }
-        guard let output = ObsidianURLBuilder.build(text: text, mode: mode, presetName: presetName) else {
+        let template = UserDefaultsStorage.appPrivate.string(forKey: UserDefaultsStorage.Keys.obsidianNoteTemplate)
+            ?? UserDefaultsStorage.defaultObsidianNoteTemplate
+        guard let output = ObsidianURLBuilder.build(text: text, template: template, modeName: mode.name, presetName: presetName) else {
             logger.logError("📱 Obsidian: failed to build URL for mode '\(mode.name)'")
             return
         }

--- a/VivaDicta/Views/SettingsScreen/IntegrationsView.swift
+++ b/VivaDicta/Views/SettingsScreen/IntegrationsView.swift
@@ -1,0 +1,60 @@
+//
+//  IntegrationsView.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.25
+//
+
+import SwiftUI
+
+/// Settings screen for third-party integrations (Obsidian today; Webhooks /
+/// Zapier later). The master Obsidian toggle here gates the per-mode toggle
+/// in `ModeEditView`; flipping it off hides per-mode controls and short-
+/// circuits the hand-off in `RecordViewModel.openObsidianIfEnabled`.
+struct IntegrationsView: View {
+    @AppStorage(UserDefaultsStorage.Keys.isObsidianGloballyEnabled)
+    private var isObsidianGloballyEnabled = false
+
+    @AppStorage(UserDefaultsStorage.Keys.obsidianNoteTemplate)
+    private var obsidianNoteTemplate = UserDefaultsStorage.defaultObsidianNoteTemplate
+
+    var body: some View {
+        Form {
+            Section(header: Text("Obsidian"),
+                    footer: obsidianFooter) {
+                Toggle(isOn: $isObsidianGloballyEnabled) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Save to Obsidian")
+                            .font(.body)
+                        Text("After each transcription, open Obsidian and save the text as a note.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .onChange(of: isObsidianGloballyEnabled) { _, _ in
+                    HapticManager.selectionChanged()
+                }
+
+                if isObsidianGloballyEnabled {
+                    HStack {
+                        Text("Note name")
+                        Spacer()
+                        TextField(UserDefaultsStorage.defaultObsidianNoteTemplate, text: $obsidianNoteTemplate)
+                            .multilineTextAlignment(.trailing)
+                            .autocorrectionDisabled()
+                            .textInputAutocapitalization(.never)
+                    }
+                }
+            }
+        }
+        .navigationTitle("Integrations")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    @ViewBuilder
+    private var obsidianFooter: some View {
+        if isObsidianGloballyEnabled {
+            Text("A new Obsidian note is created for each transcription. Placeholders: {date}, {yyyy}, {MM}, {dd}, {HH}, {mm}, {ss}, {preset}, {mode}. To instead append to a daily note, set the name to just {date}. Per-mode opt-out is available in each mode's settings. The clipboard is overwritten each time.")
+        }
+    }
+}

--- a/VivaDicta/Views/SettingsScreen/ModeEditView.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditView.swift
@@ -24,6 +24,9 @@ struct ModeEditView: View {
     @State private var showReminderExtractorModelPicker: Bool = false
     @State private var hasAttemptedSave: Bool = false
     @State private var shakeTrigger: Int = 0
+
+    @AppStorage(UserDefaultsStorage.Keys.isObsidianGloballyEnabled)
+    private var isObsidianGloballyEnabled = false
     
     let selectAIEnhacementTip = SelectAIEnhacementTip()
 
@@ -756,29 +759,19 @@ struct ModeEditView: View {
                 }
             }
 
-            Section(header: obsidianSectionHeader,
-                    footer: obsidianSectionFooter) {
-                Toggle(isOn: $viewModel.obsidianEnabled) {
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("Save to Obsidian")
-                            .font(.body)
-                        Text("After each transcription, open Obsidian and save the text as a note.")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
+            if isObsidianGloballyEnabled {
+                Section(header: obsidianSectionHeader) {
+                    Toggle(isOn: $viewModel.obsidianEnabled) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Save to Obsidian")
+                                .font(.body)
+                            Text("Save this mode's transcriptions to Obsidian. Configure the global integration in Settings → Integrations.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
                     }
-                }
-                .onChange(of: viewModel.obsidianEnabled) { _, _ in
-                    HapticManager.selectionChanged()
-                }
-
-                if viewModel.obsidianEnabled {
-                    HStack {
-                        Text("Note name")
-                        Spacer()
-                        TextField("VD {date} {HH}-{mm}-{ss}", text: $viewModel.obsidianNoteTemplate)
-                            .multilineTextAlignment(.trailing)
-                            .autocorrectionDisabled()
-                            .textInputAutocapitalization(.never)
+                    .onChange(of: viewModel.obsidianEnabled) { _, _ in
+                        HapticManager.selectionChanged()
                     }
                 }
             }
@@ -948,13 +941,6 @@ struct ModeEditView: View {
 
     private var obsidianSectionHeader: some View {
         Text("Obsidian")
-    }
-
-    @ViewBuilder
-    private var obsidianSectionFooter: some View {
-        if viewModel.obsidianEnabled {
-            Text("A new Obsidian note is created for each transcription. Placeholders: {date}, {yyyy}, {MM}, {dd}, {HH}, {mm}, {ss}, {preset}, {mode}. To instead append to a daily note, set the name to just {date}. The clipboard is overwritten each time.")
-        }
     }
 
     private var reminderSuggestionsSectionHeader: some View {

--- a/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
@@ -29,8 +29,7 @@ class ModeEditViewModel {
     var isAutoTextFormattingEnabled: Bool = false
     var isSmartInsertEnabled: Bool = false
 
-    var obsidianEnabled: Bool = false
-    var obsidianNoteTemplate: String = "VD {date} {HH}-{mm}-{ss}"
+    var obsidianEnabled: Bool = true
 
     let aiService: AIService
     private let transcriptionManager: TranscriptionManager
@@ -189,7 +188,6 @@ class ModeEditViewModel {
             isAutoTextFormattingEnabled = existingMode.isAutoTextFormattingEnabled
             isSmartInsertEnabled = existingMode.isSmartInsertEnabled
             obsidianEnabled = existingMode.obsidianEnabled
-            obsidianNoteTemplate = existingMode.obsidianNoteTemplate
 
             validateLanguageSelection()
             validateAIModelSelection()
@@ -231,8 +229,7 @@ class ModeEditViewModel {
             useClipboardContext: aiEnhanceEnabled ? useClipboardContext : false,
             isAutoTextFormattingEnabled: isAutoTextFormattingEnabled,
             isSmartInsertEnabled: isSmartInsertEnabled,
-            obsidianEnabled: obsidianEnabled,
-            obsidianNoteTemplate: obsidianNoteTemplate.trimmingCharacters(in: .whitespacesAndNewlines)
+            obsidianEnabled: obsidianEnabled
         )
     }
 

--- a/VivaDicta/Views/SettingsScreen/SettingsDestination.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsDestination.swift
@@ -24,4 +24,7 @@ enum SettingsDestination: Hashable {
 
     // Smart Search
     case smartSearch
+
+    // Integrations
+    case integrations
 }

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -514,6 +514,16 @@ struct SettingsView: View {
                     Text("Requires app restart to take effect.")
                 }
 
+                Section("Integrations") {
+                    NavigationLink(value: SettingsDestination.integrations) {
+                        HStack {
+                            Image(systemName: "puzzlepiece.extension")
+                                .foregroundStyle(.purple)
+                            Text("Integrations")
+                        }
+                    }
+                }
+
                 Section("Support") {
                     Link(destination: URL(string: "https://vivadicta.com/ios/docs")!) {
                         HStack {
@@ -606,6 +616,8 @@ struct SettingsView: View {
                     ChatToolsSettingsView()
                 case .smartSearch:
                     SmartSearchSettingsView()
+                case .integrations:
+                    IntegrationsView()
                 }
             }
             .navigationDestination(for: Preset.self) { preset in


### PR DESCRIPTION
## Summary

Promotes the Obsidian feature out of the per-mode editor and into a dedicated **Settings → Integrations** screen, so it can scale to other integrations (Webhooks, Zapier, etc.) without cluttering the mode form.

- New \`IntegrationsView\` (Settings → Integrations) hosts the master Obsidian toggle, the note-name template, and the explanatory footer. Reserved as the home for future integration rows.
- Two new app-private \`UserDefaults\` keys: \`isObsidianGloballyEnabled\` (default off) and \`obsidianNoteTemplate\` (default \`VD {date} {HH}-{mm}-{ss}\`). Keyboard never reads these - it just consumes the App Group hand-off the main app stashes.
- \`VivaMode.obsidianNoteTemplate\` is removed (template is now global). \`VivaMode.obsidianEnabled\` stays as a per-mode opt-out, default flipped to \`true\` so flipping the global toggle on auto-enables every mode.
- \`ModeEditView\`'s Obsidian section is now a single toggle that only renders when the global integration is on.
- \`RecordViewModel.openObsidianIfEnabled\` short-circuits when the global flag is off and reads the template from the global setting.
- \`ObsidianURLBuilder.build\` now takes \`template:\` + \`modeName:\` instead of the whole \`VivaMode\`.

The integration shipped to main yesterday so there's no installed-base mode JSON with these fields - simple decoder defaults are sufficient (no migration logic).

## Test plan

- [ ] Fresh install: Settings → Integrations shows Obsidian toggle off, no template field. Mode editor has no Obsidian section.
- [ ] Flip global toggle on: template field appears with default \`VD {date} {HH}-{mm}-{ss}\` placeholder. Mode editor now shows a per-mode \"Save to Obsidian\" toggle, on by default.
- [ ] Record from main app → Obsidian opens directly with the correct content.
- [ ] Record from keyboard (Hot Mic) → main app delegates via App Group, keyboard opens Obsidian with the correct content.
- [ ] Edit the global template (e.g. \`{date}\`) → next transcription uses the new template.
- [ ] Disable per-mode toggle on one mode, leave others on → only that mode skips Obsidian.
- [ ] Flip global off → mode editor hides the per-mode toggle; subsequent transcriptions skip Obsidian regardless of per-mode state.