### PR TITLE
Multilingual filler-word filtering (EN/RU/ES/DE/FR)

### DIFF
--- a/VivaDicta/Services/Transcription/LanguageDetector.swift
+++ b/VivaDicta/Services/Transcription/LanguageDetector.swift
@@ -1,0 +1,32 @@
+//
+//  LanguageDetector.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.04.29
+//
+
+import Foundation
+import NaturalLanguage
+
+/// Lightweight wrapper around `NLLanguageRecognizer` for transcript text.
+enum LanguageDetector {
+    /// Detect the dominant language of `text` and return its ISO 639-1 code (e.g. "en", "ru").
+    ///
+    /// Returns nil when:
+    /// - the text is shorter than `minLength` characters (signal too weak)
+    /// - no hypothesis meets the confidence threshold
+    static func detect(_ text: String, minLength: Int = 12, minConfidence: Double = 0.5) -> String? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count >= minLength else { return nil }
+
+        let recognizer = NLLanguageRecognizer()
+        recognizer.processString(trimmed)
+
+        let hypotheses = recognizer.languageHypotheses(withMaximum: 1)
+        guard let best = hypotheses.max(by: { $0.value < $1.value }),
+              best.value >= minConfidence else {
+            return nil
+        }
+        return best.key.rawValue
+    }
+}

--- a/VivaDicta/Services/Transcription/TranscriptionManager.swift
+++ b/VivaDicta/Services/Transcription/TranscriptionManager.swift
@@ -218,7 +218,10 @@ class TranscriptionManager {
             transcriptionResult = try await cloudTranscriptionService.transcribe(audioURL: audioURL, model: model)
         }
 
