### PR TITLE
Add per-mode Trim Trailing Period toggle

### DIFF
--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -301,7 +301,8 @@ class AIService {
             useClipboardContext: mode.useClipboardContext,
 
             isAutoTextFormattingEnabled: mode.isAutoTextFormattingEnabled,
-            isSmartInsertEnabled: mode.isSmartInsertEnabled
+            isSmartInsertEnabled: mode.isSmartInsertEnabled,
+            isStripTrailingPeriodEnabled: mode.isStripTrailingPeriodEnabled
         )
 
         addMode(duplicatedMode)
@@ -369,9 +370,10 @@ class AIService {
                     reminderExtractorModel: mode.reminderExtractorModel,
                     aiEnhanceEnabled: false,
                     useClipboardContext: mode.useClipboardContext,
-        
+
                     isAutoTextFormattingEnabled: mode.isAutoTextFormattingEnabled,
-                    isSmartInsertEnabled: mode.isSmartInsertEnabled
+                    isSmartInsertEnabled: mode.isSmartInsertEnabled,
+                    isStripTrailingPeriodEnabled: mode.isStripTrailingPeriodEnabled
                 )
             },
             logMessage: { "Disabled AI processing for mode '\($0.name)' due to API key deletion for provider: \(provider.rawValue)" }
@@ -397,9 +399,10 @@ class AIService {
                     reminderExtractorModel: mode.reminderExtractorModel,
                     aiEnhanceEnabled: false,
                     useClipboardContext: mode.useClipboardContext,
-        
+
                     isAutoTextFormattingEnabled: mode.isAutoTextFormattingEnabled,
-                    isSmartInsertEnabled: mode.isSmartInsertEnabled
+                    isSmartInsertEnabled: mode.isSmartInsertEnabled,
+                    isStripTrailingPeriodEnabled: mode.isStripTrailingPeriodEnabled
                 )
             },
             logMessage: { "Disabled AI processing for mode '\($0.name)' due to preset deletion" }
@@ -425,9 +428,10 @@ class AIService {
                     reminderExtractorModel: mode.reminderExtractorModel,
                     aiEnhanceEnabled: false,
                     useClipboardContext: mode.useClipboardContext,
-        
+
                     isAutoTextFormattingEnabled: mode.isAutoTextFormattingEnabled,
-                    isSmartInsertEnabled: mode.isSmartInsertEnabled
+                    isSmartInsertEnabled: mode.isSmartInsertEnabled,
+                    isStripTrailingPeriodEnabled: mode.isStripTrailingPeriodEnabled
                 )
             },
             logMessage: { "Disabled AI processing for mode '\($0.name)' due to Ollama connection failure" }
@@ -521,7 +525,8 @@ class AIService {
                 aiEnhanceEnabled: defaultMode.aiEnhanceEnabled,
                 useClipboardContext: defaultMode.useClipboardContext,
                 isAutoTextFormattingEnabled: defaultMode.isAutoTextFormattingEnabled,
-                isSmartInsertEnabled: defaultMode.isSmartInsertEnabled
+                isSmartInsertEnabled: defaultMode.isSmartInsertEnabled,
+                isStripTrailingPeriodEnabled: defaultMode.isStripTrailingPeriodEnabled
             )
 
             // Update the mode
@@ -2213,9 +2218,10 @@ class AIService {
                     reminderExtractorModel: mode.reminderExtractorModel,
                     aiEnhanceEnabled: false,
                     useClipboardContext: mode.useClipboardContext,
-        
+
                     isAutoTextFormattingEnabled: mode.isAutoTextFormattingEnabled,
-                    isSmartInsertEnabled: mode.isSmartInsertEnabled
+                    isSmartInsertEnabled: mode.isSmartInsertEnabled,
+                    isStripTrailingPeriodEnabled: mode.isStripTrailingPeriodEnabled
                 )
             },
             logMessage: { "Disabled AI processing for mode '\($0.name)' due to Custom OpenAI configuration removal" }

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -302,7 +302,8 @@ class AIService {
 
             isAutoTextFormattingEnabled: mode.isAutoTextFormattingEnabled,
             isSmartInsertEnabled: mode.isSmartInsertEnabled,
-            isStripTrailingPeriodEnabled: mode.isStripTrailingPeriodEnabled
+            isStripTrailingPeriodEnabled: mode.isStripTrailingPeriodEnabled,
+            obsidianEnabled: mode.obsidianEnabled
         )
 
         addMode(duplicatedMode)
