### PR TITLE
Auto-save transcriptions as markdown to a picked folder

### DIFF
--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -303,7 +303,8 @@ class AIService {
             isAutoTextFormattingEnabled: mode.isAutoTextFormattingEnabled,
             isSmartInsertEnabled: mode.isSmartInsertEnabled,
             isStripTrailingPeriodEnabled: mode.isStripTrailingPeriodEnabled,
-            obsidianEnabled: mode.obsidianEnabled
+            obsidianEnabled: mode.obsidianEnabled,
+            folderExportEnabled: mode.folderExportEnabled
         )
 
         addMode(duplicatedMode)
@@ -375,7 +376,8 @@ class AIService {
                     isAutoTextFormattingEnabled: mode.isAutoTextFormattingEnabled,
                     isSmartInsertEnabled: mode.isSmartInsertEnabled,
                     isStripTrailingPeriodEnabled: mode.isStripTrailingPeriodEnabled,
-                    obsidianEnabled: mode.obsidianEnabled
+                    obsidianEnabled: mode.obsidianEnabled,
+                    folderExportEnabled: mode.folderExportEnabled
                 )
             },
             logMessage: { "Disabled AI processing for mode '\($0.name)' due to API key deletion for provider: \(provider.rawValue)" }
@@ -405,7 +407,8 @@ class AIService {
                     isAutoTextFormattingEnabled: mode.isAutoTextFormattingEnabled,
                     isSmartInsertEnabled: mode.isSmartInsertEnabled,
                     isStripTrailingPeriodEnabled: mode.isStripTrailingPeriodEnabled,
-                    obsidianEnabled: mode.obsidianEnabled
+                    obsidianEnabled: mode.obsidianEnabled,
+                    folderExportEnabled: mode.folderExportEnabled
                 )
             },
             logMessage: { "Disabled AI processing for mode '\($0.name)' due to preset deletion" }
@@ -435,7 +438,8 @@ class AIService {
                     isAutoTextFormattingEnabled: mode.isAutoTextFormattingEnabled,
                     isSmartInsertEnabled: mode.isSmartInsertEnabled,
                     isStripTrailingPeriodEnabled: mode.isStripTrailingPeriodEnabled,
-                    obsidianEnabled: mode.obsidianEnabled
+                    obsidianEnabled: mode.obsidianEnabled,
+                    folderExportEnabled: mode.folderExportEnabled
                 )
             },
             logMessage: { "Disabled AI processing for mode '\($0.name)' due to Ollama connection failure" }
@@ -531,7 +535,8 @@ class AIService {
                 isAutoTextFormattingEnabled: defaultMode.isAutoTextFormattingEnabled,
                 isSmartInsertEnabled: defaultMode.isSmartInsertEnabled,
                 isStripTrailingPeriodEnabled: defaultMode.isStripTrailingPeriodEnabled,
-                obsidianEnabled: defaultMode.obsidianEnabled
+                obsidianEnabled: defaultMode.obsidianEnabled,
+                folderExportEnabled: defaultMode.folderExportEnabled
             )
 
             // Update the mode
@@ -2227,7 +2232,8 @@ class AIService {
                     isAutoTextFormattingEnabled: mode.isAutoTextFormattingEnabled,
                     isSmartInsertEnabled: mode.isSmartInsertEnabled,
                     isStripTrailingPeriodEnabled: mode.isStripTrailingPeriodEnabled,
-                    obsidianEnabled: mode.obsidianEnabled
+                    obsidianEnabled: mode.obsidianEnabled,
+                    folderExportEnabled: mode.folderExportEnabled
                 )
             },
             logMessage: { "Disabled AI processing for mode '\($0.name)' due to Custom OpenAI configuration removal" }

