### PR TITLE
Add Live Translation: speak in one language, hear it in another

### DIFF
--- a/VivaDicta/Models/SourceTag.swift
+++ b/VivaDicta/Models/SourceTag.swift
@@ -19,6 +19,7 @@ enum SourceTag {
     static let macApp = "macApp"
     static let youtube = "youtube"
     static let appleWatch = "appleWatch"
+    static let liveTranslation = "liveTranslation"
 
     static func displayName(for tag: String?) -> String {
         switch tag {
@@ -29,6 +30,7 @@ enum SourceTag {
         case macApp: "Mac"
         case youtube: "YouTube"
         case appleWatch: "Watch"
+        case liveTranslation: "Live Translation"
         default: "Unknown"
         }
     }
@@ -42,6 +44,7 @@ enum SourceTag {
         case macApp: "desktopcomputer"
         case youtube: "play.rectangle.fill"
         case appleWatch: "applewatch"
+        case liveTranslation: "globe.americas.fill"
         default: "questionmark.circle"
         }
     }
@@ -55,6 +58,7 @@ enum SourceTag {
         case macApp: .teal
         case youtube: .red
         case appleWatch: .mint
+        case liveTranslation: .indigo
         default: .secondary
         }
     }

--- a/VivaDicta/Services/LiveTranslation/LiveTranslationAudio.swift
+++ b/VivaDicta/Services/LiveTranslation/LiveTranslationAudio.swift
@@ -14,9 +14,15 @@ final class LiveTranslationAudio {
     static let captureSampleRate: Double = 16000
     static let playbackSampleRate: Double = SonioxRealtimeTTSClient.outputSampleRate
 
+    /// Playback rate for the TTS audio. Russian/translated text often runs
+    /// longer than the source speech; speeding up modestly keeps the queue
+    /// from growing during long sessions without sounding chipmunked.
+    static let playbackRate: Float = 1.15
+
     private let logger = Logger(category: .liveTranslationAudio)
     private let engine = AVAudioEngine()
     private let playerNode = AVAudioPlayerNode()
+    private let varispeedNode = AVAudioUnitVarispeed()
 
     private var captureContinuation: AsyncStream<Data>.Continuation?
     private var isStarted = false
@@ -84,6 +90,11 @@ final class LiveTranslationAudio {
         guard isStarted else { return }
         guard let buffer = makePlaybackBuffer(from: data) else { return }
         playerNode.scheduleBuffer(buffer, completionHandler: nil)
+        // After long silences the engine may suspend the player node implicitly.
+        // Re-arm it whenever new audio arrives.
+        if !playerNode.isPlaying {
+            playerNode.play()
+        }
     }
 
     // MARK: - Private
@@ -136,7 +147,10 @@ final class LiveTranslationAudio {
         }
 
         engine.attach(playerNode)
-        engine.connect(playerNode, to: engine.mainMixerNode, format: playbackFormat)
+        engine.attach(varispeedNode)
+        varispeedNode.rate = Self.playbackRate
+        engine.connect(playerNode, to: varispeedNode, format: playbackFormat)
+        engine.connect(varispeedNode, to: engine.mainMixerNode, format: playbackFormat)
 
         guard let continuation = captureContinuation else {
             throw LiveTranslationError.audioEngineFailure("capture stream not initialized")

--- a/VivaDicta/Services/LiveTranslation/LiveTranslationAudio.swift
+++ b/VivaDicta/Services/LiveTranslation/LiveTranslationAudio.swift
@@ -91,16 +91,39 @@ final class LiveTranslationAudio {
     private func configureSession() throws {
         let session = AVAudioSession.sharedInstance()
         do {
+            // Do NOT include .defaultToSpeaker — it overrides A2DP routing and
+            // forces output to the iPhone speaker even when AirPods are paired,
+            // which causes mic feedback.
             try session.setCategory(
                 .playAndRecord,
                 mode: .spokenAudio,
-                options: [.allowBluetoothA2DP, .defaultToSpeaker, .duckOthers]
+                options: [.allowBluetoothA2DP, .duckOthers]
             )
             try session.setPreferredSampleRate(48000)
             try session.setPreferredIOBufferDuration(0.02)
             try session.setActive(true, options: [])
+            try session.overrideOutputAudioPort(.none)
         } catch {
             throw LiveTranslationError.audioSessionFailure(error.localizedDescription)
+        }
+    }
+
+    static var isHeadphonesRouteActive: Bool {
+        let route = AVAudioSession.sharedInstance().currentRoute
+        return route.outputs.contains { output in
+            switch output.portType {
+            case .headphones,
+                 .bluetoothA2DP,
+                 .bluetoothLE,
+                 .bluetoothHFP,
+                 .airPlay,
+                 .usbAudio,
+                 .carAudio,
+                 .lineOut:
+                return true
+            default:
+                return false
+            }
         }
     }
 

--- a/VivaDicta/Services/LiveTranslation/LiveTranslationAudio.swift
+++ b/VivaDicta/Services/LiveTranslation/LiveTranslationAudio.swift
@@ -1,0 +1,237 @@
+//
+//  LiveTranslationAudio.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.28
+//
+
+import AVFoundation
+import Foundation
+import os
+
+@MainActor
+final class LiveTranslationAudio {
+    static let captureSampleRate: Double = 16000
+    static let playbackSampleRate: Double = SonioxRealtimeTTSClient.outputSampleRate
+
+    private let logger = Logger(category: .liveTranslationAudio)
+    private let engine = AVAudioEngine()
+    private let playerNode = AVAudioPlayerNode()
+
+    private var captureContinuation: AsyncStream<Data>.Continuation?
+    private var isStarted = false
+    private var tapInstaller: TapInstaller?
+
+    private let captureFormat: AVAudioFormat = {
+        AVAudioFormat(
+            commonFormat: .pcmFormatInt16,
+            sampleRate: LiveTranslationAudio.captureSampleRate,
+            channels: 1,
+            interleaved: true
+        )!
+    }()
+
+    private let playbackFormat: AVAudioFormat = {
+        AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: LiveTranslationAudio.playbackSampleRate,
+            channels: 1,
+            interleaved: false
+        )!
+    }()
+
+    func makeCaptureStream() -> AsyncStream<Data> {
+        AsyncStream<Data> { continuation in
+            captureContinuation = continuation
+            continuation.onTermination = { @Sendable [weak self] _ in
+                Task { @MainActor [weak self] in
+                    self?.captureContinuation = nil
+                }
+            }
+        }
+    }
+
+    func start() async throws {
+        guard !isStarted else { return }
+
+        try configureSession()
+        try await configureEngine()
+        try engine.start()
+        playerNode.play()
+        isStarted = true
+    }
+
+    func stop() {
+        guard isStarted else { return }
+        isStarted = false
+
+        playerNode.stop()
+        engine.inputNode.removeTap(onBus: 0)
+        engine.stop()
+        engine.reset()
+        captureContinuation?.finish()
+        captureContinuation = nil
+        tapInstaller = nil
+
+        do {
+            try AVAudioSession.sharedInstance().setActive(false, options: [.notifyOthersOnDeactivation])
+        } catch {
+            logger.logWarning("Audio session deactivate failed: \(error.localizedDescription)")
+        }
+    }
+
+    func enqueuePlayback(_ data: Data) {
+        guard isStarted else { return }
+        guard let buffer = makePlaybackBuffer(from: data) else { return }
+        playerNode.scheduleBuffer(buffer, completionHandler: nil)
+    }
+
+    // MARK: - Private
+
+    private func configureSession() throws {
+        let session = AVAudioSession.sharedInstance()
+        do {
+            try session.setCategory(
+                .playAndRecord,
+                mode: .spokenAudio,
+                options: [.allowBluetoothA2DP, .defaultToSpeaker, .duckOthers]
+            )
+            try session.setPreferredSampleRate(48000)
+            try session.setPreferredIOBufferDuration(0.02)
+            try session.setActive(true, options: [])
+        } catch {
+            throw LiveTranslationError.audioSessionFailure(error.localizedDescription)
+        }
+    }
+
+    private func configureEngine() async throws {
+        let inputNode = engine.inputNode
+        let inputFormat = inputNode.outputFormat(forBus: 0)
+
+        guard inputFormat.sampleRate > 0, inputFormat.channelCount > 0 else {
+            throw LiveTranslationError.audioEngineFailure("invalid input format")
+        }
+
+        engine.attach(playerNode)
+        engine.connect(playerNode, to: engine.mainMixerNode, format: playbackFormat)
+
+        guard let continuation = captureContinuation else {
+            throw LiveTranslationError.audioEngineFailure("capture stream not initialized")
+        }
+
+        guard let converter = AVAudioConverter(from: inputFormat, to: captureFormat) else {
+            throw LiveTranslationError.audioEngineFailure("converter init failed")
+        }
+
+        let installer = TapInstaller(
+            converter: converter,
+            captureFormat: captureFormat,
+            continuation: continuation
+        )
+        tapInstaller = installer
+
+        // Install the tap from a background queue to ensure the tap closure is
+        // not @MainActor-isolated. AVAudioEngine invokes the tap on its realtime
+        // audio thread; an inherited MainActor isolation trips
+        // _dispatch_assert_queue_fail. Mirrors AudioPrewarmManager's pattern.
+        await withCheckedContinuation { resume in
+            DispatchQueue.global(qos: .userInitiated).async {
+                installLiveTranslationInputTap(
+                    inputNode: inputNode,
+                    format: inputFormat,
+                    installer: installer
+                )
+                resume.resume()
+            }
+        }
+
+        engine.prepare()
+    }
+
+    private func makePlaybackBuffer(from data: Data) -> AVAudioPCMBuffer? {
+        let int16ByteCount = data.count - (data.count % 2)
+        guard int16ByteCount > 0 else { return nil }
+
+        let frameCount = AVAudioFrameCount(int16ByteCount / 2)
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: playbackFormat, frameCapacity: frameCount) else {
+            return nil
+        }
+        buffer.frameLength = frameCount
+
+        guard let floatChannel = buffer.floatChannelData?[0] else { return nil }
+
+        data.withUnsafeBytes { (rawPtr: UnsafeRawBufferPointer) in
+            let int16Ptr = rawPtr.bindMemory(to: Int16.self)
+            for index in 0..<Int(frameCount) {
+                let sample = Int16(littleEndian: int16Ptr[index])
+                floatChannel[index] = Float(sample) / 32768.0
+            }
+        }
+
+        return buffer
+    }
+}
+
+/// Installs the AVAudioEngine input tap from a non-isolated context so the
+/// resulting closure does not inherit MainActor isolation. The closure is
+/// invoked on AVAudioEngine's realtime audio thread.
+nonisolated private func installLiveTranslationInputTap(
+    inputNode: AVAudioInputNode,
+    format: AVAudioFormat,
+    installer: TapInstaller
+) {
+    inputNode.installTap(onBus: 0, bufferSize: 4096, format: format) { buffer, _ in
+        installer.process(buffer)
+    }
+}
+
+/// Holds state used inside the realtime audio tap callback. Runs entirely on the
+/// AVAudioEngine input thread - never touches MainActor state. The continuation
+/// is the only cross-thread channel and `AsyncStream.Continuation` is Sendable.
+nonisolated private final class TapInstaller: @unchecked Sendable {
+    private let converter: AVAudioConverter
+    private let captureFormat: AVAudioFormat
+    private let continuation: AsyncStream<Data>.Continuation
+
+    nonisolated init(converter: AVAudioConverter, captureFormat: AVAudioFormat, continuation: AsyncStream<Data>.Continuation) {
+        self.converter = converter
+        self.captureFormat = captureFormat
+        self.continuation = continuation
+    }
+
+    nonisolated func process(_ buffer: AVAudioPCMBuffer) {
+        let sourceFormat = buffer.format
+        let ratio = captureFormat.sampleRate / sourceFormat.sampleRate
+        let estimatedFrames = Double(buffer.frameLength) * ratio
+        let outCapacity = AVAudioFrameCount(estimatedFrames.rounded(.up)) + 1024
+
+        guard let outBuffer = AVAudioPCMBuffer(pcmFormat: captureFormat, frameCapacity: outCapacity) else {
+            return
+        }
+
+        var providedInput = false
+        var conversionError: NSError?
+        let status = converter.convert(to: outBuffer, error: &conversionError) { _, statusPtr in
+            if providedInput {
+                statusPtr.pointee = .noDataNow
+                return nil
+            }
+            providedInput = true
+            statusPtr.pointee = .haveData
+            return buffer
+        }
+
+        if status == .error || conversionError != nil {
+            return
+        }
+
+        guard outBuffer.frameLength > 0,
+              let channelData = outBuffer.int16ChannelData else {
+            return
+        }
+
+        let byteCount = Int(outBuffer.frameLength) * 2
+        let data = Data(bytes: channelData[0], count: byteCount)
+        continuation.yield(data)
+    }
+}

--- a/VivaDicta/Services/LiveTranslation/LiveTranslationAudio.swift
+++ b/VivaDicta/Services/LiveTranslation/LiveTranslationAudio.swift
@@ -14,15 +14,21 @@ final class LiveTranslationAudio {
     static let captureSampleRate: Double = 16000
     static let playbackSampleRate: Double = SonioxRealtimeTTSClient.outputSampleRate
 
-    /// Playback rate for the TTS audio. Russian/translated text often runs
-    /// longer than the source speech; speeding up modestly keeps the queue
-    /// from growing during long sessions without sounding chipmunked.
-    static let playbackRate: Float = 1.15
-
     private let logger = Logger(category: .liveTranslationAudio)
     private let engine = AVAudioEngine()
     private let playerNode = AVAudioPlayerNode()
     private let varispeedNode = AVAudioUnitVarispeed()
+    private let bufferQueue = PlaybackBufferQueue()
+
+    /// Playback rate applied via AVAudioUnitVarispeed. Russian/translated text
+    /// usually runs longer than the source, so we play back faster than 1.0
+    /// to keep the buffer queue from growing. Adjustable live; takes effect
+    /// immediately whether the engine is running or not.
+    var playbackRate: Float = LiveTranslationPreferences.defaultTTSRate {
+        didSet {
+            varispeedNode.rate = playbackRate
+        }
+    }
 
     private var captureContinuation: AsyncStream<Data>.Continuation?
     private var isStarted = false
@@ -78,6 +84,7 @@ final class LiveTranslationAudio {
         captureContinuation?.finish()
         captureContinuation = nil
         tapInstaller = nil
+        bufferQueue.reset()
 
         do {
             try AVAudioSession.sharedInstance().setActive(false, options: [.notifyOthersOnDeactivation])
@@ -89,10 +96,22 @@ final class LiveTranslationAudio {
     func enqueuePlayback(_ data: Data) {
         guard isStarted else { return }
         guard let buffer = makePlaybackBuffer(from: data) else { return }
-        playerNode.scheduleBuffer(buffer, completionHandler: nil)
-        // After long silences the engine may suspend the player node implicitly.
-        // Re-arm it whenever new audio arrives.
-        if !playerNode.isPlaying {
+
+        let duration = TimeInterval(buffer.frameLength) / playbackFormat.sampleRate
+
+        let playerNode = self.playerNode
+        playerNode.scheduleBuffer(buffer) { [weak bufferQueue, weak playerNode] in
+            // Completion handler runs on a non-main audio thread.
+            // PlaybackBufferQueue is lock-protected; AVAudioPlayerNode play/pause
+            // is safe to call from any thread.
+            guard let bufferQueue, let playerNode else { return }
+            if bufferQueue.didCompleteBuffer(duration: duration) {
+                playerNode.pause()
+            }
+        }
+
+        let shouldResume = bufferQueue.didQueueBuffer(duration: duration)
+        if shouldResume || (!playerNode.isPlaying && bufferQueue.canStartFresh()) {
             playerNode.play()
         }
     }
@@ -148,7 +167,7 @@ final class LiveTranslationAudio {
 
         engine.attach(playerNode)
         engine.attach(varispeedNode)
-        varispeedNode.rate = Self.playbackRate
+        varispeedNode.rate = playbackRate
         engine.connect(playerNode, to: varispeedNode, format: playbackFormat)
         engine.connect(varispeedNode, to: engine.mainMixerNode, format: playbackFormat)
 
@@ -206,6 +225,70 @@ final class LiveTranslationAudio {
         }
 
         return buffer
+    }
+}
+
+/// Tracks how much TTS audio is currently scheduled on the player node and
+/// gates playback so that we accumulate enough buffer before resuming after
+/// starvation. Without this, faster playback rates drain the queue almost as
+/// quickly as audio arrives, producing rapid stutter. With a refill threshold
+/// we trade rapid micro-gaps for rarer, longer pauses that sound smoother.
+nonisolated private final class PlaybackBufferQueue: @unchecked Sendable {
+    private let lock = NSLock()
+    private var queuedDuration: TimeInterval = 0
+    private var isStarved = true
+    private var hasEverStarted = false
+
+    /// Buffer that must be queued before playback resumes after the queue
+    /// has emptied. Higher values produce fewer, longer gaps. Tuned to ~1s
+    /// so a single Russian phrase can usually play continuously.
+    private let refillThreshold: TimeInterval = 1.0
+
+    /// Threshold below which the queue is considered empty.
+    private let lowWaterMark: TimeInterval = 0.05
+
+    /// Returns `true` if the caller should resume playback.
+    nonisolated func didQueueBuffer(duration: TimeInterval) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        queuedDuration += duration
+
+        if isStarved && queuedDuration >= refillThreshold {
+            isStarved = false
+            hasEverStarted = true
+            return true
+        }
+        return false
+    }
+
+    /// Returns `true` if the caller should pause playback (queue starved).
+    nonisolated func didCompleteBuffer(duration: TimeInterval) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        queuedDuration -= duration
+        if queuedDuration < 0 { queuedDuration = 0 }
+
+        if !isStarved && queuedDuration <= lowWaterMark {
+            isStarved = true
+            return true
+        }
+        return false
+    }
+
+    /// Allows kick-starting playback the very first time without crossing the
+    /// refill threshold (so the listener doesn't wait too long for first audio).
+    nonisolated func canStartFresh() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return !hasEverStarted && queuedDuration > 0
+    }
+
+    nonisolated func reset() {
+        lock.lock()
+        defer { lock.unlock() }
+        queuedDuration = 0
+        isStarved = true
+        hasEverStarted = false
     }
 }
 

--- a/VivaDicta/Services/LiveTranslation/LiveTranslationAudio.swift
+++ b/VivaDicta/Services/LiveTranslation/LiveTranslationAudio.swift
@@ -137,6 +137,15 @@ final class LiveTranslationAudio {
 
     func enqueuePlayback(_ data: Data) {
         guard isStarted else { return }
+
+        // Defense against the AirPods-disconnect-mid-session feedback loop.
+        // If the audio route is no longer headphones, the iPhone speaker would
+        // blast TTS audio into the mic which STT then re-captures - producing
+        // a runaway loop. Drop the buffer; the View's headphones banner
+        // already explains why no audio is playing. When headphones reconnect,
+        // future buffers schedule normally.
+        guard Self.isHeadphonesRouteActive else { return }
+
         guard let buffer = makePlaybackBuffer(from: data) else { return }
 
         let duration = TimeInterval(buffer.frameLength) / playbackFormat.sampleRate

--- a/VivaDicta/Services/LiveTranslation/LiveTranslationAudio.swift
+++ b/VivaDicta/Services/LiveTranslation/LiveTranslationAudio.swift
@@ -52,8 +52,23 @@ final class LiveTranslationAudio {
         )!
     }()
 
+    init() {
+        // Attach + connect once per lifetime. Repeated start/stop cycles must NOT
+        // re-attach nodes; AVAudioEngine throws on duplicate attach. The graph
+        // stays intact across stop()/start(); we only stop/start the engine and
+        // re-install the input tap.
+        engine.attach(playerNode)
+        engine.attach(varispeedNode)
+        varispeedNode.rate = playbackRate
+        engine.connect(playerNode, to: varispeedNode, format: playbackFormat)
+        engine.connect(varispeedNode, to: engine.mainMixerNode, format: playbackFormat)
+    }
+
     func makeCaptureStream() -> AsyncStream<Data> {
-        AsyncStream<Data> { continuation in
+        // Bound the buffer so a slow STT WS doesn't pile up audio in memory.
+        // 50 chunks at ~20ms each ≈ 1 second of headroom; older chunks are
+        // dropped under backpressure rather than growing latency unboundedly.
+        AsyncStream<Data>(bufferingPolicy: .bufferingNewest(50)) { continuation in
             captureContinuation = continuation
             continuation.onTermination = { @Sendable [weak self] _ in
                 Task { @MainActor [weak self] in
@@ -80,7 +95,9 @@ final class LiveTranslationAudio {
         playerNode.stop()
         engine.inputNode.removeTap(onBus: 0)
         engine.stop()
-        engine.reset()
+        // Do NOT call engine.reset(); it detaches nodes and the next start()
+        // would crash on re-attach. Stopping the engine alone is enough to
+        // release CPU/audio hardware.
         captureContinuation?.finish()
         captureContinuation = nil
         tapInstaller = nil
@@ -165,11 +182,10 @@ final class LiveTranslationAudio {
             throw LiveTranslationError.audioEngineFailure("invalid input format")
         }
 
-        engine.attach(playerNode)
-        engine.attach(varispeedNode)
+        // Apply the latest preferred rate every start() in case it was changed
+        // while idle. The output graph itself stays attached for the lifetime
+        // of this object (set up in init).
         varispeedNode.rate = playbackRate
-        engine.connect(playerNode, to: varispeedNode, format: playbackFormat)
-        engine.connect(varispeedNode, to: engine.mainMixerNode, format: playbackFormat)
 
         guard let continuation = captureContinuation else {
             throw LiveTranslationError.audioEngineFailure("capture stream not initialized")

--- a/VivaDicta/Services/LiveTranslation/LiveTranslationAudio.swift
+++ b/VivaDicta/Services/LiveTranslation/LiveTranslationAudio.swift
@@ -33,6 +33,12 @@ final class LiveTranslationAudio {
     private var captureContinuation: AsyncStream<Data>.Continuation?
     private var isStarted = false
     private var tapInstaller: TapInstaller?
+    /// Tracks whether configureSession() activated AVAudioSession so partial
+    /// startup failures still deactivate it on cleanup.
+    private var sessionActivated = false
+    /// Tracks whether the input tap was actually installed (separate from
+    /// `tapInstaller != nil` because the install runs on a global queue).
+    private var tapInstalled = false
 
     private let captureFormat: AVAudioFormat = {
         AVAudioFormat(
@@ -81,32 +87,51 @@ final class LiveTranslationAudio {
     func start() async throws {
         guard !isStarted else { return }
 
-        try configureSession()
-        try await configureEngine()
-        try engine.start()
-        playerNode.play()
-        isStarted = true
+        // If any step throws, call stop() to clean up anything we already
+        // activated (session, tap, etc.). stop() is idempotent and safe to
+        // call before isStarted flips to true.
+        do {
+            try configureSession()
+            try await configureEngine()
+            try engine.start()
+            playerNode.play()
+            isStarted = true
+        } catch {
+            stop()
+            throw error
+        }
     }
 
+    /// Idempotent: safe to call regardless of how far start() got. Each step
+    /// is guarded by its own `did-start` flag so a partial-start failure
+    /// still tears down the audio session and tap.
     func stop() {
-        guard isStarted else { return }
         isStarted = false
 
         playerNode.stop()
-        engine.inputNode.removeTap(onBus: 0)
+
+        if tapInstalled {
+            engine.inputNode.removeTap(onBus: 0)
+            tapInstalled = false
+        }
+
         engine.stop()
         // Do NOT call engine.reset(); it detaches nodes and the next start()
         // would crash on re-attach. Stopping the engine alone is enough to
         // release CPU/audio hardware.
+
         captureContinuation?.finish()
         captureContinuation = nil
         tapInstaller = nil
         bufferQueue.reset()
 
-        do {
-            try AVAudioSession.sharedInstance().setActive(false, options: [.notifyOthersOnDeactivation])
-        } catch {
-            logger.logWarning("Audio session deactivate failed: \(error.localizedDescription)")
+        if sessionActivated {
+            do {
+                try AVAudioSession.sharedInstance().setActive(false, options: [.notifyOthersOnDeactivation])
+            } catch {
+                logger.logWarning("Audio session deactivate failed: \(error.localizedDescription)")
+            }
+            sessionActivated = false
         }
     }
 
@@ -149,6 +174,7 @@ final class LiveTranslationAudio {
             try session.setPreferredSampleRate(48000)
             try session.setPreferredIOBufferDuration(0.02)
             try session.setActive(true, options: [])
+            sessionActivated = true
             try session.overrideOutputAudioPort(.none)
         } catch {
             throw LiveTranslationError.audioSessionFailure(error.localizedDescription)
@@ -216,6 +242,7 @@ final class LiveTranslationAudio {
                 resume.resume()
             }
         }
+        tapInstalled = true
 
         engine.prepare()
     }

--- a/VivaDicta/Services/LiveTranslation/LiveTranslationModels.swift
+++ b/VivaDicta/Services/LiveTranslation/LiveTranslationModels.swift
@@ -1,0 +1,117 @@
+//
+//  LiveTranslationModels.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.28
+//
+
+import Foundation
+
+enum LiveTranslationLanguage: String, CaseIterable, Identifiable, Sendable {
+    case english = "en"
+    case spanish = "es"
+    case russian = "ru"
+    case ukrainian = "uk"
+    case french = "fr"
+    case german = "de"
+    case italian = "it"
+    case portuguese = "pt"
+    case dutch = "nl"
+    case polish = "pl"
+    case czech = "cs"
+    case turkish = "tr"
+    case arabic = "ar"
+    case hebrew = "he"
+    case hindi = "hi"
+    case chinese = "zh"
+    case japanese = "ja"
+    case korean = "ko"
+    case indonesian = "id"
+    case vietnamese = "vi"
+    case thai = "th"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .english: "English"
+        case .spanish: "Spanish"
+        case .russian: "Russian"
+        case .ukrainian: "Ukrainian"
+        case .french: "French"
+        case .german: "German"
+        case .italian: "Italian"
+        case .portuguese: "Portuguese"
+        case .dutch: "Dutch"
+        case .polish: "Polish"
+        case .czech: "Czech"
+        case .turkish: "Turkish"
+        case .arabic: "Arabic"
+        case .hebrew: "Hebrew"
+        case .hindi: "Hindi"
+        case .chinese: "Chinese"
+        case .japanese: "Japanese"
+        case .korean: "Korean"
+        case .indonesian: "Indonesian"
+        case .vietnamese: "Vietnamese"
+        case .thai: "Thai"
+        }
+    }
+}
+
+enum LiveTranslationStatus: Equatable, Sendable {
+    case idle
+    case starting
+    case running
+    case stopping
+    case failed(String)
+}
+
+struct LiveTranslationToken: Sendable, Hashable {
+    let id: UUID
+    let text: String
+    let isFinal: Bool
+    let kind: Kind
+
+    enum Kind: Sendable, Hashable {
+        case original
+        case translation
+    }
+}
+
+struct LiveTranslationConfig: Sendable {
+    var sourceLanguage: LiveTranslationLanguage
+    var targetLanguage: LiveTranslationLanguage
+    var ttsEnabled: Bool
+    var ttsVoice: String
+
+    static let `default` = LiveTranslationConfig(
+        sourceLanguage: .spanish,
+        targetLanguage: .russian,
+        ttsEnabled: true,
+        ttsVoice: "Adrian"
+    )
+}
+
+enum LiveTranslationError: LocalizedError {
+    case missingAPIKey
+    case microphonePermissionDenied
+    case audioSessionFailure(String)
+    case webSocketFailure(String)
+    case audioEngineFailure(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingAPIKey:
+            "Soniox API key is missing. Add it in Settings."
+        case .microphonePermissionDenied:
+            "Microphone access is required for live translation."
+        case .audioSessionFailure(let message):
+            "Audio session error: \(message)"
+        case .webSocketFailure(let message):
+            "Connection error: \(message)"
+        case .audioEngineFailure(let message):
+            "Audio error: \(message)"
+        }
+    }
+}

--- a/VivaDicta/Services/LiveTranslation/LiveTranslationModels.swift
+++ b/VivaDicta/Services/LiveTranslation/LiveTranslationModels.swift
@@ -57,6 +57,35 @@ enum LiveTranslationLanguage: String, CaseIterable, Identifiable, Sendable {
         case .thai: "Thai"
         }
     }
+
+    var displayNameWithFlag: String {
+        TranscriptionModelProvider.languageWithFlag(rawValue, name: displayName)
+    }
+
+    /// Languages alphabetically sorted by display name. Use this for the
+    /// "rest" section of the picker.
+    static var alphabetical: [LiveTranslationLanguage] {
+        allCases.sorted { $0.displayName < $1.displayName }
+    }
+
+    /// User's preferred languages from `Locale.preferredLanguages`, intersected
+    /// with what we support, in order of preference. Used to surface the most
+    /// likely picks at the top of the picker.
+    static var userPreferred: [LiveTranslationLanguage] {
+        var seen: Set<LiveTranslationLanguage> = []
+        var ordered: [LiveTranslationLanguage] = []
+        for identifier in Locale.preferredLanguages {
+            let locale = Locale(identifier: identifier)
+            guard let code = locale.language.languageCode?.identifier,
+                  let lang = LiveTranslationLanguage(rawValue: code),
+                  !seen.contains(lang) else {
+                continue
+            }
+            seen.insert(lang)
+            ordered.append(lang)
+        }
+        return ordered
+    }
 }
 
 enum LiveTranslationStatus: Equatable, Sendable {

--- a/VivaDicta/Services/LiveTranslation/LiveTranslationModels.swift
+++ b/VivaDicta/Services/LiveTranslation/LiveTranslationModels.swift
@@ -84,13 +84,64 @@ struct LiveTranslationConfig: Sendable {
     var targetLanguage: LiveTranslationLanguage
     var ttsEnabled: Bool
     var ttsVoice: String
+    var ttsRate: Float
 
-    static let `default` = LiveTranslationConfig(
-        sourceLanguage: .spanish,
-        targetLanguage: .russian,
-        ttsEnabled: true,
-        ttsVoice: "Adrian"
-    )
+    static var stored: LiveTranslationConfig {
+        LiveTranslationConfig(
+            sourceLanguage: LiveTranslationPreferences.sourceLanguage,
+            targetLanguage: LiveTranslationPreferences.targetLanguage,
+            ttsEnabled: LiveTranslationPreferences.ttsEnabled,
+            ttsVoice: "Adrian",
+            ttsRate: LiveTranslationPreferences.ttsRate
+        )
+    }
+}
+
+enum LiveTranslationPreferences {
+    static let minTTSRate: Float = 1.0
+    static let maxTTSRate: Float = 2.0
+    static let defaultTTSRate: Float = 1.15
+
+    static var sourceLanguage: LiveTranslationLanguage {
+        get {
+            let raw = UserDefaultsStorage.appPrivate.string(forKey: UserDefaultsStorage.Keys.liveTranslationSourceLanguage) ?? ""
+            return LiveTranslationLanguage(rawValue: raw) ?? .english
+        }
+        set {
+            UserDefaultsStorage.appPrivate.set(newValue.rawValue, forKey: UserDefaultsStorage.Keys.liveTranslationSourceLanguage)
+        }
+    }
+
+    static var targetLanguage: LiveTranslationLanguage {
+        get {
+            let raw = UserDefaultsStorage.appPrivate.string(forKey: UserDefaultsStorage.Keys.liveTranslationTargetLanguage) ?? ""
+            return LiveTranslationLanguage(rawValue: raw) ?? .english
+        }
+        set {
+            UserDefaultsStorage.appPrivate.set(newValue.rawValue, forKey: UserDefaultsStorage.Keys.liveTranslationTargetLanguage)
+        }
+    }
+
+    static var ttsEnabled: Bool {
+        get {
+            UserDefaultsStorage.appPrivate.object(forKey: UserDefaultsStorage.Keys.liveTranslationTTSEnabled) as? Bool ?? true
+        }
+        set {
+            UserDefaultsStorage.appPrivate.set(newValue, forKey: UserDefaultsStorage.Keys.liveTranslationTTSEnabled)
+        }
+    }
+
+    static var ttsRate: Float {
+        get {
+            let stored = UserDefaultsStorage.appPrivate.object(forKey: UserDefaultsStorage.Keys.liveTranslationTTSRate) as? Double
+            let value = Float(stored ?? Double(defaultTTSRate))
+            return min(max(value, minTTSRate), maxTTSRate)
+        }
+        set {
+            let clamped = min(max(newValue, minTTSRate), maxTTSRate)
+            UserDefaultsStorage.appPrivate.set(Double(clamped), forKey: UserDefaultsStorage.Keys.liveTranslationTTSRate)
+        }
+    }
 }
 
 enum LiveTranslationError: LocalizedError {

--- a/VivaDicta/Services/LiveTranslation/LiveTranslationService.swift
+++ b/VivaDicta/Services/LiveTranslation/LiveTranslationService.swift
@@ -16,18 +16,27 @@ final class LiveTranslationService {
     private(set) var originalTokens: [LiveTranslationToken] = []
     private(set) var translatedTokens: [LiveTranslationToken] = []
 
-    var config = LiveTranslationConfig.default {
+    var config: LiveTranslationConfig = .stored {
         didSet {
+            persistConfig(oldValue: oldValue)
             if oldValue.ttsEnabled != config.ttsEnabled, status == .running {
                 handleTTSToggle()
+            }
+            if oldValue.ttsRate != config.ttsRate {
+                audio.playbackRate = config.ttsRate
             }
         }
     }
 
     private let logger = Logger(category: .liveTranslationService)
-    private let audio = LiveTranslationAudio()
+    private let audio: LiveTranslationAudio
     private let sttClient = SonioxRealtimeSTTClient()
     private var ttsClient: SonioxRealtimeTTSClient?
+
+    init() {
+        audio = LiveTranslationAudio()
+        audio.playbackRate = LiveTranslationPreferences.ttsRate
+    }
 
     private var sttTask: Task<Void, Never>?
     private var ttsTask: Task<Void, Never>?
@@ -245,6 +254,21 @@ final class LiveTranslationService {
                     continuation.resume(returning: granted)
                 }
             }
+        }
+    }
+
+    private func persistConfig(oldValue: LiveTranslationConfig) {
+        if oldValue.sourceLanguage != config.sourceLanguage {
+            LiveTranslationPreferences.sourceLanguage = config.sourceLanguage
+        }
+        if oldValue.targetLanguage != config.targetLanguage {
+            LiveTranslationPreferences.targetLanguage = config.targetLanguage
+        }
+        if oldValue.ttsEnabled != config.ttsEnabled {
+            LiveTranslationPreferences.ttsEnabled = config.ttsEnabled
+        }
+        if oldValue.ttsRate != config.ttsRate {
+            LiveTranslationPreferences.ttsRate = config.ttsRate
         }
     }
 

--- a/VivaDicta/Services/LiveTranslation/LiveTranslationService.swift
+++ b/VivaDicta/Services/LiveTranslation/LiveTranslationService.swift
@@ -1,0 +1,238 @@
+//
+//  LiveTranslationService.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.28
+//
+
+import AVFoundation
+import Foundation
+import os
+
+@MainActor
+@Observable
+final class LiveTranslationService {
+    private(set) var status: LiveTranslationStatus = .idle
+    private(set) var originalTokens: [LiveTranslationToken] = []
+    private(set) var translatedTokens: [LiveTranslationToken] = []
+
+    var config = LiveTranslationConfig.default {
+        didSet {
+            if oldValue.ttsEnabled != config.ttsEnabled, status == .running {
+                handleTTSToggle()
+            }
+        }
+    }
+
+    private let logger = Logger(category: .liveTranslationService)
+    private let audio = LiveTranslationAudio()
+    private let sttClient = SonioxRealtimeSTTClient()
+    private var ttsClient: SonioxRealtimeTTSClient?
+
+    private var sttTask: Task<Void, Never>?
+    private var ttsTask: Task<Void, Never>?
+    private var captureTask: Task<Void, Never>?
+
+    func start() async {
+        guard status == .idle || isFailed(status) else { return }
+
+        status = .starting
+        originalTokens.removeAll()
+        translatedTokens.removeAll()
+
+        guard let apiKey = KeychainService.shared.getString(forKey: "sonioxAPIKey"),
+              !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            await fail(LiveTranslationError.missingAPIKey)
+            return
+        }
+
+        guard await requestMicrophonePermission() else {
+            await fail(LiveTranslationError.microphonePermissionDenied)
+            return
+        }
+
+        let captureStream = audio.makeCaptureStream()
+
+        do {
+            try await audio.start()
+        } catch {
+            await fail(error)
+            return
+        }
+
+        let vocabularyTerms = CustomVocabulary.getTerms()
+        let sttStream = await sttClient.connect(
+            apiKey: apiKey,
+            sourceLanguage: config.sourceLanguage,
+            targetLanguage: config.targetLanguage,
+            vocabularyTerms: vocabularyTerms
+        )
+
+        if config.ttsEnabled {
+            await openTTSStream(apiKey: apiKey)
+        }
+
+        captureTask = Task { [weak self] in
+            for await chunk in captureStream {
+                guard let self else { return }
+                await self.sttClient.sendAudioChunk(chunk)
+            }
+        }
+
+        sttTask = Task { [weak self] in
+            for await event in sttStream {
+                guard let self else { return }
+                await self.handleSTTEvent(event)
+            }
+        }
+
+        status = .running
+    }
+
+    func stop() async {
+        guard status == .running || status == .starting else { return }
+        status = .stopping
+        await teardown()
+        status = .idle
+    }
+
+    func transcriptSnapshot() -> (original: String, translation: String) {
+        let original = renderText(from: originalTokens)
+        let translation = renderText(from: translatedTokens)
+        return (original, translation)
+    }
+
+    // MARK: - Private
+
+    private func handleSTTEvent(_ event: SonioxRealtimeSTTClient.Event) async {
+        switch event {
+        case .token(let token):
+            appendToken(token)
+            if token.kind == .translation, !token.text.isEmpty {
+                await ttsClient?.sendText(token.text)
+            }
+        case .finished:
+            break
+        case .failed(let message):
+            await fail(LiveTranslationError.webSocketFailure(message))
+        }
+    }
+
+    private func handleTTSEvent(_ event: SonioxRealtimeTTSClient.Event) async {
+        switch event {
+        case .audio(let data):
+            audio.enqueuePlayback(data)
+        case .finished:
+            break
+        case .failed(let message):
+            logger.logError("TTS stream failed: \(message)")
+        }
+    }
+
+    private func appendToken(_ token: LiveTranslationToken) {
+        switch token.kind {
+        case .original:
+            mergeToken(token, into: &originalTokens)
+        case .translation:
+            mergeToken(token, into: &translatedTokens)
+        }
+    }
+
+    private func mergeToken(_ token: LiveTranslationToken, into list: inout [LiveTranslationToken]) {
+        if let last = list.last, last.isFinal == false {
+            if token.isFinal {
+                list.removeLast()
+                list.append(token)
+            } else {
+                list.removeLast()
+                list.append(token)
+            }
+        } else {
+            list.append(token)
+        }
+    }
+
+    private func openTTSStream(apiKey: String) async {
+        let client = SonioxRealtimeTTSClient()
+        ttsClient = client
+        let stream = await client.connect(
+            apiKey: apiKey,
+            language: config.targetLanguage,
+            voice: config.ttsVoice
+        )
+        ttsTask = Task { [weak self] in
+            for await event in stream {
+                guard let self else { return }
+                await self.handleTTSEvent(event)
+            }
+        }
+    }
+
+    private func handleTTSToggle() {
+        Task { [weak self] in
+            guard let self else { return }
+            if self.config.ttsEnabled {
+                guard let apiKey = KeychainService.shared.getString(forKey: "sonioxAPIKey"),
+                      !apiKey.isEmpty else { return }
+                await self.openTTSStream(apiKey: apiKey)
+            } else {
+                await self.ttsClient?.disconnect()
+                self.ttsClient = nil
+                self.ttsTask?.cancel()
+                self.ttsTask = nil
+            }
+        }
+    }
+
+    private func teardown() async {
+        captureTask?.cancel()
+        captureTask = nil
+        sttTask?.cancel()
+        sttTask = nil
+        ttsTask?.cancel()
+        ttsTask = nil
+
+        await sttClient.finalizeAudio()
+        await sttClient.disconnect()
+        await ttsClient?.disconnect()
+        ttsClient = nil
+
+        audio.stop()
+    }
+
+    private func fail(_ error: Error) async {
+        let message: String
+        if let translationError = error as? LiveTranslationError {
+            message = translationError.errorDescription ?? "Unknown error"
+        } else {
+            message = error.localizedDescription
+        }
+        logger.logError("Live translation failed: \(message)")
+        await teardown()
+        status = .failed(message)
+    }
+
+    private func isFailed(_ status: LiveTranslationStatus) -> Bool {
+        if case .failed = status { return true }
+        return false
+    }
+
+    private func requestMicrophonePermission() async -> Bool {
+        if #available(iOS 17, *) {
+            return await AVAudioApplication.requestRecordPermission()
+        } else {
+            return await withCheckedContinuation { continuation in
+                AVAudioSession.sharedInstance().requestRecordPermission { granted in
+                    continuation.resume(returning: granted)
+                }
+            }
+        }
+    }
+
+    private func renderText(from tokens: [LiveTranslationToken]) -> String {
+        tokens
+            .map(\.text)
+            .joined()
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/VivaDicta/Services/LiveTranslation/LiveTranslationService.swift
+++ b/VivaDicta/Services/LiveTranslation/LiveTranslationService.swift
@@ -39,6 +39,18 @@ final class LiveTranslationService {
     private var interruptionObserver: NSObjectProtocol?
     private var apiKeyCache: String?
 
+    /// Bounded retry state for STT reconnect on `.failed` events. Prevents a
+    /// busy reconnect loop when the failure is persistent (revoked key, quota,
+    /// malformed config). Reset on successful token receipt or graceful close.
+    private var sttFailureRetries: Int = 0
+    private let maxSTTFailureRetries: Int = 3
+
+    /// Source/target language captured at session start. `combineSnapshot`
+    /// uses these so save-as-note labels never reflect a picker change made
+    /// after Stop and before tapping Save.
+    private(set) var sessionSourceLanguage: LiveTranslationLanguage = .english
+    private(set) var sessionTargetLanguage: LiveTranslationLanguage = .english
+
     init() {
         audio = LiveTranslationAudio()
         audio.playbackRate = LiveTranslationPreferences.ttsRate
@@ -54,6 +66,9 @@ final class LiveTranslationService {
         status = .starting
         originalTokens.removeAll()
         translatedTokens.removeAll()
+        sttFailureRetries = 0
+        sessionSourceLanguage = config.sourceLanguage
+        sessionTargetLanguage = config.targetLanguage
 
         guard let apiKey = KeychainService.shared.getString(forKey: "sonioxAPIKey"),
               !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
@@ -90,6 +105,17 @@ final class LiveTranslationService {
         }
 
         observeInterruptions()
+
+        // Reconcile TTS toggle changes that happened mid-startup. The didSet
+        // observer ignores changes while status == .starting (because the
+        // start() flow hasn't yet reached the openTTSStream call); apply the
+        // current desired state here once setup is otherwise complete.
+        if config.ttsEnabled, ttsClient == nil {
+            await openTTSStream(apiKey: apiKey)
+        } else if !config.ttsEnabled, ttsClient != nil {
+            await closeTTSStream()
+        }
+
         status = .running
     }
 
@@ -121,10 +147,15 @@ final class LiveTranslationService {
         status = .idle
     }
 
-    func transcriptSnapshot() -> (original: String, translation: String) {
+    func transcriptSnapshot() -> (
+        sourceLanguage: LiveTranslationLanguage,
+        original: String,
+        targetLanguage: LiveTranslationLanguage,
+        translation: String
+    ) {
         let original = renderText(from: originalTokens)
         let translation = renderText(from: translatedTokens)
-        return (original, translation)
+        return (sessionSourceLanguage, original, sessionTargetLanguage, translation)
     }
 
     // MARK: - Private
@@ -132,6 +163,10 @@ final class LiveTranslationService {
     private func handleSTTEvent(_ event: SonioxRealtimeSTTClient.Event) async {
         switch event {
         case .token(let token):
+            // Successful token receipt means the connection is healthy; reset
+            // the failure retry counter so future transient blips have a fresh
+            // budget.
+            sttFailureRetries = 0
             appendToken(token)
             // Only forward FINAL translation tokens to TTS. Soniox revises
             // interim tokens; speaking them produces duplicated/garbled audio.
@@ -139,21 +174,38 @@ final class LiveTranslationService {
                 await ttsClient?.sendText(token.text)
             }
         case .finished:
-            // STT stream ended (idle timeout or server-side close). Reopen if
-            // we're still running, mirroring TTS reconnect behaviour.
+            // Graceful close (idle timeout or server-side rotation). Reconnect
+            // without consuming the failure budget — these aren't errors.
             guard status == .running, let apiKey = apiKeyCache else { return }
             logger.logInfo("STT stream ended mid-session - reconnecting")
             startSTT(apiKey: apiKey)
         case .failed(let message):
-            // Only treat as fatal when not running; transient network blips
-            // mid-session reconnect transparently.
-            if status == .running, let apiKey = apiKeyCache {
-                logger.logInfo("STT stream failed mid-session - reconnecting: \(message)")
-                startSTT(apiKey: apiKey)
-            } else {
-                await fail(LiveTranslationError.webSocketFailure(message))
-            }
+            await handleSTTFailure(message: message)
         }
+    }
+
+    private func handleSTTFailure(message: String) async {
+        guard status == .running, let apiKey = apiKeyCache else {
+            await fail(LiveTranslationError.webSocketFailure(message))
+            return
+        }
+
+        sttFailureRetries += 1
+        if sttFailureRetries > maxSTTFailureRetries {
+            logger.logError("STT failed \(sttFailureRetries) times - giving up: \(message)")
+            await fail(LiveTranslationError.webSocketFailure(message))
+            return
+        }
+
+        // Exponential-ish backoff: 1s, 2s, 4s. Caps the worst-case spin rate
+        // so a persistent failure (revoked key, server outage) doesn't hammer
+        // Soniox or burn the device battery.
+        let backoffSeconds = pow(2.0, Double(sttFailureRetries - 1))
+        logger.logInfo("STT failed mid-session - reconnect attempt \(sttFailureRetries)/\(maxSTTFailureRetries) in \(backoffSeconds)s: \(message)")
+
+        try? await Task.sleep(for: .seconds(backoffSeconds))
+        guard status == .running else { return }
+        startSTT(apiKey: apiKey)
     }
 
     private func handleTTSEvent(_ event: SonioxRealtimeTTSClient.Event) async {
@@ -230,12 +282,16 @@ final class LiveTranslationService {
                       !apiKey.isEmpty else { return }
                 await self.openTTSStream(apiKey: apiKey)
             } else {
-                await self.ttsClient?.disconnect()
-                self.ttsClient = nil
-                self.ttsTask?.cancel()
-                self.ttsTask = nil
+                await self.closeTTSStream()
             }
         }
+    }
+
+    private func closeTTSStream() async {
+        await ttsClient?.disconnect()
+        ttsClient = nil
+        ttsTask?.cancel()
+        ttsTask = nil
     }
 
     private func teardown() async {
@@ -268,9 +324,8 @@ final class LiveTranslationService {
             forName: AVAudioSession.interruptionNotification,
             object: AVAudioSession.sharedInstance(),
             queue: .main
-        ) { [weak self] notification in
-            guard self != nil,
-                  let info = notification.userInfo,
+        ) { notification in
+            guard let info = notification.userInfo,
                   let typeRaw = info[AVAudioSessionInterruptionTypeKey] as? UInt,
                   let type = AVAudioSession.InterruptionType(rawValue: typeRaw) else {
                 return

--- a/VivaDicta/Services/LiveTranslation/LiveTranslationService.swift
+++ b/VivaDicta/Services/LiveTranslation/LiveTranslationService.swift
@@ -182,15 +182,15 @@ final class LiveTranslationService {
 
     private func handleSTTEvent(_ event: SonioxRealtimeSTTClient.Event) async {
         switch event {
-        case .token(let token):
+        case .tokens(let batch):
             // Successful token receipt means the connection is healthy; reset
             // the failure retry counter so future transient blips have a fresh
             // budget.
             sttFailureRetries = 0
-            appendToken(token)
+            appendTokens(batch)
             // Only forward FINAL translation tokens to TTS. Soniox revises
             // interim tokens; speaking them produces duplicated/garbled audio.
-            if token.kind == .translation, token.isFinal, !token.text.isEmpty {
+            for token in batch where token.kind == .translation && token.isFinal && !token.text.isEmpty {
                 await ttsClient?.sendText(token.text)
             }
         case .finished:
@@ -282,24 +282,33 @@ final class LiveTranslationService {
         await openTTSStream(apiKey: apiKey)
     }
 
-    private func appendToken(_ token: LiveTranslationToken) {
-        switch token.kind {
-        case .original:
-            mergeToken(token, into: &originalTokens)
-        case .translation:
-            mergeToken(token, into: &translatedTokens)
+    private func appendTokens(_ batch: [LiveTranslationToken]) {
+        // Split the batch by stream (original vs translation) and merge each
+        // into its respective list. We split first so a response that updates
+        // only one side doesn't disturb the other side's non-final tail.
+        var originalBatch: [LiveTranslationToken] = []
+        var translationBatch: [LiveTranslationToken] = []
+        for token in batch {
+            switch token.kind {
+            case .original: originalBatch.append(token)
+            case .translation: translationBatch.append(token)
+            }
         }
+        mergeBatch(originalBatch, into: &originalTokens)
+        mergeBatch(translationBatch, into: &translatedTokens)
     }
 
-    private func mergeToken(_ token: LiveTranslationToken, into list: inout [LiveTranslationToken]) {
-        // If the trailing token is non-final, replace it with the incoming
-        // token (whether final or not). Soniox emits interim tokens that get
-        // superseded; this keeps the rendered text from doubling. Multi-token
-        // interim tails are not perfectly preserved - acceptable trade-off.
-        if let last = list.last, !last.isFinal {
+    private func mergeBatch(_ batch: [LiveTranslationToken], into list: inout [LiveTranslationToken]) {
+        guard !batch.isEmpty else { return }
+        // Per Soniox protocol: non-final tokens in each response are a full
+        // replacement set, so drop ALL trailing non-finals before appending
+        // the new batch (which may itself contain finals followed by a new
+        // non-final tail). Final tokens already in the list are committed
+        // forever and stay put.
+        while let last = list.last, !last.isFinal {
             list.removeLast()
         }
-        list.append(token)
+        list.append(contentsOf: batch)
     }
 
     private func openTTSStream(apiKey: String) async {

--- a/VivaDicta/Services/LiveTranslation/LiveTranslationService.swift
+++ b/VivaDicta/Services/LiveTranslation/LiveTranslationService.swift
@@ -123,10 +123,29 @@ final class LiveTranslationService {
         case .audio(let data):
             audio.enqueuePlayback(data)
         case .finished:
-            break
+            // Soniox auto-terminates a TTS stream after some duration. If we're
+            // still in a running session and TTS is still enabled, transparently
+            // reopen the stream so playback continues.
+            guard status == .running, config.ttsEnabled else { return }
+            logger.logInfo("TTS stream ended mid-session - reconnecting")
+            await reopenTTSStream()
         case .failed(let message):
             logger.logError("TTS stream failed: \(message)")
+            guard status == .running, config.ttsEnabled else { return }
+            logger.logInfo("TTS stream failed mid-session - reconnecting")
+            await reopenTTSStream()
         }
+    }
+
+    private func reopenTTSStream() async {
+        await ttsClient?.disconnect()
+        ttsClient = nil
+        ttsTask?.cancel()
+        ttsTask = nil
+
+        guard let apiKey = KeychainService.shared.getString(forKey: "sonioxAPIKey"),
+              !apiKey.isEmpty else { return }
+        await openTTSStream(apiKey: apiKey)
     }
 
     private func appendToken(_ token: LiveTranslationToken) {

--- a/VivaDicta/Services/LiveTranslation/LiveTranslationService.swift
+++ b/VivaDicta/Services/LiveTranslation/LiveTranslationService.swift
@@ -45,6 +45,13 @@ final class LiveTranslationService {
     private var sttFailureRetries: Int = 0
     private let maxSTTFailureRetries: Int = 3
 
+    /// Same bounded retry state for TTS reconnect. Without this a persistent
+    /// TTS failure (e.g., voice not supported for target language) loops the
+    /// reopen path on MainActor and can starve SwiftUI updates - which is
+    /// what was hanging the Save and Stop buttons in practice.
+    private var ttsFailureRetries: Int = 0
+    private let maxTTSFailureRetries: Int = 3
+
     /// Source/target language captured at session start. `combineSnapshot`
     /// uses these so save-as-note labels never reflect a picker change made
     /// after Stop and before tapping Save.
@@ -67,6 +74,7 @@ final class LiveTranslationService {
         originalTokens.removeAll()
         translatedTokens.removeAll()
         sttFailureRetries = 0
+        ttsFailureRetries = 0
         sessionSourceLanguage = config.sourceLanguage
         sessionTargetLanguage = config.targetLanguage
 
@@ -116,7 +124,12 @@ final class LiveTranslationService {
             await closeTTSStream()
         }
 
-        status = .running
+        // Only transition to .running if the user (or a failure) didn't move
+        // us elsewhere while we were suspended on the awaits above. Otherwise
+        // we'd revive a session that's already been torn down by stop()/fail().
+        if status == .starting {
+            status = .running
+        }
     }
 
     private func startSTT(apiKey: String) {
@@ -211,28 +224,52 @@ final class LiveTranslationService {
     private func handleTTSEvent(_ event: SonioxRealtimeTTSClient.Event) async {
         switch event {
         case .audio(let data):
+            // Successful audio receipt = healthy connection; reset budget.
+            ttsFailureRetries = 0
             audio.enqueuePlayback(data)
         case .finished:
-            // Soniox auto-terminates a TTS stream after some duration. If we're
-            // still in a running session and TTS is still enabled, transparently
-            // reopen the stream so playback continues.
+            // Graceful close (Soniox auto-terminates after ~2 minutes). Reopen
+            // without consuming the failure budget.
             guard status == .running, config.ttsEnabled else { return }
             logger.logInfo("TTS stream ended mid-session - reconnecting")
             await reopenTTSStream()
         case .failed(let message):
-            logger.logError("TTS stream failed: \(message)")
-            guard status == .running, config.ttsEnabled else { return }
-            logger.logInfo("TTS stream failed mid-session - reconnecting")
-            await reopenTTSStream()
+            await handleTTSFailure(message: message)
         }
     }
 
+    private func handleTTSFailure(message: String) async {
+        guard status == .running, config.ttsEnabled else {
+            logger.logError("TTS stream failed (not running): \(message)")
+            return
+        }
+
+        ttsFailureRetries += 1
+        if ttsFailureRetries > maxTTSFailureRetries {
+            logger.logError("TTS failed \(ttsFailureRetries) times - giving up: \(message)")
+            // Tear down TTS only; keep STT/transcript running so the user
+            // still sees text even though playback is gone.
+            await closeTTSStream()
+            return
+        }
+
+        let backoffSeconds = pow(2.0, Double(ttsFailureRetries - 1))
+        logger.logInfo("TTS failed mid-session - reconnect attempt \(ttsFailureRetries)/\(maxTTSFailureRetries) in \(backoffSeconds)s: \(message)")
+
+        try? await Task.sleep(for: .seconds(backoffSeconds))
+        guard status == .running, config.ttsEnabled else { return }
+        await reopenTTSStream()
+    }
+
     private func reopenTTSStream() async {
+        // Don't self-cancel ttsTask here; the OLD task's stream is finished
+        // by disconnect() below and its for-await loop exits naturally on
+        // the next iteration. openTTSStream will overwrite the ttsTask
+        // reference with the new task.
         await ttsClient?.disconnect()
         ttsClient = nil
-        ttsTask?.cancel()
-        ttsTask = nil
 
+        guard status == .running, config.ttsEnabled else { return }
         guard let apiKey = KeychainService.shared.getString(forKey: "sonioxAPIKey"),
               !apiKey.isEmpty else { return }
         await openTTSStream(apiKey: apiKey)
@@ -324,7 +361,12 @@ final class LiveTranslationService {
             forName: AVAudioSession.interruptionNotification,
             object: AVAudioSession.sharedInstance(),
             queue: .main
-        ) { notification in
+        ) { [weak self] notification in
+            // Outer [weak self] is necessary even though the inner Task uses
+            // [weak self]: otherwise the inner reference makes the outer
+            // closure capture self strongly, creating a retain cycle with
+            // interruptionObserver.
+            guard self != nil else { return }
             guard let info = notification.userInfo,
                   let typeRaw = info[AVAudioSessionInterruptionTypeKey] as? UInt,
                   let type = AVAudioSession.InterruptionType(rawValue: typeRaw) else {

--- a/VivaDicta/Services/LiveTranslation/LiveTranslationService.swift
+++ b/VivaDicta/Services/LiveTranslation/LiveTranslationService.swift
@@ -33,14 +33,20 @@ final class LiveTranslationService {
     private let sttClient = SonioxRealtimeSTTClient()
     private var ttsClient: SonioxRealtimeTTSClient?
 
+    private var sttTask: Task<Void, Never>?
+    private var ttsTask: Task<Void, Never>?
+    private var captureTask: Task<Void, Never>?
+    private var interruptionObserver: NSObjectProtocol?
+    private var apiKeyCache: String?
+
     init() {
         audio = LiveTranslationAudio()
         audio.playbackRate = LiveTranslationPreferences.ttsRate
     }
 
-    private var sttTask: Task<Void, Never>?
-    private var ttsTask: Task<Void, Never>?
-    private var captureTask: Task<Void, Never>?
+    func clearFailureIfNeeded() {
+        if case .failed = status { status = .idle }
+    }
 
     func start() async {
         guard status == .idle || isFailed(status) else { return }
@@ -54,6 +60,7 @@ final class LiveTranslationService {
             await fail(LiveTranslationError.missingAPIKey)
             return
         }
+        apiKeyCache = apiKey
 
         guard await requestMicrophonePermission() else {
             await fail(LiveTranslationError.microphonePermissionDenied)
@@ -69,13 +76,7 @@ final class LiveTranslationService {
             return
         }
 
-        let vocabularyTerms = CustomVocabulary.getTerms()
-        let sttStream = await sttClient.connect(
-            apiKey: apiKey,
-            sourceLanguage: config.sourceLanguage,
-            targetLanguage: config.targetLanguage,
-            vocabularyTerms: vocabularyTerms
-        )
+        startSTT(apiKey: apiKey)
 
         if config.ttsEnabled {
             await openTTSStream(apiKey: apiKey)
@@ -88,14 +89,29 @@ final class LiveTranslationService {
             }
         }
 
+        observeInterruptions()
+        status = .running
+    }
+
+    private func startSTT(apiKey: String) {
+        let vocabularyTerms = CustomVocabulary.getTerms()
+        let sourceLang = config.sourceLanguage
+        let targetLang = config.targetLanguage
+        let sttClient = self.sttClient
+
+        sttTask?.cancel()
         sttTask = Task { [weak self] in
-            for await event in sttStream {
+            let stream = await sttClient.connect(
+                apiKey: apiKey,
+                sourceLanguage: sourceLang,
+                targetLanguage: targetLang,
+                vocabularyTerms: vocabularyTerms
+            )
+            for await event in stream {
                 guard let self else { return }
                 await self.handleSTTEvent(event)
             }
         }
-
-        status = .running
     }
 
     func stop() async {
@@ -117,13 +133,26 @@ final class LiveTranslationService {
         switch event {
         case .token(let token):
             appendToken(token)
-            if token.kind == .translation, !token.text.isEmpty {
+            // Only forward FINAL translation tokens to TTS. Soniox revises
+            // interim tokens; speaking them produces duplicated/garbled audio.
+            if token.kind == .translation, token.isFinal, !token.text.isEmpty {
                 await ttsClient?.sendText(token.text)
             }
         case .finished:
-            break
+            // STT stream ended (idle timeout or server-side close). Reopen if
+            // we're still running, mirroring TTS reconnect behaviour.
+            guard status == .running, let apiKey = apiKeyCache else { return }
+            logger.logInfo("STT stream ended mid-session - reconnecting")
+            startSTT(apiKey: apiKey)
         case .failed(let message):
-            await fail(LiveTranslationError.webSocketFailure(message))
+            // Only treat as fatal when not running; transient network blips
+            // mid-session reconnect transparently.
+            if status == .running, let apiKey = apiKeyCache {
+                logger.logInfo("STT stream failed mid-session - reconnecting: \(message)")
+                startSTT(apiKey: apiKey)
+            } else {
+                await fail(LiveTranslationError.webSocketFailure(message))
+            }
         }
     }
 
@@ -167,17 +196,14 @@ final class LiveTranslationService {
     }
 
     private func mergeToken(_ token: LiveTranslationToken, into list: inout [LiveTranslationToken]) {
-        if let last = list.last, last.isFinal == false {
-            if token.isFinal {
-                list.removeLast()
-                list.append(token)
-            } else {
-                list.removeLast()
-                list.append(token)
-            }
-        } else {
-            list.append(token)
+        // If the trailing token is non-final, replace it with the incoming
+        // token (whether final or not). Soniox emits interim tokens that get
+        // superseded; this keeps the rendered text from doubling. Multi-token
+        // interim tails are not perfectly preserved - acceptable trade-off.
+        if let last = list.last, !last.isFinal {
+            list.removeLast()
         }
+        list.append(token)
     }
 
     private func openTTSStream(apiKey: String) async {
@@ -213,6 +239,11 @@ final class LiveTranslationService {
     }
 
     private func teardown() async {
+        if let interruptionObserver {
+            NotificationCenter.default.removeObserver(interruptionObserver)
+            self.interruptionObserver = nil
+        }
+
         captureTask?.cancel()
         captureTask = nil
         sttTask?.cancel()
@@ -224,8 +255,45 @@ final class LiveTranslationService {
         await sttClient.disconnect()
         await ttsClient?.disconnect()
         ttsClient = nil
+        apiKeyCache = nil
 
         audio.stop()
+    }
+
+    private func observeInterruptions() {
+        if let interruptionObserver {
+            NotificationCenter.default.removeObserver(interruptionObserver)
+        }
+        interruptionObserver = NotificationCenter.default.addObserver(
+            forName: AVAudioSession.interruptionNotification,
+            object: AVAudioSession.sharedInstance(),
+            queue: .main
+        ) { [weak self] notification in
+            guard self != nil,
+                  let info = notification.userInfo,
+                  let typeRaw = info[AVAudioSessionInterruptionTypeKey] as? UInt,
+                  let type = AVAudioSession.InterruptionType(rawValue: typeRaw) else {
+                return
+            }
+            Task { @MainActor [weak self] in
+                await self?.handleInterruption(type: type)
+            }
+        }
+    }
+
+    private func handleInterruption(type: AVAudioSession.InterruptionType) async {
+        switch type {
+        case .began:
+            logger.logInfo("Audio session interrupted - stopping live translation")
+            await fail(LiveTranslationError.audioSessionFailure("Interrupted by another app"))
+        case .ended:
+            // We don't auto-resume; user must restart explicitly. Resuming a
+            // mid-translation session after interruption produces inconsistent
+            // STT context anyway.
+            break
+        @unknown default:
+            break
+        }
     }
 
     private func fail(_ error: Error) async {
@@ -246,15 +314,7 @@ final class LiveTranslationService {
     }
 
     private func requestMicrophonePermission() async -> Bool {
-        if #available(iOS 17, *) {
-            return await AVAudioApplication.requestRecordPermission()
-        } else {
-            return await withCheckedContinuation { continuation in
-                AVAudioSession.sharedInstance().requestRecordPermission { granted in
-                    continuation.resume(returning: granted)
-                }
-            }
-        }
+        await AVAudioApplication.requestRecordPermission()
     }
 
     private func persistConfig(oldValue: LiveTranslationConfig) {

--- a/VivaDicta/Services/LiveTranslation/LiveTranslationService.swift
+++ b/VivaDicta/Services/LiveTranslation/LiveTranslationService.swift
@@ -99,11 +99,18 @@ final class LiveTranslationService {
             return
         }
 
+        // After every suspension point we re-check status. If a concurrent
+        // fail() (e.g. STT WS rejected the config and emitted .failed) tore
+        // the session down, we must not create more orphan resources.
+        guard status == .starting else { return }
+
         startSTT(apiKey: apiKey)
 
         if config.ttsEnabled {
             await openTTSStream(apiKey: apiKey)
         }
+
+        guard status == .starting else { return }
 
         captureTask = Task { [weak self] in
             for await chunk in captureStream {
@@ -312,6 +319,11 @@ final class LiveTranslationService {
     }
 
     private func handleTTSToggle() {
+        // A manual toggle is a fresh user intent — give it a fresh retry
+        // budget so a previous run that hit the TTS retry cap doesn't make
+        // the very next failure give up immediately.
+        ttsFailureRetries = 0
+
         Task { [weak self] in
             guard let self else { return }
             if self.config.ttsEnabled {

--- a/VivaDicta/Services/LiveTranslation/SonioxRealtimeSTTClient.swift
+++ b/VivaDicta/Services/LiveTranslation/SonioxRealtimeSTTClient.swift
@@ -10,7 +10,12 @@ import os
 
 actor SonioxRealtimeSTTClient {
     enum Event: Sendable {
-        case token(LiveTranslationToken)
+        /// All tokens from a single Soniox server response, in order. Per the
+        /// Soniox protocol the non-final tokens in each response are a *full
+        /// replacement set* - any non-final from the previous response is
+        /// superseded. The service must drop trailing non-finals before
+        /// appending this batch to keep interim text in sync.
+        case tokens([LiveTranslationToken])
         case finished
         case failed(String)
     }
@@ -105,8 +110,12 @@ actor SonioxRealtimeSTTClient {
             "audio_format": "pcm_s16le",
             "sample_rate": 16000,
             "num_channels": 1,
+            // Soft hint only - do NOT set language_hints_strict here. Lecturers
+            // routinely code-switch into English for technical terms, names, and
+            // slide titles; strict mode forces those into the source language's
+            // phonetics and produces garbled transcripts. Keep enable_language_identification
+            // on so each token still carries its detected language.
             "language_hints": [sourceLanguage.rawValue],
-            "language_hints_strict": true,
             "enable_language_identification": true,
             "enable_endpoint_detection": true,
             "translation": [
@@ -161,9 +170,15 @@ actor SonioxRealtimeSTTClient {
             return
         }
 
-        if let tokens = json["tokens"] as? [[String: Any]] {
-            for tokenJson in tokens {
-                emitToken(from: tokenJson)
+        if let tokenJsonList = json["tokens"] as? [[String: Any]] {
+            var batch: [LiveTranslationToken] = []
+            for tokenJson in tokenJsonList {
+                if let token = makeToken(from: tokenJson) {
+                    batch.append(token)
+                }
+            }
+            if !batch.isEmpty {
+                continuation?.yield(.tokens(batch))
             }
         }
 
@@ -174,27 +189,26 @@ actor SonioxRealtimeSTTClient {
         }
     }
 
-    private func emitToken(from json: [String: Any]) {
-        guard let text = json["text"] as? String, !text.isEmpty else { return }
+    private func makeToken(from json: [String: Any]) -> LiveTranslationToken? {
+        guard let text = json["text"] as? String, !text.isEmpty else { return nil }
 
         // Soniox emits angle-bracketed marker tokens like "<end>" for endpoint
         // detection (we enable it for better token finalisation latency).
         // They're control signals, not visible transcript text - drop them.
         if text.hasPrefix("<") && text.hasSuffix(">") {
-            return
+            return nil
         }
 
         let isFinal = json["is_final"] as? Bool ?? false
         let translationStatus = (json["translation_status"] as? String)?.lowercased() ?? "original"
         let kind: LiveTranslationToken.Kind = translationStatus == "translation" ? .translation : .original
 
-        let token = LiveTranslationToken(
+        return LiveTranslationToken(
             id: UUID(),
             text: text,
             isFinal: isFinal,
             kind: kind
         )
-        continuation?.yield(.token(token))
     }
 
     private func emitFailure(_ message: String) {

--- a/VivaDicta/Services/LiveTranslation/SonioxRealtimeSTTClient.swift
+++ b/VivaDicta/Services/LiveTranslation/SonioxRealtimeSTTClient.swift
@@ -1,0 +1,199 @@
+//
+//  SonioxRealtimeSTTClient.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.28
+//
+
+import Foundation
+import os
+
+actor SonioxRealtimeSTTClient {
+    enum Event: Sendable {
+        case token(LiveTranslationToken)
+        case finished
+        case failed(String)
+    }
+
+    private let logger = Logger(category: .liveTranslationSTT)
+    private let endpoint = URL(string: "wss://stt-rt.soniox.com/transcribe-websocket")!
+
+    private var task: URLSessionWebSocketTask?
+    private var receiveTask: Task<Void, Never>?
+    private var continuation: AsyncStream<Event>.Continuation?
+
+    func connect(
+        apiKey: String,
+        sourceLanguage: LiveTranslationLanguage,
+        targetLanguage: LiveTranslationLanguage,
+        vocabularyTerms: [String]
+    ) -> AsyncStream<Event> {
+        disconnect()
+
+        let session = URLSession(configuration: .default)
+        let task = session.webSocketTask(with: endpoint)
+        self.task = task
+
+        let stream = AsyncStream<Event> { continuation in
+            self.continuation = continuation
+            continuation.onTermination = { [weak self] _ in
+                Task { await self?.disconnect() }
+            }
+        }
+
+        task.resume()
+
+        do {
+            let config = makeConfigPayload(
+                apiKey: apiKey,
+                sourceLanguage: sourceLanguage,
+                targetLanguage: targetLanguage,
+                vocabularyTerms: vocabularyTerms
+            )
+            let data = try JSONSerialization.data(withJSONObject: config)
+            let message = URLSessionWebSocketTask.Message.string(String(decoding: data, as: UTF8.self))
+            task.send(message) { [weak self] error in
+                if let error {
+                    Task { await self?.emitFailure("config send failed: \(error.localizedDescription)") }
+                }
+            }
+        } catch {
+            emitFailure("config encode failed: \(error.localizedDescription)")
+        }
+
+        receiveTask = Task { [weak self] in
+            await self?.receiveLoop()
+        }
+
+        return stream
+    }
+
+    func sendAudioChunk(_ data: Data) {
+        guard let task else { return }
+        task.send(.data(data)) { [weak self] error in
+            if let error {
+                Task { await self?.emitFailure("audio send failed: \(error.localizedDescription)") }
+            }
+        }
+    }
+
+    func finalizeAudio() {
+        guard let task else { return }
+        task.send(.string("")) { _ in }
+    }
+
+    func disconnect() {
+        receiveTask?.cancel()
+        receiveTask = nil
+        task?.cancel(with: .normalClosure, reason: nil)
+        task = nil
+        continuation?.finish()
+        continuation = nil
+    }
+
+    // MARK: - Private
+
+    private func makeConfigPayload(
+        apiKey: String,
+        sourceLanguage: LiveTranslationLanguage,
+        targetLanguage: LiveTranslationLanguage,
+        vocabularyTerms: [String]
+    ) -> [String: Any] {
+        var payload: [String: Any] = [
+            "api_key": apiKey,
+            "model": "stt-rt-v4",
+            "audio_format": "pcm_s16le",
+            "sample_rate": 16000,
+            "num_channels": 1,
+            "language_hints": [sourceLanguage.rawValue],
+            "language_hints_strict": true,
+            "enable_language_identification": true,
+            "enable_endpoint_detection": true,
+            "translation": [
+                "type": "one_way",
+                "target_language": targetLanguage.rawValue
+            ]
+        ]
+
+        if !vocabularyTerms.isEmpty {
+            payload["context"] = ["terms": vocabularyTerms]
+        }
+
+        return payload
+    }
+
+    private func receiveLoop() async {
+        guard let task else { return }
+        while !Task.isCancelled {
+            do {
+                let message = try await task.receive()
+                handleMessage(message)
+            } catch {
+                if !Task.isCancelled {
+                    emitFailure("receive failed: \(error.localizedDescription)")
+                }
+                return
+            }
+        }
+    }
+
+    private func handleMessage(_ message: URLSessionWebSocketTask.Message) {
+        switch message {
+        case .string(let text):
+            decodeAndEmit(text: text)
+        case .data(let data):
+            if let text = String(data: data, encoding: .utf8) {
+                decodeAndEmit(text: text)
+            }
+        @unknown default:
+            break
+        }
+    }
+
+    private func decodeAndEmit(text: String) {
+        guard let data = text.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return
+        }
+
+        if let errorMessage = json["error_message"] as? String, !errorMessage.isEmpty {
+            emitFailure(errorMessage)
+            return
+        }
+
+        if let tokens = json["tokens"] as? [[String: Any]] {
+            for tokenJson in tokens {
+                emitToken(from: tokenJson)
+            }
+        }
+
+        if let finished = json["finished"] as? Bool, finished {
+            continuation?.yield(.finished)
+            continuation?.finish()
+            continuation = nil
+        }
+    }
+
+    private func emitToken(from json: [String: Any]) {
+        guard let text = json["text"] as? String, !text.isEmpty else { return }
+
+        let isFinal = json["is_final"] as? Bool ?? false
+        let translationStatus = (json["translation_status"] as? String)?.lowercased() ?? "original"
+        let kind: LiveTranslationToken.Kind = translationStatus == "translation" ? .translation : .original
+
+        let token = LiveTranslationToken(
+            id: UUID(),
+            text: text,
+            isFinal: isFinal,
+            kind: kind
+        )
+        continuation?.yield(.token(token))
+    }
+
+    private func emitFailure(_ message: String) {
+        logger.logError("STT WS failure: \(message)")
+        continuation?.yield(.failed(message))
+        continuation?.finish()
+        continuation = nil
+    }
+}

--- a/VivaDicta/Services/LiveTranslation/SonioxRealtimeSTTClient.swift
+++ b/VivaDicta/Services/LiveTranslation/SonioxRealtimeSTTClient.swift
@@ -177,6 +177,13 @@ actor SonioxRealtimeSTTClient {
     private func emitToken(from json: [String: Any]) {
         guard let text = json["text"] as? String, !text.isEmpty else { return }
 
+        // Soniox emits angle-bracketed marker tokens like "<end>" for endpoint
+        // detection (we enable it for better token finalisation latency).
+        // They're control signals, not visible transcript text - drop them.
+        if text.hasPrefix("<") && text.hasSuffix(">") {
+            return
+        }
+
         let isFinal = json["is_final"] as? Bool ?? false
         let translationStatus = (json["translation_status"] as? String)?.lowercased() ?? "original"
         let kind: LiveTranslationToken.Kind = translationStatus == "translation" ? .translation : .original

--- a/VivaDicta/Services/LiveTranslation/SonioxRealtimeTTSClient.swift
+++ b/VivaDicta/Services/LiveTranslation/SonioxRealtimeTTSClient.swift
@@ -1,0 +1,170 @@
+//
+//  SonioxRealtimeTTSClient.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.28
+//
+
+import Foundation
+import os
+
+actor SonioxRealtimeTTSClient {
+    enum Event: Sendable {
+        case audio(Data)
+        case finished
+        case failed(String)
+    }
+
+    static let outputSampleRate: Double = 24000
+
+    private let logger = Logger(category: .liveTranslationTTS)
+    private let endpoint = URL(string: "wss://tts-rt.soniox.com/tts-websocket")!
+    private let streamID = "vivadicta-\(UUID().uuidString)"
+
+    private var task: URLSessionWebSocketTask?
+    private var receiveTask: Task<Void, Never>?
+    private var continuation: AsyncStream<Event>.Continuation?
+
+    func connect(
+        apiKey: String,
+        language: LiveTranslationLanguage,
+        voice: String
+    ) -> AsyncStream<Event> {
+        disconnect()
+
+        let session = URLSession(configuration: .default)
+        let task = session.webSocketTask(with: endpoint)
+        self.task = task
+
+        let stream = AsyncStream<Event> { continuation in
+            self.continuation = continuation
+            continuation.onTermination = { [weak self] _ in
+                Task { await self?.disconnect() }
+            }
+        }
+
+        task.resume()
+
+        let payload: [String: Any] = [
+            "api_key": apiKey,
+            "model": "tts-rt-v1-preview",
+            "language": language.rawValue,
+            "voice": voice,
+            "audio_format": "pcm_s16le",
+            "sample_rate": Int(Self.outputSampleRate),
+            "stream_id": streamID
+        ]
+
+        if let data = try? JSONSerialization.data(withJSONObject: payload),
+           let configString = String(data: data, encoding: .utf8) {
+            task.send(.string(configString)) { [weak self] error in
+                if let error {
+                    Task { await self?.emitFailure("config send failed: \(error.localizedDescription)") }
+                }
+            }
+        } else {
+            emitFailure("config encode failed")
+        }
+
+        receiveTask = Task { [weak self] in
+            await self?.receiveLoop()
+        }
+
+        return stream
+    }
+
+    func sendText(_ text: String, end: Bool = false) {
+        guard let task else { return }
+        let payload: [String: Any] = [
+            "stream_id": streamID,
+            "text": text,
+            "text_end": end
+        ]
+        guard let data = try? JSONSerialization.data(withJSONObject: payload),
+              let string = String(data: data, encoding: .utf8) else {
+            return
+        }
+        task.send(.string(string)) { [weak self] error in
+            if let error {
+                Task { await self?.emitFailure("text send failed: \(error.localizedDescription)") }
+            }
+        }
+    }
+
+    func cancelStream() {
+        guard let task else { return }
+        let payload: [String: Any] = ["stream_id": streamID, "cancel": true]
+        guard let data = try? JSONSerialization.data(withJSONObject: payload),
+              let string = String(data: data, encoding: .utf8) else {
+            return
+        }
+        task.send(.string(string)) { _ in }
+    }
+
+    func disconnect() {
+        receiveTask?.cancel()
+        receiveTask = nil
+        task?.cancel(with: .normalClosure, reason: nil)
+        task = nil
+        continuation?.finish()
+        continuation = nil
+    }
+
+    // MARK: - Private
+
+    private func receiveLoop() async {
+        guard let task else { return }
+        while !Task.isCancelled {
+            do {
+                let message = try await task.receive()
+                handleMessage(message)
+            } catch {
+                if !Task.isCancelled {
+                    emitFailure("receive failed: \(error.localizedDescription)")
+                }
+                return
+            }
+        }
+    }
+
+    private func handleMessage(_ message: URLSessionWebSocketTask.Message) {
+        let text: String?
+        switch message {
+        case .string(let value):
+            text = value
+        case .data(let data):
+            text = String(data: data, encoding: .utf8)
+        @unknown default:
+            text = nil
+        }
+        guard let text,
+              let data = text.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return
+        }
+
+        if let errorMessage = json["error_message"] as? String, !errorMessage.isEmpty {
+            emitFailure(errorMessage)
+            return
+        }
+
+        if let audioBase64 = json["audio"] as? String,
+           !audioBase64.isEmpty,
+           let audio = Data(base64Encoded: audioBase64) {
+            continuation?.yield(.audio(audio))
+        }
+
+        if let terminated = json["terminated"] as? Bool, terminated {
+            continuation?.yield(.finished)
+            continuation?.finish()
+            continuation = nil
+        }
+    }
+
+    private func emitFailure(_ message: String) {
+        logger.logError("TTS WS failure: \(message)")
+        continuation?.yield(.failed(message))
+        continuation?.finish()
+        continuation = nil
+    }
+}

--- a/VivaDicta/Shared/UserDefaultsStorage.swift
+++ b/VivaDicta/Shared/UserDefaultsStorage.swift
@@ -83,6 +83,12 @@ enum UserDefaultsStorage {
         // Integrations - Obsidian
         static let isObsidianGloballyEnabled = "isObsidianGloballyEnabled"
         static let obsidianNoteTemplate = "obsidianNoteTemplate"
+
+        // Live Translation
+        static let liveTranslationSourceLanguage = "liveTranslation.sourceLanguage"
+        static let liveTranslationTargetLanguage = "liveTranslation.targetLanguage"
+        static let liveTranslationTTSEnabled = "liveTranslation.ttsEnabled"
+        static let liveTranslationTTSRate = "liveTranslation.ttsRate"
     }
 
     // MARK: - Integrations defaults

--- a/VivaDicta/Utilities/LoggerExtension.swift
+++ b/VivaDicta/Utilities/LoggerExtension.swift
@@ -40,6 +40,12 @@ public enum LogCategory: String {
     case cohereTranscriptionService = "CohereTranscriptionService"
     case customTranscriptionService = "CustomTranscriptionService"
 
+    // MARK: - Services - Live Translation
+    case liveTranslationService = "LiveTranslationService"
+    case liveTranslationSTT = "LiveTranslationSTT"
+    case liveTranslationTTS = "LiveTranslationTTS"
+    case liveTranslationAudio = "LiveTranslationAudio"
+
     // MARK: - Services - Other
     case aiService = "AIService"
     case modelDownloadManager = "ModelDownloadManager"

--- a/VivaDicta/Views/LiveTranslation/LiveTranslationView.swift
+++ b/VivaDicta/Views/LiveTranslation/LiveTranslationView.swift
@@ -15,6 +15,7 @@ struct LiveTranslationView: View {
 
     @State private var service = LiveTranslationService()
     @State private var savedSnapshot: SavedSnapshot?
+    @State private var saveError: SaveErrorAlert?
     @State private var headphonesConnected = LiveTranslationAudio.isHeadphonesRouteActive
 
     var body: some View {
@@ -59,6 +60,13 @@ struct LiveTranslationView: View {
                 Button("OK", role: .cancel) {}
             } message: {
                 Text("The transcript was saved as a note.")
+            }
+            .alert(item: $saveError) { error in
+                Alert(
+                    title: Text("Couldn't Save Note"),
+                    message: Text(error.message),
+                    dismissButton: .default(Text("OK"))
+                )
             }
         }
     }
@@ -211,16 +219,24 @@ struct LiveTranslationView: View {
     // MARK: - Helpers
 
     private func languageMenu(title: String, selection: Binding<LiveTranslationLanguage>) -> some View {
-        Menu {
-            ForEach(LiveTranslationLanguage.allCases) { language in
-                Button {
-                    selection.wrappedValue = language
-                } label: {
-                    if language == selection.wrappedValue {
-                        Label(language.displayName, systemImage: "checkmark")
-                    } else {
-                        Text(language.displayName)
+        let preferred = LiveTranslationLanguage.userPreferred
+        let preferredSet = Set(preferred)
+        let rest = LiveTranslationLanguage.alphabetical.filter { !preferredSet.contains($0) }
+
+        return Menu {
+            // User-preferred languages first (matches the mode-settings pattern).
+            if !preferred.isEmpty {
+                Section {
+                    ForEach(preferred) { language in
+                        languageMenuItem(language: language, selection: selection)
                     }
+                }
+            }
+            // Rest alphabetically. Section gives an automatic divider between
+            // groups in iOS 17+ menus.
+            Section {
+                ForEach(rest) { language in
+                    languageMenuItem(language: language, selection: selection)
                 }
             }
         } label: {
@@ -228,7 +244,7 @@ struct LiveTranslationView: View {
                 Text(title)
                     .font(.caption)
                     .foregroundStyle(.secondary)
-                Text(selection.wrappedValue.displayName)
+                Text(selection.wrappedValue.displayNameWithFlag)
                     .font(.subheadline.weight(.medium))
                 Image(systemName: "chevron.down")
                     .font(.caption2)
@@ -236,6 +252,18 @@ struct LiveTranslationView: View {
             .padding(.horizontal, 12)
             .padding(.vertical, 8)
             .background(.fill.tertiary, in: .capsule)
+        }
+    }
+
+    private func languageMenuItem(language: LiveTranslationLanguage, selection: Binding<LiveTranslationLanguage>) -> some View {
+        Button {
+            selection.wrappedValue = language
+        } label: {
+            if language == selection.wrappedValue {
+                Label(language.displayNameWithFlag, systemImage: "checkmark")
+            } else {
+                Text(language.displayNameWithFlag)
+            }
         }
     }
 
@@ -293,8 +321,18 @@ struct LiveTranslationView: View {
         )
 
         modelContext.insert(transcription)
-        try? modelContext.save()
-        savedSnapshot = SavedSnapshot()
+
+        do {
+            try modelContext.save()
+            savedSnapshot = SavedSnapshot()
+        } catch {
+            // Roll the insert out of the context so the same Transcription
+            // instance isn't dangling in memory and won't auto-save next
+            // time the context flushes. Keep the in-memory transcript so
+            // the user can retry.
+            modelContext.delete(transcription)
+            saveError = SaveErrorAlert(message: error.localizedDescription)
+        }
     }
 
     private func combineSnapshot(
@@ -319,6 +357,11 @@ struct LiveTranslationView: View {
 
     private struct SavedSnapshot {
         let id = UUID()
+    }
+
+    private struct SaveErrorAlert: Identifiable {
+        let id = UUID()
+        let message: String
     }
 }
 

--- a/VivaDicta/Views/LiveTranslation/LiveTranslationView.swift
+++ b/VivaDicta/Views/LiveTranslation/LiveTranslationView.swift
@@ -256,8 +256,13 @@ struct LiveTranslationView: View {
                 }
                 return nil
             },
-            set: { _ in
-                Task { await service.stop() }
+            set: { newValue in
+                // Clear the .failed status on dismissal; otherwise the getter
+                // keeps returning a fresh FailureAlert and the alert reappears
+                // immediately, trapping the user in a loop.
+                if newValue == nil {
+                    service.clearFailureIfNeeded()
+                }
             }
         )
     }
@@ -273,9 +278,14 @@ struct LiveTranslationView: View {
         let snapshot = service.transcriptSnapshot()
         guard !snapshot.original.isEmpty || !snapshot.translation.isEmpty else { return }
 
+        // Combine source + translation into the `text` field with section
+        // headings; leave `enhancedText` nil so Spotlight, list previews,
+        // search, and the dual-write Variation pipeline aren't confused
+        // (`enhancedText` is the AI-output cache and must not hold raw MT).
+        let combined = combineSnapshot(snapshot)
+
         let transcription = Transcription(
-            text: snapshot.original.isEmpty ? snapshot.translation : snapshot.original,
-            enhancedText: snapshot.translation.isEmpty ? nil : snapshot.translation,
+            text: combined,
             audioDuration: 0,
             transcriptionModelName: "stt-rt-v4",
             transcriptionProviderName: TranscriptionModelProvider.soniox.rawValue,
@@ -285,6 +295,20 @@ struct LiveTranslationView: View {
         modelContext.insert(transcription)
         try? modelContext.save()
         savedSnapshot = SavedSnapshot()
+    }
+
+    private func combineSnapshot(_ snapshot: (original: String, translation: String)) -> String {
+        let sourceName = service.config.sourceLanguage.displayName
+        let targetName = service.config.targetLanguage.displayName
+
+        var sections: [String] = []
+        if !snapshot.original.isEmpty {
+            sections.append("\(sourceName):\n\(snapshot.original)")
+        }
+        if !snapshot.translation.isEmpty {
+            sections.append("\(targetName):\n\(snapshot.translation)")
+        }
+        return sections.joined(separator: "\n\n")
     }
 
     private struct FailureAlert: Identifiable {

--- a/VivaDicta/Views/LiveTranslation/LiveTranslationView.swift
+++ b/VivaDicta/Views/LiveTranslation/LiveTranslationView.swift
@@ -232,6 +232,8 @@ struct LiveTranslationView: View {
                 ForEach(preferred) { language in
                     Text(language.displayNameWithFlag).tag(language)
                 }
+                
+                
 
                 ForEach(rest) { language in
                     Text(language.displayNameWithFlag).tag(language)

--- a/VivaDicta/Views/LiveTranslation/LiveTranslationView.swift
+++ b/VivaDicta/Views/LiveTranslation/LiveTranslationView.swift
@@ -5,6 +5,7 @@
 //  Created by Anton Novoselov on 2026.04.28
 //
 
+import AVFoundation
 import SwiftData
 import SwiftUI
 
@@ -14,16 +15,23 @@ struct LiveTranslationView: View {
 
     @State private var service = LiveTranslationService()
     @State private var savedSnapshot: SavedSnapshot?
+    @State private var headphonesConnected = LiveTranslationAudio.isHeadphonesRouteActive
 
     var body: some View {
         NavigationStack {
             VStack(spacing: 0) {
                 languageBar
                 Divider()
+                if !headphonesConnected && service.config.ttsEnabled {
+                    headphonesHint
+                }
                 transcriptColumns
                 Divider()
                 ttsBar
                 actionBar
+            }
+            .onReceive(NotificationCenter.default.publisher(for: AVAudioSession.routeChangeNotification)) { _ in
+                headphonesConnected = LiveTranslationAudio.isHeadphonesRouteActive
             }
             .navigationTitle("Live Translation")
             .navigationBarTitleDisplayMode(.inline)
@@ -83,6 +91,20 @@ struct LiveTranslationView: View {
         .padding(.horizontal)
         .padding(.vertical, 12)
         .disabled(isRunning)
+    }
+
+    private var headphonesHint: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "airpods")
+                .foregroundStyle(.orange)
+            Text("Use headphones to prevent feedback into the mic")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Spacer()
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(.orange.opacity(0.1))
     }
 
     private var transcriptColumns: some View {

--- a/VivaDicta/Views/LiveTranslation/LiveTranslationView.swift
+++ b/VivaDicta/Views/LiveTranslation/LiveTranslationView.swift
@@ -297,16 +297,17 @@ struct LiveTranslationView: View {
         savedSnapshot = SavedSnapshot()
     }
 
-    private func combineSnapshot(_ snapshot: (original: String, translation: String)) -> String {
-        let sourceName = service.config.sourceLanguage.displayName
-        let targetName = service.config.targetLanguage.displayName
-
+    private func combineSnapshot(
+        _ snapshot: (sourceLanguage: LiveTranslationLanguage, original: String, targetLanguage: LiveTranslationLanguage, translation: String)
+    ) -> String {
+        // Use the snapshot's session-time languages, not service.config.* —
+        // the user can change pickers between Stop and Save.
         var sections: [String] = []
         if !snapshot.original.isEmpty {
-            sections.append("\(sourceName):\n\(snapshot.original)")
+            sections.append("\(snapshot.sourceLanguage.displayName):\n\(snapshot.original)")
         }
         if !snapshot.translation.isEmpty {
-            sections.append("\(targetName):\n\(snapshot.translation)")
+            sections.append("\(snapshot.targetLanguage.displayName):\n\(snapshot.translation)")
         }
         return sections.joined(separator: "\n\n")
     }

--- a/VivaDicta/Views/LiveTranslation/LiveTranslationView.swift
+++ b/VivaDicta/Views/LiveTranslation/LiveTranslationView.swift
@@ -124,17 +124,45 @@ struct LiveTranslationView: View {
     }
 
     private var ttsBar: some View {
-        HStack {
-            Image(systemName: service.config.ttsEnabled ? "speaker.wave.2.fill" : "speaker.slash.fill")
-                .foregroundStyle(service.config.ttsEnabled ? .indigo : .secondary)
-            Toggle("Speak translation", isOn: Binding(
-                get: { service.config.ttsEnabled },
-                set: { service.config.ttsEnabled = $0 }
-            ))
-            .labelsHidden()
-            Text("Speak translation")
-                .font(.subheadline)
-            Spacer()
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Image(systemName: service.config.ttsEnabled ? "speaker.wave.2.fill" : "speaker.slash.fill")
+                    .foregroundStyle(service.config.ttsEnabled ? .indigo : .secondary)
+                Toggle("Speak translation", isOn: Binding(
+                    get: { service.config.ttsEnabled },
+                    set: { service.config.ttsEnabled = $0 }
+                ))
+                .labelsHidden()
+                Text("Speak translation")
+                    .font(.subheadline)
+                Spacer()
+            }
+
+            if service.config.ttsEnabled {
+                HStack(spacing: 12) {
+                    Image(systemName: "tortoise.fill")
+                        .foregroundStyle(.secondary)
+                        .font(.caption)
+                    Slider(
+                        value: Binding(
+                            get: { Double(service.config.ttsRate) },
+                            set: { service.config.ttsRate = Float($0) }
+                        ),
+                        in: Double(LiveTranslationPreferences.minTTSRate)...Double(LiveTranslationPreferences.maxTTSRate),
+                        step: 0.05
+                    )
+                    Image(systemName: "hare.fill")
+                        .foregroundStyle(.secondary)
+                        .font(.caption)
+                    HStack(spacing: 0) {
+                        Text(Double(service.config.ttsRate), format: .number.precision(.fractionLength(2)))
+                        Text("x")
+                    }
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
+                    .frame(width: 44, alignment: .trailing)
+                }
+            }
         }
         .padding(.horizontal)
         .padding(.vertical, 10)

--- a/VivaDicta/Views/LiveTranslation/LiveTranslationView.swift
+++ b/VivaDicta/Views/LiveTranslation/LiveTranslationView.swift
@@ -1,0 +1,293 @@
+//
+//  LiveTranslationView.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.28
+//
+
+import SwiftData
+import SwiftUI
+
+struct LiveTranslationView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var modelContext
+
+    @State private var service = LiveTranslationService()
+    @State private var savedSnapshot: SavedSnapshot?
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                languageBar
+                Divider()
+                transcriptColumns
+                Divider()
+                ttsBar
+                actionBar
+            }
+            .navigationTitle("Live Translation")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button {
+                        Task {
+                            await service.stop()
+                            dismiss()
+                        }
+                    } label: {
+                        Image(systemName: "xmark")
+                    }
+                    .accessibilityLabel("Close")
+                }
+            }
+            .alert(item: failureBinding) { failure in
+                Alert(
+                    title: Text("Live Translation Error"),
+                    message: Text(failure.message),
+                    dismissButton: .default(Text("OK"))
+                )
+            }
+            .alert("Saved", isPresented: savedAlertBinding) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text("The transcript was saved as a note.")
+            }
+        }
+    }
+
+    // MARK: - Subviews
+
+    private var languageBar: some View {
+        HStack(spacing: 12) {
+            languageMenu(
+                title: "From",
+                selection: Binding(
+                    get: { service.config.sourceLanguage },
+                    set: { service.config.sourceLanguage = $0 }
+                )
+            )
+
+            Image(systemName: "arrow.right")
+                .foregroundStyle(.secondary)
+
+            languageMenu(
+                title: "To",
+                selection: Binding(
+                    get: { service.config.targetLanguage },
+                    set: { service.config.targetLanguage = $0 }
+                )
+            )
+
+            Spacer()
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 12)
+        .disabled(isRunning)
+    }
+
+    private var transcriptColumns: some View {
+        HStack(spacing: 0) {
+            TranscriptColumn(
+                title: service.config.sourceLanguage.displayName,
+                tokens: service.originalTokens,
+                accent: .secondary
+            )
+            Divider()
+            TranscriptColumn(
+                title: service.config.targetLanguage.displayName,
+                tokens: service.translatedTokens,
+                accent: .indigo
+            )
+        }
+    }
+
+    private var ttsBar: some View {
+        HStack {
+            Image(systemName: service.config.ttsEnabled ? "speaker.wave.2.fill" : "speaker.slash.fill")
+                .foregroundStyle(service.config.ttsEnabled ? .indigo : .secondary)
+            Toggle("Speak translation", isOn: Binding(
+                get: { service.config.ttsEnabled },
+                set: { service.config.ttsEnabled = $0 }
+            ))
+            .labelsHidden()
+            Text("Speak translation")
+                .font(.subheadline)
+            Spacer()
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 10)
+    }
+
+    @ViewBuilder
+    private var actionBar: some View {
+        VStack(spacing: 12) {
+            if isRunning {
+                Button {
+                    Task { await service.stop() }
+                } label: {
+                    Label("Stop", systemImage: "stop.fill")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.red)
+                .controlSize(.large)
+            } else {
+                Button {
+                    Task { await service.start() }
+                } label: {
+                    Label("Start listening", systemImage: "waveform.and.mic")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.indigo)
+                .controlSize(.large)
+                .disabled(service.status == .starting)
+            }
+
+            if shouldShowSaveButton {
+                Button {
+                    saveAsNote()
+                } label: {
+                    Label("Save as note", systemImage: "square.and.arrow.down")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.large)
+            }
+        }
+        .padding()
+    }
+
+    // MARK: - Helpers
+
+    private func languageMenu(title: String, selection: Binding<LiveTranslationLanguage>) -> some View {
+        Menu {
+            ForEach(LiveTranslationLanguage.allCases) { language in
+                Button {
+                    selection.wrappedValue = language
+                } label: {
+                    if language == selection.wrappedValue {
+                        Label(language.displayName, systemImage: "checkmark")
+                    } else {
+                        Text(language.displayName)
+                    }
+                }
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Text(title)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(selection.wrappedValue.displayName)
+                    .font(.subheadline.weight(.medium))
+                Image(systemName: "chevron.down")
+                    .font(.caption2)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(.fill.tertiary, in: .capsule)
+        }
+    }
+
+    private var isRunning: Bool {
+        service.status == .running || service.status == .starting
+    }
+
+    private var shouldShowSaveButton: Bool {
+        guard !isRunning else { return false }
+        return !service.originalTokens.isEmpty || !service.translatedTokens.isEmpty
+    }
+
+    private var failureBinding: Binding<FailureAlert?> {
+        Binding(
+            get: {
+                if case .failed(let message) = service.status {
+                    return FailureAlert(message: message)
+                }
+                return nil
+            },
+            set: { _ in
+                Task { await service.stop() }
+            }
+        )
+    }
+
+    private var savedAlertBinding: Binding<Bool> {
+        Binding(
+            get: { savedSnapshot != nil },
+            set: { if !$0 { savedSnapshot = nil } }
+        )
+    }
+
+    private func saveAsNote() {
+        let snapshot = service.transcriptSnapshot()
+        guard !snapshot.original.isEmpty || !snapshot.translation.isEmpty else { return }
+
+        let transcription = Transcription(
+            text: snapshot.original.isEmpty ? snapshot.translation : snapshot.original,
+            enhancedText: snapshot.translation.isEmpty ? nil : snapshot.translation,
+            audioDuration: 0,
+            transcriptionModelName: "stt-rt-v4",
+            transcriptionProviderName: TranscriptionModelProvider.soniox.rawValue,
+            sourceTag: SourceTag.liveTranslation
+        )
+
+        modelContext.insert(transcription)
+        try? modelContext.save()
+        savedSnapshot = SavedSnapshot()
+    }
+
+    private struct FailureAlert: Identifiable {
+        let id = UUID()
+        let message: String
+    }
+
+    private struct SavedSnapshot {
+        let id = UUID()
+    }
+}
+
+private struct TranscriptColumn: View {
+    let title: String
+    let tokens: [LiveTranslationToken]
+    let accent: Color
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title.uppercased())
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(accent)
+                .padding(.horizontal, 12)
+                .padding(.top, 12)
+
+            ScrollViewReader { proxy in
+                ScrollView {
+                    Text(renderedText)
+                        .font(.body)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 12)
+                        .padding(.bottom, 12)
+                        .id(scrollAnchor)
+                }
+                .onChange(of: tokens.count) { _, _ in
+                    withAnimation { proxy.scrollTo(scrollAnchor, anchor: .bottom) }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    private var renderedText: AttributedString {
+        var attributed = AttributedString()
+        for token in tokens {
+            var part = AttributedString(token.text)
+            if !token.isFinal {
+                part.foregroundColor = .secondary
+            }
+            attributed.append(part)
+        }
+        return attributed
+    }
+
+    private let scrollAnchor = "transcriptBottom"
+}

--- a/VivaDicta/Views/LiveTranslation/LiveTranslationView.swift
+++ b/VivaDicta/Views/LiveTranslation/LiveTranslationView.swift
@@ -229,17 +229,12 @@ struct LiveTranslationView: View {
         // its own column so flags + names stay aligned across rows.
         return Menu {
             Picker("Language", selection: selection) {
-                if !preferred.isEmpty {
-                    Section {
-                        ForEach(preferred) { language in
-                            Text(language.displayNameWithFlag).tag(language)
-                        }
-                    }
+                ForEach(preferred) { language in
+                    Text(language.displayNameWithFlag).tag(language)
                 }
-                Section {
-                    ForEach(rest) { language in
-                        Text(language.displayNameWithFlag).tag(language)
-                    }
+
+                ForEach(rest) { language in
+                    Text(language.displayNameWithFlag).tag(language)
                 }
             }
         } label: {

--- a/VivaDicta/Views/LiveTranslation/LiveTranslationView.swift
+++ b/VivaDicta/Views/LiveTranslation/LiveTranslationView.swift
@@ -223,20 +223,23 @@ struct LiveTranslationView: View {
         let preferredSet = Set(preferred)
         let rest = LiveTranslationLanguage.alphabetical.filter { !preferredSet.contains($0) }
 
+        // Picker nested inside Menu: the outer Menu keeps the custom chip
+        // label (title caption, capsule background, chevron-down), while the
+        // inner Picker drives selection state - iOS draws the checkmark in
+        // its own column so flags + names stay aligned across rows.
         return Menu {
-            // User-preferred languages first (matches the mode-settings pattern).
-            if !preferred.isEmpty {
-                Section {
-                    ForEach(preferred) { language in
-                        languageMenuItem(language: language, selection: selection)
+            Picker("Language", selection: selection) {
+                if !preferred.isEmpty {
+                    Section {
+                        ForEach(preferred) { language in
+                            Text(language.displayNameWithFlag).tag(language)
+                        }
                     }
                 }
-            }
-            // Rest alphabetically. Section gives an automatic divider between
-            // groups in iOS 17+ menus.
-            Section {
-                ForEach(rest) { language in
-                    languageMenuItem(language: language, selection: selection)
+                Section {
+                    ForEach(rest) { language in
+                        Text(language.displayNameWithFlag).tag(language)
+                    }
                 }
             }
         } label: {
@@ -252,18 +255,6 @@ struct LiveTranslationView: View {
             .padding(.horizontal, 12)
             .padding(.vertical, 8)
             .background(.fill.tertiary, in: .capsule)
-        }
-    }
-
-    private func languageMenuItem(language: LiveTranslationLanguage, selection: Binding<LiveTranslationLanguage>) -> some View {
-        Button {
-            selection.wrappedValue = language
-        } label: {
-            if language == selection.wrappedValue {
-                Label(language.displayNameWithFlag, systemImage: "checkmark")
-            } else {
-                Text(language.displayNameWithFlag)
-            }
         }
     }
 

--- a/VivaDicta/Views/MainView.swift
+++ b/VivaDicta/Views/MainView.swift
@@ -20,6 +20,7 @@ struct MainView: View {
 
     @State private var showingRecordingSheet = false
     @State private var showingSettings = false
+    @State private var showingLiveTranslation = false
     @State private var showingNotesFilter = false
     @State private var showingFileImport = false
     @State private var searchText = ""
@@ -230,6 +231,10 @@ struct MainView: View {
             SettingsView()
                 .interactiveDismissDisabled(true)
                 .navigationTransition(.zoom(sourceID: "SettingsSheetTransition", in: sheetTransitions))
+        }
+        .fullScreenCover(isPresented: $showingLiveTranslation) {
+            LiveTranslationView()
+                .navigationTransition(.zoom(sourceID: "LiveTranslationSheetTransition", in: sheetTransitions))
         }
         .fullScreenCover(isPresented: $showMultiNoteChats) {
             MultiNoteChatsListView()
@@ -451,6 +456,21 @@ struct MainView: View {
                 }
                 .accessibilityLabel(savedNotesFilter.isActive ? "Edit Active Notes Filter" : "Filter Notes")
                 .matchedTransitionSource(id: "NotesFilterSheetTransition", in: sheetTransitions)
+            }
+
+            if #available(iOS 26.0, *) {
+                ToolbarSpacer(.fixed, placement: .topBarTrailing)
+            }
+
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    HapticManager.lightImpact()
+                    showingLiveTranslation = true
+                } label: {
+                    Image(systemName: "globe.americas.fill")
+                }
+                .accessibilityLabel("Live Translation")
+                .matchedTransitionSource(id: "LiveTranslationSheetTransition", in: sheetTransitions)
             }
 
             if #available(iOS 26.0, *) {


### PR DESCRIPTION
## Summary
- New Live Translation feature: tap the globe icon next to Settings to open a full-screen translator that streams microphone audio to Soniox realtime STT (with one-way translation enabled), forwards translated tokens incrementally to Soniox realtime TTS, and plays the spoken translation through the user's current audio output (AirPods preferred).
- Dual-column live transcript shows source and translated text side-by-side as Soniox emits tokens. Source language picker, target language picker, "Speak translation" toggle, 1.0x-2.0x rate slider, optional "Save as note" after stop.
- Audio-thread safety, AirPods routing, TTS auto-reconnect when Soniox terminates the stream, varispeed-based playback rate, and a starvation-aware playback buffer queue all included.

## What landed

### New service layer (`VivaDicta/Services/LiveTranslation/`)
- `LiveTranslationModels.swift` - `LiveTranslationLanguage` (21 codes), `LiveTranslationStatus`, `LiveTranslationToken`, `LiveTranslationConfig`, `LiveTranslationError`, plus `LiveTranslationPreferences` namespace persisting source/target language, TTS toggle, and TTS rate to ` UserDefaultsStorage.appPrivate`.
- `SonioxRealtimeSTTClient.swift` - `actor` wrapping `URLSessionWebSocketTask` against `wss://stt-rt.soniox.com/transcribe-websocket`. Sends config JSON with `enable_speaker_diarization`, `enable_language_identification`, `language_hints_strict`, `translation: { type: one_way, target_language }`, then forwards binary PCM s16le 16 kHz mono frames. Parses tokens with `translation_status` to distinguish original vs translation.
- `SonioxRealtimeTTSClient.swift` - `actor` against `wss://tts-rt.soniox.com/tts-websocket`. Sends incremental text JSON with a per-session `stream_id`, decodes base64 PCM s16le 24 kHz audio chunks, emits them via an `AsyncStream`. Handles the protocol's `terminated: true` message.
- `LiveTranslationAudio.swift` - owns `AVAudioEngine` with mic capture (-> 16 kHz s16le mono via `AVAudioConverter`) and playback (24 kHz Float32 via `AVAudioPlayerNode -> AVAudioUnitVarispeed -> mainMixer`). Audio session uses `.playAndRecord` + `.spokenAudio` + `.allowBluetoothA2DP` (no `.defaultToSpeaker` - that flag was overriding A2DP routing and causing mic feedback). Includes `PlaybackBufferQueue` lock-protected helper to gate playback after starvation.
- `LiveTranslationService.swift` - `@Observable @MainActor` orchestrator. Manages STT and TTS lifecycle, wiring captureStream -> STT WS, STT events -> transcript, translation tokens -> TTS WS, TTS audio -> playback. Auto-reopens TTS WebSocket if Soniox terminates the stream mid-session.

### New view layer (`VivaDicta/Views/LiveTranslation/`)
- `LiveTranslationView.swift` - SwiftUI screen with language pickers, dual-column transcript (`AttributedString`), TTS toggle + rate slider, primary Start/Stop button, post-stop "Save as note" button, and a small headphones hint when no headphones are detected (subscribed to `AVAudioSession.routeChangeNotification`).

### Wiring
- `Views/MainView.swift` - new globe (`globe.americas.fill`) toolbar button between filter and settings; opens the live translation full-screen cover. Matched zoom transition consistent with Settings/Chats.
- `Models/SourceTag.swift` - new `liveTranslation` source tag (indigo, globe icon).
- `Utilities/LoggerExtension.swift` - four new log categories: `LiveTranslationService`, `LiveTranslationSTT`, `LiveTranslationTTS`, `LiveTranslationAudio`.
- `Shared/UserDefaultsStorage.swift` - four new private preference keys.

## Architecture and concurrency notes
- The AVAudioEngine input tap closure is installed from `DispatchQueue.global(qos: .userInitiated).async {}` via a top-level `nonisolated` function, mirroring `AudioPrewarmManager`. This avoids the closure inheriting `@MainActor` isolation, which would trip `_dispatch_assert_queue_fail` on the realtime audio thread.
- `TapInstaller` is `nonisolated final class @unchecked Sendable` with `nonisolated` methods so the audio-thread call doesn't cross an actor boundary and trigger Swift 6 sending diagnostics.
- `AsyncStream<Data>.Continuation` is the only cross-thread channel from the audio thread back to the `@MainActor` consumer.
- Playback rate uses `AVAudioUnitVarispeed` (preserves pitch). `PlaybackBufferQueue` is `@unchecked Sendable` with `NSLock`, called from both the audio completion handler and `enqueuePlayback` on MainActor.
- TTS Soniox WebSocket auto-terminates after a couple of minutes; service detects `terminated: true` and reopens transparently.

## Test plan
- [ ] Open via the new globe toolbar button. Defaults are English -> English on first launch.
- [ ] Change source / target / TTS toggle / rate. Close screen, reopen. Last-picked values are restored.
- [ ] Smoke test on simulator with Mac mic and speakers.
- [ ] Real-device test with AirPods. Verify TTS audio routes through AirPods, mic uses iPhone built-in.
- [ ] Speak Spanish (or play a Spanish lecture clip) and listen to the Russian translation through headphones. Watch the dual-column transcript update.
- [ ] Run a session for 5+ minutes and confirm TTS does not silently die after ~2 minutes (auto-reconnect path).
- [ ] Crank the rate slider to 1.5x-1.8x and verify gaps are bigger but rarer (`PlaybackBufferQueue` smoothing). At 1.0x there should be virtually no gaps.
- [ ] Without headphones, confirm the orange headphones hint appears.
- [ ] Tap Stop, then Save as note. Confirm a note appears in the main list with the indigo Live Translation source tag, source text in `text`, translation in `enhancedText`.

## Known caveats and v2 follow-ups
- Voice is hardcoded to `Adrian` (the only Soniox voice publicly named). Quality may vary across non-English target languages. v2 should fetch `/v1/tts-models` and surface a voice picker.
- Token merge logic in the service is conservative - drops a single trailing non-final token when a new one arrives. If Soniox emits multi-token interim tails in practice, brief ghost duplicates may appear during the interim phase.
- Two-way conversation mode (Soniox `translation: { type: two_way }`) deferred to v2; this PR ships one-way only.