### PR TITLE
Fix Stop button hang in Live Translation

### DIFF
--- a/VivaDicta/Services/LiveTranslation/LiveTranslationAudio.swift
+++ b/VivaDicta/Services/LiveTranslation/LiveTranslationAudio.swift
@@ -97,7 +97,7 @@ final class LiveTranslationAudio {
             playerNode.play()
             isStarted = true
         } catch {
-            stop()
+            await stop()
             throw error
         }
     }
@@ -105,34 +105,39 @@ final class LiveTranslationAudio {
     /// Idempotent: safe to call regardless of how far start() got. Each step
     /// is guarded by its own `did-start` flag so a partial-start failure
     /// still tears down the audio session and tap.
-    func stop() {
+    ///
+    /// The hardware teardown runs off MainActor via Task.detached: AVAudioEngine
+    /// stop, removeTap, and AVAudioSession.setActive can each take a noticeable
+    /// moment in some scenarios (especially after route changes), and if they
+    /// run on MainActor SwiftUI freezes for the duration - which is what was
+    /// reproducing as "Stop button hangs the app forever". Yielding MainActor
+    /// keeps the UI responsive while the engine cleans up.
+    func stop() async {
+        guard isStarted || tapInstalled || sessionActivated else { return }
+
+        let needsTap = tapInstalled
+        let needsSessionDeactivate = sessionActivated
+
         isStarted = false
-
-        playerNode.stop()
-
-        if tapInstalled {
-            engine.inputNode.removeTap(onBus: 0)
-            tapInstalled = false
-        }
-
-        engine.stop()
-        // Do NOT call engine.reset(); it detaches nodes and the next start()
-        // would crash on re-attach. Stopping the engine alone is enough to
-        // release CPU/audio hardware.
+        tapInstalled = false
+        sessionActivated = false
 
         captureContinuation?.finish()
         captureContinuation = nil
         tapInstaller = nil
         bufferQueue.reset()
 
-        if sessionActivated {
-            do {
-                try AVAudioSession.sharedInstance().setActive(false, options: [.notifyOthersOnDeactivation])
-            } catch {
-                logger.logWarning("Audio session deactivate failed: \(error.localizedDescription)")
-            }
-            sessionActivated = false
-        }
+        let context = AudioTeardownContext(
+            engine: engine,
+            playerNode: playerNode,
+            removeTap: needsTap,
+            deactivateSession: needsSessionDeactivate,
+            logger: logger
+        )
+
+        await Task.detached(priority: .userInitiated) {
+            context.perform()
+        }.value
     }
 
     func enqueuePlayback(_ data: Data) {
@@ -350,6 +355,62 @@ nonisolated private final class PlaybackBufferQueue: @unchecked Sendable {
         queuedDuration = 0
         isStarved = true
         hasEverStarted = false
+    }
+}
+
+/// Hardware-side teardown of the AVAudioEngine + AVAudioSession. Wrapped in a
+/// `@unchecked Sendable` class so we can run it on a detached Task without
+/// MainActor isolation. AVAudioEngine, AVAudioPlayerNode, and AVAudioSession
+/// are all documented as thread-safe for these operations - the wrapper just
+/// satisfies Swift 6's strict concurrency checking.
+///
+/// Each step logs entry/exit so the device console pinpoints which call stalls
+/// if the hang ever resurfaces. We deliberately do NOT pass
+/// `.notifyOthersOnDeactivation` - it triggers synchronous notifications to
+/// other apps that have been observed to take seconds in some iOS scenarios.
+nonisolated private final class AudioTeardownContext: @unchecked Sendable {
+    private let engine: AVAudioEngine
+    private let playerNode: AVAudioPlayerNode
+    private let removeTap: Bool
+    private let deactivateSession: Bool
+    private let logger: Logger
+
+    nonisolated init(
+        engine: AVAudioEngine,
+        playerNode: AVAudioPlayerNode,
+        removeTap: Bool,
+        deactivateSession: Bool,
+        logger: Logger
+    ) {
+        self.engine = engine
+        self.playerNode = playerNode
+        self.removeTap = removeTap
+        self.deactivateSession = deactivateSession
+        self.logger = logger
+    }
+
+    nonisolated func perform() {
+        logger.logInfo("Audio teardown: stopping player node")
+        playerNode.stop()
+
+        if removeTap {
+            logger.logInfo("Audio teardown: removing input tap")
+            engine.inputNode.removeTap(onBus: 0)
+        }
+
+        logger.logInfo("Audio teardown: stopping engine")
+        engine.stop()
+
+        if deactivateSession {
+            logger.logInfo("Audio teardown: deactivating session")
+            do {
+                try AVAudioSession.sharedInstance().setActive(false)
+            } catch {
+                logger.logWarning("Audio session deactivate failed: \(error.localizedDescription)")
+            }
+        }
+
+        logger.logInfo("Audio teardown: complete")
     }
 }
 

--- a/VivaDicta/Services/LiveTranslation/LiveTranslationService.swift
+++ b/VivaDicta/Services/LiveTranslation/LiveTranslationService.swift
@@ -353,11 +353,13 @@ final class LiveTranslationService {
     }
 
     private func teardown() async {
+        logger.logInfo("teardown: removing interruption observer")
         if let interruptionObserver {
             NotificationCenter.default.removeObserver(interruptionObserver)
             self.interruptionObserver = nil
         }
 
+        logger.logInfo("teardown: cancelling tasks")
         captureTask?.cancel()
         captureTask = nil
         sttTask?.cancel()
@@ -365,13 +367,18 @@ final class LiveTranslationService {
         ttsTask?.cancel()
         ttsTask = nil
 
+        logger.logInfo("teardown: finalizing STT")
         await sttClient.finalizeAudio()
+        logger.logInfo("teardown: disconnecting STT")
         await sttClient.disconnect()
+        logger.logInfo("teardown: disconnecting TTS")
         await ttsClient?.disconnect()
         ttsClient = nil
         apiKeyCache = nil
 
-        audio.stop()
+        logger.logInfo("teardown: stopping audio")
+        await audio.stop()
+        logger.logInfo("teardown: complete")
     }
 
     private func observeInterruptions() {


### PR DESCRIPTION
## Summary
The Live Translation Stop button could freeze the UI for several seconds or indefinitely. Both `LiveTranslationService` and `LiveTranslationAudio` are `@MainActor`, so when `audio.stop()` ran the AVAudioEngine + AVAudioSession teardown synchronously, MainActor was blocked for the duration. SwiftUI couldn't process state updates or tap events, so the user perceived it as "app hangs forever, only restart helps".

## Changes

- `audio.stop()` is now `async`. The hardware teardown (`playerNode.stop`, `inputNode.removeTap`, `engine.stop`, `AVAudioSession.setActive(false)`) runs in a `Task.detached` wrapped in a small `@unchecked Sendable` `AudioTeardownContext` class. MainActor is yielded for the duration; SwiftUI continues to process updates and taps while the engine cleans up. AVAudioEngine and AVAudioSession are documented as thread-safe for these operations - the wrapper just satisfies Swift 6 strict concurrency.
- Drop `.notifyOthersOnDeactivation` from `setActive(false)`. It triggers synchronous notifications to other apps that have been observed to take seconds in some iOS scenarios; we don't strictly need it for this feature.
- Per-step diagnostic logging in `LiveTranslationService.teardown()` and `AudioTeardownContext.perform()`. If the hang ever resurfaces, the device console (subsystem `com.antonnovoselov.VivaDicta`, categories `LiveTranslationService` / `LiveTranslationAudio`) will print exactly which step is stalled so we can target that specific call.

## Test plan
- [ ] Open Live Translation, tap Start.
- [ ] Speak / play a short audio clip so STT and TTS produce real activity.
- [ ] Tap Stop. UI should respond within ~1 second; the Save button should appear.
- [ ] Repeat 3-4 Start -> Stop cycles in the same screen session.
- [ ] Long-running session (~5 minutes), Stop should still respond promptly.
- [ ] No headphones case (held to ear / earpiece). Stop should still work.
- [ ] If hang resurfaces, capture Console.app filtered to `LiveTranslationAudio` to identify which teardown step stalled.

## Notes
This was already pushed to `main` as `558cc9065` and then reverted out of `main` so it could go through normal PR review. The branch carries the same commit; merging this PR re-introduces the fix.