### PR TITLE
Add Cartesia cloud transcription provider

### DIFF
--- a/VivaDicta/Assets.xcassets/AIProviders/cartesia.imageset/Contents.json
+++ b/VivaDicta/Assets.xcassets/AIProviders/cartesia.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "filename" : "cartesia.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
+  }
+}

--- a/VivaDicta/Assets.xcassets/AIProviders/cartesia.imageset/cartesia.svg
+++ b/VivaDicta/Assets.xcassets/AIProviders/cartesia.imageset/cartesia.svg
@@ -1,0 +1,23 @@
+<svg width="700" height="700" viewBox="0 0 700 700" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_1180_921)">
+<path d="M331.579 36.8423H221.053V147.369H331.579V36.8423Z" fill="black"/>
+<path d="M552.632 36.8423H442.105V147.369H552.632V36.8423Z" fill="black"/>
+<path d="M221.052 147.369H110.525V257.895H221.052V147.369Z" fill="black"/>
+<path d="M442.104 147.369H331.578V257.895H442.104V147.369Z" fill="black"/>
+<path d="M663.157 147.369H552.631V257.895H663.157V147.369Z" fill="black"/>
+<path d="M110.526 257.895H0V368.421H110.526V257.895Z" fill="black"/>
+<path d="M331.579 257.895H221.053V368.421H331.579V257.895Z" fill="black"/>
+<path d="M110.526 368.421H0V478.947H110.526V368.421Z" fill="black"/>
+<path d="M331.579 368.421H221.053V478.947H331.579V368.421Z" fill="black"/>
+<path d="M221.052 478.947H110.525V589.474H221.052V478.947Z" fill="black"/>
+<path d="M442.104 478.947H331.578V589.474H442.104V478.947Z" fill="black"/>
+<path d="M663.157 478.947H552.631V589.474H663.157V478.947Z" fill="black"/>
+<path d="M331.579 589.474H221.053V700H331.579V589.474Z" fill="black"/>
+<path d="M552.632 589.474H442.105V700H552.632V589.474Z" fill="black"/>
+</g>
+<defs>
+<clipPath id="clip0_1180_921">
+<rect width="700" height="700" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/VivaDicta/Models/TranscriptionModelProvider.swift
+++ b/VivaDicta/Models/TranscriptionModelProvider.swift
@@ -303,7 +303,7 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
                 provider: .cartesia,
                 speed: 0.9,
                 accuracy: 0.95,
-                cost: 0.4,
+                cost: 0.4,  // Placeholder - Cartesia bills per credit, not per minute
                 supportManyLanguages: true,
                 supportedLanguages: cartesiaLanguages
             ),

--- a/VivaDicta/Models/TranscriptionModelProvider.swift
+++ b/VivaDicta/Models/TranscriptionModelProvider.swift
@@ -20,6 +20,7 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
     case gladia
     case speechmatics
     case cohere
+    case cartesia
     case customTranscription
     
     var id: Self { self }
@@ -50,6 +51,8 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
             "Speechmatics"
         case .cohere:
             "Cohere"
+        case .cartesia:
+            "Cartesia"
         case .customTranscription:
             "Custom"
         }
@@ -67,6 +70,7 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
         .mistral,
         .deepgram,
         .cohere,
+        .cartesia,
         .elevenLabs,
         .gemini,
         .openAI,
@@ -115,6 +119,7 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
         case .gladia: "solaria-1"
         case .speechmatics: "speechmatics-batch-v2"
         case .cohere: "cohere-transcribe-03-2026"
+        case .cartesia: "ink-whisper"
         default: nil
         }
     }
@@ -153,6 +158,8 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
             return .speechmatics
         case .cohere:
             return .cohere
+        case .cartesia:
+            return .cartesia
         default:
             return nil
         }
