### PR TITLE
Remove redundant MainActor.run and tidy concurrency annotations

### DIFF
--- a/VivaDicta/AppIntents/CancelRecordIntent.swift
+++ b/VivaDicta/AppIntents/CancelRecordIntent.swift
@@ -15,10 +15,9 @@ struct CancelRecordIntent: AppIntent {
 
     static let openAppWhenRun: Bool = true
 
+    @MainActor
     func perform() async throws -> some IntentResult {
-        await MainActor.run {
-            AppGroupCoordinator.shared.requestCancelRecording()
-        }
+        AppGroupCoordinator.shared.requestCancelRecording()
         return .result()
     }
 }

--- a/VivaDicta/AppIntents/StartRecordIntent.swift
+++ b/VivaDicta/AppIntents/StartRecordIntent.swift
@@ -15,10 +15,9 @@ struct StartRecordIntent: AppIntent {
 
     static let openAppWhenRun: Bool = true
 
+    @MainActor
     func perform() async throws -> some IntentResult {
-        await MainActor.run {
-            AppGroupCoordinator.shared.requestStartRecordingFromControl()
-        }
+        AppGroupCoordinator.shared.requestStartRecordingFromControl()
         return .result()
     }
 }

--- a/VivaDicta/AppIntents/StopRecordIntent.swift
+++ b/VivaDicta/AppIntents/StopRecordIntent.swift
@@ -15,10 +15,9 @@ struct StopRecordIntent: AppIntent {
 
     static let openAppWhenRun: Bool = true
 
+    @MainActor
     func perform() async throws -> some IntentResult {
-        await MainActor.run {
-            AppGroupCoordinator.shared.requestStopRecording()
-        }
+        AppGroupCoordinator.shared.requestStopRecording()
         return .result()
     }
 }