@@ -373,7 +374,8 @@ class AIService {
 
                     isAutoTextFormattingEnabled: mode.isAutoTextFormattingEnabled,
                     isSmartInsertEnabled: mode.isSmartInsertEnabled,
-                    isStripTrailingPeriodEnabled: mode.isStripTrailingPeriodEnabled
+                    isStripTrailingPeriodEnabled: mode.isStripTrailingPeriodEnabled,
+                    obsidianEnabled: mode.obsidianEnabled
                 )
             },
             logMessage: { "Disabled AI processing for mode '\($0.name)' due to API key deletion for provider: \(provider.rawValue)" }
@@ -402,7 +404,8 @@ class AIService {
 
                     isAutoTextFormattingEnabled: mode.isAutoTextFormattingEnabled,
                     isSmartInsertEnabled: mode.isSmartInsertEnabled,
-                    isStripTrailingPeriodEnabled: mode.isStripTrailingPeriodEnabled
+                    isStripTrailingPeriodEnabled: mode.isStripTrailingPeriodEnabled,
+                    obsidianEnabled: mode.obsidianEnabled
                 )
             },
             logMessage: { "Disabled AI processing for mode '\($0.name)' due to preset deletion" }
@@ -431,7 +434,8 @@ class AIService {
 
                     isAutoTextFormattingEnabled: mode.isAutoTextFormattingEnabled,
                     isSmartInsertEnabled: mode.isSmartInsertEnabled,
-                    isStripTrailingPeriodEnabled: mode.isStripTrailingPeriodEnabled
+                    isStripTrailingPeriodEnabled: mode.isStripTrailingPeriodEnabled,
+                    obsidianEnabled: mode.obsidianEnabled
                 )
             },
             logMessage: { "Disabled AI processing for mode '\($0.name)' due to Ollama connection failure" }
@@ -526,7 +530,8 @@ class AIService {
                 useClipboardContext: defaultMode.useClipboardContext,
                 isAutoTextFormattingEnabled: defaultMode.isAutoTextFormattingEnabled,
                 isSmartInsertEnabled: defaultMode.isSmartInsertEnabled,
-                isStripTrailingPeriodEnabled: defaultMode.isStripTrailingPeriodEnabled
+                isStripTrailingPeriodEnabled: defaultMode.isStripTrailingPeriodEnabled,
+                obsidianEnabled: defaultMode.obsidianEnabled
             )
 
             // Update the mode
@@ -2221,7 +2226,8 @@ class AIService {
 
                     isAutoTextFormattingEnabled: mode.isAutoTextFormattingEnabled,
                     isSmartInsertEnabled: mode.isSmartInsertEnabled,
-                    isStripTrailingPeriodEnabled: mode.isStripTrailingPeriodEnabled
+                    isStripTrailingPeriodEnabled: mode.isStripTrailingPeriodEnabled,
+                    obsidianEnabled: mode.obsidianEnabled
                 )
             },
             logMessage: { "Disabled AI processing for mode '\($0.name)' due to Custom OpenAI configuration removal" }