@@ -290,6 +297,18 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
             ),
 
             CloudModel(
+                name: "ink-whisper",
+                displayName: "Cartesia Ink Whisper",
+                description: "Cartesia's batch Speech-to-Text with arbitrary-length audio support, word-level timestamps, and 100+ languages. Free credits on signup.",
+                provider: .cartesia,
+                speed: 0.9,
+                accuracy: 0.95,
+                cost: 0.4,
+                supportManyLanguages: true,
+                supportedLanguages: cartesiaLanguages
+            ),
+
+            CloudModel(
                 name: "scribe_v2",
                 displayName: "Scribe v2",
                 description: "Enhanced accuracy model supporting 92+ languages with improved accent handling. Free tier: ~150 mins/month",
@@ -399,9 +418,28 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
         supportManyLanguages ? allLanguages : ["en": "English"]
     }
 
-    /// Cohere supports 14 languages. No auto-detect — language must be specified.
+    /// Cohere supports 14 languages. No auto-detect - language must be specified.
     static let cohereLanguages: [String: String] = {
         let codes = ["en", "fr", "de", "it", "es", "pt", "el", "nl", "pl", "zh", "ja", "ko", "vi", "ar"]
+        return allLanguages.filter { codes.contains($0.key) }
+    }()
+
+    /// Cartesia ink-whisper supports 104 languages via Whisper. No auto-detect -
+    /// the API defaults to "en" if omitted, so the service falls back to "en" when
+    /// the user has selected "auto".
+    static let cartesiaLanguages: [String: String] = {
+        let codes: Set<String> = [
+            "en", "zh", "de", "es", "ru", "ko", "fr", "ja", "pt", "tr",
+            "pl", "ca", "nl", "ar", "sv", "it", "id", "hi", "fi", "vi",
+            "he", "uk", "el", "ms", "cs", "ro", "da", "hu", "ta", "no",
+            "th", "ur", "hr", "bg", "lt", "la", "mi", "ml", "cy", "sk",
+            "te", "fa", "lv", "bn", "sr", "az", "sl", "kn", "et", "mk",
+            "br", "eu", "is", "hy", "ne", "mn", "bs", "kk", "sq", "sw",
+            "gl", "mr", "pa", "si", "km", "sn", "yo", "so", "af", "oc",
+            "ka", "be", "tg", "sd", "gu", "am", "yi", "lo", "uz", "fo",
+            "ht", "ps", "tk", "nn", "mt", "sa", "lb", "my", "bo", "tl",
+            "mg", "as", "tt", "haw", "ln", "ha", "ba", "jw", "su", "yue",
+        ]
         return allLanguages.filter { codes.contains($0.key) }
     }()
 

--- a/VivaDicta/Services/AIEnhance/AIProvider.swift
+++ b/VivaDicta/Services/AIEnhance/AIProvider.swift
@@ -188,7 +188,7 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
         case .zai: URL(string: "https://open.z.ai/")
         case .kimi: URL(string: "https://platform.moonshot.cn/console/api-keys")
         case .cohere: URL(string: "https://dashboard.cohere.com/api-keys")
-        case .cartesia: URL(string: "https://play.cartesia.ai/")
+        case .cartesia: URL(string: "https://play.cartesia.ai/keys")
         default: nil
         }
     }

--- a/VivaDicta/Services/AIEnhance/AIProvider.swift
+++ b/VivaDicta/Services/AIEnhance/AIProvider.swift
@@ -25,6 +25,7 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
     case gladia
     case speechmatics
     case cohere
+    case cartesia
     case zai
     case kimi
     case vercelAIGateway
@@ -59,6 +60,8 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
             "Speechmatics"
         case .cohere:
             "Cohere"
+        case .cartesia:
+            "Cartesia"
         case .anthropic:
             "Anthropic"
         case .openRouter:
@@ -119,6 +122,8 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
             "speechmatics"
         case .cohere:
             "cohere-color"
+        case .cartesia:
+            "cartesia"
         case .vercelAIGateway:
             "vercel"
         case .huggingFace:
