### PR TITLE
Add typed analytics facade and instrument chats, RAG, watch, transcription, AI rewrites

### DIFF
--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -811,6 +811,16 @@ class AIService {
         }
         let duration = Date().timeIntervalSince(startTime)
         Task { await AIVariationsDiscoveryTip.variationGeneratedEvent.donate() }
+
+        AnalyticsService.track(.variationGenerated(
+            presetId: preset.isBuiltIn ? preset.id : "custom",
+            isBuiltInPreset: preset.isBuiltIn,
+            provider: selectedMode.aiProvider?.rawValue ?? "unknown",
+            model: selectedMode.aiModel,
+            durationSeconds: duration,
+            outputLength: result.count
+        ))
+
         return (result, duration)
     }
 

--- a/VivaDicta/Services/Analytics/AnalyticsService.swift
+++ b/VivaDicta/Services/Analytics/AnalyticsService.swift
@@ -51,6 +51,21 @@ enum AnalyticsEvent {
     )
 
     case watchRecordingReceived(durationSeconds: Double?, hasModeId: Bool)
+
+    case transcriptionCompleted(
+        engine: String,
+        isOnDevice: Bool,
+        durationSeconds: Double,
+        outputLength: Int
+    )
+    case variationGenerated(
+        presetId: String,
+        isBuiltInPreset: Bool,
+        provider: String,
+        model: String,
+        durationSeconds: Double,
+        outputLength: Int
+    )
 }
 
 extension AnalyticsEvent {
@@ -68,6 +83,8 @@ extension AnalyticsEvent {
         case .smartSearchQueryExecuted: "smart_search_query_executed"
         case .ragIndexingCompleted: "rag_indexing_completed"
         case .watchRecordingReceived: "watch_recording_received"
+        case .transcriptionCompleted: "transcription_completed"
+        case .variationGenerated: "variation_generated"
         }
     }
 
@@ -126,6 +143,24 @@ extension AnalyticsEvent {
                 params["duration_seconds"] = durationSeconds
             }
             return params
+
+        case .transcriptionCompleted(let engine, let isOnDevice, let durationSeconds, let outputLength):
+            return [
+                "engine": engine,
+                "is_on_device": isOnDevice,
+                "duration_seconds": durationSeconds,
+                "output_length": outputLength
+            ]
+
+        case .variationGenerated(let presetId, let isBuiltInPreset, let provider, let model, let durationSeconds, let outputLength):
+            return [
+                "preset_id": presetId,
+                "is_built_in_preset": isBuiltInPreset,
+                "provider": provider,
+                "model": model,
+                "duration_seconds": durationSeconds,
+                "output_length": outputLength
+            ]
         }
     }
 }