--- a/VivaDicta/AppIntents/ToggleRecordIntent.swift
+++ b/VivaDicta/AppIntents/ToggleRecordIntent.swift
@@ -17,16 +17,15 @@ struct ToggleRecordIntent: SetValueIntent {
     @Parameter(title: "Recording")
     var value: Bool
 
+    @MainActor
     func perform() async throws -> some IntentResult {
-        await MainActor.run {
-            let coordinator = AppGroupCoordinator.shared
-            let isCurrentlyRecording = coordinator.isRecording
+        let coordinator = AppGroupCoordinator.shared
+        let isCurrentlyRecording = coordinator.isRecording
 
-            if isCurrentlyRecording {
-                coordinator.requestStopRecording()
-            } else {
-                coordinator.requestStartRecordingFromControl()
-            }
+        if isCurrentlyRecording {
+            coordinator.requestStopRecording()
+        } else {
+            coordinator.requestStartRecordingFromControl()
         }
         return .result()
     }

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -1898,10 +1898,8 @@ class AIService {
 
             let models = dataArray.compactMap { $0["id"] as? String }.sorted()
 
-            await MainActor.run {
-                self.ollamaModels = models
-                self.saveOllamaModels()
-            }
+            self.ollamaModels = models
+            self.saveOllamaModels()
 
             logger.logInfo("Successfully fetched \(models.count) Ollama models via OpenAI endpoint")
 
@@ -1938,10 +1936,8 @@ class AIService {
 
             let models = modelsArray.compactMap { $0["name"] as? String }.sorted()
 
-            await MainActor.run {
-                self.ollamaModels = models
-                self.saveOllamaModels()
-            }
+            self.ollamaModels = models
+            self.saveOllamaModels()
 
             logger.logInfo("Successfully fetched \(models.count) Ollama models via native endpoint")
 
@@ -2311,16 +2307,14 @@ class AIService {
     
     public func saveAPIKey(_ key: String, for provider: AIProvider) async -> Bool {
         let isValid = await verifyAPIKey(key, provider: provider)
-        
-        await MainActor.run {
-            if isValid {
-                KeychainService.shared.save(key, forKey: provider.keychainKey)
 
-                // Refresh connected providers to trigger UI update
-                self.refreshConnectedProviders()
-            }
+        if isValid {
+            KeychainService.shared.save(key, forKey: provider.keychainKey)
+
+            // Refresh connected providers to trigger UI update
+            self.refreshConnectedProviders()
         }
-        
+
         // Fetch models for providers that support dynamic model fetching
         if isValid && provider == .openRouter {
             await fetchOpenRouterModels()
@@ -2858,10 +2852,8 @@ class AIService {
             }
 
             let models = dataArray.compactMap { $0["id"] as? String }
-            await MainActor.run {
-                self.openRouterModels = models.sorted()
-                self.saveOpenRouterModels()
-            }
+            self.openRouterModels = models.sorted()
+            self.saveOpenRouterModels()
             logger.logInfo("Successfully fetched \(models.count) OpenRouter models.")
 
         } catch {
@@ -2905,10 +2897,8 @@ class AIService {
                 logger.logInfo("Vercel AI Gateway: Filtered \(totalCount) models to \(models.count) language models.")
             }
 
-            await MainActor.run {
-                self.vercelAIGatewayModels = models.sorted()
-                self.saveVercelAIGatewayModels()
-            }
+            self.vercelAIGatewayModels = models.sorted()
+            self.saveVercelAIGatewayModels()
             logger.logInfo("Successfully fetched \(models.count) Vercel AI Gateway models.")
 
         } catch {
@@ -2971,10 +2961,8 @@ class AIService {
                 logger.logInfo("HuggingFace: Filtered \(totalCount) models to \(models.count) text-to-text models (skipped \(nonTextModelsCount) non-text, \(missingArchitectureCount) malformed).")
             }
 
-            await MainActor.run {
-                self.huggingFaceModels = models.sorted()
-                self.saveHuggingFaceModels()
-            }
+            self.huggingFaceModels = models.sorted()
+            self.saveHuggingFaceModels()
             logger.logInfo("Successfully fetched \(models.count) HuggingFace models.")
 
         } catch {

--- a/VivaDicta/Services/ModelDownloadManager.swift
+++ b/VivaDicta/Services/ModelDownloadManager.swift
@@ -115,12 +115,10 @@ class ModelDownloadManager {
     ///   - model: The model that failed to download.
     ///   - error: The error that occurred.
     public func handleModelDownloadError(_ model: any TranscriptionModel, _ error: any Error) async {
-        await MainActor.run {
-            downloadStatuses[model.name] = .download
-            downloadProgress.removeValue(forKey: model.name + "_main")
-            downloadProgress.removeValue(forKey: model.name + "_coreml")
-            downloadProgress.removeValue(forKey: model.name)
-        }
+        downloadStatuses[model.name] = .download
+        downloadProgress.removeValue(forKey: model.name + "_main")
+        downloadProgress.removeValue(forKey: model.name + "_coreml")
+        downloadProgress.removeValue(forKey: model.name)
         logger.logError("Error downloading model \(model.name): \(error.localizedDescription)")
     }
 
@@ -192,15 +190,11 @@ class ModelDownloadManager {
     public func deleteModel(_ model: any TranscriptionModel) async throws {
         if let parakeetModel = model as? ParakeetModel {
             try parakeetModel.deleteModel()
-            await MainActor.run {
-                downloadStatuses[model.name] = .download
-            }
+            downloadStatuses[model.name] = .download
             logger.logNotice("🗑️ Deleted model \(model.name)")
         } else if let whisperKitModel = model as? WhisperKitModel {
             try whisperKitModel.deleteModel()
-            await MainActor.run {
-                downloadStatuses[model.name] = .download
-            }
+            downloadStatuses[model.name] = .download
             logger.logNotice("🗑️ Deleted model \(model.name)")
         } else {
             throw ModelDownloadError.unsupportedModelType
@@ -211,10 +205,8 @@ class ModelDownloadManager {
     private func downloadParakeetModel(_ model: ParakeetModel) async throws {
         try Task.checkCancellation()
 
-        await MainActor.run {
-            downloadStatuses[model.name] = .downloading
-            downloadProgress[model.name] = 0.0
-        }
+        downloadStatuses[model.name] = .downloading
+        downloadProgress[model.name] = 0.0
 
         logger.logNotice("📥 Starting download of \(model.displayName)")
 
@@ -246,30 +238,24 @@ class ModelDownloadManager {
 
             try Task.checkCancellation()
 
-            await MainActor.run {
-                self.downloadProgress[model.name] = 1.0
-                self.downloadStatuses[model.name] = .downloaded
-                logger.logNotice("✅ Successfully downloaded \(model.displayName)")
-            }
+            self.downloadProgress[model.name] = 1.0
+            self.downloadStatuses[model.name] = .downloaded
+            logger.logNotice("✅ Successfully downloaded \(model.displayName)")
 
             // Log model download to Firebase Analytics
             AnalyticsService.track(.modelDownloaded(name: model.displayName, type: "parakeet"))
 
             try? await Task.sleep(for: .seconds(0.5))
 
-            await MainActor.run {
-                self.downloadProgress.removeValue(forKey: model.name)
-                self.onModelDownloaded?(model)
-            }
+            self.downloadProgress.removeValue(forKey: model.name)
+            self.onModelDownloaded?(model)
 
         } catch is CancellationError {
             logger.logNotice("🛑 Download of \(model.displayName) was cancelled")
             throw CancellationError()
         } catch {
-            await MainActor.run {
-                self.downloadStatuses[model.name] = .download
-                self.downloadProgress.removeValue(forKey: model.name)
-            }
+            self.downloadStatuses[model.name] = .download
+            self.downloadProgress.removeValue(forKey: model.name)
 
             logger.logError("❌ Failed to download \(model.displayName): \(error.localizedDescription)")
             throw error
@@ -297,10 +283,8 @@ class ModelDownloadManager {
         // Check for cancellation before starting
         try Task.checkCancellation()
 
-        await MainActor.run {
-            downloadStatuses[model.name] = .downloading
-            downloadProgress[model.name] = 0.0
-        }
+        downloadStatuses[model.name] = .downloading
+        downloadProgress[model.name] = 0.0
 
         logger.logNotice("📥 Starting download and preparation of \(model.displayName)")
 
@@ -342,9 +326,7 @@ class ModelDownloadManager {
                 whisperKit.modelFolder = downloadedFolder
             } else {
                 whisperKit.modelFolder = modelFolder
-                await MainActor.run {
-                    self.downloadProgress[model.name] = 0.7
-                }
+                self.downloadProgress[model.name] = 0.7
             }
 
             // Check for cancellation before prewarm
@@ -352,9 +334,7 @@ class ModelDownloadManager {
 
             // Prewarm models with animated progress (critical for first-time performance)
             logger.logNotice("🔥 Prewarming model: \(model.whisperKitModelName)")
-            await MainActor.run {
-                self.downloadProgress[model.name] = 0.75
-            }
+            self.downloadProgress[model.name] = 0.75
 
             // Start progress animation for pre-warming phase
             let progressTask = Task { @MainActor in
@@ -379,9 +359,7 @@ class ModelDownloadManager {
             // Check for cancellation after prewarm
             try Task.checkCancellation()
 
-            await MainActor.run {
-                self.downloadProgress[model.name] = 0.9
-            }
+            self.downloadProgress[model.name] = 0.9
 
             // Load models with animated progress
             logger.logNotice("📚 Loading model: \(model.whisperKitModelName)")
@@ -407,12 +385,10 @@ class ModelDownloadManager {
             // Check for cancellation after load
             try Task.checkCancellation()
 
-            await MainActor.run {
-                self.downloadProgress[model.name] = 1.0
-                self.downloadStatuses[model.name] = .downloaded
-                logger.logNotice("✅ Successfully downloaded and prepared \(model.displayName)")
-                logger.logNotice("⏱️ Preparation time: prewarm: \(prewarmDuration.formatted(.number.precision(.fractionLength(2))))s, load: \(loadDuration.formatted(.number.precision(.fractionLength(2))))s")
-            }
+            self.downloadProgress[model.name] = 1.0
+            self.downloadStatuses[model.name] = .downloaded
+            logger.logNotice("✅ Successfully downloaded and prepared \(model.displayName)")
+            logger.logNotice("⏱️ Preparation time: prewarm: \(prewarmDuration.formatted(.number.precision(.fractionLength(2))))s, load: \(loadDuration.formatted(.number.precision(.fractionLength(2))))s")
 
             // Log model download to Firebase Analytics
             AnalyticsService.track(.modelDownloaded(name: model.displayName, type: "whisperkit"))
@@ -423,19 +399,15 @@ class ModelDownloadManager {
 
             try? await Task.sleep(for: .seconds(0.5))
 
-            await MainActor.run {
-                self.downloadProgress.removeValue(forKey: model.name)
-                self.onModelDownloaded?(model)
-            }
+            self.downloadProgress.removeValue(forKey: model.name)
+            self.onModelDownloaded?(model)
 
         } catch is CancellationError {
             logger.logNotice("🛑 Download of \(model.displayName) was cancelled")
             throw CancellationError()
         } catch {
-            await MainActor.run {
-                self.downloadStatuses[model.name] = .download
-                self.downloadProgress.removeValue(forKey: model.name)
-            }
+            self.downloadStatuses[model.name] = .download
+            self.downloadProgress.removeValue(forKey: model.name)
 
             logger.logError("❌ Failed to download \(model.displayName): \(error.localizedDescription)")
             throw error
@@ -469,12 +441,10 @@ class ModelDownloadManager {
             let decayFactor = exp(-decayConstant * Float(elapsedTime))
             let currentProgress = initialProgress + progressRange * (1 - decayFactor)
 
-            await MainActor.run {
-                self.downloadProgress[modelName] = Double(currentProgress)
-                updateCount += 1
-                if updateCount % 10 == 0 { // Log every 5 seconds (10 * 0.5s)
-                    logger.logInfo("📊 Progress update #\(updateCount): \((currentProgress * 100).formatted(.number.precision(.fractionLength(1))))%")
-                }
+            self.downloadProgress[modelName] = Double(currentProgress)
+            updateCount += 1
+            if updateCount % 10 == 0 { // Log every 5 seconds (10 * 0.5s)
+                logger.logInfo("📊 Progress update #\(updateCount): \((currentProgress * 100).formatted(.number.precision(.fractionLength(1))))%")
             }
 
             // Stop when we're close enough to target or time limit exceeded

--- a/VivaDicta/Services/RAG/RAGIndexingService.swift
+++ b/VivaDicta/Services/RAG/RAGIndexingService.swift
@@ -37,10 +37,10 @@ final class RAGIndexingService {
     static let shared = RAGIndexingService()
     private static let previewCharacterLimit = 180
     private static let maxLoggedChunksPerNote = 3
-    nonisolated(unsafe) private static let semanticSearchThreshold: Float = 0.25
+    nonisolated private static let semanticSearchThreshold: Float = 0.25
     private static let diagnosticThresholds: [Float] = [0.2, 0.0]
-    nonisolated(unsafe) private static let indexVersion = "v14_potion_base_32m"
-    nonisolated(unsafe) private static let vectorStoreName = "vivadicta-rag-\(indexVersion)"
+    nonisolated private static let indexVersion = "v14_potion_base_32m"
+    nonisolated private static let vectorStoreName = "vivadicta-rag-\(indexVersion)"
 
     @ObservationIgnored
     private let logger = Logger(category: .ragIndexing)

--- a/VivaDicta/Utilities/LoggerExtension.swift
+++ b/VivaDicta/Utilities/LoggerExtension.swift
@@ -98,7 +98,7 @@ public enum LogCategory: String {
 
 /// The app's subsystem identifier for all loggers
 /// Using the main app bundle ID for consistency across main app and extensions
-private nonisolated(unsafe) let kLoggingSubsystem = "com.antonnovoselov.VivaDicta"
+private nonisolated let kLoggingSubsystem = "com.antonnovoselov.VivaDicta"
 
 public extension Logger {
     /// Creates a Logger with the app's bundle identifier as subsystem and the specified category

--- a/VivaDicta/Views/AudioPlayerView.swift
+++ b/VivaDicta/Views/AudioPlayerView.swift
@@ -75,10 +75,8 @@ class AudioPlayerManager: NSObject, AVAudioPlayerDelegate {
             
             Task {
                 let samples = await WaveformGenerator.generateWaveformSamples(from: url)
-                await MainActor.run {
-                    self.waveformSamples = samples
-                    self.isLoadingWaveform = false
-                }
+                self.waveformSamples = samples
+                self.isLoadingWaveform = false
             }
         } catch {
             logger.logError("❌ Error loading audio: \(error.localizedDescription)")

--- a/VivaDicta/Views/ModelsScreen/AddCustomTranscriptionModelView.swift
+++ b/VivaDicta/Views/ModelsScreen/AddCustomTranscriptionModelView.swift
@@ -395,10 +395,8 @@ struct AddCustomTranscriptionModelView: View {
             // Dismiss after short delay
             Task {
                 try? await Task.sleep(for: .milliseconds(500))
-                await MainActor.run {
-                    onSave()
-                    dismiss()
-                }
+                onSave()
+                dismiss()
             }
         } else {
             connectionStatus = .failed(message: "Failed to save configuration")

--- a/VivaDicta/Views/ModelsScreen/CloudModelConfigurationView.swift
+++ b/VivaDicta/Views/ModelsScreen/CloudModelConfigurationView.swift
@@ -218,29 +218,23 @@ struct CloudModelConfigurationView: View {
     func saveKey() {
         Task {
             guard let aiProvider = model.provider.mappedAIProvider else {
-                await MainActor.run {
-                    verificationError = "API verification not supported for this provider"
-                }
+                verificationError = "API verification not supported for this provider"
                 return
             }
             
-            await MainActor.run {
-                isVerifying = true
-                verificationError = nil
-            }
-            
+            isVerifying = true
+            verificationError = nil
+
             HapticManager.mediumImpact()
             
             let isValid = await aiService.saveAPIKey(apiKey, for: aiProvider)
             
-            await MainActor.run {
-                isVerifying = false
+            isVerifying = false
 
-                if isValid {
-                    onSave(model)
-                } else {
-                    verificationError = "Invalid API key. Please check your key and try again."
-                }
+            if isValid {
+                onSave(model)
+            } else {
+                verificationError = "Invalid API key. Please check your key and try again."
             }
         }
     }

--- a/VivaDicta/Views/SettingsScreen/AddAPIKeyView.swift
+++ b/VivaDicta/Views/SettingsScreen/AddAPIKeyView.swift
@@ -248,24 +248,20 @@ struct AddAPIKeyView: View {
     
     func saveKey() {
         Task {
-            await MainActor.run {
-                isVerifying = true
-                verificationError = nil
-            }
+            isVerifying = true
+            verificationError = nil
             
             HapticManager.mediumImpact()
             
             let isValid = await aiService.saveAPIKey(apiKey, for: provider)
             
-            await MainActor.run {
-                isVerifying = false
+            isVerifying = false
                 
-                if isValid {
-                    onSave(provider)
-                    dismiss()
-                } else {
-                    verificationError = "Invalid API key. Please check your key and try again."
-                }
+            if isValid {
+                onSave(provider)
+                dismiss()
+            } else {
+                verificationError = "Invalid API key. Please check your key and try again."
             }
         }
     }

--- a/VivaDicta/Views/SettingsScreen/CustomOpenAIConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/CustomOpenAIConfigurationView.swift
@@ -383,61 +383,51 @@ struct CustomOpenAIConfigurationView: View {
 
         guard isValidURL(urlToTest) else {
             logger.debug("CustomOpenAI Config - Invalid URL")
-            await MainActor.run {
-                connectionStatus = .invalidURL
-                isChecking = false
-            }
+            connectionStatus = .invalidURL
+            isChecking = false
             return
         }
 
         guard !modelToTest.isEmpty else {
             logger.debug("CustomOpenAI Config - Missing model name")
-            await MainActor.run {
-                connectionStatus = .missingModel
-                isChecking = false
-            }
+            connectionStatus = .missingModel
+            isChecking = false
             return
         }
 
-        await MainActor.run {
-            connectionStatus = .checking
-        }
+        connectionStatus = .checking
 
         HapticManager.lightImpact()
 
         // Save configuration to test
-        await MainActor.run {
-            aiService.customOpenAIEndpointURL = urlToTest
-            aiService.customOpenAIModelName = modelToTest
+        aiService.customOpenAIEndpointURL = urlToTest
+        aiService.customOpenAIModelName = modelToTest
 
-            if !apiKeyToSave.isEmpty {
-                KeychainService.shared.save(apiKeyToSave, forKey: AIProvider.customOpenAI.keychainKey)
-            } else {
-                KeychainService.shared.delete(forKey: AIProvider.customOpenAI.keychainKey)
-            }
+        if !apiKeyToSave.isEmpty {
+            KeychainService.shared.save(apiKeyToSave, forKey: AIProvider.customOpenAI.keychainKey)
+        } else {
+            KeychainService.shared.delete(forKey: AIProvider.customOpenAI.keychainKey)
         }
 
         let result = await aiService.verifyCustomOpenAISetup()
         logger.debug("CustomOpenAI Config - Result: success=\(result.success)")
 
-        await MainActor.run {
-            if result.success {
-                connectionStatus = .connected
-                // Mark as verified so other screens know it's ready
-                aiService.customOpenAIIsVerified = true
-                aiService.refreshConnectedProviders()
-                HapticManager.success()
-            } else {
-                connectionStatus = .failed(message: result.message)
-                // Mark as NOT verified - this invalidates the configuration
-                aiService.customOpenAIIsVerified = false
-                // Disable AI processing for all modes using Custom OpenAI
-                aiService.disableCustomOpenAIEnhancementForAllModes()
-                aiService.refreshConnectedProviders()
-                HapticManager.error()
-            }
-            isChecking = false
+        if result.success {
+            connectionStatus = .connected
+            // Mark as verified so other screens know it's ready
+            aiService.customOpenAIIsVerified = true
+            aiService.refreshConnectedProviders()
+            HapticManager.success()
+        } else {
+            connectionStatus = .failed(message: result.message)
+            // Mark as NOT verified - this invalidates the configuration
+            aiService.customOpenAIIsVerified = false
+            // Disable AI processing for all modes using Custom OpenAI
+            aiService.disableCustomOpenAIEnhancementForAllModes()
+            aiService.refreshConnectedProviders()
+            HapticManager.error()
         }
+        isChecking = false
     }
 
     private func clearConfiguration() {

--- a/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
@@ -618,24 +618,22 @@ class ModeEditViewModel {
     private func verifyOllamaConnection(for target: ModelSelectionTarget) {
         Task {
             let result = await aiService.verifyOllamaSetup()
-            await MainActor.run {
-                if result.success {
-                    logger.logInfo("Ollama connection verified: \(result.message)")
-                    if let firstModel = aiService.ollamaModels.first {
-                        if let currentModel = currentModel(for: target),
-                           aiService.ollamaModels.contains(currentModel) {
-                            return
-                        }
-                        setModel(firstModel, for: target)
+            if result.success {
+                logger.logInfo("Ollama connection verified: \(result.message)")
+                if let firstModel = aiService.ollamaModels.first {
+                    if let currentModel = currentModel(for: target),
+                       aiService.ollamaModels.contains(currentModel) {
+                        return
                     }
-                } else {
-                    logger.logWarning("Ollama connection failed: \(result.message)")
-                    aiService.ollamaModels = []
-                    aiService.disableOllamaEnhancementForAllModes()
-                    setModel(nil, for: target)
+                    setModel(firstModel, for: target)
                 }
-                aiService.refreshConnectedProviders()
+            } else {
+                logger.logWarning("Ollama connection failed: \(result.message)")
+                aiService.ollamaModels = []
+                aiService.disableOllamaEnhancementForAllModes()
+                setModel(nil, for: target)
             }
+            aiService.refreshConnectedProviders()
         }
     }
 
@@ -647,22 +645,20 @@ class ModeEditViewModel {
 
         Task {
             let result = await aiService.verifyCustomOpenAISetup()
-            await MainActor.run {
-                if result.success {
-                    aiService.customOpenAIIsVerified = true
-                    logger.logInfo("Custom OpenAI connection verified: \(result.message)")
-                    let configuredModel = aiService.customOpenAIModelName
-                    if !configuredModel.isEmpty {
-                        setModel(configuredModel, for: target)
-                    }
-                } else {
-                    aiService.customOpenAIIsVerified = false
-                    aiService.disableCustomOpenAIEnhancementForAllModes()
-                    logger.logWarning("Custom OpenAI connection failed: \(result.message)")
-                    setModel(nil, for: target)
+            if result.success {
+                aiService.customOpenAIIsVerified = true
+                logger.logInfo("Custom OpenAI connection verified: \(result.message)")
+                let configuredModel = aiService.customOpenAIModelName
+                if !configuredModel.isEmpty {
+                    setModel(configuredModel, for: target)
                 }
-                aiService.refreshConnectedProviders()
+            } else {
+                aiService.customOpenAIIsVerified = false
+                aiService.disableCustomOpenAIEnhancementForAllModes()
+                logger.logWarning("Custom OpenAI connection failed: \(result.message)")
+                setModel(nil, for: target)
             }
+            aiService.refreshConnectedProviders()
         }
     }
 

--- a/VivaDicta/Views/SettingsScreen/OllamaConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/OllamaConfigurationView.swift
@@ -239,16 +239,12 @@ struct OllamaConfigurationView: View {
         let urlToTest = trimmedServerURL
 
         guard !urlToTest.isEmpty && isValidOllamaURL(urlToTest) else {
-            await MainActor.run {
-                connectionStatus = .invalidURL
-                isChecking = false
-            }
+            connectionStatus = .invalidURL
+            isChecking = false
             return
         }
 
-        await MainActor.run {
-            connectionStatus = .checking
-        }
+        connectionStatus = .checking
 
         HapticManager.lightImpact()
 
@@ -256,20 +252,18 @@ struct OllamaConfigurationView: View {
 
         let result = await aiService.verifyOllamaSetup()
 
-        await MainActor.run {
-            if result.success {
-                connectionStatus = .connected(modelCount: aiService.ollamaModels.count)
-                HapticManager.success()
-            } else {
-                connectionStatus = .failed(message: result.message)
-                // Clear models so other screens know Ollama is not ready
-                aiService.ollamaModels = []
-                // Disable AI processing for all modes using Ollama
-                aiService.disableOllamaEnhancementForAllModes()
-                HapticManager.error()
-            }
-            isChecking = false
+        if result.success {
+            connectionStatus = .connected(modelCount: aiService.ollamaModels.count)
+            HapticManager.success()
+        } else {
+            connectionStatus = .failed(message: result.message)
+            // Clear models so other screens know Ollama is not ready
+            aiService.ollamaModels = []
+            // Disable AI processing for all modes using Ollama
+            aiService.disableOllamaEnhancementForAllModes()
+            HapticManager.error()
         }
+        isChecking = false
     }
 }
 

--- a/VivaDicta/Views/TranscriptionsContentView.swift
+++ b/VivaDicta/Views/TranscriptionsContentView.swift
@@ -181,9 +181,7 @@ struct TranscriptionsContentView: View {
                     // Remove from the set after animation completes (1 second)
                     Task {
                         try? await Task.sleep(for: .seconds(1))
-                        await MainActor.run {
-                            _ = newlyInsertedIDs.remove(transcription.id)
-                        }
+                        _ = newlyInsertedIDs.remove(transcription.id)
                     }
                 }
             }
@@ -333,39 +331,31 @@ struct TranscriptionsContentView: View {
                 try await Task.sleep(for: .milliseconds(200))
 
                 guard !searchTerm.isEmpty else {
-                    await MainActor.run {
-                        filteredTranscriptions = allTranscriptions
-                        smartSearchMatches = []
-                        semanticScoresByID = [:]
-                    }
+                    filteredTranscriptions = allTranscriptions
+                    smartSearchMatches = []
+                    semanticScoresByID = [:]
                     return
                 }
 
                 let keywordResults = keywordSearchResults(for: searchTerm)
                 guard isSmartSearchEnabled else {
-                    await MainActor.run {
-                        filteredTranscriptions = keywordResults
-                        smartSearchMatches = []
-                        semanticScoresByID = [:]
-                    }
+                    filteredTranscriptions = keywordResults
+                    smartSearchMatches = []
+                    semanticScoresByID = [:]
                     return
                 }
 
                 guard searchMode != .keyword else {
-                    await MainActor.run {
-                        filteredTranscriptions = keywordResults
-                        smartSearchMatches = []
-                        semanticScoresByID = [:]
-                    }
+                    filteredTranscriptions = keywordResults
+                    smartSearchMatches = []
+                    semanticScoresByID = [:]
                     return
                 }
 
                 guard shouldRunSemanticSearch(for: searchTerm) else {
-                    await MainActor.run {
-                        filteredTranscriptions = keywordResults
-                        smartSearchMatches = []
-                        semanticScoresByID = [:]
-                    }
+                    filteredTranscriptions = keywordResults
+                    smartSearchMatches = []
+                    semanticScoresByID = [:]
                     return
                 }
 
@@ -373,24 +363,20 @@ struct TranscriptionsContentView: View {
 
                 switch searchMode {
                 case .all:
-                    await MainActor.run {
-                        filteredTranscriptions = keywordResults
-                        smartSearchMatches = smartMatches
-                        semanticScoresByID = Dictionary(
-                            uniqueKeysWithValues: smartMatches.map { ($0.transcriptionId, $0.relevanceScore) }
-                        )
-                    }
+                    filteredTranscriptions = keywordResults
+                    smartSearchMatches = smartMatches
+                    semanticScoresByID = Dictionary(
+                        uniqueKeysWithValues: smartMatches.map { ($0.transcriptionId, $0.relevanceScore) }
+                    )
                 case .smart:
                     let orderedResults = smartMatches.compactMap { match in
                         allTranscriptions.first(where: { $0.id == match.transcriptionId })
                     }
-                    await MainActor.run {
-                        filteredTranscriptions = orderedResults
-                        smartSearchMatches = smartMatches
-                        semanticScoresByID = Dictionary(
-                            uniqueKeysWithValues: smartMatches.map { ($0.transcriptionId, $0.relevanceScore) }
-                        )
-                    }
+                    filteredTranscriptions = orderedResults
+                    smartSearchMatches = smartMatches
+                    semanticScoresByID = Dictionary(
+                        uniqueKeysWithValues: smartMatches.map { ($0.transcriptionId, $0.relevanceScore) }
+                    )
                 case .keyword:
                     break
                 }


### PR DESCRIPTION
## Summary

Concurrency annotation cleanup for the Swift 6.2 / `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` build. Three related changes:

1. **Remove 45 redundant `await MainActor.run` wrappers** (10 files) - in contexts already `@MainActor` via default isolation, the wrapper was a no-op hop. Inlined the bodies.
2. **Use `@MainActor perform()` in the 4 record AppIntents** - `AppIntent.perform()` is `nonisolated`, so touching `@MainActor` state (`AppGroupCoordinator`) required an `await MainActor.run` hop. Annotating `perform()` removes the wrapper and matches the 6 other intents in the folder that already do this.
3. **Downgrade 4 `nonisolated(unsafe)` to `nonisolated`** - these are immutable `let`s of `Sendable` types (`Float`, `String`), so plain `nonisolated` is compiler-provable; the `(unsafe)` escape hatch was unearned. Restores the data-race check.

## Deliberately left alone

- **`RecordViewModel` transcription progress handler** - load-bearing `MainActor.run` (the `@Sendable` callback is genuinely nonisolated). Build-verified that removing it fails.
- **The other 6 `nonisolated(unsafe)`** - genuinely required (`var`s or non-`Sendable` types).
- **`FolderExportService`** - its 2 redundant `MainActor.run` need a `nonisolated` refactor (the `@concurrent` Tasks are currently defeated by it), not a plain deletion. Separate follow-up.
- **`nonisolated` keywords broadly** - audited; all load-bearing (OS/C callbacks, real-time audio, universal infra, protocol witnesses).

## Testing

- `xcodebuild build`: succeeds, 0 errors (full branch)
- Test suite: 323 passing, 0 failures (run on the core MainActor.run cleanup; the AppIntent and nonisolated commits are build-verified isolation-annotation changes)

## Notes

No behavior change - all three changes are isolation-annotation-only. The `MainActor.run` removals eliminate no-op hops; `@MainActor perform()` and the `nonisolated` downgrade are equivalent forms that let the compiler verify more.