### PR TITLE
Append with Voice style picker (Settings -> Advanced)

### DIFF
--- a/VivaDicta/Shared/UserDefaultsStorage.swift
+++ b/VivaDicta/Shared/UserDefaultsStorage.swift
@@ -87,6 +87,9 @@ enum UserDefaultsStorage {
         // Recording sheet visualization
         static let isASCIIOrbEnabled = "isASCIIOrbEnabled"
 
+        // Advanced settings
+        static let appendWithVoiceStyle = "appendWithVoiceStyle"
+
         // Notes filter
         static let savedNotesFilterSourceTags = "savedNotesFilterSourceTags"
         static let savedNotesFilterUserTagIds = "savedNotesFilterUserTagIds"

--- a/VivaDicta/Utils/Extensions/View+Ext.swift
+++ b/VivaDicta/Utils/Extensions/View+Ext.swift
@@ -259,6 +259,28 @@ extension View {
     }
 }
 
+// MARK: - Glass FAB Circle
+/// Floating action button background: regular interactive glass on iOS 26+, regular material fallback on older.
+struct GlassFABCircleModifier: ViewModifier {
+    var fallback: AnyShapeStyle
+
+    func body(content: Content) -> some View {
+        if #available(iOS 26, *) {
+            content
+                .glassEffect(.regular.interactive(), in: .circle)
+        } else {
+            content
+                .background(fallback, in: .circle)
+        }
+    }
+}
+
+extension View {
+    func glassFABCircle(fallback: some ShapeStyle = .regularMaterial) -> some View {
+        modifier(GlassFABCircleModifier(fallback: AnyShapeStyle(fallback)))
+    }
+}
+
 // MARK: - Glass Capsule
 /// Capsule background: interactive glass with optional tint on iOS 26+, solid fallback on older.
 struct GlassCapsuleModifier: ViewModifier {

--- a/VivaDicta/Views/SettingsScreen/AdvancedSettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/AdvancedSettingsView.swift
@@ -1,0 +1,72 @@
+//
+//  AdvancedSettingsView.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.05.08
+//
+
+import SwiftUI
+
+enum AppendWithVoiceStyle: String, CaseIterable, Identifiable {
+    case toolbar
+    case floatingButton
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .toolbar: "Toolbar"
+        case .floatingButton: "Floating Button"
+        }
+    }
+}
+
+struct AdvancedSettingsView: View {
+    @AppStorage(UserDefaultsStorage.Keys.appendWithVoiceStyle)
+    private var appendWithVoiceStyleRaw: String = AppendWithVoiceStyle.toolbar.rawValue
+
+    private var appendWithVoiceStyle: Binding<AppendWithVoiceStyle> {
+        Binding(
+            get: {
+                AppendWithVoiceStyle(rawValue: appendWithVoiceStyleRaw) ?? .toolbar
+            },
+            set: { newValue in
+                appendWithVoiceStyleRaw = newValue.rawValue
+            }
+        )
+    }
+
+    var body: some View {
+        Form {
+            Section {
+                VStack(alignment: .leading, spacing: 4) {
+                    Picker("Append with Voice", selection: appendWithVoiceStyle) {
+                        ForEach(AppendWithVoiceStyle.allCases) { style in
+                            Text(style.displayName).tag(style)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                    .tint(.primary)
+                    .onChange(of: appendWithVoiceStyle.wrappedValue) { _, _ in
+                        HapticManager.selectionChanged()
+                    }
+                    Text("Choose how to access the Append with Voice action on a note. Toolbar puts it inside the pencil menu in the bottom action bar; Floating Button shows a microphone shortcut in the bottom-right corner.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            } header: {
+                Text("Note Detail")
+            }
+        }
+        .navigationTitle("Advanced")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+#if DEBUG
+#Preview {
+    NavigationStack {
+        AdvancedSettingsView()
+    }
+}
+#endif

--- a/VivaDicta/Views/SettingsScreen/SettingsDestination.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsDestination.swift
@@ -27,4 +27,7 @@ enum SettingsDestination: Hashable {
 
     // Integrations
     case integrations
+
+    // Advanced
+    case advanced
 }

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -577,6 +577,16 @@ struct SettingsView: View {
                     }
                 }
 
+                Section("Advanced") {
+                    NavigationLink(value: SettingsDestination.advanced) {
+                        HStack {
+                            Image(systemName: "slider.horizontal.3")
+                                .foregroundStyle(.gray)
+                            Text("Advanced")
+                        }
+                    }
+                }
+
                 Section("Support") {
                     Link(destination: URL(string: "https://vivadicta.com/ios/docs")!) {
                         HStack {
@@ -687,6 +697,8 @@ struct SettingsView: View {
                     SmartSearchSettingsView()
                 case .integrations:
                     IntegrationsView()
+                case .advanced:
+                    AdvancedSettingsView()
                 }
             }
             .navigationDestination(for: Preset.self) { preset in

--- a/VivaDicta/Views/TranscriptionDetailView.swift
+++ b/VivaDicta/Views/TranscriptionDetailView.swift
@@ -42,6 +42,13 @@ struct TranscriptionDetailView: View {
     @State private var showExportErrorAlert: Bool = false
     @State private var exportErrorMessage: String = ""
 
+    @AppStorage(UserDefaultsStorage.Keys.appendWithVoiceStyle)
+    private var appendWithVoiceStyleRaw: String = AppendWithVoiceStyle.toolbar.rawValue
+
+    private var appendWithVoiceStyle: AppendWithVoiceStyle {
+        AppendWithVoiceStyle(rawValue: appendWithVoiceStyleRaw) ?? .toolbar
+    }
+
     // Ripple effect state for processing animations
     @State private var rippleEffectTimer: Timer?
     @State private var rippleEffectTrigger = false
@@ -368,6 +375,13 @@ struct TranscriptionDetailView: View {
                     .padding(.horizontal)
             }
         }
+        .overlay(alignment: .bottomTrailing) {
+            if appendWithVoiceStyle == .floatingButton {
+                voiceAppendFloatingButton
+                    .padding(.trailing, 16)
+                    .padding(.bottom, 12)
+            }
+        }
         .safeAreaInset(edge: .bottom) {
             if pendingReminderDraftCount > 0 {
                 HStack {
@@ -676,6 +690,23 @@ struct TranscriptionDetailView: View {
 
     // MARK: - Bottom Action Bar
 
+    @ViewBuilder
+    private var voiceAppendFloatingButton: some View {
+        Button {
+            startVoiceAppend()
+        } label: {
+            Image(systemName: "mic.fill")
+                .font(.system(size: 22, weight: .semibold))
+                .foregroundStyle(.tint)
+                .frame(width: 56, height: 56)
+                .floatingMicGlassBackground()
+                .shadow(color: .black.opacity(0.18), radius: 10, y: 4)
+        }
+        .buttonStyle(.plain)
+        .disabled(appState.recordViewModel.recordingState != .idle)
+        .accessibilityLabel("Append with Voice")
+    }
+
     private var bottomActionBar: some View {
         VStack(spacing: 0) {
             Divider()
@@ -763,10 +794,12 @@ struct TranscriptionDetailView: View {
                         showTextEditor = true
                     }
 
-                    Button("Append with Voice", systemImage: "mic") {
-                        startVoiceAppend()
+                    if appendWithVoiceStyle == .toolbar {
+                        Button("Append with Voice", systemImage: "mic") {
+                            startVoiceAppend()
+                        }
+                        .disabled(appState.recordViewModel.recordingState != .idle)
                     }
-                    .disabled(appState.recordViewModel.recordingState != .idle)
                 } label: {
                     Image(systemName: "pencil")
                         .font(.system(size: 20))
@@ -1749,6 +1782,24 @@ private struct TextEditSheet: View {
                     }
                 }
         }
+    }
+}
+
+private struct FloatingMicGlassBackground: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(iOS 26, *) {
+            content
+                .glassEffect(.regular.interactive(), in: .circle)
+        } else {
+            content
+                .background(.regularMaterial, in: .circle)
+        }
+    }
+}
+
+private extension View {
+    func floatingMicGlassBackground() -> some View {
+        modifier(FloatingMicGlassBackground())
     }
 }
 

--- a/VivaDicta/Views/TranscriptionDetailView.swift
+++ b/VivaDicta/Views/TranscriptionDetailView.swift
@@ -375,13 +375,6 @@ struct TranscriptionDetailView: View {
                     .padding(.horizontal)
             }
         }
-        .overlay(alignment: .bottomTrailing) {
-            if appendWithVoiceStyle == .floatingButton {
-                voiceAppendFloatingButton
-                    .padding(.trailing, 16)
-                    .padding(.bottom, 12)
-            }
-        }
         .safeAreaInset(edge: .bottom) {
             if pendingReminderDraftCount > 0 {
                 HStack {
@@ -402,6 +395,15 @@ struct TranscriptionDetailView: View {
         }
         .safeAreaInset(edge: .bottom) {
             VStack(spacing: 0) {
+                if appendWithVoiceStyle == .floatingButton {
+                    HStack {
+                        Spacer()
+                        voiceAppendFloatingButton
+                    }
+                    .padding(.trailing, 16)
+                    .padding(.bottom, 12)
+                }
+
                 TranscriptionTagChipsView(
                     transcription: transcription,
                     showTagPicker: $showTagPicker
@@ -695,11 +697,11 @@ struct TranscriptionDetailView: View {
         Button {
             startVoiceAppend()
         } label: {
-            Image(systemName: "mic.fill")
+            Image(systemName: "microphone.badge.plus.fill")
                 .font(.system(size: 22, weight: .semibold))
                 .foregroundStyle(.tint)
                 .frame(width: 56, height: 56)
-                .floatingMicGlassBackground()
+                .glassFABCircle()
                 .shadow(color: .black.opacity(0.18), radius: 10, y: 4)
         }
         .buttonStyle(.plain)
@@ -1782,24 +1784,6 @@ private struct TextEditSheet: View {
                     }
                 }
         }
-    }
-}
-
-private struct FloatingMicGlassBackground: ViewModifier {
-    func body(content: Content) -> some View {
-        if #available(iOS 26, *) {
-            content
-                .glassEffect(.regular.interactive(), in: .circle)
-        } else {
-            content
-                .background(.regularMaterial, in: .circle)
-        }
-    }
-}
-
-private extension View {
-    func floatingMicGlassBackground() -> some View {
-        modifier(FloatingMicGlassBackground())
     }
 }
 


### PR DESCRIPTION
## Summary
- New Settings -> Advanced screen with a single picker: **Append with Voice** -> Toolbar (default) | Floating Button.
- Toolbar restores the original menu inside the pencil icon (Edit Text + Append with Voice) - same as it was before the FAB landed.
- Floating Button shows a circular mic FAB in the bottom-right of the note detail screen with a glass effect on iOS 26+ and `.regularMaterial` fallback below.

## Why
The FAB was opt-out for everyone in the previous PR. That's overkill for a request from a single user. Defaulting to Toolbar keeps the original UI for everyone who didn't ask for the FAB and lets the user opt in if they want it.

## Implementation notes
- New `AppendWithVoiceStyle` enum (`toolbar`, `floatingButton`), persisted via `UserDefaultsStorage.Keys.appendWithVoiceStyle`.
- New `AdvancedSettingsView` with a menu-style picker and a short footer explaining the two layouts.
- New `SettingsDestination.advanced` case wired into `SettingsView`'s `.navigationDestination`. The "Advanced" section sits just above "Support" near the bottom of the Settings screen, with a `slider.horizontal.3` icon.
- `TranscriptionDetailView` reads the setting reactively via `@AppStorage`. The pencil-icon `Menu` conditionally includes the "Append with Voice" item when the style is `.toolbar`. The FAB overlay is conditionally rendered when the style is `.floatingButton`.
- No data migration; new key reads as nil on first launch and the binding falls back to `.toolbar`.

## Test plan
- [ ] Build clean on iPhone 17 Pro Max simulator (verified locally).
- [ ] Default install: open a note, confirm pencil icon menu has both "Edit Text" and "Append with Voice" - identical to pre-FAB behavior. No floating button visible.
- [ ] Settings -> Advanced -> Append with Voice -> Floating Button. Confirm pencil menu now has only "Edit Text" and the mic FAB appears in the bottom-right.
- [ ] Tap the FAB -> voice append flow starts as expected. While recording, the FAB is disabled.
- [ ] Toggle back to Toolbar -> FAB disappears, "Append with Voice" reappears in the menu.
- [ ] Below iOS 26 the FAB renders with a `.regularMaterial` circle fallback (verify on older simulator if available).