-        var result = TranscriptionOutputFilter.filter(transcriptionResult.text)
+        var result = TranscriptionOutputFilter.filter(
+            transcriptionResult.text,
+            language: currentMode.transcriptionLanguage
+        )
 
         // Apply text formatting if enabled for current mode
         if currentMode.isAutoTextFormattingEnabled && transcriptionResult.isSpeakerAttributed == false {

--- a/VivaDicta/Services/Transcription/TranscriptionOutputFilter.swift
+++ b/VivaDicta/Services/Transcription/TranscriptionOutputFilter.swift
@@ -32,7 +32,7 @@ struct TranscriptionOutputFilter {
         "ru": ["ээ", "эээ", "ээээ", "э-э", "э-э-э", "эм", "эмм", "ыы", "ыыы"],
         "es": ["ehm", "ehmm", "eee", "eeh"],
         "de": ["äh", "ähm", "ähh", "ähhh", "ähmm", "öh", "öhm"],
-        "fr": ["euh", "euhh", "euhhh", "euhm", "heu", "heuu", "bah"]
+        "fr": ["euh", "euhh", "euhhh", "euhm", "heu", "heuu"]
     ]
 
     /// Returns true if the text contains meaningful content for a transcription.

--- a/VivaDicta/Services/Transcription/TranscriptionOutputFilter.swift
+++ b/VivaDicta/Services/Transcription/TranscriptionOutputFilter.swift
@@ -29,7 +29,7 @@ struct TranscriptionOutputFilter {
     /// (either explicitly via the mode or detected with high confidence).
     private static let fillersByLanguage: [String: [String]] = [
         "en": ["ah", "eh", "ehh", "ha"],
-        "ru": ["ээ", "эээ", "ээээ", "эм", "эмм", "ыы", "ыыы"],
+        "ru": ["ээ", "эээ", "ээээ", "э-э", "э-э-э", "эм", "эмм", "ыы", "ыыы"],
         "es": ["ehm", "ehmm", "eee", "eeh"],
         "de": ["äh", "ähm", "ähh", "ähhh", "ähmm", "öh", "öhm"],
         "fr": ["euh", "euhh", "euhhh", "euhm", "heu", "heuu", "bah"]

--- a/VivaDicta/Services/Transcription/TranscriptionOutputFilter.swift
+++ b/VivaDicta/Services/Transcription/TranscriptionOutputFilter.swift
@@ -10,17 +10,31 @@ import os
 
 struct TranscriptionOutputFilter {
     private static let logger = Logger(category: .transcriptionOutputFilter)
-    
+
     private static let hallucinationPatterns = [
         #"\[.*?\]"#,     // []
         #"\(.*?\)"#,     // ()
         #"\{.*?\}"#      // {}
     ]
 
-    private static let fillerWords = [
-        "uh", "um", "uhm", "umm", "uhh", "uhhh", "ah", "eh",
-        "hmm", "hm", "mmm", "mm", "mh", "ha", "ehh"
+    /// Hesitation sounds that have no real-word collisions across the supported
+    /// languages. Always stripped regardless of language.
+    private static let universalFillers = [
+        "uh", "um", "uhm", "umm", "uhh", "uhhh",
+        "hmm", "hm", "mmm", "mm", "mh"
     ]
+
+    /// Per-language fillers that may collide with real words in *other* languages
+    /// and are therefore only stripped when the transcript's language is known
+    /// (either explicitly via the mode or detected with high confidence).
+    private static let fillersByLanguage: [String: [String]] = [
+        "en": ["ah", "eh", "ehh", "ha"],
+        "ru": ["ээ", "эээ", "ээээ", "эм", "эмм", "ыы", "ыыы"],
+        "es": ["ehm", "ehmm", "eee", "eeh"],
+        "de": ["äh", "ähm", "ähh", "ähhh", "ähmm", "öh", "öhm"],
+        "fr": ["euh", "euhh", "euhhh", "euhm", "heu", "heuu", "bah"]
+    ]
+
     /// Returns true if the text contains meaningful content for a transcription.
     /// Returns false for empty strings, whitespace-only strings, or strings containing only punctuation.
     static func hasMeaningfulContent(_ text: String) -> Bool {
@@ -33,7 +47,14 @@ struct TranscriptionOutputFilter {
         }
     }
 
-    static func filter(_ text: String) -> String {
+    /// Strip known hallucination markers and filler words from a transcript.
+    ///
+    /// - Parameters:
+    ///   - text: Raw transcript output.
+    ///   - language: ISO 639-1 code from the active mode (e.g. "en", "ru") or "auto"/nil.
+    ///     When unspecified or "auto", `NLLanguageRecognizer` is used; if detection
+    ///     also fails, English is the final fallback.
+    static func filter(_ text: String, language: String? = nil) -> String {
         var filteredText = text
 
         // Remove <TAG>...</TAG> blocks
@@ -51,8 +72,15 @@ struct TranscriptionOutputFilter {
             }
         }
 
+        // Resolve language and pick filler set.
+        let resolvedLanguage = resolveLanguage(explicit: language, text: text) ?? "en"
+        var fillers = universalFillers
+        if let extras = fillersByLanguage[resolvedLanguage] {
+            fillers.append(contentsOf: extras)
+        }
+
         // Remove filler words
-        for fillerWord in fillerWords {
+        for fillerWord in fillers {
             let pattern = "\\b\(NSRegularExpression.escapedPattern(for: fillerWord))\\b[,.]?"
             if let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) {
                 let range = NSRange(filteredText.startIndex..., in: filteredText)
@@ -69,11 +97,25 @@ struct TranscriptionOutputFilter {
 
         // Log results
         if filteredText != text {
-            logger.logNotice("📝 Output filter result: \(filteredText)")
+            logger.logNotice("📝 Output filter (\(resolvedLanguage)) result: \(filteredText)")
         } else {
-            logger.logNotice("📝 Output filter result (unchanged): \(filteredText)")
+            logger.logNotice("📝 Output filter (\(resolvedLanguage)) result (unchanged): \(filteredText)")
         }
 
         return filteredText
+    }
+
+    /// Resolves the language code used to pick the filler set.
+    ///
+    /// Order of preference:
+    /// 1. Explicit, non-"auto" mode language (region suffixes are stripped: "en-US" → "en").
+    /// 2. `NLLanguageRecognizer` over the raw transcript.
+    /// 3. nil (caller falls back to English).
+    private static func resolveLanguage(explicit: String?, text: String) -> String? {
+        if let explicit, !explicit.isEmpty, explicit.lowercased() != "auto" {
+            let primary = explicit.split(separator: "-").first.map(String.init) ?? explicit
+            return primary.lowercased()
+        }
+        return LanguageDetector.detect(text)
     }
 }

--- a/VivaDictaTests/TextProcessingFilterTests.swift
+++ b/VivaDictaTests/TextProcessingFilterTests.swift
@@ -121,6 +121,83 @@ struct TranscriptionOutputFilterTests {
 
         #expect(result == input)
     }
+
+    // MARK: - filter Tests — Multilingual Fillers
+
+    @Test func filter_universalFillers_strippedRegardlessOfLanguage() {
+        // "uh", "um", "hmm" should be removed for any language.
+        let inputRu = "Это um важное hmm сообщение для теста."
+        let result = TranscriptionOutputFilter.filter(inputRu, language: "ru")
+
+        #expect(!result.contains("um"))
+        #expect(!result.contains("hmm"))
+    }
+
+    @Test func filter_russianFillers_removedWhenLanguageIsRussian() {
+        let input = "Я думаю ээ что нам ыыы нужно идти."
+        let result = TranscriptionOutputFilter.filter(input, language: "ru")
+
+        #expect(!result.contains("ээ"))
+        #expect(!result.contains("ыыы"))
+        #expect(result.contains("Я думаю"))
+        #expect(result.contains("нужно идти"))
+    }
+
+    @Test func filter_germanFillers_removedWhenLanguageIsGerman() {
+        let input = "Ich denke äh dass wir ähm gehen sollten."
+        let result = TranscriptionOutputFilter.filter(input, language: "de")
+
+        #expect(!result.contains("äh"))
+        #expect(!result.contains("ähm"))
+        #expect(result.contains("Ich denke"))
+        #expect(result.contains("gehen sollten"))
+    }
+
+    @Test func filter_frenchFillers_removedWhenLanguageIsFrench() {
+        let input = "Je pense euh qu'on devrait heu y aller."
+        let result = TranscriptionOutputFilter.filter(input, language: "fr")
+
+        #expect(!result.contains("euh"))
+        #expect(!result.contains("heu"))
+        #expect(result.contains("Je pense"))
+        #expect(result.contains("y aller"))
+    }
+
+    @Test func filter_spanishFillers_removedWhenLanguageIsSpanish() {
+        let input = "Yo creo ehm que deberíamos eee ir."
+        let result = TranscriptionOutputFilter.filter(input, language: "es")
+
+        #expect(!result.contains("ehm"))
+        #expect(!result.contains("eee"))
+        #expect(result.contains("Yo creo"))
+        #expect(result.contains("deberíamos"))
+    }
+
+    @Test func filter_germanFillers_notRemovedWhenLanguageIsRussian() {
+        // German "äh" should NOT be stripped when language is Russian
+        // (it's not in the Russian filler list).
+        let input = "äh test"
+        let result = TranscriptionOutputFilter.filter(input, language: "ru")
+
+        #expect(result.contains("äh"))
+    }
+
+    @Test func filter_englishFallback_whenLanguageUnknown() {
+        // "auto" with text too short for confident detection → English fallback,
+        // so English-specific fillers (eh) should still be stripped.
+        let input = "Well, eh, ok."
+        let result = TranscriptionOutputFilter.filter(input, language: "auto")
+
+        #expect(!result.contains("eh"))
+    }
+
+    @Test func filter_explicitLanguageWithRegionSuffix_resolvesToBase() {
+        // "en-US" should be treated as "en".
+        let input = "I think eh we should go."
+        let result = TranscriptionOutputFilter.filter(input, language: "en-US")
+
+        #expect(!result.contains(" eh "))
+    }
 }
 
 // MARK: - AI Processing Output Filter Tests

--- a/VivaDictaTests/TextProcessingFilterTests.swift
+++ b/VivaDictaTests/TextProcessingFilterTests.swift
@@ -143,6 +143,16 @@ struct TranscriptionOutputFilterTests {
         #expect(result.contains("нужно идти"))
     }
 
+    @Test func filter_russianHyphenatedFillers_removedWhenLanguageIsRussian() {
+        let input = "Я э-э думаю что э-э-э нам нужно идти."
+        let result = TranscriptionOutputFilter.filter(input, language: "ru")
+
+        #expect(!result.contains("э-э"))
+        #expect(result.contains("Я"))
+        #expect(result.contains("думаю"))
+        #expect(result.contains("нужно идти"))
+    }
+
     @Test func filter_germanFillers_removedWhenLanguageIsGerman() {
         let input = "Ich denke äh dass wir ähm gehen sollten."
         let result = TranscriptionOutputFilter.filter(input, language: "de")


### PR DESCRIPTION
## Summary
- Split `TranscriptionOutputFilter` into a universal hesitation list (`uh`, `um`, `hmm`, ...) that's always stripped, plus per-language extras for English, Russian, Spanish, German, and French.
- Resolution order: explicit mode language → `NLLanguageRecognizer` on the raw transcript (min 12 chars, confidence ≥ 0.5) → English fallback.
- Region suffixes are normalized (`en-US` → `en`).
- New `LanguageDetector` wraps `NLLanguageRecognizer` with conservative thresholds to avoid stripping based on a wrong guess on short text.
- `TranscriptionManager.transcribe` now passes `currentMode.transcriptionLanguage` into the filter so explicit mode language is honored before any detection.

## Why
The previous filter ran a hardcoded English list against any transcript. Real fillers in other languages (`ээ`, `äh`, `euh`, `ehm`) passed through untouched, while English-only words like `ah`/`eh`/`ha` could clip valid words/interjections in non-English transcripts.

## Per-language lists
- **EN** (full set, current behavior): `ah, eh, ehh, ha`
- **RU**: `ээ, эээ, ээээ, эм, эмм, ыы, ыыы` (only unmistakable elongated hesitations - skipped `ну/типа/вот` because they're real words)
- **ES**: `ehm, ehmm, eee, eeh` (skipped `este/pues`)
- **DE**: `äh, ähm, ähh, ähhh, ähmm, öh, öhm` (skipped `halt/eben`)
- **FR**: `euh, euhh, euhhh, euhm, heu, heuu, bah` (skipped `ben`)

## Test plan
- [x] `xcodebuild build` succeeds
- [x] All 23 `TranscriptionOutputFilterTests` pass (15 existing + 8 new)
  - Universal fillers stripped regardless of language
  - RU/ES/DE/FR fillers stripped when mode language matches
  - German `äh` is **not** stripped when mode language is Russian (no cross-language collision)
  - English fallback applied when language is `auto` and detection fails
  - Region suffix `en-US` resolves to `en`