### PR TITLE
Add Export Settings screen and manual Export to Folder button

### DIFF
--- a/VivaDicta/Services/FolderExportService.swift
+++ b/VivaDicta/Services/FolderExportService.swift
@@ -70,28 +70,37 @@ enum FolderExportService {
         }
     }
 
+    /// Outcome of a manual export attempt. Distinguishes failures so the UI
+    /// can show specific guidance instead of a generic "something went wrong".
+    enum ManualSaveResult: Equatable {
+        case success(filename: String)
+        case noFolderPicked
+        case bookmarkUnusable
+        case writeFailed(String)
+    }
+
     /// Manually writes the transcription as a markdown file in the picked
     /// folder. Bypasses the global auto-export toggle and per-mode opt-out
     /// because the user explicitly tapped the Export to Folder button.
-    /// Returns whether a write was scheduled - callers can use this to
-    /// surface a "no folder picked" hint to the user.
+    ///
+    /// Awaits the actual write (unlike `saveIfEnabled`) so callers can
+    /// surface real success or failure to the user instead of giving a
+    /// false success signal when the bookmark is stale or access is revoked.
     @MainActor
-    @discardableResult
-    static func saveManually(transcription: Transcription) -> Bool {
+    static func saveManually(transcription: Transcription) async -> ManualSaveResult {
         guard let bookmark = UserDefaultsStorage.shared.data(forKey: UserDefaultsStorage.SharedKeys.folderExportBookmark) else {
             logger.logInfo("📁 Folder export: manual save requested but no folder picked")
-            return false
+            return .noFolderPicked
         }
 
         let snapshots = TranscriptionMarkdownExportService.snapshots(for: [transcription])
-        guard let snapshot = snapshots.first else { return false }
+        guard let snapshot = snapshots.first else { return .writeFailed("No transcription snapshot") }
         let items = TranscriptionMarkdownExportService.items(forSnapshots: snapshots)
-        guard let item = items.first else { return false }
+        guard let item = items.first else { return .writeFailed("No exportable item") }
 
-        Task.detached(priority: .utility) {
-            await write(item: item, snapshot: snapshot, bookmark: bookmark)
-        }
-        return true
+        return await Task.detached(priority: .userInitiated) {
+            await writeWithResult(item: item, snapshot: snapshot, bookmark: bookmark)
+        }.value
     }
 
     private static func write(
@@ -99,6 +108,17 @@ enum FolderExportService {
         snapshot: TranscriptionMarkdownExportService.Snapshot,
         bookmark: Data
     ) async {
+        _ = await writeWithResult(item: item, snapshot: snapshot, bookmark: bookmark)
+    }
+
+    /// Same as `write`, but returns a typed outcome so manual callers can
+    /// surface accurate UI feedback (e.g. distinguish "bookmark stale" from
+    /// "write failed").
+    private static func writeWithResult(
+        item: MarkdownExportItem,
+        snapshot: TranscriptionMarkdownExportService.Snapshot,
+        bookmark: Data
+    ) async -> ManualSaveResult {
         var isStale = false
         let folderURL: URL
         do {
@@ -110,19 +130,19 @@ enum FolderExportService {
             )
         } catch {
             logger.logError("📁 Folder export: bookmark resolution failed - \(error.localizedDescription)")
-            return
+            return .bookmarkUnusable
         }
 
         if isStale {
             logger.logError("📁 Folder export: bookmark is stale - clearing so the user re-picks")
             await MainActor.run { Self.clearBookmark() }
-            return
+            return .bookmarkUnusable
         }
 
         guard folderURL.startAccessingSecurityScopedResource() else {
             logger.logError("📁 Folder export: cannot access \(folderURL.path) - clearing bookmark so the user re-picks")
             await MainActor.run { Self.clearBookmark() }
-            return
+            return .bookmarkUnusable
         }
         defer { folderURL.stopAccessingSecurityScopedResource() }
 
@@ -130,8 +150,10 @@ enum FolderExportService {
         do {
             try Data(item.text.utf8).write(to: destination, options: .atomic)
             logger.logInfo("📁 Folder export: wrote \(destination.lastPathComponent)")
+            return .success(filename: destination.lastPathComponent)
         } catch {
             logger.logError("📁 Folder export: write failed for \(destination.lastPathComponent) - \(error.localizedDescription)")
+            return .writeFailed(error.localizedDescription)
         }
     }
 

--- a/VivaDicta/Services/FolderExportService.swift
+++ b/VivaDicta/Services/FolderExportService.swift
@@ -70,6 +70,30 @@ enum FolderExportService {
         }
     }
 
+    /// Manually writes the transcription as a markdown file in the picked
+    /// folder. Bypasses the global auto-export toggle and per-mode opt-out
+    /// because the user explicitly tapped the Export to Folder button.
+    /// Returns whether a write was scheduled - callers can use this to
+    /// surface a "no folder picked" hint to the user.
+    @MainActor
+    @discardableResult
+    static func saveManually(transcription: Transcription) -> Bool {
+        guard let bookmark = UserDefaultsStorage.shared.data(forKey: UserDefaultsStorage.SharedKeys.folderExportBookmark) else {
+            logger.logInfo("📁 Folder export: manual save requested but no folder picked")
+            return false
+        }
+
+        let snapshots = TranscriptionMarkdownExportService.snapshots(for: [transcription])
+        guard let snapshot = snapshots.first else { return false }
+        let items = TranscriptionMarkdownExportService.items(forSnapshots: snapshots)
+        guard let item = items.first else { return false }
+
+        Task.detached(priority: .utility) {
+            await write(item: item, snapshot: snapshot, bookmark: bookmark)
+        }
+        return true
+    }
+
     private static func write(
         item: MarkdownExportItem,
         snapshot: TranscriptionMarkdownExportService.Snapshot,

--- a/VivaDicta/Shared/UserDefaultsStorage.swift
+++ b/VivaDicta/Shared/UserDefaultsStorage.swift
@@ -101,6 +101,7 @@ enum UserDefaultsStorage {
 
         // Integrations - Folder export (silent markdown save to user-picked folder)
         static let isFolderExportGloballyEnabled = "isFolderExportGloballyEnabled"
+        static let isFolderExportButtonEnabled = "isFolderExportButtonEnabled"
 
         // Live Translation
         static let liveTranslationSourceLanguage = "liveTranslation.sourceLanguage"

--- a/VivaDicta/Views/HudView.swift
+++ b/VivaDicta/Views/HudView.swift
@@ -320,7 +320,7 @@ struct HudViewDark: View {
                 .blur(radius: 1)
                 .blendMode(.overlay)
         )
-        .background(.black.opacity(0.1))
+        .background(.black.opacity(0.7))
         .clipShape(.rect(cornerRadius: 30))
         .applyHudGlassEffect(cornerRadius: 30, isInteractive: onCancel != nil)
     }

--- a/VivaDicta/Views/HudView.swift
+++ b/VivaDicta/Views/HudView.swift
@@ -320,7 +320,7 @@ struct HudViewDark: View {
                 .blur(radius: 1)
                 .blendMode(.overlay)
         )
-//        .background(.black)
+        .background(.black.opacity(0.1))
         .clipShape(.rect(cornerRadius: 30))
         .applyHudGlassEffect(cornerRadius: 30, isInteractive: onCancel != nil)
     }

--- a/VivaDicta/Views/SettingsScreen/ExportSettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/ExportSettingsView.swift
@@ -108,7 +108,7 @@ struct ExportSettingsView: View {
                 }
             }
         }