--- a/VivaDicta/Services/AIEnhance/VivaMode.swift
+++ b/VivaDicta/Services/AIEnhance/VivaMode.swift
@@ -83,6 +83,10 @@ struct VivaMode: Identifiable, Hashable, Codable {
     /// Whether smart insert (auto-adjust spacing and capitalization) is applied when inserting text via keyboard.
     let isSmartInsertEnabled: Bool
 
+    /// Whether to strip a single trailing period from the final transcript so casual messages
+    /// like "Okay." don't read as cold/passive-aggressive in chat contexts.
+    let isStripTrailingPeriodEnabled: Bool
+
     /// Whether this mode opts in to saving transcriptions to Obsidian.
     /// Only effective when the global Obsidian integration is enabled in
     /// Settings → Integrations.
@@ -104,6 +108,7 @@ struct VivaMode: Identifiable, Hashable, Codable {
          useClipboardContext: Bool = false,
          isAutoTextFormattingEnabled: Bool = false,
          isSmartInsertEnabled: Bool = false,
+         isStripTrailingPeriodEnabled: Bool = false,
          obsidianEnabled: Bool = true) {
         self.id = id
         self.name = name
@@ -120,6 +125,7 @@ struct VivaMode: Identifiable, Hashable, Codable {
         self.useClipboardContext = useClipboardContext
         self.isAutoTextFormattingEnabled = isAutoTextFormattingEnabled
         self.isSmartInsertEnabled = isSmartInsertEnabled
+        self.isStripTrailingPeriodEnabled = isStripTrailingPeriodEnabled
         self.obsidianEnabled = obsidianEnabled
     }
 
@@ -142,6 +148,7 @@ struct VivaMode: Identifiable, Hashable, Codable {
         useClipboardContext = try container.decodeIfPresent(Bool.self, forKey: .useClipboardContext) ?? false
         isAutoTextFormattingEnabled = try container.decodeIfPresent(Bool.self, forKey: .isAutoTextFormattingEnabled) ?? true
         isSmartInsertEnabled = try container.decodeIfPresent(Bool.self, forKey: .isSmartInsertEnabled) ?? true
+        isStripTrailingPeriodEnabled = try container.decodeIfPresent(Bool.self, forKey: .isStripTrailingPeriodEnabled) ?? false
         obsidianEnabled = try container.decodeIfPresent(Bool.self, forKey: .obsidianEnabled) ?? true
 
         // Try new format first
@@ -165,6 +172,7 @@ struct VivaMode: Identifiable, Hashable, Codable {
         case aiProvider, aiModel, reminderExtractorProvider, reminderExtractorModel, aiEnhanceEnabled
         case useClipboardContext
         case isAutoTextFormattingEnabled, isSmartInsertEnabled
+        case isStripTrailingPeriodEnabled
         case obsidianEnabled
     }
 
@@ -186,6 +194,7 @@ struct VivaMode: Identifiable, Hashable, Codable {
         try container.encode(useClipboardContext, forKey: .useClipboardContext)
         try container.encode(isAutoTextFormattingEnabled, forKey: .isAutoTextFormattingEnabled)
         try container.encode(isSmartInsertEnabled, forKey: .isSmartInsertEnabled)
+        try container.encode(isStripTrailingPeriodEnabled, forKey: .isStripTrailingPeriodEnabled)
         try container.encode(obsidianEnabled, forKey: .obsidianEnabled)
     }
 

--- a/VivaDicta/Services/PresetMigrationService.swift
+++ b/VivaDicta/Services/PresetMigrationService.swift
@@ -127,7 +127,12 @@ enum PresetMigrationService {
                     aiModel: mode.aiModel,
                     reminderExtractorProvider: mode.reminderExtractorProvider,
                     reminderExtractorModel: mode.reminderExtractorModel,
-                    aiEnhanceEnabled: mode.aiEnhanceEnabled
+                    aiEnhanceEnabled: mode.aiEnhanceEnabled,
+                    useClipboardContext: mode.useClipboardContext,
+                    isAutoTextFormattingEnabled: mode.isAutoTextFormattingEnabled,
+                    isSmartInsertEnabled: mode.isSmartInsertEnabled,
+                    isStripTrailingPeriodEnabled: mode.isStripTrailingPeriodEnabled,
+                    obsidianEnabled: mode.obsidianEnabled
                 )
                 updated = true
                 logger.logInfo("Normalized mode '\(mode.name)' presetId: '\(presetId)' → '\(builtInId)'")
@@ -146,7 +151,12 @@ enum PresetMigrationService {
                         aiModel: mode.aiModel,
                         reminderExtractorProvider: mode.reminderExtractorProvider,
                         reminderExtractorModel: mode.reminderExtractorModel,
-                        aiEnhanceEnabled: mode.aiEnhanceEnabled
+                        aiEnhanceEnabled: mode.aiEnhanceEnabled,
+                        useClipboardContext: mode.useClipboardContext,
+                        isAutoTextFormattingEnabled: mode.isAutoTextFormattingEnabled,
+                        isSmartInsertEnabled: mode.isSmartInsertEnabled,
+                        isStripTrailingPeriodEnabled: mode.isStripTrailingPeriodEnabled,
+                        obsidianEnabled: mode.obsidianEnabled
                     )
                     updated = true
                     logger.logInfo("Normalized mode '\(mode.name)' presetId: '\(presetId)' → '\(mappedId)'")

--- a/VivaDicta/Services/Transcription/TranscriptionManager.swift
+++ b/VivaDicta/Services/Transcription/TranscriptionManager.swift
@@ -233,11 +233,11 @@ class TranscriptionManager {
             result = ReplacementsService.applyReplacements(to: result)
         }
 
-        // Strip trailing period if the active mode opts in. Runs last so it
+        // Strip trailing periods if the active mode opts in. Runs last so it
         // operates on the final user-visible text, after replacements may have
         // adjusted the tail.
         if currentMode.isStripTrailingPeriodEnabled {
-            result = TranscriptionOutputFilter.stripTrailingPeriod(result)
+            result = TranscriptionOutputFilter.stripTrailingPeriods(result)
         }
 
         AnalyticsService.track(.transcriptionCompleted(

--- a/VivaDicta/Services/Transcription/TranscriptionManager.swift
+++ b/VivaDicta/Services/Transcription/TranscriptionManager.swift
@@ -233,6 +233,13 @@ class TranscriptionManager {
             result = ReplacementsService.applyReplacements(to: result)
         }
 
+        // Strip trailing period if the active mode opts in. Runs last so it
+        // operates on the final user-visible text, after replacements may have
+        // adjusted the tail.
+        if currentMode.isStripTrailingPeriodEnabled {
+            result = TranscriptionOutputFilter.stripTrailingPeriod(result)
+        }
+
         AnalyticsService.track(.transcriptionCompleted(
             engine: model.provider.rawValue,
             isOnDevice: TranscriptionModelProvider.localProviders.contains(model.provider),

--- a/VivaDicta/Services/Transcription/TranscriptionOutputFilter.swift
+++ b/VivaDicta/Services/Transcription/TranscriptionOutputFilter.swift
@@ -107,18 +107,22 @@ struct TranscriptionOutputFilter {
 
     /// Strips any number of trailing periods from the transcript so casual
     /// messages like "Okay." or "Wait..." don't read as cold or trailing-off
-    /// in chat contexts. Mirrors Python's `text.strip().rstrip('.')`.
+    /// in chat contexts.
     ///
-    /// Question marks and exclamation marks are kept - they carry their own
-    /// meaning and removing them would change tone, not soften it.
-    static func stripTrailingPeriod(_ text: String) -> String {
-        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty, trimmed.hasSuffix(".") else { return text }
-        var stripped = Substring(trimmed)
-        while stripped.last == "." {
-            stripped = stripped.dropLast()
+    /// Only the tail is touched: leading and internal whitespace are preserved,
+    /// internal periods (acronyms, mid-sentence) are kept, and "?" / "!" carry
+    /// their own meaning so they pass through unchanged.
+    static func stripTrailingPeriods(_ text: String) -> String {
+        var view = Substring(text)
+        // Skip past any trailing whitespace so "Okay.   " is still recognized.
+        while let last = view.last, last.isWhitespace {
+            view = view.dropLast()
         }
-        return String(stripped)
+        guard view.last == "." else { return text }
+        while view.last == "." {
+            view = view.dropLast()
+        }
+        return String(view)
     }
 
     /// Resolves the language code used to pick the filler set.

--- a/VivaDicta/Services/Transcription/TranscriptionOutputFilter.swift
+++ b/VivaDicta/Services/Transcription/TranscriptionOutputFilter.swift
@@ -105,6 +105,22 @@ struct TranscriptionOutputFilter {
         return filteredText
     }
 
+    /// Strips any number of trailing periods from the transcript so casual
+    /// messages like "Okay." or "Wait..." don't read as cold or trailing-off
+    /// in chat contexts. Mirrors Python's `text.strip().rstrip('.')`.
+    ///
+    /// Question marks and exclamation marks are kept - they carry their own
+    /// meaning and removing them would change tone, not soften it.
+    static func stripTrailingPeriod(_ text: String) -> String {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, trimmed.hasSuffix(".") else { return text }
+        var stripped = Substring(trimmed)
+        while stripped.last == "." {
+            stripped = stripped.dropLast()
+        }
+        return String(stripped)
+    }
+
     /// Resolves the language code used to pick the filler set.
     ///
     /// Order of preference:

--- a/VivaDicta/Views/SettingsScreen/ModeEditView.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditView.swift
@@ -334,7 +334,7 @@ struct ModeEditView: View {
                         VStack(alignment: .leading, spacing: 4) {
                             Text("Trim Trailing Period")
                                 .font(.body)
-                            Text("Strips trailing \".\" or \"...\" so casual messages don't read as cold. \"!\" and \"?\" are kept.")
+                            Text("Strips trailing \".\" or \"...\"")
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                         }

--- a/VivaDicta/Views/SettingsScreen/ModeEditView.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditView.swift
@@ -329,6 +329,19 @@ struct ModeEditView: View {
                     .onChange(of: viewModel.isSmartInsertEnabled) { _, _ in
                         HapticManager.selectionChanged()
                     }
+
+                    Toggle(isOn: $viewModel.isStripTrailingPeriodEnabled) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Trim Trailing Period")
+                                .font(.body)
+                            Text("Strips trailing \".\" or \"...\" so casual messages don't read as cold. \"!\" and \"?\" are kept.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .onChange(of: viewModel.isStripTrailingPeriodEnabled) { _, _ in
+                        HapticManager.selectionChanged()
+                    }
                 }
 
                 Section(header: aiProcessingSectionHeader,

--- a/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
@@ -30,6 +30,7 @@ class ModeEditViewModel {
     var useClipboardContext: Bool = false
     var isAutoTextFormattingEnabled: Bool = false
     var isSmartInsertEnabled: Bool = false
+    var isStripTrailingPeriodEnabled: Bool = false
 
     var obsidianEnabled: Bool = true
 
@@ -190,6 +191,7 @@ class ModeEditViewModel {
             useClipboardContext = existingMode.useClipboardContext
             isAutoTextFormattingEnabled = existingMode.isAutoTextFormattingEnabled
             isSmartInsertEnabled = existingMode.isSmartInsertEnabled
+            isStripTrailingPeriodEnabled = existingMode.isStripTrailingPeriodEnabled
             obsidianEnabled = existingMode.obsidianEnabled
 
             validateLanguageSelection()
@@ -238,6 +240,7 @@ class ModeEditViewModel {
             useClipboardContext: aiEnhanceEnabled ? useClipboardContext : false,
             isAutoTextFormattingEnabled: isAutoTextFormattingEnabled,
             isSmartInsertEnabled: isSmartInsertEnabled,
+            isStripTrailingPeriodEnabled: isStripTrailingPeriodEnabled,
             obsidianEnabled: obsidianEnabled
         )
     }

--- a/VivaDictaTests/TextProcessingFilterTests.swift
+++ b/VivaDictaTests/TextProcessingFilterTests.swift
@@ -212,49 +212,55 @@ struct TranscriptionOutputFilterTests {
     // MARK: - stripTrailingPeriod Tests
 
     @Test func stripTrailingPeriod_singleSentence_removesPeriod() {
-        #expect(TranscriptionOutputFilter.stripTrailingPeriod("Okay.") == "Okay")
-        #expect(TranscriptionOutputFilter.stripTrailingPeriod("Sure.") == "Sure")
+        #expect(TranscriptionOutputFilter.stripTrailingPeriods("Okay.") == "Okay")
+        #expect(TranscriptionOutputFilter.stripTrailingPeriods("Sure.") == "Sure")
     }
 
     @Test func stripTrailingPeriod_multipleSentences_removesOnlyTrailing() {
         #expect(
-            TranscriptionOutputFilter.stripTrailingPeriod("Sure. I'll be there.")
+            TranscriptionOutputFilter.stripTrailingPeriods("Sure. I'll be there.")
             == "Sure. I'll be there"
         )
     }
 
     @Test func stripTrailingPeriod_ellipsis_strippedToo() {
         // Per the user spec (Peter Szemraj): rstrip('.') eats trailing ellipses too.
-        #expect(TranscriptionOutputFilter.stripTrailingPeriod("Wait...") == "Wait")
+        #expect(TranscriptionOutputFilter.stripTrailingPeriods("Wait...") == "Wait")
     }
 
     @Test func stripTrailingPeriod_questionMark_unchanged() {
-        #expect(TranscriptionOutputFilter.stripTrailingPeriod("What?") == "What?")
+        #expect(TranscriptionOutputFilter.stripTrailingPeriods("What?") == "What?")
     }
 
     @Test func stripTrailingPeriod_exclamation_unchanged() {
-        #expect(TranscriptionOutputFilter.stripTrailingPeriod("Yes!") == "Yes!")
+        #expect(TranscriptionOutputFilter.stripTrailingPeriods("Yes!") == "Yes!")
     }
 
     @Test func stripTrailingPeriod_noTrailingPeriod_unchanged() {
-        #expect(TranscriptionOutputFilter.stripTrailingPeriod("Okay") == "Okay")
+        #expect(TranscriptionOutputFilter.stripTrailingPeriods("Okay") == "Okay")
     }
 
     @Test func stripTrailingPeriod_emptyString_unchanged() {
-        #expect(TranscriptionOutputFilter.stripTrailingPeriod("") == "")
+        #expect(TranscriptionOutputFilter.stripTrailingPeriods("") == "")
     }
 
     @Test func stripTrailingPeriod_trailingWhitespaceAfterPeriod_stillStrips() {
         // "Okay.   " - trim runs first inside the helper, so the period is still recognized.
-        #expect(TranscriptionOutputFilter.stripTrailingPeriod("Okay.   ") == "Okay")
+        #expect(TranscriptionOutputFilter.stripTrailingPeriods("Okay.   ") == "Okay")
     }
 
     @Test func stripTrailingPeriod_internalPeriods_untouched() {
         // Periods that aren't at the very end (acronyms, mid-sentence) stay put.
         #expect(
-            TranscriptionOutputFilter.stripTrailingPeriod("J.R.R. Tolkien")
+            TranscriptionOutputFilter.stripTrailingPeriods("J.R.R. Tolkien")
             == "J.R.R. Tolkien"
         )
+    }
+
+    @Test func stripTrailingPeriod_leadingWhitespace_preserved() {
+        // Function only touches the tail - leading whitespace passes through
+        // even though the rest of the pipeline normally trims it.
+        #expect(TranscriptionOutputFilter.stripTrailingPeriods("  Okay.") == "  Okay")
     }
 }
 

--- a/VivaDictaTests/TextProcessingFilterTests.swift
+++ b/VivaDictaTests/TextProcessingFilterTests.swift
@@ -208,6 +208,54 @@ struct TranscriptionOutputFilterTests {
 
         #expect(!result.contains(" eh "))
     }
+
+    // MARK: - stripTrailingPeriod Tests
+
+    @Test func stripTrailingPeriod_singleSentence_removesPeriod() {
+        #expect(TranscriptionOutputFilter.stripTrailingPeriod("Okay.") == "Okay")
+        #expect(TranscriptionOutputFilter.stripTrailingPeriod("Sure.") == "Sure")
+    }
+
+    @Test func stripTrailingPeriod_multipleSentences_removesOnlyTrailing() {
+        #expect(
+            TranscriptionOutputFilter.stripTrailingPeriod("Sure. I'll be there.")
+            == "Sure. I'll be there"
+        )
+    }
+
+    @Test func stripTrailingPeriod_ellipsis_strippedToo() {
+        // Per the user spec (Peter Szemraj): rstrip('.') eats trailing ellipses too.
+        #expect(TranscriptionOutputFilter.stripTrailingPeriod("Wait...") == "Wait")
+    }
+
+    @Test func stripTrailingPeriod_questionMark_unchanged() {
+        #expect(TranscriptionOutputFilter.stripTrailingPeriod("What?") == "What?")
+    }
+
+    @Test func stripTrailingPeriod_exclamation_unchanged() {
+        #expect(TranscriptionOutputFilter.stripTrailingPeriod("Yes!") == "Yes!")
+    }
+
+    @Test func stripTrailingPeriod_noTrailingPeriod_unchanged() {
+        #expect(TranscriptionOutputFilter.stripTrailingPeriod("Okay") == "Okay")
+    }
+
+    @Test func stripTrailingPeriod_emptyString_unchanged() {
+        #expect(TranscriptionOutputFilter.stripTrailingPeriod("") == "")
+    }
+
+    @Test func stripTrailingPeriod_trailingWhitespaceAfterPeriod_stillStrips() {
+        // "Okay.   " - trim runs first inside the helper, so the period is still recognized.
+        #expect(TranscriptionOutputFilter.stripTrailingPeriod("Okay.   ") == "Okay")
+    }
+
+    @Test func stripTrailingPeriod_internalPeriods_untouched() {
+        // Periods that aren't at the very end (acronyms, mid-sentence) stay put.
+        #expect(
+            TranscriptionOutputFilter.stripTrailingPeriod("J.R.R. Tolkien")
+            == "J.R.R. Tolkien"
+        )
+    }
 }
 
 // MARK: - AI Processing Output Filter Tests


### PR DESCRIPTION
## Summary

- Adds a per-mode **Trim Trailing Period** toggle in Edit Mode → Text Processing (right below Smart Insert) that strips trailing \`.\` or \`...\` from the final transcript.
- Mirrors Python's \`text.strip().rstrip('.')\` - eats any number of trailing periods, leaves \`!\` and \`?\` alone, and never touches internal periods (e.g. acronyms like \`J.R.R. Tolkien\` pass through unchanged).
- Default **off**; existing users see no behavior change.
- Runs as the last step of the post-transcription pipeline in \`TranscriptionManager\` so it operates on the final user-visible text after replacements.

## Why

Customer request from a VivaDicta user (Peter Szemraj) who dictates casual messages 90%+ of the time. In chat contexts, terminal periods read as cold or passive-aggressive (well-documented in psycholinguistics - "Okay." reads colder than "Okay" because the message bubble already marks the end of the utterance). Per-mode means he can have it on for the messaging mode and off for notes/email modes.

## Smart Insert interaction

Traced the keyboard-side flow. \`TextInsertionFormatter\` only modifies whitespace and capitalization - it never inserts or removes periods. The two features compose cleanly:

- **Strip on + Smart Insert on:** consistent casual style. Stripping the period also causes Smart Insert to lowercase the next dictation (since it caps after \`.!?\\n\`), so multi-message flows stay in the casual register.
- **Strip off + Smart Insert on:** existing formal style preserved.

## Test plan

- [x] 9 new unit tests in \`TranscriptionOutputFilterTests\` covering single-sentence strip, multi-sentence (only trailing period removed), ellipsis (stripped per spec), \`?\` and \`!\` preserved, no-op on missing trailing period, empty string, trailing-whitespace handling, internal periods untouched (acronym test). All 33 tests pass.
- [x] Clean \`xcodebuild\` for iPhone 17 Pro Max, OS 26.4 simulator.
- [x] Codable round-trip is backwards-compatible: \`decodeIfPresent ?? false\` for the new field, so existing serialized modes load without migration.