--- a/VivaDicta/Services/Analytics/AnalyticsService.swift
+++ b/VivaDicta/Services/Analytics/AnalyticsService.swift
@@ -1,0 +1,152 @@
+//
+//  AnalyticsService.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.27
+//
+
+import Foundation
+import FirebaseAnalytics
+import os
+
+/// Strongly-typed catalog of every analytics event the app reports.
+///
+/// Adding a new event:
+/// 1. Add a case here with the parameters you want to attach.
+/// 2. Map it in `name` and `parameters`.
+/// 3. Call `AnalyticsService.track(.yourEvent(...))` from the relevant call site.
+enum AnalyticsEvent {
+
+    enum ChatType: String {
+        case singleNote = "single_note"
+        case multiNote = "multi_note"
+        case allNotes = "all_notes"
+        case smartSearch = "smart_search"
+    }
+
+    case onboardingCompleted
+    case unrecognizedHostApp(bundleId: String)
+    case keyboardSessionStarted(hostBundleId: String?)
+    case modelDownloaded(name: String, type: String)
+
+    case chatConversationStarted(
+        chatType: ChatType,
+        provider: String,
+        model: String,
+        noteCount: Int?
+    )
+    case chatMessageSent(
+        chatType: ChatType,
+        provider: String,
+        model: String,
+        turnCount: Int
+    )
+
+    case smartSearchQueryExecuted(queryLength: Int, topK: Int, resultCount: Int)
+    case ragIndexingCompleted(
+        indexedCount: Int,
+        skippedCount: Int,
+        totalChunks: Int,
+        isFirstRun: Bool
+    )
+
+    case watchRecordingReceived(durationSeconds: Double?, hasModeId: Bool)
+}
+
+extension AnalyticsEvent {
+
+    /// The Firebase event name. Keep names stable - changing one breaks
+    /// historical reporting in the Firebase console.
+    nonisolated var name: String {
+        switch self {
+        case .onboardingCompleted: "onboarding_completed"
+        case .unrecognizedHostApp: "unrecognized_host_app"
+        case .keyboardSessionStarted: "keyboard_session_started"
+        case .modelDownloaded: "model_downloaded"
+        case .chatConversationStarted: "chat_conversation_started"
+        case .chatMessageSent: "chat_message_sent"
+        case .smartSearchQueryExecuted: "smart_search_query_executed"
+        case .ragIndexingCompleted: "rag_indexing_completed"
+        case .watchRecordingReceived: "watch_recording_received"
+        }
+    }
+
+    /// Parameters attached to the event. Keep keys snake_case and consistent
+    /// across events (`provider`, `model`, `chat_type`, ...). Do not include
+    /// raw user content - only counts, lengths, enum values, and IDs.
+    nonisolated var parameters: [String: Any]? {
+        switch self {
+        case .onboardingCompleted:
+            return nil
+
+        case .unrecognizedHostApp(let bundleId):
+            return ["bundle_id": bundleId]
+
+        case .keyboardSessionStarted(let hostBundleId):
+            return ["host_bundle_id": hostBundleId ?? "unknown"]
+
+        case .modelDownloaded(let name, let type):
+            return ["model_name": name, "model_type": type]
+
+        case .chatConversationStarted(let chatType, let provider, let model, let noteCount):
+            var params: [String: Any] = [
+                "chat_type": chatType.rawValue,
+                "provider": provider,
+                "model": model
+            ]
+            if let noteCount { params["note_count"] = noteCount }
+            return params
+
+        case .chatMessageSent(let chatType, let provider, let model, let turnCount):
+            return [
+                "chat_type": chatType.rawValue,
+                "provider": provider,
+                "model": model,
+                "turn_count": turnCount
+            ]
+
+        case .smartSearchQueryExecuted(let queryLength, let topK, let resultCount):
+            return [
+                "query_length": queryLength,
+                "top_k": topK,
+                "result_count": resultCount
+            ]
+
+        case .ragIndexingCompleted(let indexedCount, let skippedCount, let totalChunks, let isFirstRun):
+            return [
+                "indexed_count": indexedCount,
+                "skipped_count": skippedCount,
+                "total_chunks": totalChunks,
+                "is_first_run": isFirstRun
+            ]
+
+        case .watchRecordingReceived(let durationSeconds, let hasModeId):
+            var params: [String: Any] = ["has_mode_id": hasModeId]
+            if let durationSeconds {
+                params["duration_seconds"] = durationSeconds
+            }
+            return params
+        }
+    }
+}
+
+/// Single chokepoint for reporting analytics events. Wraps Firebase Analytics
+/// behind a typed API so call sites can't typo event names or drift in
+/// parameter keys.
+///
+/// `Analytics.logEvent` is thread-safe; `track` can be called from any context.
+enum AnalyticsService {
+    nonisolated private static let logger = Logger(category: .analytics)
+
+    nonisolated static func track(_ event: AnalyticsEvent) {
+        let name = event.name
+        let params = event.parameters
+        Analytics.logEvent(name, parameters: params)
+
+        if let params {
+            logger.logDebug("📊 \(name) \(params)")
+        } else {
+            logger.logDebug("📊 \(name)")
+        }
+    }
+}

--- a/VivaDicta/Services/ModelDownloadManager.swift
+++ b/VivaDicta/Services/ModelDownloadManager.swift
@@ -9,7 +9,6 @@ import SwiftUI
 import FluidAudio
 import WhisperKit
 import os
