### PR TITLE
Move markdown auto-save toggle to Settings Export section

### DIFF
--- a/VivaDicta/Views/SettingsScreen/IntegrationsView.swift
+++ b/VivaDicta/Views/SettingsScreen/IntegrationsView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import UniformTypeIdentifiers
 
 /// Settings screen for third-party integrations (Obsidian today; Webhooks /
 /// Zapier later). The master Obsidian toggle here gates the per-mode toggle
@@ -18,15 +17,6 @@ struct IntegrationsView: View {
 
     @AppStorage(UserDefaultsStorage.Keys.obsidianNoteTemplate)
     private var obsidianNoteTemplate = UserDefaultsStorage.defaultObsidianNoteTemplate
-
-    @AppStorage(UserDefaultsStorage.Keys.isFolderExportGloballyEnabled)
-    private var isFolderExportGloballyEnabled = false
-
-    @AppStorage(UserDefaultsStorage.SharedKeys.folderExportDisplayName, store: UserDefaultsStorage.shared)
-    private var folderExportDisplayName: String = ""
-
-    @State private var isFolderPickerPresented = false
-    @State private var folderPickerError: String?
 
     var body: some View {
         Form {
@@ -56,94 +46,15 @@ struct IntegrationsView: View {
                     }
                 }
             }
-
-            Section(header: Text("Save to Folder"),
-                    footer: folderExportFooter) {
-                Toggle(isOn: $isFolderExportGloballyEnabled) {
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("Save markdown file")
-                            .font(.body)
-                        Text("After each transcription, silently save a .md file to a folder of your choice (e.g. an Obsidian vault in iCloud Drive).")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                }
-                .onChange(of: isFolderExportGloballyEnabled) { _, _ in
-                    HapticManager.selectionChanged()
-                }
-
-                if isFolderExportGloballyEnabled {
-                    Button {
-                        isFolderPickerPresented = true
-                    } label: {
-                        HStack {
-                            Text(folderExportDisplayName.isEmpty ? "Choose folder..." : "Folder")
-                            Spacer()
-                            if !folderExportDisplayName.isEmpty {
-                                Text(folderExportDisplayName)
-                                    .foregroundStyle(.secondary)
-                                    .lineLimit(1)
-                                    .truncationMode(.middle)
-                            }
-                        }
-                    }
-
-                    if !folderExportDisplayName.isEmpty {
-                        Button("Clear folder", role: .destructive) {
-                            FolderExportService.clearBookmark()
-                            folderExportDisplayName = ""
-                        }
-                    }
-                }
-            }
         }
         .navigationTitle("Integrations")
         .navigationBarTitleDisplayMode(.inline)
-        .fileImporter(
-            isPresented: $isFolderPickerPresented,
-            allowedContentTypes: [.folder],
-            allowsMultipleSelection: false
-        ) { result in
-            switch result {
-            case .success(let urls):
-                guard let url = urls.first else { return }
-                guard url.startAccessingSecurityScopedResource() else {
-                    folderPickerError = "Could not access the selected folder."
-                    return
-                }
-                defer { url.stopAccessingSecurityScopedResource() }
-                do {
-                    try FolderExportService.storeBookmark(for: url)
-                } catch {
-                    folderPickerError = error.localizedDescription
-                }
-            case .failure(let error):
-                folderPickerError = error.localizedDescription
-            }
-        }
-        .alert("Folder selection failed",
-               isPresented: Binding(
-                   get: { folderPickerError != nil },
-                   set: { if !$0 { folderPickerError = nil } }
-               ),
-               presenting: folderPickerError) { _ in
-            Button("OK", role: .cancel) { folderPickerError = nil }
-        } message: { message in
-            Text(message)
-        }
     }
 
     @ViewBuilder
     private var obsidianFooter: some View {
         if isObsidianGloballyEnabled {
             Text("A new Obsidian note is created for each transcription. Placeholders: {date}, {yyyy}, {MM}, {dd}, {HH}, {mm}, {ss}, {preset}, {mode}. To instead append to a daily note, set the name to just {date}. Per-mode opt-out is available in each mode's settings. The clipboard is overwritten each time.")
-        }
-    }
-
-    @ViewBuilder
-    private var folderExportFooter: some View {
-        if isFolderExportGloballyEnabled {
-            Text("One markdown file per transcription, named VivaDicta-YYYY-MM-DD_HHmmss.md. Pick any folder, including an Obsidian vault. Once you pick a folder, every mode silently writes a file - opt out per-mode in each mode's settings.")
         }
     }
 }

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 import AppIntents
 import TipKit
 import MessageUI