--- a/VivaDicta/Services/AIEnhance/VivaMode.swift
+++ b/VivaDicta/Services/AIEnhance/VivaMode.swift
@@ -92,6 +92,11 @@ struct VivaMode: Identifiable, Hashable, Codable {
     /// Settings → Integrations.
     var obsidianEnabled: Bool
 
+    /// Whether this mode opts in to silently saving each transcription as a
+    /// markdown file in the user-picked folder. Only effective when the
+    /// global folder-export integration is enabled in Settings → Integrations.
+    var folderExportEnabled: Bool
+
     /// Creates a new VivaMode with the specified settings.
     init(id: UUID,
          name: String,
@@ -109,7 +114,8 @@ struct VivaMode: Identifiable, Hashable, Codable {
          isAutoTextFormattingEnabled: Bool = false,
          isSmartInsertEnabled: Bool = false,
          isStripTrailingPeriodEnabled: Bool = false,
-         obsidianEnabled: Bool = true) {
+         obsidianEnabled: Bool = true,
+         folderExportEnabled: Bool = true) {
         self.id = id
         self.name = name
         self.transcriptionProvider = transcriptionProvider
@@ -127,6 +133,7 @@ struct VivaMode: Identifiable, Hashable, Codable {
         self.isSmartInsertEnabled = isSmartInsertEnabled
         self.isStripTrailingPeriodEnabled = isStripTrailingPeriodEnabled
         self.obsidianEnabled = obsidianEnabled
+        self.folderExportEnabled = folderExportEnabled
     }
 
     // MARK: - Backward-Compatible Decoding
@@ -150,6 +157,7 @@ struct VivaMode: Identifiable, Hashable, Codable {
         isSmartInsertEnabled = try container.decodeIfPresent(Bool.self, forKey: .isSmartInsertEnabled) ?? true
         isStripTrailingPeriodEnabled = try container.decodeIfPresent(Bool.self, forKey: .isStripTrailingPeriodEnabled) ?? false
         obsidianEnabled = try container.decodeIfPresent(Bool.self, forKey: .obsidianEnabled) ?? true
+        folderExportEnabled = try container.decodeIfPresent(Bool.self, forKey: .folderExportEnabled) ?? true
 
         // Try new format first
         if let preset = try container.decodeIfPresent(String.self, forKey: .presetId) {
@@ -174,6 +182,7 @@ struct VivaMode: Identifiable, Hashable, Codable {
         case isAutoTextFormattingEnabled, isSmartInsertEnabled
         case isStripTrailingPeriodEnabled
         case obsidianEnabled
+        case folderExportEnabled
     }
 
     /// Encodes using the new format only (presetId).
@@ -196,6 +205,7 @@ struct VivaMode: Identifiable, Hashable, Codable {
         try container.encode(isSmartInsertEnabled, forKey: .isSmartInsertEnabled)
         try container.encode(isStripTrailingPeriodEnabled, forKey: .isStripTrailingPeriodEnabled)
         try container.encode(obsidianEnabled, forKey: .obsidianEnabled)
+        try container.encode(folderExportEnabled, forKey: .folderExportEnabled)
     }
 
     /// The default mode used when no custom mode is configured.

--- a/VivaDicta/Services/FolderExportService.swift
+++ b/VivaDicta/Services/FolderExportService.swift
@@ -1,0 +1,136 @@
+//
+//  FolderExportService.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.05.03
+//
+
+import Foundation
+import os
+
+/// Silently writes each transcription as a markdown file into a user-picked
+/// folder (e.g. an Obsidian vault inside iCloud Drive). The folder is selected
+/// once via `UIDocumentPickerViewController` and remembered as a security-scoped
+/// bookmark stored in the App Group, so the keyboard extension can write too.
+///
+/// Mirrors the existing Obsidian integration: gated by a global toggle plus a
+/// per-mode toggle, and triggered at the same points in `RecordViewModel`.
+enum FolderExportService {
+    private static let logger = Logger(category: .folderExportService)
+
+    // MARK: - Bookmark management
+
+    /// Stores the user-picked folder as a security-scoped bookmark in the App
+    /// Group so it is resolvable from the keyboard extension as well.
+    /// The picker URL must already be security-scoped (caller is responsible
+    /// for `startAccessingSecurityScopedResource()` around bookmark creation).
+    static func storeBookmark(for url: URL) throws {
+        let data = try url.bookmarkData(
+            options: [],
+            includingResourceValuesForKeys: nil,
+            relativeTo: nil
+        )
+        UserDefaultsStorage.shared.set(data, forKey: UserDefaultsStorage.SharedKeys.folderExportBookmark)
+        UserDefaultsStorage.appPrivate.set(url.lastPathComponent, forKey: UserDefaultsStorage.Keys.folderExportDisplayName)
+    }
+
+    static func clearBookmark() {
+        UserDefaultsStorage.shared.removeObject(forKey: UserDefaultsStorage.SharedKeys.folderExportBookmark)
+        UserDefaultsStorage.appPrivate.removeObject(forKey: UserDefaultsStorage.Keys.folderExportDisplayName)
+    }
+
+    static var hasBookmark: Bool {
+        UserDefaultsStorage.shared.data(forKey: UserDefaultsStorage.SharedKeys.folderExportBookmark) != nil
+    }
+
+    static var displayName: String? {
+        UserDefaultsStorage.appPrivate.string(forKey: UserDefaultsStorage.Keys.folderExportDisplayName)
+    }
+
+    // MARK: - Saving
+
+    /// Writes the transcription as a markdown file in the picked folder if the
+    /// global toggle is on, the mode opts in, and a bookmark exists.
+    /// Safe to call from any source. Errors are logged, never thrown to caller.
+    @MainActor
+    static func saveIfEnabled(transcription: Transcription, mode: VivaMode) {
+        guard UserDefaultsStorage.appPrivate.bool(forKey: UserDefaultsStorage.Keys.isFolderExportGloballyEnabled) else { return }
+        guard mode.folderExportEnabled else { return }
+        guard let bookmark = UserDefaultsStorage.shared.data(forKey: UserDefaultsStorage.SharedKeys.folderExportBookmark) else {
+            logger.logError("📁 Folder export enabled but no bookmark stored - user must re-pick the folder")
+            return
+        }
+
+        let snapshots = TranscriptionMarkdownExportService.snapshots(for: [transcription])
+        guard let snapshot = snapshots.first else { return }
+        let items = TranscriptionMarkdownExportService.items(forSnapshots: snapshots)
+        guard let item = items.first else { return }
+
+        Task.detached(priority: .utility) {
+            await write(item: item, snapshot: snapshot, bookmark: bookmark)
+        }
+    }
+
+    private static func write(
+        item: MarkdownExportItem,
+        snapshot: TranscriptionMarkdownExportService.Snapshot,
+        bookmark: Data
+    ) async {
+        var isStale = false
+        let folderURL: URL
+        do {
+            folderURL = try URL(
+                resolvingBookmarkData: bookmark,
+                options: [],
+                relativeTo: nil,
+                bookmarkDataIsStale: &isStale
+            )
+        } catch {
+            logger.logError("📁 Folder export: bookmark resolution failed - \(error.localizedDescription)")
+            return
+        }
+
+        if isStale {
+            logger.logError("📁 Folder export: bookmark is stale - user must re-pick the folder")
+            return
+        }
+
+        guard folderURL.startAccessingSecurityScopedResource() else {
+            logger.logError("📁 Folder export: failed to start accessing security-scoped resource at \(folderURL.path)")
+            return
+        }
+        defer { folderURL.stopAccessingSecurityScopedResource() }
+
+        let destination = uniqueDestination(in: folderURL, baseFilename: item.filename)
+        do {
+            try Data(item.text.utf8).write(to: destination, options: .atomic)
+            logger.logInfo("📁 Folder export: wrote \(destination.lastPathComponent)")
+        } catch {
+            logger.logError("📁 Folder export: write failed for \(destination.lastPathComponent) - \(error.localizedDescription)")
+        }
+    }
+
+    /// Picks a non-conflicting filename inside `folder`. The base filename
+    /// from `TranscriptionMarkdownExportService` is already unique-per-second,
+    /// but if a file with the same name exists (e.g. duplicate save) we
+    /// append `-2`, `-3`, etc.
+    private static func uniqueDestination(in folder: URL, baseFilename: String) -> URL {
+        let initial = folder.appending(path: baseFilename, directoryHint: .notDirectory)
+        guard FileManager.default.fileExists(atPath: initial.path) else { return initial }
+
+        let pathExtension = (baseFilename as NSString).pathExtension
+        let baseStem = (baseFilename as NSString).deletingPathExtension
+        var index = 2
+        while index < 1_000 {
+            let candidateName = pathExtension.isEmpty
+                ? "\(baseStem)-\(index)"
+                : "\(baseStem)-\(index).\(pathExtension)"
+            let candidate = folder.appending(path: candidateName, directoryHint: .notDirectory)
+            if !FileManager.default.fileExists(atPath: candidate.path) {
+                return candidate
+            }
+            index += 1
+        }
+        return initial
+    }
+}

--- a/VivaDicta/Services/FolderExportService.swift
+++ b/VivaDicta/Services/FolderExportService.swift
@@ -25,26 +25,25 @@ enum FolderExportService {
     /// The picker URL must already be security-scoped (caller is responsible
     /// for `startAccessingSecurityScopedResource()` around bookmark creation).
     static func storeBookmark(for url: URL) throws {
+        // iOS does not support `.withSecurityScope` (macOS-only). Picker URLs
+        // from `UIDocumentPickerViewController` are inherently security-scoped,
+        // and the default-options bookmark preserves that on iOS.
         let data = try url.bookmarkData(
             options: [],
             includingResourceValuesForKeys: nil,
             relativeTo: nil
         )
         UserDefaultsStorage.shared.set(data, forKey: UserDefaultsStorage.SharedKeys.folderExportBookmark)
-        UserDefaultsStorage.appPrivate.set(url.lastPathComponent, forKey: UserDefaultsStorage.Keys.folderExportDisplayName)
+        UserDefaultsStorage.shared.set(url.lastPathComponent, forKey: UserDefaultsStorage.SharedKeys.folderExportDisplayName)
     }
 
     static func clearBookmark() {
         UserDefaultsStorage.shared.removeObject(forKey: UserDefaultsStorage.SharedKeys.folderExportBookmark)
-        UserDefaultsStorage.appPrivate.removeObject(forKey: UserDefaultsStorage.Keys.folderExportDisplayName)
-    }
-
-    static var hasBookmark: Bool {
-        UserDefaultsStorage.shared.data(forKey: UserDefaultsStorage.SharedKeys.folderExportBookmark) != nil
+        UserDefaultsStorage.shared.removeObject(forKey: UserDefaultsStorage.SharedKeys.folderExportDisplayName)
     }
 
     static var displayName: String? {
-        UserDefaultsStorage.appPrivate.string(forKey: UserDefaultsStorage.Keys.folderExportDisplayName)
+        UserDefaultsStorage.shared.string(forKey: UserDefaultsStorage.SharedKeys.folderExportDisplayName)
     }
 
     // MARK: - Saving
@@ -57,7 +56,7 @@ enum FolderExportService {
         guard UserDefaultsStorage.appPrivate.bool(forKey: UserDefaultsStorage.Keys.isFolderExportGloballyEnabled) else { return }
         guard mode.folderExportEnabled else { return }
         guard let bookmark = UserDefaultsStorage.shared.data(forKey: UserDefaultsStorage.SharedKeys.folderExportBookmark) else {
-            logger.logError("📁 Folder export enabled but no bookmark stored - user must re-pick the folder")
+            logger.logInfo("📁 Folder export enabled but no folder picked yet - skipping")
             return
         }
 
@@ -91,12 +90,14 @@ enum FolderExportService {
         }
 
         if isStale {
-            logger.logError("📁 Folder export: bookmark is stale - user must re-pick the folder")
+            logger.logError("📁 Folder export: bookmark is stale - clearing so the user re-picks")
+            await MainActor.run { Self.clearBookmark() }
             return
         }
 
         guard folderURL.startAccessingSecurityScopedResource() else {
-            logger.logError("📁 Folder export: failed to start accessing security-scoped resource at \(folderURL.path)")
+            logger.logError("📁 Folder export: cannot access \(folderURL.path) - clearing bookmark so the user re-picks")
+            await MainActor.run { Self.clearBookmark() }
             return
         }
         defer { folderURL.stopAccessingSecurityScopedResource() }

--- a/VivaDicta/Services/PresetMigrationService.swift
+++ b/VivaDicta/Services/PresetMigrationService.swift
@@ -157,7 +157,8 @@ enum PresetMigrationService {
                         isAutoTextFormattingEnabled: mode.isAutoTextFormattingEnabled,
                         isSmartInsertEnabled: mode.isSmartInsertEnabled,
                         isStripTrailingPeriodEnabled: mode.isStripTrailingPeriodEnabled,
-                        obsidianEnabled: mode.obsidianEnabled
+                        obsidianEnabled: mode.obsidianEnabled,
+                        folderExportEnabled: mode.folderExportEnabled
                     )
                     updated = true
                     logger.logInfo("Normalized mode '\(mode.name)' presetId: '\(presetId)' → '\(mappedId)'")

--- a/VivaDicta/Services/PresetMigrationService.swift
+++ b/VivaDicta/Services/PresetMigrationService.swift
@@ -132,7 +132,8 @@ enum PresetMigrationService {
                     isAutoTextFormattingEnabled: mode.isAutoTextFormattingEnabled,
                     isSmartInsertEnabled: mode.isSmartInsertEnabled,
                     isStripTrailingPeriodEnabled: mode.isStripTrailingPeriodEnabled,
-                    obsidianEnabled: mode.obsidianEnabled
+                    obsidianEnabled: mode.obsidianEnabled,
+                    folderExportEnabled: mode.folderExportEnabled
                 )
                 updated = true
                 logger.logInfo("Normalized mode '\(mode.name)' presetId: '\(presetId)' → '\(builtInId)'")

--- a/VivaDicta/Shared/UserDefaultsStorage.swift
+++ b/VivaDicta/Shared/UserDefaultsStorage.swift
@@ -26,6 +26,10 @@ enum UserDefaultsStorage {
     enum SharedKeys {
         static let presets = "Presets_v1"
         static let hiddenPresetIDs = "HiddenPresetIDs_v1"
+
+        /// Security-scoped bookmark Data for the user-picked folder export destination.
+        /// Lives in the App Group so the keyboard extension can resolve it.
+        static let folderExportBookmark = "folderExportBookmark"
     }
 
     // MARK: - App-Private Keys
@@ -83,6 +87,10 @@ enum UserDefaultsStorage {
         // Integrations - Obsidian
         static let isObsidianGloballyEnabled = "isObsidianGloballyEnabled"
         static let obsidianNoteTemplate = "obsidianNoteTemplate"
+
+        // Integrations - Folder export (silent markdown save to user-picked folder)
+        static let isFolderExportGloballyEnabled = "isFolderExportGloballyEnabled"
+        static let folderExportDisplayName = "folderExportDisplayName"
 
         // Live Translation
         static let liveTranslationSourceLanguage = "liveTranslation.sourceLanguage"

--- a/VivaDicta/Shared/UserDefaultsStorage.swift
+++ b/VivaDicta/Shared/UserDefaultsStorage.swift
@@ -30,6 +30,10 @@ enum UserDefaultsStorage {
         /// Security-scoped bookmark Data for the user-picked folder export destination.
         /// Lives in the App Group so the keyboard extension can resolve it.
         static let folderExportBookmark = "folderExportBookmark"
+
+        /// Display name of the folder picked for export. Shared so the keyboard
+        /// extension can also read it (kept symmetric with the bookmark Data).
+        static let folderExportDisplayName = "folderExportDisplayName"
     }
 
     // MARK: - App-Private Keys
@@ -90,7 +94,6 @@ enum UserDefaultsStorage {
 
         // Integrations - Folder export (silent markdown save to user-picked folder)
         static let isFolderExportGloballyEnabled = "isFolderExportGloballyEnabled"
-        static let folderExportDisplayName = "folderExportDisplayName"
 
         // Live Translation
         static let liveTranslationSourceLanguage = "liveTranslation.sourceLanguage"

--- a/VivaDicta/Utilities/LoggerExtension.swift
+++ b/VivaDicta/Utilities/LoggerExtension.swift
@@ -91,6 +91,7 @@ public enum LogCategory: String {
 
     // MARK: - Utility
     case installInputTapNonisolated = "installInputTapNonisolated"
+    case folderExportService = "FolderExportService"
 }
 
 /// The app's subsystem identifier for all loggers

--- a/VivaDicta/Views/RecordViewModel.swift
+++ b/VivaDicta/Views/RecordViewModel.swift
@@ -611,6 +611,11 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
                 // Darwin notification shareTranscribedText posts).
                 self.openObsidianIfEnabled(text: textToShare, presetName: promptName, sourceTag: resolvedSourceTag)
 
+                FolderExportService.saveIfEnabled(
+                    transcription: savedTranscription,
+                    mode: aiService.selectedMode
+                )
+
                 AppGroupCoordinator.shared.shareTranscribedText(textToShare)
 
                 // Cache for keyboard "Recent Notes" feature
@@ -780,6 +785,11 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
                         text: pending.text,
                         presetName: nil,
                         sourceTag: pending.sourceTag ?? SourceTag.app
+                    )
+
+                    FolderExportService.saveIfEnabled(
+                        transcription: transcription,
+                        mode: aiService.selectedMode
                     )
 
                     // Share with keyboard

--- a/VivaDicta/Views/SettingsScreen/IntegrationsView.swift
+++ b/VivaDicta/Views/SettingsScreen/IntegrationsView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import UniformTypeIdentifiers
 
 /// Settings screen for third-party integrations (Obsidian today; Webhooks /
 /// Zapier later). The master Obsidian toggle here gates the per-mode toggle
@@ -17,6 +18,15 @@ struct IntegrationsView: View {
 
     @AppStorage(UserDefaultsStorage.Keys.obsidianNoteTemplate)
     private var obsidianNoteTemplate = UserDefaultsStorage.defaultObsidianNoteTemplate
+
+    @AppStorage(UserDefaultsStorage.Keys.isFolderExportGloballyEnabled)
+    private var isFolderExportGloballyEnabled = false
+
+    @AppStorage(UserDefaultsStorage.Keys.folderExportDisplayName)
+    private var folderExportDisplayName: String = ""
+
+    @State private var isFolderPickerPresented = false
+    @State private var folderPickerError: String?
 
     var body: some View {
         Form {
@@ -46,15 +56,94 @@ struct IntegrationsView: View {
                     }
                 }
             }
+
+            Section(header: Text("Save to Folder"),
+                    footer: folderExportFooter) {
+                Toggle(isOn: $isFolderExportGloballyEnabled) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Save markdown file")
+                            .font(.body)
+                        Text("After each transcription, silently save a .md file to a folder of your choice (e.g. an Obsidian vault in iCloud Drive).")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .onChange(of: isFolderExportGloballyEnabled) { _, _ in
+                    HapticManager.selectionChanged()
+                }
+
+                if isFolderExportGloballyEnabled {
+                    Button {
+                        isFolderPickerPresented = true
+                    } label: {
+                        HStack {
+                            Text(folderExportDisplayName.isEmpty ? "Choose folder..." : "Folder")
+                            Spacer()
+                            if !folderExportDisplayName.isEmpty {
+                                Text(folderExportDisplayName)
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(1)
+                                    .truncationMode(.middle)
+                            }
+                        }
+                    }
+
+                    if !folderExportDisplayName.isEmpty {
+                        Button("Clear folder", role: .destructive) {
+                            FolderExportService.clearBookmark()
+                            folderExportDisplayName = ""
+                        }
+                    }
+                }
+            }
         }
         .navigationTitle("Integrations")
         .navigationBarTitleDisplayMode(.inline)
+        .fileImporter(
+            isPresented: $isFolderPickerPresented,
+            allowedContentTypes: [.folder],
+            allowsMultipleSelection: false
+        ) { result in
+            switch result {
+            case .success(let urls):
+                guard let url = urls.first else { return }
+                guard url.startAccessingSecurityScopedResource() else {
+                    folderPickerError = "Could not access the selected folder."
+                    return
+                }
+                defer { url.stopAccessingSecurityScopedResource() }
+                do {
+                    try FolderExportService.storeBookmark(for: url)
+                } catch {
+                    folderPickerError = error.localizedDescription
+                }
+            case .failure(let error):
+                folderPickerError = error.localizedDescription
+            }
+        }
+        .alert("Folder selection failed",
+               isPresented: Binding(
+                   get: { folderPickerError != nil },
+                   set: { if !$0 { folderPickerError = nil } }
+               ),
+               presenting: folderPickerError) { _ in
+            Button("OK", role: .cancel) { folderPickerError = nil }
+        } message: { message in
+            Text(message)
+        }
     }
 
     @ViewBuilder
     private var obsidianFooter: some View {
         if isObsidianGloballyEnabled {
             Text("A new Obsidian note is created for each transcription. Placeholders: {date}, {yyyy}, {MM}, {dd}, {HH}, {mm}, {ss}, {preset}, {mode}. To instead append to a daily note, set the name to just {date}. Per-mode opt-out is available in each mode's settings. The clipboard is overwritten each time.")
+        }
+    }
+
+    @ViewBuilder
+    private var folderExportFooter: some View {
+        if isFolderExportGloballyEnabled {
+            Text("One markdown file per transcription, named VivaDicta-YYYY-MM-DD_HHmmss.md. Pick any folder, including an iCloud Drive Obsidian vault. Per-mode opt-out is available in each mode's settings. Saving from the keyboard requires Full Access.")
         }
     }
 }

--- a/VivaDicta/Views/SettingsScreen/IntegrationsView.swift
+++ b/VivaDicta/Views/SettingsScreen/IntegrationsView.swift
@@ -22,7 +22,7 @@ struct IntegrationsView: View {
     @AppStorage(UserDefaultsStorage.Keys.isFolderExportGloballyEnabled)
     private var isFolderExportGloballyEnabled = false
 
-    @AppStorage(UserDefaultsStorage.Keys.folderExportDisplayName)
+    @AppStorage(UserDefaultsStorage.SharedKeys.folderExportDisplayName, store: UserDefaultsStorage.shared)
     private var folderExportDisplayName: String = ""
 
     @State private var isFolderPickerPresented = false
@@ -143,7 +143,7 @@ struct IntegrationsView: View {
     @ViewBuilder
     private var folderExportFooter: some View {
         if isFolderExportGloballyEnabled {
-            Text("One markdown file per transcription, named VivaDicta-YYYY-MM-DD_HHmmss.md. Pick any folder, including an iCloud Drive Obsidian vault. Per-mode opt-out is available in each mode's settings. Saving from the keyboard requires Full Access.")
+            Text("One markdown file per transcription, named VivaDicta-YYYY-MM-DD_HHmmss.md. Pick any folder, including an Obsidian vault. Once you pick a folder, every mode silently writes a file - opt out per-mode in each mode's settings.")
         }
     }
 }

--- a/VivaDicta/Views/SettingsScreen/ModeEditView.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditView.swift
@@ -27,6 +27,9 @@ struct ModeEditView: View {
 
     @AppStorage(UserDefaultsStorage.Keys.isObsidianGloballyEnabled)
     private var isObsidianGloballyEnabled = false
+
+    @AppStorage(UserDefaultsStorage.Keys.isFolderExportGloballyEnabled)
+    private var isFolderExportGloballyEnabled = false
     
     let selectAIEnhacementTip = SelectAIEnhacementTip()
 
@@ -814,6 +817,23 @@ struct ModeEditView: View {
                 }
             }
 
+            if isFolderExportGloballyEnabled {
+                Section(header: folderExportSectionHeader) {
+                    Toggle(isOn: $viewModel.folderExportEnabled) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Save markdown file")
+                                .font(.body)
+                            Text("Save this mode's transcriptions as a .md file in the folder picked in Settings → Integrations.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .onChange(of: viewModel.folderExportEnabled) { _, _ in
+                        HapticManager.selectionChanged()
+                    }
+                }
+            }
+
             if viewModel.isEditing {
                 if viewModel.isValid {
                     Section {
@@ -979,6 +999,10 @@ struct ModeEditView: View {
 
     private var obsidianSectionHeader: some View {
         Text("Obsidian")
+    }
+
+    private var folderExportSectionHeader: some View {
+        Text("Save to Folder")
     }
 
     private var reminderSuggestionsSectionHeader: some View {

--- a/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
@@ -33,6 +33,7 @@ class ModeEditViewModel {
     var isStripTrailingPeriodEnabled: Bool = false
 
     var obsidianEnabled: Bool = true
+    var folderExportEnabled: Bool = true
 
     let aiService: AIService
     private let transcriptionManager: TranscriptionManager
@@ -193,6 +194,7 @@ class ModeEditViewModel {
             isSmartInsertEnabled = existingMode.isSmartInsertEnabled
             isStripTrailingPeriodEnabled = existingMode.isStripTrailingPeriodEnabled
             obsidianEnabled = existingMode.obsidianEnabled
+            folderExportEnabled = existingMode.folderExportEnabled
 
             validateLanguageSelection()
             validateAIModelSelection()
@@ -241,7 +243,8 @@ class ModeEditViewModel {
             isAutoTextFormattingEnabled: isAutoTextFormattingEnabled,
             isSmartInsertEnabled: isSmartInsertEnabled,
             isStripTrailingPeriodEnabled: isStripTrailingPeriodEnabled,
-            obsidianEnabled: obsidianEnabled
+            obsidianEnabled: obsidianEnabled,
+            folderExportEnabled: folderExportEnabled
         )
     }
 


### PR DESCRIPTION
## Summary

Adds a new **Settings → Integrations → Save to Folder** option that silently writes each transcription as a markdown file into a user-picked folder (e.g. an Obsidian vault under \`On My iPhone → Obsidian\` or any Files-app-accessible location). No share sheet, no \`obsidian://\` round-trip.

Mirrors the existing Obsidian integration exactly:
- Same markdown content from \`TranscriptionMarkdownExportService\` (Original + variations + metadata)
- Same \`VivaDicta-YYYY-MM-DD_HHmmss.md\` filename convention
- Same global + per-mode toggle pattern
- Same trigger points in \`RecordViewModel\` (post-AI and raw-text save)

## How it works

- User picks a folder once via \`UIDocumentPickerViewController\` (\`fileImporter\` for \`.folder\`)
- Security-scoped bookmark is stored as \`Data\` in the App Group's shared UserDefaults so the keyboard extension can resolve it too
- \`FolderExportService.saveIfEnabled(transcription:mode:)\` is called from the same two sites where \`openObsidianIfEnabled\` runs
- File writes happen on a detached utility-priority Task; errors are logged, never thrown to the caller

## Files changed

- \`Services/FolderExportService.swift\` (new) - bookmark management + silent file write
- \`Shared/UserDefaultsStorage.swift\` - \`isFolderExportGloballyEnabled\`, \`folderExportDisplayName\`, \`folderExportBookmark\` (shared)
- \`Services/AIEnhance/VivaMode.swift\` - \`folderExportEnabled\` per-mode flag, decode default \`true\` for existing modes
- \`Services/AIEnhance/AIService.swift\`, \`Services/PresetMigrationService.swift\` - propagate new flag through every \`VivaMode(...)\` callsite
- \`Views/SettingsScreen/IntegrationsView.swift\` - new section with toggle + folder picker + clear button
- \`Views/SettingsScreen/ModeEditView.swift\`, \`ModeEditViewModel.swift\` - per-mode toggle
- \`Views/RecordViewModel.swift\` - call \`FolderExportService.saveIfEnabled\` next to existing Obsidian hand-off

## Open risks (not de-risked yet)

1. **Bookmark resolvability from the keyboard process.** The save call fires from \`RecordViewModel\` regardless of source, but if the keyboard's RecordViewModel context cannot resolve a bookmark created by the main app, keyboard transcriptions silently won't write. Settings footer mentions Full Access requirement; needs a real-device smoke test before shipping.
2. **Stale bookmark handling.** If the user moves/renames the picked folder, the next save logs \`bookmark is stale\` and stops. There is no proactive notification yet - the user has to come back into Settings and re-pick.

## Test plan

- [ ] Main-app: pick a folder in \`On My iPhone\`, record a transcription, confirm \`.md\` file appears with same content as \"Export as Markdown\" produces
- [ ] Per-mode toggle: disable for one mode, confirm no file written when using that mode
- [ ] Bookmark persistence: force-quit the app, relaunch, record again - confirm second file appears
- [ ] Stale bookmark: rename the picked folder via Files app, record, confirm error logged and re-picking recovers
- [ ] Keyboard: enable Full Access, dictate via keyboard, confirm file appears with \`Source: keyboard\` metadata
- [ ] Files-app-exposed Obsidian local vault: pick \`On My iPhone → Obsidian → <Vault> → Inbox\`, confirm note shows up in Obsidian