-import FirebaseAnalytics
 
 /// Status of a model download operation.
 enum DownloadStatus: String {
@@ -254,10 +253,7 @@ class ModelDownloadManager: @unchecked Sendable {
             }
 
             // Log model download to Firebase Analytics
-            Analytics.logEvent("model_downloaded", parameters: [
-                "model_name": model.displayName,
-                "model_type": "parakeet"
-            ])
+            AnalyticsService.track(.modelDownloaded(name: model.displayName, type: "parakeet"))
 
             try? await Task.sleep(for: .seconds(0.5))
 
@@ -419,10 +415,7 @@ class ModelDownloadManager: @unchecked Sendable {
             }
 
             // Log model download to Firebase Analytics
-            Analytics.logEvent("model_downloaded", parameters: [
-                "model_name": model.displayName,
-                "model_type": "whisperkit"
-            ])
+            AnalyticsService.track(.modelDownloaded(name: model.displayName, type: "whisperkit"))
 
             // Unload models after download to free memory
             // They will be loaded again when needed for transcription

--- a/VivaDicta/Services/PhoneWatchConnectivityService.swift
+++ b/VivaDicta/Services/PhoneWatchConnectivityService.swift
@@ -158,6 +158,7 @@ extension PhoneWatchConnectivityService: WCSessionDelegate {
         let timestamp = rawMetadata["timestamp"] as? Double ?? Date().timeIntervalSince1970
         let recordingTimestamp = Date(timeIntervalSince1970: timestamp)
         let modeId = rawMetadata["modeId"] as? String
+        let duration = rawMetadata["duration"] as? Double
 
         let audioDir = URL.documentsDirectory.appending(path: "Audio")
 
@@ -167,6 +168,11 @@ extension PhoneWatchConnectivityService: WCSessionDelegate {
             let destURL = audioDir.appending(path: "watch-\(UUID().uuidString).\(ext)")
             try FileManager.default.moveItem(at: sourceURL, to: destURL)
             logger.logInfo("Received watch audio: \(destURL.lastPathComponent)")
+
+            AnalyticsService.track(.watchRecordingReceived(
+                durationSeconds: duration,
+                hasModeId: modeId != nil
+            ))
 
             Task { @MainActor in
                 self.processInBackground(audioURL: destURL, sourceTag: sourceTag, recordingTimestamp: recordingTimestamp, modeId: modeId)

--- a/VivaDicta/Services/RAG/RAGIndexingService.swift
+++ b/VivaDicta/Services/RAG/RAGIndexingService.swift
@@ -359,6 +359,12 @@ final class RAGIndexingService {
             let totalChunks = try await _documentCount()
             logger.logInfo("Indexing complete: \(indexed) indexed, \(skipped) skipped, \(orphanedIds.count) orphans removed, \(totalChunks) total chunks")
             await logIndexSnapshot(reason: "bulk-index-complete", using: logger)
+            AnalyticsService.track(.ragIndexingCompleted(
+                indexedCount: indexed,
+                skippedCount: skipped,
+                totalChunks: totalChunks,
+                isFirstRun: isFirstRun
+            ))
         } catch {
             logger.logError("Bulk indexing failed: \(error.localizedDescription)")
         }
@@ -553,6 +559,11 @@ final class RAGIndexingService {
                 baseThreshold: threshold,
                 mapping: mapping
             )
+            AnalyticsService.track(.smartSearchQueryExecuted(
+                queryLength: query.count,
+                topK: topK,
+                resultCount: 0
+            ))
             return []
         }
 
@@ -603,6 +614,11 @@ final class RAGIndexingService {
             await logIndexSnapshot(reason: "search-unmapped-raw-hits", using: searchLogger)
         }
         searchLogger.logInfo("Search '\(query.prefix(50))': \(finalResults.count) transcriptions matched")
+        AnalyticsService.track(.smartSearchQueryExecuted(
+            queryLength: query.count,
+            topK: topK,
+            resultCount: finalResults.count
+        ))
         return finalResults
     }
 

--- a/VivaDicta/Services/Transcription/TranscriptionManager.swift
+++ b/VivaDicta/Services/Transcription/TranscriptionManager.swift
@@ -191,6 +191,7 @@ class TranscriptionManager {
             throw TranscriptionError.transcriptionFailed
         }
 
+        let startTime = Date()
         let transcriptionResult: TranscriptionServiceResult
         switch model.provider {
         case .parakeet:
@@ -216,6 +217,13 @@ class TranscriptionManager {
         if UserDefaults.standard.object(forKey: UserDefaultsStorage.Keys.isReplacementsEnabled) as? Bool ?? true {
             result = ReplacementsService.applyReplacements(to: result)
         }
+
+        AnalyticsService.track(.transcriptionCompleted(
+            engine: model.provider.rawValue,
+            isOnDevice: TranscriptionModelProvider.localProviders.contains(model.provider),
+            durationSeconds: Date().timeIntervalSince(startTime),
+            outputLength: result.count
+        ))
 
         return result
     }

--- a/VivaDicta/Utilities/LoggerExtension.swift
+++ b/VivaDicta/Utilities/LoggerExtension.swift
@@ -71,6 +71,9 @@ public enum LogCategory: String {
     // MARK: - Watch Connectivity
     case watchConnectivity = "WatchConnectivity"
 
+    // MARK: - Analytics
+    case analytics = "Analytics"
+
     // MARK: - Background Tasks
     case backgroundTask = "BackgroundTask"
 

--- a/VivaDicta/Views/Chat/ChatViewModel.swift
+++ b/VivaDicta/Views/Chat/ChatViewModel.swift
@@ -150,6 +150,7 @@ final class ChatViewModel {
     private let webSearchToolCaptureID = UUID()
     private var successfulReplyCount = 0
     private var hasRequestedReviewForSession = false
+    private var hasLoggedConversationStart = false
 
     /// The note text for this conversation.
     var assembledNoteText: String {
@@ -165,6 +166,7 @@ final class ChatViewModel {
         self.modelContext = modelContext
 
         loadMessages()
+        hasLoggedConversationStart = messages.contains { $0.role == "user" }
         noteExceedsAppleFMContext = Self.estimateNoteExceedsAppleFM(
             noteText: assembledNoteText,
             systemPrompt: ChatContextManager.chatSystemPrompt
@@ -235,13 +237,14 @@ final class ChatViewModel {
         messages.append(userMessage)
 
         let turnCount = messages.filter { $0.role == "user" }.count
-        if turnCount == 1 {
+        if !hasLoggedConversationStart {
             AnalyticsService.track(.chatConversationStarted(
                 chatType: .singleNote,
                 provider: provider.rawValue,
                 model: model,
                 noteCount: nil
             ))
+            hasLoggedConversationStart = true
         }
         AnalyticsService.track(.chatMessageSent(
             chatType: .singleNote,

--- a/VivaDicta/Views/Chat/ChatViewModel.swift
+++ b/VivaDicta/Views/Chat/ChatViewModel.swift
@@ -234,6 +234,22 @@ final class ChatViewModel {
         pendingUserMessage = userMessage
         messages.append(userMessage)
 
+        let turnCount = messages.filter { $0.role == "user" }.count
+        if turnCount == 1 {
+            AnalyticsService.track(.chatConversationStarted(
+                chatType: .singleNote,
+                provider: provider.rawValue,
+                model: model,
+                noteCount: nil
+            ))
+        }
+        AnalyticsService.track(.chatMessageSent(
+            chatType: .singleNote,
+            provider: provider.rawValue,
+            model: model,
+            turnCount: turnCount
+        ))
+
         isStreaming = true
         streamingText = ""
         HapticManager.prepareStreaming()

--- a/VivaDicta/Views/MultiNoteChat/MultiNoteChatViewModel.swift
+++ b/VivaDicta/Views/MultiNoteChat/MultiNoteChatViewModel.swift
@@ -142,6 +142,7 @@ final class MultiNoteChatViewModel {
     private var pendingUserMessage: ChatMessage?
     private var successfulReplyCount = 0
     private var hasRequestedReviewForSession = false
+    private var hasLoggedConversationStart = false
 
     var assembledNoteText: String {
         conversation.noteContext
@@ -155,6 +156,7 @@ final class MultiNoteChatViewModel {
         self.modelContext = modelContext
 
         loadMessages()
+        hasLoggedConversationStart = messages.contains { $0.role == "user" }
         noteExceedsAppleFMContext = Self.estimateNoteExceedsAppleFM(
             noteText: assembledNoteText,
             systemPrompt: MultiNoteContextManager.systemPrompt
@@ -224,13 +226,14 @@ final class MultiNoteChatViewModel {
 
         let chatType: AnalyticsEvent.ChatType = conversation.isAllNotes ? .allNotes : .multiNote
         let turnCount = messages.filter { $0.role == "user" }.count
-        if turnCount == 1 {
+        if !hasLoggedConversationStart {
             AnalyticsService.track(.chatConversationStarted(
                 chatType: chatType,
                 provider: provider.rawValue,
                 model: model,
                 noteCount: conversation.sourceNoteCount
             ))
+            hasLoggedConversationStart = true
         }
         AnalyticsService.track(.chatMessageSent(
             chatType: chatType,

--- a/VivaDicta/Views/MultiNoteChat/MultiNoteChatViewModel.swift
+++ b/VivaDicta/Views/MultiNoteChat/MultiNoteChatViewModel.swift
@@ -222,6 +222,23 @@ final class MultiNoteChatViewModel {
         pendingUserMessage = userMessage
         messages.append(userMessage)
 
+        let chatType: AnalyticsEvent.ChatType = conversation.isAllNotes ? .allNotes : .multiNote
+        let turnCount = messages.filter { $0.role == "user" }.count
+        if turnCount == 1 {
+            AnalyticsService.track(.chatConversationStarted(
+                chatType: chatType,
+                provider: provider.rawValue,
+                model: model,
+                noteCount: conversation.sourceNoteCount
+            ))
+        }
+        AnalyticsService.track(.chatMessageSent(
+            chatType: chatType,
+            provider: provider.rawValue,
+            model: model,
+            turnCount: turnCount
+        ))
+
         isStreaming = true
         streamingText = ""
         HapticManager.prepareStreaming()

--- a/VivaDicta/Views/SmartSearch/SmartSearchChatViewModel.swift
+++ b/VivaDicta/Views/SmartSearch/SmartSearchChatViewModel.swift
@@ -166,6 +166,22 @@ final class SmartSearchChatViewModel {
         pendingUserMessage = userMessage
         messages.append(userMessage)
 
+        let turnCount = messages.filter { $0.role == "user" }.count
+        if turnCount == 1 {
+            AnalyticsService.track(.chatConversationStarted(
+                chatType: .smartSearch,
+                provider: provider.rawValue,
+                model: model,
+                noteCount: nil
+            ))
+        }
+        AnalyticsService.track(.chatMessageSent(
+            chatType: .smartSearch,
+            provider: provider.rawValue,
+            model: model,
+            turnCount: turnCount
+        ))
+
         isStreaming = true
         streamingText = ""
         HapticManager.prepareStreaming()

--- a/VivaDicta/Views/SmartSearch/SmartSearchChatViewModel.swift
+++ b/VivaDicta/Views/SmartSearch/SmartSearchChatViewModel.swift
@@ -110,6 +110,7 @@ final class SmartSearchChatViewModel {
     private var streamingTask: Task<Void, Never>?
     private var pendingUserMessage: ChatMessage?
     private let webSearchToolCaptureID = UUID()
+    private var hasLoggedConversationStart = false
 
     // MARK: - Init
 
@@ -119,6 +120,7 @@ final class SmartSearchChatViewModel {
         self.modelContext = modelContext
 
         loadMessages()
+        hasLoggedConversationStart = messages.contains { $0.role == "user" }
 
         if selectedProvider == .apple {
             initializeAppleFMSession()
@@ -167,13 +169,14 @@ final class SmartSearchChatViewModel {
         messages.append(userMessage)
 
         let turnCount = messages.filter { $0.role == "user" }.count
-        if turnCount == 1 {
+        if !hasLoggedConversationStart {
             AnalyticsService.track(.chatConversationStarted(
                 chatType: .smartSearch,
                 provider: provider.rawValue,
                 model: model,
                 noteCount: nil
             ))
+            hasLoggedConversationStart = true
         }
         AnalyticsService.track(.chatMessageSent(
             chatType: .smartSearch,

--- a/VivaDicta/VivaDictaApp.swift
+++ b/VivaDicta/VivaDictaApp.swift
@@ -12,7 +12,6 @@ import AppIntents
 import CoreSpotlight
 import ActivityKit
 import TipKit
-import FirebaseAnalytics
 
 @main
 struct VivaDictaApp: App {
@@ -276,7 +275,7 @@ struct VivaDictaApp: App {
                     if let release = WhatsNewCatalog.release(for: currentVersion) {
                         UserDefaultsStorage.appPrivate.set(release.id, forKey: UserDefaultsStorage.Keys.lastSeenWhatsNewVersion)
                     }
-                    Analytics.logEvent("onboarding_completed", parameters: nil)
+                    AnalyticsService.track(.onboardingCompleted)
                 }
             }
         }
@@ -377,9 +376,7 @@ struct VivaDictaApp: App {
             if !knownNoSchemeHosts.contains(hostId) {
                 // Log unrecognized host app to Firebase Analytics
                 // This helps track which apps users are trying to use but we don't have URL schemes for yet
-                Analytics.logEvent("unrecognized_host_app", parameters: [
-                    "bundle_id": hostId
-                ])
+                AnalyticsService.track(.unrecognizedHostApp(bundleId: hostId))
             }
         }
     }
@@ -419,9 +416,7 @@ struct VivaDictaApp: App {
                     let hostId = components?.queryItems?.first(where: { $0.name == "hostId" })?.value
 
                     // Log keyboard session start to Firebase Analytics
-                    Analytics.logEvent("keyboard_session_started", parameters: [
-                        "host_bundle_id": hostId ?? "unknown"
-                    ])
+                    AnalyticsService.track(.keyboardSessionStarted(hostBundleId: hostId))
 
                     // Activate keyboard session to notify keyboard that hot mic is ready
                     let timeoutSeconds = AudioPrewarmManager.shared.audioSessionTimeout


### PR DESCRIPTION
## Summary

- Centralize Firebase event reporting behind `AnalyticsService.track(.event)` so call sites can't typo names or drift on parameter keys.
- Migrate the 4 existing events (`onboarding_completed`, `unrecognized_host_app`, `keyboard_session_started`, `model_downloaded`) to the facade with names preserved (no break in historical data).
- Add 7 new events covering recently-shipped surfaces: chats, RAG / smart search, Apple Watch handoff, plus the core transcription and AI rewrite paths.

## What's tracked

| Event | Where it fires | Signal |
|---|---|---|
| `chat_conversation_started` / `chat_message_sent` | All 3 chat view models (single / multi / all-notes / smart-search) | Conversation start fires only on first user message; turn count attached |
| `smart_search_query_executed` | `RAGIndexingService.search()` | Both empty-results and successful paths; query length only, never query text |
| `rag_indexing_completed` | End of `RAGIndexingService.indexAllIfNeeded()` | indexed / skipped / total chunks / first-run flag |
| `watch_recording_received` | `PhoneWatchConnectivityService.session(_:didReceive:)` | Logged from iPhone, not the watch (Firebase in extensions is unreliable) |
| `transcription_completed` | `TranscriptionManager.transcribe()` - the single chokepoint for all engines | engine, on-device flag, duration, output length |
| `variation_generated` | `AIService.generateVariation()` | preset id (built-in alias or `"custom"`), provider, model, duration, output length |

## Privacy / hygiene

- No event includes user content. Counts, lengths, enum values, and stable IDs only - App Store privacy nutrition label doesn't change.
- Custom preset UUIDs are reported as `"custom"` to avoid leaking user-specific IDs and bound cardinality.
- All `AnalyticsEvent` parameters and the `track(_:)` static method are `nonisolated` so the watch `WCSessionDelegate` callback (which is `nonisolated`) can call into them.

## Test plan
- [x] `xcodebuild` build succeeds for iOS Simulator (iPhone 17 Pro Max, OS 26.4)
- [ ] Manual: complete onboarding, transcribe with WhisperKit and a cloud provider, generate a variation, send chat messages in single/multi/smart-search, record from Apple Watch, verify events show up in Firebase DebugView
- [ ] Confirm Firebase Analytics console populates new event names within ~24h