+import UniformTypeIdentifiers
 
 struct SettingsView: View {
     @Environment(AppState.self) var appState
@@ -57,6 +58,12 @@ struct SettingsView: View {
     private var isICloudSyncEnabled = true
     @AppStorage(MarkdownExportContent.userDefaultsKey)
     private var markdownExportContent: MarkdownExportContent = .default
+    @AppStorage(UserDefaultsStorage.Keys.isFolderExportGloballyEnabled)
+    private var isFolderExportGloballyEnabled = false
+    @AppStorage(UserDefaultsStorage.SharedKeys.folderExportDisplayName, store: UserDefaultsStorage.shared)
+    private var folderExportDisplayName: String = ""
+    @State private var isFolderPickerPresented = false
+    @State private var folderPickerError: String?
     @State private var showRestartAlert = false
     @AppStorage(AppGroupCoordinator.isHapticsEnabled, store: UserDefaultsStorage.shared)
     private var isHapticsEnabled = true
@@ -378,15 +385,56 @@ struct SettingsView: View {
                         }
                         .pickerStyle(.menu)
                         .tint(.primary)
-                        Text("Choose what to include when exporting notes as Markdown.")
+                        Text("Choose what to include when exporting notes as Markdown. Applies to both manual export and auto-save below.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
                     .onChange(of: markdownExportContent) { _, _ in
                         HapticManager.selectionChanged()
                     }
+
+                    Toggle(isOn: $isFolderExportGloballyEnabled) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Save markdown file")
+                                .font(.body)
+                            Text("After each transcription, silently save a .md file to a folder of your choice (e.g. an Obsidian vault in iCloud Drive).")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .onChange(of: isFolderExportGloballyEnabled) { _, _ in
+                        HapticManager.selectionChanged()
+                    }
+
+                    if isFolderExportGloballyEnabled {
+                        Button {
+                            isFolderPickerPresented = true
+                        } label: {
+                            HStack {
+                                Text(folderExportDisplayName.isEmpty ? "Choose folder..." : "Folder")
+                                Spacer()
+                                if !folderExportDisplayName.isEmpty {
+                                    Text(folderExportDisplayName)
+                                        .foregroundStyle(.secondary)
+                                        .lineLimit(1)
+                                        .truncationMode(.middle)
+                                }
+                            }
+                        }
+
+                        if !folderExportDisplayName.isEmpty {
+                            Button("Clear folder", role: .destructive) {
+                                FolderExportService.clearBookmark()
+                                folderExportDisplayName = ""
+                            }
+                        }
+                    }
                 } header: {
                     Text("Export")
+                } footer: {
+                    if isFolderExportGloballyEnabled {
+                        Text("One markdown file per transcription, named VivaDicta-YYYY-MM-DD_HHmmss.md. Pick any folder, including an Obsidian vault. Once you pick a folder, every mode silently writes a file - opt out per-mode in each mode's settings.")
+                    }
                 }
 
                 Section("Storage") {
@@ -697,6 +745,38 @@ struct SettingsView: View {
             Button("Later", role: .cancel) { }
         } message: {
             Text("The app needs to restart for iCloud sync changes to take effect.")
+        }
+        .fileImporter(
+            isPresented: $isFolderPickerPresented,
+            allowedContentTypes: [.folder],
+            allowsMultipleSelection: false
+        ) { result in
+            switch result {
+            case .success(let urls):
+                guard let url = urls.first else { return }
+                guard url.startAccessingSecurityScopedResource() else {
+                    folderPickerError = "Could not access the selected folder."
+                    return
+                }
+                defer { url.stopAccessingSecurityScopedResource() }
+                do {
+                    try FolderExportService.storeBookmark(for: url)
+                } catch {
+                    folderPickerError = error.localizedDescription
+                }
+            case .failure(let error):
+                folderPickerError = error.localizedDescription
+            }
+        }
+        .alert("Folder selection failed",
+               isPresented: Binding(
+                   get: { folderPickerError != nil },
+                   set: { if !$0 { folderPickerError = nil } }
+               ),
+               presenting: folderPickerError) { _ in
+            Button("OK", role: .cancel) { folderPickerError = nil }
+        } message: { message in
+            Text(message)
         }
         .sheet(isPresented: $showMailCompose) {
             MailComposeView(


### PR DESCRIPTION
## Summary
- Moves the "Save markdown file" auto-save toggle (and its folder picker / clear-folder button) from `Settings -> Integrations -> Save to Folder` into the existing `Settings -> Export` section, right under the "Markdown Export" picker. Auto-save is an export concern, not a third-party integration.
- Reflows the picker caption to make explicit that the `MarkdownExportContent` setting (Original / Original + Last / Original + All / Last only) governs **both** manual "Export as Markdown" and auto-save. The two already share the same `TranscriptionMarkdownExportService.generateMarkdown()` builder, so format and scope are unified.
- `IntegrationsView` is now Obsidian-only.

## Notes
- Storage keys (`isFolderExportGloballyEnabled`, `folderExportBookmark`, `folderExportDisplayName`) are unchanged. No migration is needed since the auto-save feature has not shipped yet.

## Test plan
- [x] `xcodebuild` Debug build for iPhone 17 Pro Max (iOS 26.4): success, 0 errors.
- [ ] Manual: open Settings, confirm Export section now shows Picker -> "Save markdown file" toggle -> folder picker / clear button (when toggle on); confirm Integrations only shows Obsidian.
- [ ] Manual: pick a folder, record, verify .md file written; toggle picker between Original / Original + All / etc. and confirm auto-saved file content matches the manual "Export as Markdown" output for the same selection.