### PR TITLE
Temporary AI mode override in AI Actions sheet

### DIFF
--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -633,22 +633,24 @@ class AIService {
     /// - A prompt with instructions is selected
     ///
     /// - Returns: `true` if enhancement can proceed, `false` otherwise.
-    public func isProperlyConfigured() -> Bool {
+    public func isProperlyConfigured(for modeOverride: VivaMode? = nil, requirePreset: Bool = true) -> Bool {
+        let mode = modeOverride ?? selectedMode
+
         // Check if AI processing is enabled
-        guard selectedMode.aiEnhanceEnabled else {
-            logger.logInfo("AI processing is disabled for mode: \(self.selectedMode.name)")
+        guard mode.aiEnhanceEnabled else {
+            logger.logInfo("AI processing is disabled for mode: \(mode.name)")
             return false
         }
 
         // Check if AI provider is selected
-        guard let aiProvider = selectedMode.aiProvider else {
-            logger.logWarning("No AI provider selected for mode: \(self.selectedMode.name)")
+        guard let aiProvider = mode.aiProvider else {
+            logger.logWarning("No AI provider selected for mode: \(mode.name)")
             return false
         }
 
         // Check if AI model is selected (not empty)
-        guard !selectedMode.aiModel.isEmpty else {
-            logger.logWarning("No AI model selected for mode: \(self.selectedMode.name)")
+        guard !mode.aiModel.isEmpty else {
+            logger.logWarning("No AI model selected for mode: \(mode.name)")
             return false
         }
 
@@ -661,7 +663,7 @@ class AIService {
         } else if aiProvider == .ollama {
             // Ollama doesn't need API key, just needs model selected
             // Connection will be verified at enhancement time
-            guard !selectedMode.aiModel.isEmpty else {
+            guard !mode.aiModel.isEmpty else {
                 logger.logWarning("No Ollama model selected")
                 return false
             }
@@ -691,15 +693,17 @@ class AIService {
             }
         }
 
-        // Check if a preset is selected and has content
-        guard let presetId = selectedMode.presetId,
-              let preset = presetManager?.preset(for: presetId),
-              !preset.promptInstructions.isEmpty else {
-            logger.logWarning("No preset selected or preset is empty for mode: \(self.selectedMode.name)")
-            return false
+        if requirePreset {
+            // Check if a preset is selected and has content
+            guard let presetId = mode.presetId,
+                  let preset = presetManager?.preset(for: presetId),
+                  !preset.promptInstructions.isEmpty else {
+                logger.logWarning("No preset selected or preset is empty for mode: \(mode.name)")
+                return false
+            }
         }
 
-        logger.logInfo("AI processing is properly configured for mode: \(self.selectedMode.name)")
+        logger.logInfo("AI processing is properly configured for mode: \(mode.name)")
         return true
     }
 

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -733,13 +733,18 @@ class AIService {
 
     /// Returns true when the current mode can produce incremental text updates.
     public var currentModeSupportsResponseStreaming: Bool {
-        guard selectedMode.aiEnhanceEnabled,
-              let aiProvider = selectedMode.aiProvider,
-              !selectedMode.aiModel.isEmpty else {
+        supportsResponseStreaming(for: selectedMode)
+    }
+
+    /// Returns true when the supplied mode can produce incremental text updates.
+    public func supportsResponseStreaming(for mode: VivaMode) -> Bool {
+        guard mode.aiEnhanceEnabled,
+              let aiProvider = mode.aiProvider,
+              !mode.aiModel.isEmpty else {
             return false
         }
 
-        return resolvedStreamingRoute(for: aiProvider) != nil
+        return resolvedStreamingRoute(for: aiProvider, mode: mode) != nil
     }
 
     // MARK: - Enhance methods
@@ -765,7 +770,7 @@ class AIService {
         }
 
         do {
-            var result = try await makeRequest(text: text)
+            var result = try await makeRequest(text: text, mode: selectedMode)
             let isAssistantPreset = selectedMode.presetId == "assistant"
             if isAssistantPreset, selectedMode.isAutoTextFormattingEnabled {
                 result = TextFormatter.format(result)
@@ -789,13 +794,18 @@ class AIService {
     /// - Parameters:
     ///   - text: The original transcription text to process.
     ///   - preset: The preset containing the prompt instructions.
+    ///   - modeOverride: Optional mode whose AI provider/model is used for this single
+    ///     request instead of the currently selected mode. The override does not
+    ///     persist or change `selectedMode`.
     /// - Returns: A tuple of the generated text and processing duration.
     public func generateVariation(
         text: String,
         preset: Preset,
+        modeOverride: VivaMode? = nil,
         onPartialResult: (@MainActor (String) -> Void)? = nil
     ) async throws -> (String, TimeInterval) {
         let startTime = Date()
+        let mode = modeOverride ?? selectedMode
 
         let (systemMessage, formattedText) = buildVariationMessages(text: text, preset: preset)
 
@@ -803,9 +813,10 @@ class AIService {
         lastUserMessageSent = formattedText
 
         let requestResult: String
-        if let onPartialResult, currentModeSupportsResponseStreaming {
+        if let onPartialResult, supportsResponseStreaming(for: mode) {
             requestResult = try await makeStreamingRequest(
                 text: text,
+                mode: mode,
                 systemMessage: systemMessage,
                 preFormattedUserMessage: formattedText,
                 appleFMPresetID: preset.id,
@@ -814,6 +825,7 @@ class AIService {
         } else {
             requestResult = try await makeRequest(
                 text: text,
+                mode: mode,
                 systemMessage: systemMessage,
                 preFormattedUserMessage: formattedText,
                 appleFMPresetID: preset.id
@@ -821,7 +833,7 @@ class AIService {
         }
 
         var result = requestResult
-        if preset.id == "assistant", selectedMode.isAutoTextFormattingEnabled {
+        if preset.id == "assistant", mode.isAutoTextFormattingEnabled {
             result = TextFormatter.format(result)
         }
         let duration = Date().timeIntervalSince(startTime)
@@ -830,8 +842,8 @@ class AIService {
         AnalyticsService.track(.variationGenerated(
             presetId: preset.isBuiltIn ? preset.id : "custom",
             isBuiltInPreset: preset.isBuiltIn,
-            provider: selectedMode.aiProvider?.rawValue ?? "unknown",
-            model: selectedMode.aiModel,
+            provider: mode.aiProvider?.rawValue ?? "unknown",
+            model: mode.aiModel,
             durationSeconds: duration,
             outputLength: result.count
         ))
@@ -890,7 +902,7 @@ class AIService {
         return (systemMessage, userMessage)
     }
 
-    private func resolvedStreamingRoute(for aiProvider: AIProvider) -> StreamingRoute? {
+    private func resolvedStreamingRoute(for aiProvider: AIProvider, mode: VivaMode) -> StreamingRoute? {
         switch aiProvider {
         case .apple:
             return .apple
@@ -902,7 +914,7 @@ class AIService {
                let serverURL = VivAgentsClient.serverURL, !serverURL.isEmpty {
                 return nil
             }
-            return aiProvider.supportsResponseStreaming(model: selectedMode.aiModel) ? .openAICompatibleCloud : nil
+            return aiProvider.supportsResponseStreaming(model: mode.aiModel) ? .openAICompatibleCloud : nil
         case .gemini:
             if isGeminiSignedIn {
                 return .geminiOAuth
@@ -911,7 +923,7 @@ class AIService {
                let serverURL = VivAgentsClient.serverURL, !serverURL.isEmpty {
                 return nil
             }
-            return aiProvider.supportsResponseStreaming(model: selectedMode.aiModel) ? .openAICompatibleCloud : nil
+            return aiProvider.supportsResponseStreaming(model: mode.aiModel) ? .openAICompatibleCloud : nil
         case .anthropic:
             if VivAgentsClient.isEnabled && VivAgentsClient.isAnthropicCliActive,
                let serverURL = VivAgentsClient.serverURL, !serverURL.isEmpty {
@@ -925,7 +937,7 @@ class AIService {
         case .customOpenAI:
             return .customOpenAI
         default:
-            return aiProvider.supportsResponseStreaming(model: selectedMode.aiModel) ? .openAICompatibleCloud : nil
+            return aiProvider.supportsResponseStreaming(model: mode.aiModel) ? .openAICompatibleCloud : nil
         }
     }
 
@@ -1087,6 +1099,7 @@ class AIService {
         systemMessage: String,
         userMessage: String,
         apiKey: String,
+        model: String,
         onPartialResponse: @escaping @MainActor (String) -> Void
     ) async throws -> String {
         var request = URLRequest(url: URL(string: AIProvider.anthropic.baseURL)!)
@@ -1098,7 +1111,7 @@ class AIService {
         request.timeoutInterval = baseTimeout
 
         let requestBody: [String: Any] = [
-            "model": selectedMode.aiModel,
+            "model": model,
             "max_tokens": 8192,
             "system": systemMessage,
             "messages": [
@@ -1177,12 +1190,13 @@ class AIService {
 
     private func makeStreamingRequest(
         text: String,
+        mode: VivaMode,
         systemMessage: String? = nil,
         preFormattedUserMessage: String? = nil,
         appleFMPresetID: String? = nil,
         onPartialResponse: @escaping @MainActor (String) -> Void
     ) async throws -> String {
-        guard let aiProvider = self.selectedMode.aiProvider else {
+        guard let aiProvider = mode.aiProvider else {
             throw EnhancementError.notConfigured
         }
 
@@ -1196,11 +1210,11 @@ class AIService {
         lastSystemMessageSent = sysMsg
         lastUserMessageSent = userMsg
 
-        switch resolvedStreamingRoute(for: aiProvider) {
+        switch resolvedStreamingRoute(for: aiProvider, mode: mode) {
         case .apple:
             if #available(iOS 26, *) {
                 let samplingProfile = AppleFoundationModelSamplingProfile.profile(
-                    for: appleFMPresetID ?? selectedMode.presetId
+                    for: appleFMPresetID ?? mode.presetId
                 )
                 logger.logDebug("AI Processing - Using Apple Foundation Model streaming")
                 logger.logDebug("AI Processing - System Message: \(sysMsg)")
@@ -1220,17 +1234,18 @@ class AIService {
             }
 
             logger.logDebug("AI Processing - Using Anthropic streaming")
-            logger.logDebug("AI Processing - Model: \(self.selectedMode.aiModel)")
+            logger.logDebug("AI Processing - Model: \(mode.aiModel)")
 
             return try await makeAnthropicStreamingRequest(
                 systemMessage: sysMsg,
                 userMessage: userMsg,
                 apiKey: apiKey,
+                model: mode.aiModel,
                 onPartialResponse: onPartialResponse
             )
         case .copilot:
             let token = try await CopilotOAuthManager.shared.validCopilotToken()
-            let model = selectedMode.aiModel.isEmpty ? CopilotAPIClient.defaultModel : selectedMode.aiModel
+            let model = mode.aiModel.isEmpty ? CopilotAPIClient.defaultModel : mode.aiModel
             let result = try await CopilotAPIClient.enhanceStreaming(
                 text: userMsg,
                 systemPrompt: sysMsg,
@@ -1243,7 +1258,7 @@ class AIService {
             do {
                 let provider = GeminiOAuthProvider()
                 let (token, _, projectId) = try await OAuthManager.shared.validAccessToken(for: provider)
-                let model = selectedMode.aiModel.isEmpty ? GeminiAPIClient.defaultModel : selectedMode.aiModel
+                let model = mode.aiModel.isEmpty ? GeminiAPIClient.defaultModel : mode.aiModel
                 let result = try await GeminiAPIClient.enhanceStreaming(
                     text: userMsg,
                     systemPrompt: sysMsg,
@@ -1267,7 +1282,7 @@ class AIService {
             do {
                 let provider = OpenAIOAuthProvider()
                 let (token, accountId, _) = try await OAuthManager.shared.validAccessToken(for: provider)
-                let model = selectedMode.aiModel.isEmpty ? OpenAIOAuthClient.defaultModel : selectedMode.aiModel
+                let model = mode.aiModel.isEmpty ? OpenAIOAuthClient.defaultModel : mode.aiModel
                 let result = try await OpenAIOAuthClient.enhance(
                     text: userMsg,
                     systemPrompt: sysMsg,
@@ -1291,11 +1306,11 @@ class AIService {
             }
 
             logger.logDebug("AI Processing - Using \(aiProvider.displayName) streaming")
-            logger.logDebug("AI Processing - Model: \(self.selectedMode.aiModel)")
+            logger.logDebug("AI Processing - Model: \(mode.aiModel)")
 
             return try await makeOpenAICompatibleStreamingRequest(
                 url: URL(string: aiProvider.baseURL)!,
-                modelName: selectedMode.aiModel,
+                modelName: mode.aiModel,
                 systemMessage: sysMsg,
                 userMessage: userMsg,
                 headers: ["Authorization": "Bearer \(apiKey)"],
@@ -1310,17 +1325,17 @@ class AIService {
             }
 
             logger.logDebug("AI Processing - Using Ollama streaming at \(serverURL)")
-            logger.logDebug("AI Processing - Model: \(self.selectedMode.aiModel)")
+            logger.logDebug("AI Processing - Model: \(mode.aiModel)")
 
             return try await makeOpenAICompatibleStreamingRequest(
                 url: url,
-                modelName: selectedMode.aiModel,
+                modelName: mode.aiModel,
                 systemMessage: sysMsg,
                 userMessage: userMsg,
                 headers: [:],
                 timeout: 120,
                 errorPrefix: "Ollama error",
-                notFoundMessage: "Model '\(self.selectedMode.aiModel)' not found. Run 'ollama pull \(self.selectedMode.aiModel)' on your Mac/server to download it.",
+                notFoundMessage: "Model '\(mode.aiModel)' not found. Run 'ollama pull \(mode.aiModel)' on your Mac/server to download it.",
                 onPartialResponse: onPartialResponse
             )
         case .customOpenAI:
@@ -1365,6 +1380,7 @@ class AIService {
 
         let result = try await makeRequest(
             text: text,
+            mode: mode,
             systemMessage: systemMessage,
             preFormattedUserMessage: preFormattedUserMessage
         )
@@ -1374,11 +1390,12 @@ class AIService {
 
     private func makeRequest(
         text: String,
+        mode: VivaMode,
         systemMessage: String? = nil,
         preFormattedUserMessage: String? = nil,
         appleFMPresetID: String? = nil
     ) async throws -> String {
-        guard let aiProvider = self.selectedMode.aiProvider else {
+        guard let aiProvider = mode.aiProvider else {
             throw EnhancementError.notConfigured
         }
 
@@ -1386,13 +1403,13 @@ class AIService {
             return ""
         }
 
-        // Handle Apple Foundation Model (on-device) — same prompt as cloud providers
+        // Handle Apple Foundation Model (on-device) - same prompt as cloud providers
         if aiProvider == .apple {
             if #available(iOS 26, *) {
                 let sysMsg = systemMessage ?? getSystemMessage()
                 let userMsg = preFormattedUserMessage ?? formatTranscriptForLLM(text)
                 let samplingProfile = AppleFoundationModelSamplingProfile.profile(
-                    for: appleFMPresetID ?? selectedMode.presetId
+                    for: appleFMPresetID ?? mode.presetId
                 )
                 logger.logDebug("AI Processing - Using Apple Foundation Model")
                 logger.logDebug("AI Processing - System Message: \(sysMsg)")
@@ -1411,7 +1428,7 @@ class AIService {
 
         // Handle Ollama (local server)
         if aiProvider == .ollama {
-            return try await makeOllamaRequest(text: text, systemMessage: systemMessage, preFormattedUserMessage: preFormattedUserMessage)
+            return try await makeOllamaRequest(text: text, mode: mode, systemMessage: systemMessage, preFormattedUserMessage: preFormattedUserMessage)
         }
 
         // Handle Custom OpenAI (user-configured endpoint)
@@ -1433,7 +1450,7 @@ class AIService {
                 let result = try await VivAgentsClient.enhance(
                     text: formattedText,
                     systemPrompt: resolvedSystemMessage,
-                    model: selectedMode.aiModel
+                    model: mode.aiModel
                 )
                 let filteredResult = AIEnhancementOutputFilter.filter(result.trimmingCharacters(in: .whitespacesAndNewlines))
                 return filteredResult
@@ -1457,7 +1474,7 @@ class AIService {
             do {
                 let provider = OpenAIOAuthProvider()
                 let (token, accountId, _) = try await OAuthManager.shared.validAccessToken(for: provider)
-                let model = selectedMode.aiModel.isEmpty ? OpenAIOAuthClient.defaultModel : selectedMode.aiModel
+                let model = mode.aiModel.isEmpty ? OpenAIOAuthClient.defaultModel : mode.aiModel
                 let result = try await OpenAIOAuthClient.enhance(
                     text: formattedText,
                     systemPrompt: resolvedSystemMessage,
@@ -1483,7 +1500,7 @@ class AIService {
             do {
                 let provider = GeminiOAuthProvider()
                 let (token, _, projectId) = try await OAuthManager.shared.validAccessToken(for: provider)
-                let model = selectedMode.aiModel.isEmpty ? GeminiAPIClient.defaultModel : selectedMode.aiModel
+                let model = mode.aiModel.isEmpty ? GeminiAPIClient.defaultModel : mode.aiModel
                 let result = try await GeminiAPIClient.enhance(
                     text: formattedText,
                     systemPrompt: resolvedSystemMessage,
@@ -1493,7 +1510,7 @@ class AIService {
                 )
                 return AIEnhancementOutputFilter.filter(result)
             } catch let error as EnhancementError {
-                // Rate limit etc. — don't fall through, surface directly
+                // Rate limit etc. - don't fall through, surface directly
                 throw error
             } catch let error as OAuthError {
                 // If OAuth fails, fall through to CLI or API key
@@ -1515,7 +1532,7 @@ class AIService {
                 let result = try await VivAgentsClient.enhance(
                     text: formattedText,
                     systemPrompt: resolvedSystemMessage,
-                    model: selectedMode.aiModel,
+                    model: mode.aiModel,
                     provider: "codex"
                 )
                 let filteredResult = AIEnhancementOutputFilter.filter(result.trimmingCharacters(in: .whitespacesAndNewlines))
@@ -1539,7 +1556,7 @@ class AIService {
                 let result = try await VivAgentsClient.enhance(
                     text: formattedText,
                     systemPrompt: resolvedSystemMessage,
-                    model: selectedMode.aiModel,
+                    model: mode.aiModel,
                     provider: "gemini"
                 )
                 let filteredResult = AIEnhancementOutputFilter.filter(result.trimmingCharacters(in: .whitespacesAndNewlines))
@@ -1559,7 +1576,7 @@ class AIService {
             lastUserMessageSent = formattedText
             do {
                 let token = try await CopilotOAuthManager.shared.validCopilotToken()
-                let model = selectedMode.aiModel.isEmpty ? CopilotAPIClient.defaultModel : selectedMode.aiModel
+                let model = mode.aiModel.isEmpty ? CopilotAPIClient.defaultModel : mode.aiModel
                 let result = try await CopilotAPIClient.enhance(
                     text: formattedText,
                     systemPrompt: resolvedSystemMessage,
@@ -1589,7 +1606,7 @@ class AIService {
         switch aiProvider {
         case .anthropic:
             let requestBody: [String: Any] = [
-                "model": selectedMode.aiModel,
+                "model": mode.aiModel,
                 "max_tokens": 8192,
                 "system": resolvedSystemMessage,
                 "messages": [
@@ -1657,7 +1674,7 @@ class AIService {
             request.timeoutInterval = baseTimeout
 
             let requestBody = buildOpenAICompatibleRequestBody(
-                modelName: selectedMode.aiModel,
+                modelName: mode.aiModel,
                 systemMessage: resolvedSystemMessage,
                 userMessage: formattedText,
                 stream: false
@@ -1761,7 +1778,7 @@ class AIService {
     // MARK: - Ollama Methods
 
     /// Makes an enhancement request to the local Ollama server
-    private func makeOllamaRequest(text: String, systemMessage: String? = nil, preFormattedUserMessage: String? = nil) async throws -> String {
+    private func makeOllamaRequest(text: String, mode: VivaMode, systemMessage: String? = nil, preFormattedUserMessage: String? = nil) async throws -> String {
         let serverURL = ollamaServerURL
         guard let url = URL(string: "\(serverURL)/v1/chat/completions") else {
             throw EnhancementError.customError("Invalid Ollama server URL: \(serverURL)")
@@ -1775,7 +1792,7 @@ class AIService {
         lastUserMessageSent = formattedText
 
         logger.logDebug("AI Processing - Using Ollama at \(serverURL)")
-        logger.logDebug("AI Processing - Model: \(self.selectedMode.aiModel)")
+        logger.logDebug("AI Processing - Model: \(mode.aiModel)")
         logger.logDebug("AI Processing - System Message: \(systemMessage)")
         logger.logDebug("AI Processing - User Message: \(formattedText)")
 
@@ -1786,7 +1803,7 @@ class AIService {
         request.timeoutInterval = 120 // Longer timeout for local inference
 
         let finalRequestBody = buildOpenAICompatibleRequestBody(
-            modelName: selectedMode.aiModel,
+            modelName: mode.aiModel,
             systemMessage: systemMessage,
             userMessage: formattedText,
             stream: false
@@ -1819,7 +1836,7 @@ class AIService {
                 return filteredText
 
             case 404:
-                throw EnhancementError.customError("Model '\(self.selectedMode.aiModel)' not found. Run 'ollama pull \(self.selectedMode.aiModel)' on your Mac/server to download it.")
+                throw EnhancementError.customError("Model '\(mode.aiModel)' not found. Run 'ollama pull \(mode.aiModel)' on your Mac/server to download it.")
 
             case 500...599:
                 throw EnhancementError.serverError

--- a/VivaDicta/Views/TranscriptionDetailView.swift
+++ b/VivaDicta/Views/TranscriptionDetailView.swift
@@ -88,6 +88,14 @@ struct TranscriptionDetailView: View {
         appState.aiService.isProperlyConfigured()
     }
 
+    private var hasAnyAIEnabledMode: Bool {
+        appState.aiService.modes.contains { mode in
+            mode.aiEnhanceEnabled
+                && mode.aiProvider != nil
+                && !mode.aiModel.isEmpty
+        }
+    }
+
     private var pendingReminderDraftCount: Int {
         transcription.pendingExtractedReminderDraftCount
     }
@@ -406,6 +414,17 @@ struct TranscriptionDetailView: View {
             PresetPickerSheet(
                 presetManager: appState.presetManager,
                 existingVariationIds: Set(sortedVariations.map(\.presetId)),
+                activeMode: appState.aiService.selectedMode,
+                availableModes: appState.aiService.modes.filter { mode in
+                    mode.aiEnhanceEnabled
+                        && mode.aiProvider != nil
+                        && !mode.aiModel.isEmpty
+                },
+                activeModeIsAIConfigured: isAIConfigured,
+                onOpenSettings: {
+                    showPresetPicker = false
+                    appState.shouldNavigateToModeSettings = true
+                },
                 onReviewExtractedTasks: pendingReminderDraftCount > 0 ? {
                     showPresetPicker = false
                     showExtractedRemindersSheet = true
@@ -414,9 +433,9 @@ struct TranscriptionDetailView: View {
                     showPresetPicker = false
                     extractReminderSuggestions()
                 } : nil,
-                onSelect: { preset in
+                onSelect: { preset, modeOverride in
                     showPresetPicker = false
-                    generateVariation(preset: preset)
+                    generateVariation(preset: preset, modeOverride: modeOverride)
                 }
             )
             .presentationDetents([.medium, .large])
@@ -701,7 +720,7 @@ struct TranscriptionDetailView: View {
                 // Button 2: AI Presets picker
                 Button {
                     HapticManager.lightImpact()
-                    if isAIConfigured {
+                    if isAIConfigured || hasAnyAIEnabledMode {
                         showPresetPicker = true
                     } else {
                         showConfigureAI = true
@@ -995,7 +1014,7 @@ struct TranscriptionDetailView: View {
 
     private var addVariationButton: some View {
         Button {
-            if isAIConfigured {
+            if isAIConfigured || hasAnyAIEnabledMode {
                 showPresetPicker = true
             } else {
                 showConfigureAI = true
@@ -1049,8 +1068,9 @@ struct TranscriptionDetailView: View {
         }
     }
 
-    private func generateVariation(preset: Preset) {
-        let shouldStreamResponse = appState.aiService.currentModeSupportsResponseStreaming
+    private func generateVariation(preset: Preset, modeOverride: VivaMode? = nil) {
+        let mode = modeOverride ?? appState.aiService.selectedMode
+        let shouldStreamResponse = appState.aiService.supportsResponseStreaming(for: mode)
         generatingPresetId = preset.id
         streamingVariationPresetId = shouldStreamResponse ? preset.id : nil
         streamingVariationText = ""
@@ -1072,6 +1092,7 @@ struct TranscriptionDetailView: View {
                     (resultText, duration) = try await appState.aiService.generateVariation(
                         text: transcription.text,
                         preset: preset,
+                        modeOverride: modeOverride,
                         onPartialResult: { partialText in
                             let previousText = streamingVariationText
                             if previousText.isEmpty, partialText.isEmpty == false {
@@ -1085,7 +1106,8 @@ struct TranscriptionDetailView: View {
                 } else {
                     (resultText, duration) = try await appState.aiService.generateVariation(
                         text: transcription.text,
-                        preset: preset
+                        preset: preset,
+                        modeOverride: modeOverride
                     )
                 }
 
@@ -1093,8 +1115,8 @@ struct TranscriptionDetailView: View {
                 if let existing = sortedVariations.first(where: { $0.presetId == preset.id }) {
                     existing.text = resultText
                     existing.createdAt = Date()
-                    existing.aiModelName = appState.aiService.selectedMode.aiModel
-                    existing.aiProviderName = appState.aiService.selectedMode.aiProvider?.displayName
+                    existing.aiModelName = mode.aiModel
+                    existing.aiProviderName = mode.aiProvider?.displayName
                     existing.processingDuration = duration
                     existing.aiRequestSystemMessage = appState.aiService.lastSystemMessageSent
                     existing.aiRequestUserMessage = appState.aiService.lastUserMessageSent
@@ -1103,8 +1125,8 @@ struct TranscriptionDetailView: View {
                         presetId: preset.id,
                         presetDisplayName: preset.name,
                         text: resultText,
-                        aiModelName: appState.aiService.selectedMode.aiModel,
-                        aiProviderName: appState.aiService.selectedMode.aiProvider?.displayName,
+                        aiModelName: mode.aiModel,
+                        aiProviderName: mode.aiProvider?.displayName,
                         processingDuration: duration,
                         aiRequestSystemMessage: appState.aiService.lastSystemMessageSent,
                         aiRequestUserMessage: appState.aiService.lastUserMessageSent
@@ -1351,13 +1373,36 @@ private struct MetaInfoSheet: View {
 private struct PresetPickerSheet: View {
     let presetManager: PresetManager
     let existingVariationIds: Set<String>
+    let activeMode: VivaMode
+    let availableModes: [VivaMode]
+    let activeModeIsAIConfigured: Bool
+    let onOpenSettings: () -> Void
     let onReviewExtractedTasks: (() -> Void)?
     let onExtractTasks: (() -> Void)?
-    let onSelect: (Preset) -> Void
+    let onSelect: (Preset, VivaMode?) -> Void
 
     @State private var filter: PresetFilter = .all
     @State private var selectedCategory: String?
     @State private var searchText = ""
+    @State private var overrideModeId: UUID?
+
+    private var overrideMode: VivaMode? {
+        guard let overrideModeId else { return nil }
+        return availableModes.first { $0.id == overrideModeId }
+    }
+
+    private var effectiveModeName: String {
+        overrideMode?.name ?? activeMode.name
+    }
+
+    private var canShowPresets: Bool {
+        activeModeIsAIConfigured || overrideMode != nil
+    }
+
+    private var hasOverrideOptions: Bool {
+        availableModes.contains { $0.id != activeMode.id }
+            || (availableModes.count >= 1 && !activeModeIsAIConfigured)
+    }
 
     private var typeFilteredPresets: [Preset] {
         let byType: [Preset] = switch filter {
@@ -1400,8 +1445,57 @@ private struct PresetPickerSheet: View {
 
     var body: some View {
         NavigationStack {
-            List {
-                if filter == .system, let onExtractTasks {
+            Group {
+                if canShowPresets {
+                    presetList
+                } else {
+                    notConfiguredView
+                }
+            }
+            .navigationTitle("AI Actions")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                if hasOverrideOptions {
+                    ToolbarItem(placement: .topBarLeading) {
+                        modeOverrideMenu
+                    }
+                }
+            }
+        }
+    }
+
+    private var notConfiguredView: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "sparkles")
+                .font(.system(size: 40))
+                .foregroundStyle(.secondary)
+
+            Text("AI Processing Not Configured")
+                .font(.title3.bold())
+
+            Text("Set up an AI provider in your mode settings to use AI text processing.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal)
+
+            Button {
+                onOpenSettings()
+            } label: {
+                Text("Open Mode Settings")
+                    .font(.headline)
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .padding(.horizontal, 40)
+        }
+        .padding(.vertical, 24)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var presetList: some View {
+        List {
+            if filter == .system, let onExtractTasks {
                     Section("Smart Actions") {
                         if let onReviewExtractedTasks {
                             Button {
@@ -1507,15 +1601,58 @@ private struct PresetPickerSheet: View {
                     selectedCategory = nil
                 }
             }
-            .navigationTitle("AI Actions")
-            .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private var modeOverrideMenu: some View {
+        Menu {
+            Button {
+                overrideModeId = nil
+            } label: {
+                if overrideModeId == nil {
+                    Label(activeMode.name, systemImage: "checkmark")
+                } else {
+                    Text(activeMode.name)
+                }
+            }
+
+            ForEach(availableModes.filter { $0.id != activeMode.id }) { mode in
+                Button {
+                    overrideModeId = mode.id
+                } label: {
+                    if overrideModeId == mode.id {
+                        Label(mode.name, systemImage: "checkmark")
+                    } else {
+                        Text(mode.name)
+                    }
+                }
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: "brain")
+                    .font(.caption2)
+                Text(effectiveModeName)
+                    .font(.caption)
+                    .lineLimit(1)
+                Image(systemName: "chevron.down")
+                    .font(.caption2)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .background(
+                Capsule()
+                    .fill(overrideModeId == nil ? Color(.systemGray5) : Color.accentColor.opacity(0.18))
+            )
+            .foregroundStyle(overrideModeId == nil ? Color.primary : Color.accentColor)
+            .frame(maxWidth: 160)
         }
+        .accessibilityLabel("AI mode override")
+        .accessibilityValue(effectiveModeName)
     }
 
     private func presetRow(_ preset: Preset) -> some View {
         let exists = existingVariationIds.contains(preset.id)
         return Button {
-            onSelect(preset)
+            onSelect(preset, overrideMode)
         } label: {
             HStack(spacing: 10) {
                 if !preset.isBuiltIn {

--- a/VivaDicta/Views/TranscriptionDetailView.swift
+++ b/VivaDicta/Views/TranscriptionDetailView.swift
@@ -90,9 +90,7 @@ struct TranscriptionDetailView: View {
 
     private var hasAnyAIEnabledMode: Bool {
         appState.aiService.modes.contains { mode in
-            mode.aiEnhanceEnabled
-                && mode.aiProvider != nil
-                && !mode.aiModel.isEmpty
+            appState.aiService.isProperlyConfigured(for: mode, requirePreset: false)
         }
     }
 
@@ -416,9 +414,7 @@ struct TranscriptionDetailView: View {
                 existingVariationIds: Set(sortedVariations.map(\.presetId)),
                 activeMode: appState.aiService.selectedMode,
                 availableModes: appState.aiService.modes.filter { mode in
-                    mode.aiEnhanceEnabled
-                        && mode.aiProvider != nil
-                        && !mode.aiModel.isEmpty
+                    appState.aiService.isProperlyConfigured(for: mode, requirePreset: false)
                 },
                 activeModeIsAIConfigured: isAIConfigured,
                 onOpenSettings: {
@@ -1401,7 +1397,6 @@ private struct PresetPickerSheet: View {
 
     private var hasOverrideOptions: Bool {
         availableModes.contains { $0.id != activeMode.id }
-            || (availableModes.count >= 1 && !activeModeIsAIConfigured)
     }
 
     private var typeFilteredPresets: [Preset] {
@@ -1496,32 +1491,10 @@ private struct PresetPickerSheet: View {
     private var presetList: some View {
         List {
             if filter == .system, let onExtractTasks {
-                    Section("Smart Actions") {
-                        if let onReviewExtractedTasks {
-                            Button {
-                                onReviewExtractedTasks()
-                            } label: {
-                                HStack(spacing: 10) {
-                                    Image(systemName: "checklist")
-                                        .frame(width: 20)
-                                        .foregroundStyle(.secondary)
-
-                                    VStack(alignment: .leading, spacing: 2) {
-                                        Text("Review Reminder Suggestions")
-                                            .font(.body)
-                                        Text("Open the reminder suggestions already extracted from this note.")
-                                            .font(.caption)
-                                            .foregroundStyle(.secondary)
-                                    }
-
-                                    Spacer()
-                                }
-                            }
-                            .tint(.primary)
-                        }
-
+                Section("Smart Actions") {
+                    if let onReviewExtractedTasks {
                         Button {
-                            onExtractTasks()
+                            onReviewExtractedTasks()
                         } label: {
                             HStack(spacing: 10) {
                                 Image(systemName: "checklist")
@@ -1529,9 +1502,9 @@ private struct PresetPickerSheet: View {
                                     .foregroundStyle(.secondary)
 
                                 VStack(alignment: .leading, spacing: 2) {
-                                    Text("Extract Tasks to Reminders")
+                                    Text("Review Reminder Suggestions")
                                         .font(.body)
-                                    Text("Find reminder suggestions in this note and review them before importing to Apple Reminders.")
+                                    Text("Open the reminder suggestions already extracted from this note.")
                                         .font(.caption)
                                         .foregroundStyle(.secondary)
                                 }
@@ -1541,66 +1514,88 @@ private struct PresetPickerSheet: View {
                         }
                         .tint(.primary)
                     }
-                }
 
-                Section {
-                    Picker("Filter", selection: $filter) {
-                        ForEach(PresetFilter.allCases) { filter in
-                            Text(filter.title).tag(filter)
-                        }
-                    }
-                    .pickerStyle(.segmented)
-                    .listRowInsets(EdgeInsets())
-                    .listRowBackground(Color.clear)
+                    Button {
+                        onExtractTasks()
+                    } label: {
+                        HStack(spacing: 10) {
+                            Image(systemName: "checklist")
+                                .frame(width: 20)
+                                .foregroundStyle(.secondary)
 
-                    CategoryChipsView(
-                        categories: allCategories,
-                        selectedCategory: $selectedCategory,
-                        showFavorites: presetManager.hasVisibleFavorites
-                    )
-                    .listRowInsets(EdgeInsets())
-                    .listRowBackground(Color.clear)
-                }
-                .listSectionSpacing(0)
-
-                if typeFilteredPresets.isEmpty {
-                    ContentUnavailableView {
-                        Label(searchText.isEmpty ? "No Visible Presets" : "No Presets Found", systemImage: "eye.slash")
-                    } description: {
-                        Text(searchText.isEmpty
-                             ? "Unhide presets in AI Presets to show them here."
-                             : "Try a different search or filter.")
-                    }
-                } else {
-                    if selectedCategory == nil {
-                        let favorites = typeFilteredPresets.filter(\.isFavorite)
-                        if !favorites.isEmpty {
-                            Section("Favorites") {
-                                ForEach(favorites) { preset in
-                                    presetRow(preset)
-                                }
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text("Extract Tasks to Reminders")
+                                    .font(.body)
+                                Text("Find reminder suggestions in this note and review them before importing to Apple Reminders.")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
                             }
+
+                            Spacer()
                         }
                     }
+                    .tint(.primary)
+                }
+            }
 
-                    ForEach(filteredCategories, id: \.self) { category in
-                        Section(category) {
-                            ForEach(filteredPresets.filter { $0.category == category }) { preset in
+            Section {
+                Picker("Filter", selection: $filter) {
+                    ForEach(PresetFilter.allCases) { filter in
+                        Text(filter.title).tag(filter)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .listRowInsets(EdgeInsets())
+                .listRowBackground(Color.clear)
+
+                CategoryChipsView(
+                    categories: allCategories,
+                    selectedCategory: $selectedCategory,
+                    showFavorites: presetManager.hasVisibleFavorites
+                )
+                .listRowInsets(EdgeInsets())
+                .listRowBackground(Color.clear)
+            }
+            .listSectionSpacing(0)
+
+            if typeFilteredPresets.isEmpty {
+                ContentUnavailableView {
+                    Label(searchText.isEmpty ? "No Visible Presets" : "No Presets Found", systemImage: "eye.slash")
+                } description: {
+                    Text(searchText.isEmpty
+                         ? "Unhide presets in AI Presets to show them here."
+                         : "Try a different search or filter.")
+                }
+            } else {
+                if selectedCategory == nil {
+                    let favorites = typeFilteredPresets.filter(\.isFavorite)
+                    if !favorites.isEmpty {
+                        Section("Favorites") {
+                            ForEach(favorites) { preset in
                                 presetRow(preset)
                             }
                         }
                     }
                 }
-            }
-            .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always), prompt: "Search presets")
-            .onChange(of: filter) { _, _ in
-                selectedCategory = nil
-            }
-            .onChange(of: presetManager.hasVisibleFavorites) {
-                if !presetManager.hasVisibleFavorites && selectedCategory == CategoryChipsView.favoritesFilter {
-                    selectedCategory = nil
+
+                ForEach(filteredCategories, id: \.self) { category in
+                    Section(category) {
+                        ForEach(filteredPresets.filter { $0.category == category }) { preset in
+                            presetRow(preset)
+                        }
+                    }
                 }
             }
+        }
+        .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always), prompt: "Search presets")
+        .onChange(of: filter) { _, _ in
+            selectedCategory = nil
+        }
+        .onChange(of: presetManager.hasVisibleFavorites) {
+            if !presetManager.hasVisibleFavorites && selectedCategory == CategoryChipsView.favoritesFilter {
+                selectedCategory = nil
+            }
+        }
     }
 
     private var modeOverrideMenu: some View {
@@ -1640,7 +1635,7 @@ private struct PresetPickerSheet: View {
             .padding(.vertical, 5)
             .background(
                 Capsule()
-                    .fill(overrideModeId == nil ? Color(.systemGray5) : Color.accentColor.opacity(0.18))
+                    .fill(overrideModeId == nil ? Color(uiColor: .systemGray5) : Color.accentColor.opacity(0.18))
             )
             .foregroundStyle(overrideModeId == nil ? Color.primary : Color.accentColor)
             .frame(maxWidth: 160)


### PR DESCRIPTION
## Summary
- Adds a mode chip in the top-left of the AI Actions sheet so the user can swap the AI brain (provider/model) for a single preset tap without touching the active mode. Override is local to the sheet and resets on dismiss.
- When the active mode has no AI configured but other AI-enabled modes exist, the sheet opens directly into the existing "AI Processing Not Configured" empty state with the chip available. Picking an override mode swaps the body to the preset list and hides the "Open Mode Settings" button.
- The legacy `ConfigureAISheet` only appears in the cold-start case where no mode anywhere has AI configured.

## Implementation notes
- `AIService.makeRequest` / `makeStreamingRequest` and request-path helpers (`makeOllamaRequest`, `makeAnthropicStreamingRequest`, `resolvedStreamingRoute`) now thread an explicit `mode: VivaMode` parameter instead of reading `selectedMode`. The observable `selectedMode` is never mutated for an override, so SwiftUI observers do not flicker mid-request.
- `generateVariation(text:preset:modeOverride:onPartialResult:)` accepts an optional override and falls back to `selectedMode` when nil. `enhance(_:)` continues to pass `selectedMode` through.
- New public `supportsResponseStreaming(for: VivaMode) -> Bool`; `currentModeSupportsResponseStreaming` becomes a wrapper.
- `TranscriptionVariation` records the override mode's `aiModel` and `aiProvider` so history attribution is correct when comparing outputs.

## Test plan
- [ ] Build clean on iPhone 17 Pro Max simulator (verified locally).
- [ ] Active mode has AI: open AI Actions sheet, confirm chip shows "Default" gray; pick a different mode, confirm chip turns accent-tinted.
- [ ] Tap a preset with override active; confirm the resulting variation chip displays the override mode's model/provider in metadata.
- [ ] Active mode lacks AI but another mode has AI: tap AI button, confirm "Not Configured" copy + Open Mode Settings + chip in corner. Pick override -> body morphs to preset list, button disappears. Pick "Default" again -> reverts to empty state.
- [ ] No mode has AI anywhere: tap AI button, confirm legacy `ConfigureAISheet` (no chip) still appears.
- [ ] Streaming providers still stream when override picks a streaming-capable model; non-streaming fallback works otherwise.
- [ ] Regenerate-from-chip path (no override) still uses `selectedMode`.