@@ -183,6 +188,7 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
         case .zai: URL(string: "https://open.z.ai/")
         case .kimi: URL(string: "https://platform.moonshot.cn/console/api-keys")
         case .cohere: URL(string: "https://dashboard.cohere.com/api-keys")
+        case .cartesia: URL(string: "https://play.cartesia.ai/")
         default: nil
         }
     }
@@ -272,6 +278,8 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
             return "https://asr.api.speechmatics.com/v2"
         case .cohere:
             return "https://api.cohere.com/v2"
+        case .cartesia:
+            return "https://api.cartesia.ai"
         case .vercelAIGateway:
             return "https://ai-gateway.vercel.sh/v1/chat/completions"
         case .huggingFace:
@@ -324,6 +332,8 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
             return "speechmatics-batch-v2"
         case .cohere:
             return "cohere-transcribe-03-2026"
+        case .cartesia:
+            return "ink-whisper"
         case .vercelAIGateway:
             // Note: Vercel AI Gateway uses "provider/model" format with dots for versions
             // (e.g., "claude-sonnet-4.6") unlike direct Anthropic API which uses hyphens
@@ -363,6 +373,7 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
         case .gladia: "gladiaAPIKey"
         case .speechmatics: "speechmaticsAPIKey"
         case .cohere: "cohereAPIKey"
+        case .cartesia: "cartesiaAPIKey"
         case .vercelAIGateway: "vercelAIGatewayAPIKey"
         case .huggingFace: "huggingFaceAPIKey"
         case .customOpenAI: "customOpenAIAPIKey"
@@ -466,6 +477,8 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
         case .speechmatics:
             return [] // Transcription-only provider, no chat models
         case .cohere:
+            return [] // Transcription-only provider, no chat models
+        case .cartesia:
             return [] // Transcription-only provider, no chat models
         case .openRouter:
             return []

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -2341,6 +2341,8 @@ class AIService {
             return await verifySpeechmaticsAPIKey(key)
         case .cohere:
             return await verifyCohereAPIKey(key)
+        case .cartesia:
+            return await verifyCartesiaAPIKey(key)
         case .cerebras:
             return await verifyCerebrasAPIKey(key)
         case .vercelAIGateway:
@@ -2622,6 +2624,31 @@ class AIService {
             return httpResponse.statusCode == 200
         } catch {
             logger.logError("Cohere API key verification failed: \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    /// Cartesia has no public list/me endpoint, so we hit the STT endpoint with
+    /// no body. A bad key returns 401 before validation; a valid key returns
+    /// 400 (missing file) or similar - we treat any non-401 response as proof
+    /// the key is recognized.
+    private func verifyCartesiaAPIKey(_ key: String) async -> Bool {
+        let url = URL(string: "https://api.cartesia.ai/stt")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
+        request.addValue("2026-03-01", forHTTPHeaderField: "Cartesia-Version")
+
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+
+            guard let httpResponse = response as? HTTPURLResponse else {
+                return false
+            }
+
+            return httpResponse.statusCode != 401 && httpResponse.statusCode != 403
+        } catch {
+            logger.logError("Cartesia API key verification failed: \(error.localizedDescription)")
             return false
         }
     }

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -2628,16 +2628,18 @@ class AIService {
         }
     }
 
-    /// Cartesia has no public list/me endpoint, so we hit the STT endpoint with
-    /// no body. A bad key returns 401 before validation; a valid key returns
-    /// 400 (missing file) or similar - we treat any non-401 response as proof
-    /// the key is recognized.
+    /// Probes the documented `GET /voices` endpoint. A valid standard
+    /// `sk_car_...` key returns 200; an invalid or revoked key returns 401/403.
+    /// Other statuses (5xx, network errors) fail closed so a Cloudflare blip
+    /// doesn't mark a bad key as valid.
     private func verifyCartesiaAPIKey(_ key: String) async -> Bool {
-        let url = URL(string: "https://api.cartesia.ai/stt")!
+        guard let url = URL(string: "https://api.cartesia.ai/voices") else {
+            return false
+        }
         var request = URLRequest(url: url)
-        request.httpMethod = "POST"
+        request.httpMethod = "GET"
         request.addValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
-        request.addValue("2026-03-01", forHTTPHeaderField: "Cartesia-Version")
+        request.addValue(CartesiaTranscriptionService.cartesiaVersion, forHTTPHeaderField: "Cartesia-Version")
 
         do {
             let (_, response) = try await URLSession.shared.data(for: request)
@@ -2646,7 +2648,7 @@ class AIService {
                 return false
             }
 
-            return httpResponse.statusCode != 401 && httpResponse.statusCode != 403
+            return httpResponse.statusCode == 200
         } catch {
             logger.logError("Cartesia API key verification failed: \(error.localizedDescription)")
             return false

--- a/VivaDicta/Services/Transcription/CloudTranscription/CartesiaTranscriptionService.swift
+++ b/VivaDicta/Services/Transcription/CloudTranscription/CartesiaTranscriptionService.swift
@@ -4,11 +4,12 @@ import Foundation
 import os
 
 struct CartesiaTranscriptionService {
-    private let logger = Logger(category: .cartesiaTranscriptionService)
-
     /// Cartesia requires a date-formatted version header. Bumping this is a
-    /// deliberate API-version pin; check the changelog before changing.
-    private let cartesiaVersion = "2026-03-01"
+    /// deliberate API-version pin; check the changelog before changing. Single
+    /// source of truth - referenced from both transcribe and key-verify paths.
+    static let cartesiaVersion = "2026-03-01"
+
+    private let logger = Logger(category: .cartesiaTranscriptionService)
 
     func transcribe(audioURL: URL, model: any TranscriptionModel) async throws -> TranscriptionServiceResult {
         let text = try await NetworkRetry.withRetry(logger: logger) {
@@ -25,7 +26,7 @@ struct CartesiaTranscriptionService {
         request.httpMethod = "POST"
         request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
         request.setValue("Bearer \(config.apiKey)", forHTTPHeaderField: "Authorization")
-        request.setValue(cartesiaVersion, forHTTPHeaderField: "Cartesia-Version")
+        request.setValue(Self.cartesiaVersion, forHTTPHeaderField: "Cartesia-Version")
         request.timeoutInterval = NetworkRetry.defaultTimeout
 
         let body = try createRequestBody(audioURL: audioURL, modelName: config.modelName, boundary: boundary)

--- a/VivaDicta/Services/Transcription/CloudTranscription/CartesiaTranscriptionService.swift
+++ b/VivaDicta/Services/Transcription/CloudTranscription/CartesiaTranscriptionService.swift
@@ -1,0 +1,119 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import os
+
+struct CartesiaTranscriptionService {
+    private let logger = Logger(category: .cartesiaTranscriptionService)
+
+    /// Cartesia requires a date-formatted version header. Bumping this is a
+    /// deliberate API-version pin; check the changelog before changing.
+    private let cartesiaVersion = "2026-03-01"
+
+    func transcribe(audioURL: URL, model: any TranscriptionModel) async throws -> TranscriptionServiceResult {
+        let text = try await NetworkRetry.withRetry(logger: logger) {
+            try await makeTranscriptionRequest(audioURL: audioURL, model: model)
+        }
+        return .plain(text)
+    }
+
+    private func makeTranscriptionRequest(audioURL: URL, model: any TranscriptionModel) async throws -> String {
+        let config = try getAPIConfig(for: model)
+
+        let boundary = "Boundary-\(UUID().uuidString)"
+        var request = URLRequest(url: config.url)
+        request.httpMethod = "POST"
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(config.apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue(cartesiaVersion, forHTTPHeaderField: "Cartesia-Version")
+        request.timeoutInterval = NetworkRetry.defaultTimeout
+
+        let body = try createRequestBody(audioURL: audioURL, modelName: config.modelName, boundary: boundary)
+
+        let (data, response) = try await URLSession.shared.upload(for: request, from: body)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw CloudTranscriptionError.networkError(URLError(.badServerResponse))
+        }
+
+        if !(200...299).contains(httpResponse.statusCode) {
+            let errorMessage = String(data: data, encoding: .utf8) ?? "No error message"
+            logger.logError("Cartesia API request failed with status \(httpResponse.statusCode): \(errorMessage)")
+            throw CloudTranscriptionError.apiRequestFailed(statusCode: httpResponse.statusCode, message: errorMessage)
+        }
+
+        do {
+            let transcriptionResponse = try JSONDecoder().decode(TranscriptionResponse.self, from: data)
+            return transcriptionResponse.text
+        } catch {
+            logger.logError("Failed to decode Cartesia API response: \(error.localizedDescription)")
+            throw CloudTranscriptionError.noTranscriptionReturned
+        }
+    }
+
+    private func getAPIConfig(for model: any TranscriptionModel) throws -> APIConfig {
+        guard let cloudModel = model as? CloudModel,
+              let apiKey = cloudModel.apiKey,
+              !apiKey.isEmpty else {
+            throw CloudTranscriptionError.missingAPIKey
+        }
+
+        let apiURL = URL(string: "https://api.cartesia.ai/stt")!
+        return APIConfig(url: apiURL, apiKey: apiKey, modelName: model.name)
+    }
+
+    private func createRequestBody(audioURL: URL, modelName: String, boundary: String) throws -> Data {
+        var body = Data()
+        let crlf = "\r\n"
+
+        guard let audioData = try? Data(contentsOf: audioURL) else {
+            throw CloudTranscriptionError.audioFileNotFound
+        }
+
+        let selectedLanguage = UserDefaultsStorage.shared.string(forKey: AppGroupCoordinator.kSelectedLanguageKey) ?? "auto"
+
+        // Cartesia has no auto-detect - falls back to "en" when user picked
+        // "auto" or chose a language outside Cartesia's supported set.
+        let supportedCodes = Set(TranscriptionModelProvider.cartesiaLanguages.keys)
+        let language: String
+        if selectedLanguage == "auto" || selectedLanguage.isEmpty || !supportedCodes.contains(selectedLanguage) {
+            language = "en"
+        } else {
+            language = selectedLanguage
+        }
+
+        logger.logInfo("Using language: \(language) (selected: \(selectedLanguage))")
+
+        // Model
+        body.append("--\(boundary)\(crlf)".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"model\"\(crlf)\(crlf)".data(using: .utf8)!)
+        body.append(modelName.data(using: .utf8)!)
+        body.append(crlf.data(using: .utf8)!)
+
+        // Language
+        body.append("--\(boundary)\(crlf)".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"language\"\(crlf)\(crlf)".data(using: .utf8)!)
+        body.append(language.data(using: .utf8)!)
+        body.append(crlf.data(using: .utf8)!)
+
+        // File (last)
+        body.append("--\(boundary)\(crlf)".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"file\"; filename=\"\(audioURL.lastPathComponent)\"\(crlf)".data(using: .utf8)!)
+        body.append("Content-Type: \(audioURL.audioMIMEType)\(crlf)\(crlf)".data(using: .utf8)!)
+        body.append(audioData)
+        body.append(crlf.data(using: .utf8)!)
+        body.append("--\(boundary)--\(crlf)".data(using: .utf8)!)
+
+        return body
+    }
+
+    private struct APIConfig {
+        let url: URL
+        let apiKey: String
+        let modelName: String
+    }
+
+    private struct TranscriptionResponse: Decodable {
+        let text: String
+    }
+}

--- a/VivaDicta/Services/Transcription/CloudTranscription/CloudTranscriptionService.swift
+++ b/VivaDicta/Services/Transcription/CloudTranscription/CloudTranscriptionService.swift
@@ -77,6 +77,7 @@ class CloudTranscriptionService: TranscriptionService {
     private lazy var gladiaService = GladiaTranscriptionService()
     private lazy var speechmaticsService = SpeechmaticsTranscriptionService()
     private lazy var cohereService = CohereTranscriptionService()
+    private lazy var cartesiaService = CartesiaTranscriptionService()
     private lazy var customService = CustomTranscriptionService()
 
     func transcribe(audioURL: URL, model: any TranscriptionModel) async throws -> TranscriptionServiceResult {
@@ -103,6 +104,8 @@ class CloudTranscriptionService: TranscriptionService {
             result = try await speechmaticsService.transcribe(audioURL: audioURL, model: model)
         case .cohere:
             result = try await cohereService.transcribe(audioURL: audioURL, model: model)
+        case .cartesia:
+            result = try await cartesiaService.transcribe(audioURL: audioURL, model: model)
         case .customTranscription:
             guard let customModel = model as? CustomTranscriptionModel else {
                 throw CloudTranscriptionError.unsupportedProvider

--- a/VivaDicta/Utilities/LoggerExtension.swift
+++ b/VivaDicta/Utilities/LoggerExtension.swift
@@ -40,6 +40,7 @@ public enum LogCategory: String {
     case gladiaTranscriptionService = "GladiaTranscriptionService"
     case speechmaticsTranscriptionService = "SpeechmaticsTranscriptionService"
     case cohereTranscriptionService = "CohereTranscriptionService"
+    case cartesiaTranscriptionService = "CartesiaTranscriptionService"
     case customTranscriptionService = "CustomTranscriptionService"
 
     // MARK: - Services - Live Translation


### PR DESCRIPTION
## Summary

Adds Cartesia (`api.cartesia.ai/stt`) as a cloud transcription provider, alongside the existing Cohere/Soniox/Speechmatics/Gladia/etc. options.

- New `CartesiaTranscriptionService` (POST multipart, `Cartesia-Version: 2026-03-01` header, Bearer auth). Falls back to `en` when the user picked "auto" or a language outside Cartesia's supported set since the API has no auto-detect.
- New `CloudModel` entry **Cartesia Ink Whisper** (model id `ink-whisper`) with the documented 104-language list.
- `AIProvider.cartesia` and `TranscriptionModelProvider.cartesia` populated across all enum touchpoints (display name, icon "cartesia", baseURL, default model, keychain key "cartesiaAPIKey", api-key URL `play.cartesia.ai`, etc.).
- `verifyCartesiaAPIKey` POSTs to `/stt` with no body and treats any non-401/403 response as proof the key is recognized (Cartesia has no public list/me endpoint).
- Hooked into `CloudTranscriptionService.transcribe` dispatch and Logger categories.

UI surfaces automatically through the existing generic flow: provider appears in Mode Edit -> Transcription -> Cloud, "Add API Key" routes to `AddAPIKeyView(provider: .cartesia)`, model picker shows "Cartesia Ink Whisper" once a key is verified.

## Out of scope

- Word-level timestamps (`timestamp_granularities[]=word`) - Cartesia supports this but the existing pipeline only consumes `.plain(text)`.
- Pricing / `cost` field is set to `0.4` as a placeholder (Cartesia bills per credit, not per minute).

## Test plan

- [ ] Build succeeds on iPhone 17 Pro Max simulator (iOS 26.4)
- [ ] Cartesia appears under Mode Edit -> Transcription -> Cloud
- [ ] Selecting Cartesia with no key shows the "Add API Key" banner
- [ ] AddAPIKeyView shows correct title, icon, and "Get API Key" link
- [ ] Entering a valid Cartesia key passes verification
- [ ] Entering an invalid key fails verification cleanly
- [ ] Recording -> transcribing with Cartesia produces text
- [ ] Language fallback works: with selected language "auto", Cartesia receives `en`; with a Cartesia-unsupported code, Cartesia still receives `en`; with a supported code, that code is sent
- [ ] Key persists across app relaunch (keychain)