-        .navigationTitle("Export Settings")
+        .navigationTitle("Export Notes")
         .navigationBarTitleDisplayMode(.inline)
         .fileImporter(
             isPresented: $isFolderPickerPresented,

--- a/VivaDicta/Views/SettingsScreen/ExportSettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/ExportSettingsView.swift
@@ -1,0 +1,153 @@
+//
+//  ExportSettingsView.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.05.09
+//
+
+import SwiftUI
+import UniformTypeIdentifiers
+
+/// Settings screen for the markdown folder-export integration. Two sibling
+/// toggles control the hand-off:
+/// - "Auto-export after transcription" (`isFolderExportGloballyEnabled`) drives
+///   the silent post-transcription save in `FolderExportService.saveIfEnabled`
+///   and gates the per-mode opt-out in `ModeEditView`.
+/// - "Show Export to Folder button" (`isFolderExportButtonEnabled`) reveals a
+///   manual export FAB on the transcription detail screen.
+/// The folder picker and Markdown Export variation picker are shared.
+struct ExportSettingsView: View {
+    @AppStorage(MarkdownExportContent.userDefaultsKey)
+    private var markdownExportContent: MarkdownExportContent = .default
+
+    @AppStorage(UserDefaultsStorage.Keys.isFolderExportGloballyEnabled)
+    private var isFolderExportAutoEnabled = false
+
+    @AppStorage(UserDefaultsStorage.Keys.isFolderExportButtonEnabled)
+    private var isFolderExportButtonEnabled = false
+
+    @AppStorage(UserDefaultsStorage.SharedKeys.folderExportDisplayName, store: UserDefaultsStorage.shared)
+    private var folderExportDisplayName: String = ""
+
+    @State private var isFolderPickerPresented = false
+    @State private var folderPickerError: String?
+
+    private var isAnyExportEnabled: Bool {
+        isFolderExportAutoEnabled || isFolderExportButtonEnabled
+    }
+
+    var body: some View {
+        Form {
+            Section {
+                VStack(alignment: .leading, spacing: 4) {
+                    Picker("Markdown Export", selection: $markdownExportContent) {
+                        ForEach(MarkdownExportContent.allCases) { option in
+                            Text(option.displayName).tag(option)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                    .tint(.primary)
+                    Text("Choose what to include when exporting notes as Markdown. Applies to manual share, the Export to Folder button, and the auto-export below.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .onChange(of: markdownExportContent) { _, _ in
+                    HapticManager.selectionChanged()
+                }
+            }
+
+            Section(header: Text("Folder Export"), footer: exportFooter) {
+                Toggle(isOn: $isFolderExportAutoEnabled) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Auto-export after transcription")
+                            .font(.body)
+                        Text("After each transcription, silently save a .md file to the folder you pick below.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .onChange(of: isFolderExportAutoEnabled) { _, _ in
+                    HapticManager.selectionChanged()
+                }
+
+                Toggle(isOn: $isFolderExportButtonEnabled) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Show Export to Folder button")
+                            .font(.body)
+                        Text("Add a button on each note's detail screen to save the markdown file to the folder on demand.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .onChange(of: isFolderExportButtonEnabled) { _, _ in
+                    HapticManager.selectionChanged()
+                }
+
+                if isAnyExportEnabled {
+                    Button {
+                        isFolderPickerPresented = true
+                    } label: {
+                        HStack {
+                            Text(folderExportDisplayName.isEmpty ? "Choose folder..." : "Folder")
+                            Spacer()
+                            if !folderExportDisplayName.isEmpty {
+                                Text(folderExportDisplayName)
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(1)
+                                    .truncationMode(.middle)
+                            }
+                        }
+                    }
+
+                    if !folderExportDisplayName.isEmpty {
+                        Button("Clear folder", role: .destructive) {
+                            FolderExportService.clearBookmark()
+                            folderExportDisplayName = ""
+                        }
+                    }
+                }
+            }
+        }
+        .navigationTitle("Export Settings")
+        .navigationBarTitleDisplayMode(.inline)
+        .fileImporter(
+            isPresented: $isFolderPickerPresented,
+            allowedContentTypes: [.folder],
+            allowsMultipleSelection: false
+        ) { result in
+            switch result {
+            case .success(let urls):
+                guard let url = urls.first else { return }
+                guard url.startAccessingSecurityScopedResource() else {
+                    folderPickerError = "Could not access the selected folder."
+                    return
+                }
+                defer { url.stopAccessingSecurityScopedResource() }
+                do {
+                    try FolderExportService.storeBookmark(for: url)
+                } catch {
+                    folderPickerError = error.localizedDescription
+                }
+            case .failure(let error):
+                folderPickerError = error.localizedDescription
+            }
+        }
+        .alert("Folder selection failed",
+               isPresented: Binding(
+                   get: { folderPickerError != nil },
+                   set: { if !$0 { folderPickerError = nil } }
+               ),
+               presenting: folderPickerError) { _ in
+            Button("OK", role: .cancel) { folderPickerError = nil }
+        } message: { message in
+            Text(message)
+        }
+    }
+
+    @ViewBuilder
+    private var exportFooter: some View {
+        if isAnyExportEnabled {
+            Text("One markdown file per transcription, named VivaDicta-YYYY-MM-DD_HHmmss.md. Pick any folder, including an Obsidian vault. Per-mode opt-out for auto-export is available in each mode's settings.")
+        }
+    }
+}

--- a/VivaDicta/Views/SettingsScreen/SettingsDestination.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsDestination.swift
@@ -28,6 +28,9 @@ enum SettingsDestination: Hashable {
     // Integrations
     case integrations
 
+    // Export
+    case export
+
     // Advanced
     case advanced
 }

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -502,7 +502,7 @@ struct SettingsView: View {
                         HStack {
                             Image(systemName: "square.and.arrow.up.on.square")
                                 .foregroundStyle(.blue)
-                            Text("Export Notes Settings")
+                            Text("Export Notes")
                         }
                     }
                 }

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 import AppIntents
 import TipKit
 import MessageUI
-import UniformTypeIdentifiers
 
 struct SettingsView: View {
     @Environment(AppState.self) var appState
@@ -56,14 +55,6 @@ struct SettingsView: View {
 
     @AppStorage(UserDefaultsStorage.Keys.isICloudSyncEnabled)
     private var isICloudSyncEnabled = true
-    @AppStorage(MarkdownExportContent.userDefaultsKey)
-    private var markdownExportContent: MarkdownExportContent = .default
-    @AppStorage(UserDefaultsStorage.Keys.isFolderExportGloballyEnabled)
-    private var isFolderExportGloballyEnabled = false
-    @AppStorage(UserDefaultsStorage.SharedKeys.folderExportDisplayName, store: UserDefaultsStorage.shared)
-    private var folderExportDisplayName: String = ""
-    @State private var isFolderPickerPresented = false
-    @State private var folderPickerError: String?
     @State private var showRestartAlert = false
     @AppStorage(AppGroupCoordinator.isHapticsEnabled, store: UserDefaultsStorage.shared)
     private var isHapticsEnabled = true
@@ -391,67 +382,6 @@ struct SettingsView: View {
                     }
                 }
 
-                Section {
-                    VStack(alignment: .leading, spacing: 4) {
-                        Picker("Markdown Export", selection: $markdownExportContent) {
-                            ForEach(MarkdownExportContent.allCases) { option in
-                                Text(option.displayName).tag(option)
-                            }
-                        }
-                        .pickerStyle(.menu)
-                        .tint(.primary)
-                        Text("Choose what to include when exporting notes as Markdown. Applies to both manual export and auto-save below.")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                    .onChange(of: markdownExportContent) { _, _ in
-                        HapticManager.selectionChanged()
-                    }
-
-                    Toggle(isOn: $isFolderExportGloballyEnabled) {
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text("Save markdown file")
-                                .font(.body)
-                            Text("After each transcription, silently save a .md file to a folder of your choice (e.g. an Obsidian vault in iCloud Drive).")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-                    .onChange(of: isFolderExportGloballyEnabled) { _, _ in
-                        HapticManager.selectionChanged()
-                    }
-
-                    if isFolderExportGloballyEnabled {
-                        Button {
-                            isFolderPickerPresented = true
-                        } label: {
-                            HStack {
-                                Text(folderExportDisplayName.isEmpty ? "Choose folder..." : "Folder")
-                                Spacer()
-                                if !folderExportDisplayName.isEmpty {
-                                    Text(folderExportDisplayName)
-                                        .foregroundStyle(.secondary)
-                                        .lineLimit(1)
-                                        .truncationMode(.middle)
-                                }
-                            }
-                        }
-
-                        if !folderExportDisplayName.isEmpty {
-                            Button("Clear folder", role: .destructive) {
-                                FolderExportService.clearBookmark()
-                                folderExportDisplayName = ""
-                            }
-                        }
-                    }
-                } header: {
-                    Text("Export")
-                } footer: {
-                    if isFolderExportGloballyEnabled {
-                        Text("One markdown file per transcription, named VivaDicta-YYYY-MM-DD_HHmmss.md. Pick any folder, including an Obsidian vault. Once you pick a folder, every mode silently writes a file - opt out per-mode in each mode's settings.")
-                    }
-                }
-
                 Section("Storage") {
 
                     Toggle(isOn: $isAutoNoteCleanupEnabled) {
@@ -565,6 +495,16 @@ struct SettingsView: View {
                     Text("iCloud")
                 } footer: {
                     Text("Requires app restart to take effect.")
+                }
+                
+                Section("Export Notes") {
+                    NavigationLink(value: SettingsDestination.export) {
+                        HStack {
+                            Image(systemName: "square.and.arrow.up.on.square")
+                                .foregroundStyle(.blue)
+                            Text("Export Notes Settings")
+                        }
+                    }
                 }
 
                 Section("Integrations") {
@@ -697,6 +637,8 @@ struct SettingsView: View {
                     SmartSearchSettingsView()
                 case .integrations:
                     IntegrationsView()
+                case .export:
+                    ExportSettingsView()
                 case .advanced:
                     AdvancedSettingsView()
                 }
@@ -772,38 +714,6 @@ struct SettingsView: View {
             Button("Later", role: .cancel) { }
         } message: {
             Text("The app needs to restart for iCloud sync changes to take effect.")
-        }
-        .fileImporter(
-            isPresented: $isFolderPickerPresented,
-            allowedContentTypes: [.folder],
-            allowsMultipleSelection: false
-        ) { result in
-            switch result {
-            case .success(let urls):
-                guard let url = urls.first else { return }
-                guard url.startAccessingSecurityScopedResource() else {
-                    folderPickerError = "Could not access the selected folder."
-                    return
-                }
-                defer { url.stopAccessingSecurityScopedResource() }
-                do {
-                    try FolderExportService.storeBookmark(for: url)
-                } catch {
-                    folderPickerError = error.localizedDescription
-                }
-            case .failure(let error):
-                folderPickerError = error.localizedDescription
-            }
-        }
-        .alert("Folder selection failed",
-               isPresented: Binding(
-                   get: { folderPickerError != nil },
-                   set: { if !$0 { folderPickerError = nil } }
-               ),
-               presenting: folderPickerError) { _ in
-            Button("OK", role: .cancel) { folderPickerError = nil }
-        } message: { message in
-            Text(message)
         }
         .sheet(isPresented: $showMailCompose) {
             MailComposeView(

--- a/VivaDicta/Views/TranscriptionDetailView.swift
+++ b/VivaDicta/Views/TranscriptionDetailView.swift
@@ -57,7 +57,8 @@ struct TranscriptionDetailView: View {
     @AppStorage(UserDefaultsStorage.SharedKeys.folderExportDisplayName, store: UserDefaultsStorage.shared)
     private var folderExportDisplayName: String = ""
 
-    @State private var showExportNoFolderAlert: Bool = false
+    @State private var folderExportAlertMessage: String = ""
+    @State private var showFolderExportAlert: Bool = false
 
     private var appendWithVoiceStyle: AppendWithVoiceStyle {
         AppendWithVoiceStyle(rawValue: appendWithVoiceStyleRaw) ?? .toolbar
@@ -650,10 +651,10 @@ struct TranscriptionDetailView: View {
         } message: {
             Text(exportErrorMessage)
         }
-        .alert("Pick an export folder first", isPresented: $showExportNoFolderAlert) {
+        .alert("Export to Folder", isPresented: $showFolderExportAlert) {
             Button("OK", role: .cancel) {}
         } message: {
-            Text("Choose a folder in Settings -> Export before using the Export to Folder button.")
+            Text(folderExportAlertMessage)
         }
     }
 
@@ -774,17 +775,23 @@ struct TranscriptionDetailView: View {
 
     private func exportToFolder() {
         HapticManager.lightImpact()
-        if folderExportDisplayName.isEmpty {
-            showExportNoFolderAlert = true
-            return
+        Task {
+            let result = await FolderExportService.saveManually(transcription: transcription)
+            switch result {
+            case .success(let filename):
+                logger.logInfo("📁 Folder export: manual save wrote \(filename)")
+                HapticManager.success()
+            case .noFolderPicked:
+                folderExportAlertMessage = "Choose a folder in Settings → Export Notes before using the Export to Folder button."
+                showFolderExportAlert = true
+            case .bookmarkUnusable:
+                folderExportAlertMessage = "Lost access to the export folder. Pick it again in Settings → Export Notes."
+                showFolderExportAlert = true
+            case .writeFailed(let message):
+                folderExportAlertMessage = "Could not write the markdown file: \(message)"
+                showFolderExportAlert = true
+            }
         }
-        let scheduled = FolderExportService.saveManually(transcription: transcription)
-        if !scheduled {
-            showExportNoFolderAlert = true
-            return
-        }
-        logger.logInfo("📁 Folder export: manual save scheduled for \(transcription.audioFileName ?? "<no audio>")")
-        HapticManager.success()
     }
 
     private func sendToObsidian() {

--- a/VivaDicta/Views/TranscriptionDetailView.swift
+++ b/VivaDicta/Views/TranscriptionDetailView.swift
@@ -51,6 +51,14 @@ struct TranscriptionDetailView: View {
     @AppStorage(UserDefaultsStorage.Keys.isObsidianSendButtonEnabled)
     private var isObsidianSendButtonEnabled: Bool = false
 
+    @AppStorage(UserDefaultsStorage.Keys.isFolderExportButtonEnabled)
+    private var isFolderExportButtonEnabled: Bool = false
+
+    @AppStorage(UserDefaultsStorage.SharedKeys.folderExportDisplayName, store: UserDefaultsStorage.shared)
+    private var folderExportDisplayName: String = ""
+
+    @State private var showExportNoFolderAlert: Bool = false
+
     private var appendWithVoiceStyle: AppendWithVoiceStyle {
         AppendWithVoiceStyle(rawValue: appendWithVoiceStyleRaw) ?? .toolbar
     }
@@ -402,9 +410,12 @@ struct TranscriptionDetailView: View {
         .safeAreaInset(edge: .bottom) {
             VStack(spacing: 0) {
                 let showsVoiceFAB = appendWithVoiceStyle == .floatingButton
-                if isObsidianSendButtonEnabled || showsVoiceFAB {
+                if isObsidianSendButtonEnabled || isFolderExportButtonEnabled || showsVoiceFAB {
                     HStack(spacing: 12) {
                         Spacer()
+                        if isFolderExportButtonEnabled {
+                            folderExportFloatingButton
+                        }
                         if isObsidianSendButtonEnabled {
                             obsidianSendFloatingButton
                         }
@@ -639,6 +650,11 @@ struct TranscriptionDetailView: View {
         } message: {
             Text(exportErrorMessage)
         }
+        .alert("Pick an export folder first", isPresented: $showExportNoFolderAlert) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("Choose a folder in Settings -> Export before using the Export to Folder button.")
+        }
     }
 
     private var exportSheetBinding: Binding<Bool> {
@@ -737,6 +753,38 @@ struct TranscriptionDetailView: View {
         .buttonStyle(.plain)
         .disabled(appState.recordViewModel.recordingState != .idle)
         .accessibilityLabel("Send to Obsidian")
+    }
+
+    @ViewBuilder
+    private var folderExportFloatingButton: some View {
+        Button {
+            exportToFolder()
+        } label: {
+            Image(systemName: "folder.fill.badge.plus")
+                .font(.system(size: 22, weight: .semibold))
+                .foregroundStyle(.tint)
+                .frame(width: 56, height: 56)
+                .glassFABCircle()
+                .shadow(color: .black.opacity(0.18), radius: 10, y: 4)
+        }
+        .buttonStyle(.plain)
+        .disabled(appState.recordViewModel.recordingState != .idle)
+        .accessibilityLabel("Export to Folder")
+    }
+
+    private func exportToFolder() {
+        HapticManager.lightImpact()
+        if folderExportDisplayName.isEmpty {
+            showExportNoFolderAlert = true
+            return
+        }
+        let scheduled = FolderExportService.saveManually(transcription: transcription)
+        if !scheduled {
+            showExportNoFolderAlert = true
+            return
+        }
+        logger.logInfo("📁 Folder export: manual save scheduled for \(transcription.audioFileName ?? "<no audio>")")
+        HapticManager.success()
     }
 
     private func sendToObsidian() {


### PR DESCRIPTION
## Summary

Mirrors the recent Obsidian split (PR #246) for the markdown folder-export integration.

### Settings reshape

Moved the inline `Section("Export")` out of the main Settings screen and into a new push screen `Settings -> Export Settings`. The new screen hosts:

- `Markdown Export` variation picker (top, applies to manual share + auto + button paths)
- `Auto-export after transcription` toggle - renamed from "Save markdown file", **storage key `isFolderExportGloballyEnabled` retained** so existing users keep their preference
- `Show Export to Folder button` toggle - new key `isFolderExportButtonEnabled`
- Folder picker + Clear folder (gated to appear when either toggle is on)

Removed the supporting state, `.fileImporter`, and folder-picker error alert from `SettingsView.swift`. Dropped `import UniformTypeIdentifiers` since it's no longer needed there. New `SettingsDestination.export` case wired to push `ExportSettingsView`.

### Manual export FAB

New `folderExportFloatingButton` on `TranscriptionDetailView`, gated by `isFolderExportButtonEnabled`. Renders as a third FAB in the bottom-right safe area, to the left of the Obsidian send button (when both are on).

Tap behavior:
- No folder picked → "Pick an export folder first" alert directing the user to Settings → Export Settings
- Folder picked → schedules a write via the new `FolderExportService.saveManually(transcription:)` entry point, gives a success haptic
- Disabled while recording, same as the other two FABs

### Service

- New `FolderExportService.saveManually(transcription:) -> Bool` - bypasses both the global auto-export toggle and the per-mode `folderExportEnabled` flag (explicit user action overrides the auto-save opt-out, same call we made for the manual Obsidian send). Reuses the existing bookmark resolution + write logic.

### Misc

- Small `HudViewDark` cleanup: uncomments a `.background(.black)` and changes it to `.opacity(0.1)`.

## Test plan

- [ ] Settings → Export Settings shows the new screen; row label and nav title both read \"Export Settings\".
- [ ] With both toggles off, only the Markdown Export picker shows; folder picker hidden.
- [ ] With either toggle on, folder picker appears; picking a folder + dismissing reflects the display name.
- [ ] Auto-export still works when \"Auto-export after transcription\" is on (regression check after rename).
- [ ] Per-mode `folderExportEnabled` toggle in mode settings still suppresses auto-export but does NOT suppress the manual button.
- [ ] Tap the Export FAB with no folder picked → alert points to Settings → Export Settings.
- [ ] Tap with a folder picked → check the picked folder for a new `VivaDicta-YYYY-MM-DD_HHmmss.md` file.
- [ ] When all three FABs (Export, Obsidian, Mic) are enabled, they render side by side without overflowing on iPhone SE width.