### PR TITLE
Live Translation onboarding polish: missing-key empty state + softer headphones tip

### DIFF
--- a/VivaDicta/AppState.swift
+++ b/VivaDicta/AppState.swift
@@ -86,9 +86,13 @@ class AppState {
     /// Triggers navigation to the current mode's settings screen.
     var shouldNavigateToModeSettings: Bool = false
 
-    /// Triggers Settings → AI Providers → <provider> deep link, used by
-    /// "missing API key" empty states (e.g. Live Translation needs Soniox).
-    var shouldNavigateToAIProviderKey: AIProvider? = nil
+    /// Triggers Settings → Transcription Models → <cloud provider config>
+    /// deep link, used by "missing API key" empty states (e.g. Live
+    /// Translation needs Soniox). The Models screen mirrors this provider's
+    /// cloud row to its `cloudModelToConfigure` state on appear, which then
+    /// opens CloudModelConfigurationView via the existing
+    /// `.navigationDestination(item:)` binding.
+    var pendingCloudTranscriptionProvider: TranscriptionModelProvider? = nil
 
     /// Triggers the start of a new recording.
     var shouldStartRecording: Bool = false

--- a/VivaDicta/AppState.swift
+++ b/VivaDicta/AppState.swift
@@ -86,6 +86,10 @@ class AppState {
     /// Triggers navigation to the current mode's settings screen.
     var shouldNavigateToModeSettings: Bool = false
 
+    /// Triggers Settings → AI Providers → <provider> deep link, used by
+    /// "missing API key" empty states (e.g. Live Translation needs Soniox).
+    var shouldNavigateToAIProviderKey: AIProvider? = nil
+
     /// Triggers the start of a new recording.
     var shouldStartRecording: Bool = false
 

--- a/VivaDicta/Views/LiveTranslation/LiveTranslationView.swift
+++ b/VivaDicta/Views/LiveTranslation/LiveTranslationView.swift
@@ -20,7 +20,8 @@ struct LiveTranslationView: View {
     @State private var headphonesConnected = LiveTranslationAudio.isHeadphonesRouteActive
     @State private var hasSonioxKey: Bool = false
 
-    private static let sonioxConsoleURL = URL(string: "https://console.soniox.com/")!
+    private static let sonioxConsoleURL = URL(string: "https://console.soniox.com/", encodingInvalidCharacters: false)
+        ?? URL(string: "https://soniox.com")!
 
     var body: some View {
         NavigationStack {
@@ -106,7 +107,7 @@ struct LiveTranslationView: View {
 
             VStack(spacing: 12) {
                 Button {
-                    appState.shouldNavigateToModels = true
+                    appState.shouldNavigateToAIProviderKey = .soniox
                     dismiss()
                 } label: {
                     Label("Open Settings", systemImage: "gearshape")
@@ -170,7 +171,7 @@ struct LiveTranslationView: View {
         HStack(spacing: 6) {
             Image(systemName: "info.circle")
                 .font(.caption)
-            Text("Use headphones, or hold your iPhone to your ear, to hear the translation")
+            Text("Use headphones for clearer audio, or hold your iPhone near your ear")
                 .font(.caption)
             Spacer()
         }

--- a/VivaDicta/Views/LiveTranslation/LiveTranslationView.swift
+++ b/VivaDicta/Views/LiveTranslation/LiveTranslationView.swift
@@ -12,24 +12,27 @@ import SwiftUI
 struct LiveTranslationView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.modelContext) private var modelContext
+    @Environment(AppState.self) private var appState
 
     @State private var service = LiveTranslationService()
     @State private var savedSnapshot: SavedSnapshot?
     @State private var saveError: SaveErrorAlert?
     @State private var headphonesConnected = LiveTranslationAudio.isHeadphonesRouteActive
+    @State private var hasSonioxKey: Bool = false
+
+    private static let sonioxConsoleURL = URL(string: "https://console.soniox.com/")!
 
     var body: some View {
         NavigationStack {
-            VStack(spacing: 0) {
-                languageBar
-                Divider()
-                if !headphonesConnected && service.config.ttsEnabled {
-                    headphonesHint
+            Group {
+                if hasSonioxKey {
+                    sessionContent
+                } else {
+                    missingKeyEmptyState
                 }
-                transcriptColumns
-                Divider()
-                ttsBar
-                actionBar
+            }
+            .onAppear {
+                hasSonioxKey = checkSonioxKey()
             }
             .onReceive(NotificationCenter.default.publisher(for: AVAudioSession.routeChangeNotification)) { _ in
                 headphonesConnected = LiveTranslationAudio.isHeadphonesRouteActive
@@ -71,6 +74,68 @@ struct LiveTranslationView: View {
         }
     }
 
+    @ViewBuilder
+    private var sessionContent: some View {
+        VStack(spacing: 0) {
+            languageBar
+            Divider()
+            transcriptColumns
+            Divider()
+            ttsBar
+            actionBar
+        }
+    }
+
+    private var missingKeyEmptyState: some View {
+        VStack(spacing: 20) {
+            Spacer()
+
+            Image(systemName: "key.horizontal.fill")
+                .font(.system(size: 56))
+                .foregroundStyle(.indigo)
+
+            VStack(spacing: 8) {
+                Text("Soniox API key required")
+                    .font(.title2.weight(.semibold))
+                Text("Live Translation uses Soniox for real-time speech recognition and translation. Add your API key in Settings to get started.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 32)
+            }
+
+            VStack(spacing: 12) {
+                Button {
+                    appState.shouldNavigateToModels = true
+                    dismiss()
+                } label: {
+                    Label("Open Settings", systemImage: "gearshape")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.indigo)
+                .controlSize(.large)
+
+                Link(destination: Self.sonioxConsoleURL) {
+                    Label("Get a Soniox key", systemImage: "safari")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.large)
+            }
+            .padding(.horizontal)
+
+            Spacer()
+        }
+    }
+
+    private func checkSonioxKey() -> Bool {
+        guard let key = KeychainService.shared.getString(forKey: "sonioxAPIKey") else {
+            return false
+        }
+        return !key.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
     // MARK: - Subviews
 
     private var languageBar: some View {
@@ -102,17 +167,14 @@ struct LiveTranslationView: View {
     }
 
     private var headphonesHint: some View {
-        HStack(spacing: 8) {
-            Image(systemName: "airpods")
-                .foregroundStyle(.orange)
-            Text("Use headphones to prevent feedback into the mic")
+        HStack(spacing: 6) {
+            Image(systemName: "info.circle")
                 .font(.caption)
-                .foregroundStyle(.secondary)
+            Text("Use headphones, or hold your iPhone to your ear, to hear the translation")
+                .font(.caption)
             Spacer()
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 8)
-        .background(.orange.opacity(0.1))
+        .foregroundStyle(.secondary)
     }
 
     private var transcriptColumns: some View {
@@ -169,6 +231,10 @@ struct LiveTranslationView: View {
                     .font(.caption.monospacedDigit())
                     .foregroundStyle(.secondary)
                     .frame(width: 44, alignment: .trailing)
+                }
+
+                if !headphonesConnected {
+                    headphonesHint
                 }
             }
         }

--- a/VivaDicta/Views/LiveTranslation/LiveTranslationView.swift
+++ b/VivaDicta/Views/LiveTranslation/LiveTranslationView.swift
@@ -107,7 +107,7 @@ struct LiveTranslationView: View {
 
             VStack(spacing: 12) {
                 Button {
-                    appState.shouldNavigateToAIProviderKey = .soniox
+                    appState.pendingCloudTranscriptionProvider = .soniox
                     dismiss()
                 } label: {
                     Label("Open Settings", systemImage: "gearshape")

--- a/VivaDicta/Views/MainView.swift
+++ b/VivaDicta/Views/MainView.swift
@@ -126,7 +126,7 @@ struct MainView: View {
     @ViewBuilder
     private var contentNavigationView: some View {
         contentNavigationViewBase
-            .onChange(of: appState.shouldNavigateToAIProviderKey) { _, newValue in
+            .onChange(of: appState.pendingCloudTranscriptionProvider) { _, newValue in
                 if newValue != nil { showingSettings = true }
             }
             .overlay(alignment: .top) {

--- a/VivaDicta/Views/MainView.swift
+++ b/VivaDicta/Views/MainView.swift
@@ -125,6 +125,22 @@ struct MainView: View {
 
     @ViewBuilder
     private var contentNavigationView: some View {
+        contentNavigationViewBase
+            .onChange(of: appState.shouldNavigateToAIProviderKey) { _, newValue in
+                if newValue != nil { showingSettings = true }
+            }
+            .overlay(alignment: .top) {
+                if appState.showKeyboardFlowToast {
+                    KeyboardFlowToast()
+                        .padding(.top, 60)
+                        .transition(.move(edge: .top).combined(with: .opacity))
+                }
+            }
+            .animation(.spring(duration: 0.4, bounce: 0.2), value: appState.showKeyboardFlowToast)
+    }
+
+    @ViewBuilder
+    private var contentNavigationViewBase: some View {
         rootNavigationStack
             .overlay { recordingOverlay }
             .overlay { hudOverlay }
@@ -189,14 +205,6 @@ struct MainView: View {
                     handleOpenedAudioTranscription()
                 }
             }
-            .overlay(alignment: .top) {
-                if appState.showKeyboardFlowToast {
-                    KeyboardFlowToast()
-                        .padding(.top, 60)
-                        .transition(.move(edge: .top).combined(with: .opacity))
-                }
-            }
-            .animation(.spring(duration: 0.4, bounce: 0.2), value: appState.showKeyboardFlowToast)
     }
 
     // MARK: - Main Content View

--- a/VivaDicta/Views/SettingsScreen/ModelsView.swift
+++ b/VivaDicta/Views/SettingsScreen/ModelsView.swift
@@ -91,6 +91,9 @@ struct ModelsView: View {
                 })
             .navigationTransition(.zoom(sourceID: model.id, in: zoomNamespace))
         })
+        .onAppear {
+            consumePendingCloudTranscriptionProvider()
+        }
         .sheet(isPresented: $showCustomModelConfiguration) {
             AddCustomTranscriptionModelView(onSave: {
                 handleCustomModelSaved()
@@ -149,6 +152,22 @@ struct ModelsView: View {
 
         appState.transcriptionManager.updateCloudModels()
         cloudModelToConfigure = nil
+    }
+
+    /// If another screen requested deep-linking into a specific cloud
+    /// transcription provider's API key entry (e.g., Live Translation's
+    /// missing-key empty state), consume that request here: switch to the
+    /// cloud tab and trigger the configuration sheet for the matching model.
+    private func consumePendingCloudTranscriptionProvider() {
+        guard let provider = appState.pendingCloudTranscriptionProvider else { return }
+        appState.pendingCloudTranscriptionProvider = nil
+
+        modelType = .cloud
+        let cloudModels = appState.transcriptionManager.allAvailableModels
+            .compactMap { $0 as? CloudModel }
+        if let match = cloudModels.first(where: { $0.provider == provider }) {
+            cloudModelToConfigure = match
+        }
     }
 
     func handleAPIKeyDeletion(for model: CloudModel) {

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -663,10 +663,11 @@ struct SettingsView: View {
                 appState.shouldNavigateToModeSettings = false
                 navigationPath.append(appState.aiService.selectedMode)
             }
-            if let provider = appState.shouldNavigateToAIProviderKey {
-                appState.shouldNavigateToAIProviderKey = nil
-                navigationPath.append(SettingsDestination.aiProviders)
-                navigationPath.append(provider)
+            if appState.pendingCloudTranscriptionProvider != nil {
+                // Don't clear the flag here; ModelsView reads it on appear
+                // and uses it to switch to the cloud tab + open the matching
+                // CloudModelConfigurationView. Clearing happens there.
+                navigationPath.append(SettingsDestination.transcriptionModels)
             }
         }
         .safeAreaInset(edge: .bottom) {

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -663,6 +663,11 @@ struct SettingsView: View {
                 appState.shouldNavigateToModeSettings = false
                 navigationPath.append(appState.aiService.selectedMode)
             }
+            if let provider = appState.shouldNavigateToAIProviderKey {
+                appState.shouldNavigateToAIProviderKey = nil
+                navigationPath.append(SettingsDestination.aiProviders)
+                navigationPath.append(provider)
+            }
         }
         .safeAreaInset(edge: .bottom) {
             if navigationPath.isEmpty {


### PR DESCRIPTION
## Summary
Two small UX wins for the Live Translation screen that can ship together.

### Missing Soniox API key
Today, a user without a Soniox API key opens Live Translation, configures pickers/toggles, taps **Start listening**, and gets a generic alert telling them to add the key in Settings. They have to dismiss, navigate manually, and figure out what Soniox is.

This PR replaces the session UI with a dedicated empty state when no key is present:
- Headline: "Soniox API key required"
- One-sentence explainer
- Primary button **Open Settings** that closes the sheet and triggers `appState.shouldNavigateToModels` (the existing deep-link path used by the "no transcription model" alert in MainView)
- Secondary `Link` button **Get a Soniox key** opening `https://console.soniox.com/` in Safari
- The X button in the toolbar still closes the sheet

The session UI shows once the key is configured.

### Headphones tip
Previously the Live Translation screen carried an orange warning banner above the transcript columns: *"Use headphones to prevent feedback into the mic"*. That copy is no longer accurate - the audio engine only blocks playback on the loud bottom speaker (`.builtInSpeaker`); the earpiece (phone held to ear) and any external route (headphones, AirPods, AirPlay, car audio) all play fine. The orange warning style oversold the risk.

The banner moves into the TTS bar under the rate slider, only renders while TTS is enabled, and is styled as a quiet secondary-text tip:

> Use headphones, or hold your iPhone to your ear, to hear the translation

No background tint, no warning color. Hides when any non-speaker route is active.

## Test plan
- [ ] Without a Soniox key in Settings: open Live Translation. Empty state shows. Tap **Open Settings**. Sheet dismisses; Settings opens.
- [ ] Tap **Get a Soniox key**. Safari opens to console.soniox.com.
- [ ] Add a Soniox key. Reopen Live Translation. Session UI shows.
- [ ] No headphones connected, TTS enabled. Tip appears under the rate slider, secondary text style.
- [ ] Connect AirPods. Tip disappears.
- [ ] Disconnect AirPods. Tip reappears.
- [ ] Toggle TTS off. Tip hides (along with the rate slider).