### PR TITLE
Rename protocols: Servicing/Syncing -> Service/Sync (Bev-style nouns)

### DIFF
--- a/Modules/Keychain/Sources/Keychain/KeychainService.swift
+++ b/Modules/Keychain/Sources/Keychain/KeychainService.swift
@@ -1,5 +1,5 @@
 //
-//  KeychainServicing.swift
+//  KeychainService.swift
 //  Keychain
 //
 //  Created by Anton Novoselov on 2026.05.15
@@ -10,7 +10,7 @@ import Foundation
 /// Secure storage abstraction. The `syncable` flag controls whether the item
 /// participates in iCloud Keychain sync; the VivaDicta macOS app and iOS app
 /// share API keys via this mechanism.
-public protocol KeychainServicing: Sendable {
+public protocol KeychainService: Sendable {
 
     @discardableResult
     func save(_ value: String, forKey key: String, syncable: Bool) -> Bool
@@ -29,7 +29,7 @@ public protocol KeychainServicing: Sendable {
 // Default-syncable convenience overloads. Protocol methods cannot carry
 // default parameter values, so these live in an extension to preserve the
 // `keychain.save(value, forKey: key)` call shape used today.
-public extension KeychainServicing {
+public extension KeychainService {
 
     @discardableResult
     func save(_ value: String, forKey key: String) -> Bool {

--- a/Modules/Keychain/Sources/Keychain/KeychainServiceImpl.swift
+++ b/Modules/Keychain/Sources/Keychain/KeychainServiceImpl.swift
@@ -12,7 +12,7 @@ import Security
 /// Production keychain implementation. The default `service` value must match
 /// the macOS VivaDicta app for iCloud Keychain sync to work; do not change it
 /// without coordinating across both platforms.
-public final class KeychainServiceImpl: KeychainServicing, Sendable {
+public final class KeychainServiceImpl: KeychainService, Sendable {
 
     public static let defaultService = "com.antonnovoselov.VivaDicta"
 

--- a/Modules/Keychain/Sources/KeychainMocks/MockKeychainService.swift
+++ b/Modules/Keychain/Sources/KeychainMocks/MockKeychainService.swift
@@ -8,14 +8,14 @@
 import Foundation
 import Keychain
 
-/// Hybrid fake/mock for `KeychainServicing`.
+/// Hybrid fake/mock for `KeychainService`.
 ///
 /// Backed by an in-memory `[String: Data]` store so tests don't have to stub
 /// every read/write to model state. Stub-style overrides (`stub*Result`) take
 /// precedence when set, letting tests force specific failure modes. Per-method
 /// `didFoo` callbacks fire via `defer` so test expectations are only signaled
 /// after the side effect completes.
-public final class MockKeychainService: KeychainServicing, @unchecked Sendable {
+public final class MockKeychainService: KeychainService, @unchecked Sendable {
 
     public init() {}
 

--- a/Modules/OAuth/Sources/OAuth/BackgroundTaskService.swift
+++ b/Modules/OAuth/Sources/OAuth/BackgroundTaskService.swift
@@ -7,7 +7,7 @@ import Foundation
 /// in Safari) without depending on the app target's `BackgroundTaskService`.
 ///
 /// The app target provides an adapter that forwards to `UIApplication`.
-public protocol BackgroundTaskServicing: Sendable {
+public protocol BackgroundTaskService: Sendable {
     /// Begin a background task with the given name. `onExpiration` runs when
     /// the system is about to terminate the task. Returns an opaque identifier
     /// used to end the task, or `nil` if the task could not be started.

--- a/Modules/OAuth/Sources/OAuth/CopilotOAuthManager.swift
+++ b/Modules/OAuth/Sources/OAuth/CopilotOAuthManager.swift
@@ -9,8 +9,8 @@ import os
 @MainActor
 public final class CopilotOAuthManager: Sendable {
     private let logger = Logger(oauthCategory: "CopilotOAuth")
-    private let keychain: any KeychainServicing
-    private let backgroundTaskService: (any BackgroundTaskServicing)?
+    private let keychain: any KeychainService
+    private let backgroundTaskService: (any BackgroundTaskService)?
 
     /// GitHub OAuth client ID (same as VS Code Copilot extension).
     private let clientId = "Iv1.b507a08c87ecfe98"
@@ -22,8 +22,8 @@ public final class CopilotOAuthManager: Sendable {
     private var credential: CopilotCredential?
 
     public init(
-        keychain: any KeychainServicing,
-        backgroundTaskService: (any BackgroundTaskServicing)? = nil
+        keychain: any KeychainService,
+        backgroundTaskService: (any BackgroundTaskService)? = nil
     ) {
         self.keychain = keychain
         self.backgroundTaskService = backgroundTaskService

--- a/Modules/OAuth/Sources/OAuth/OAuthManager.swift
+++ b/Modules/OAuth/Sources/OAuth/OAuthManager.swift
@@ -11,12 +11,12 @@ import os
 @MainActor
 public final class OAuthManager: Sendable {
     private let logger = Logger(oauthCategory: "OAuthManager")
-    private let keychain: any KeychainServicing
+    private let keychain: any KeychainService
 
     /// In-memory cache of credentials.
     private var credentials: [String: OAuthCredential] = [:]
 
-    public init(keychain: any KeychainServicing) {
+    public init(keychain: any KeychainService) {
         self.keychain = keychain
     }
 

--- a/Modules/OAuth/Sources/OAuthMocks/MockBackgroundTaskService.swift
+++ b/Modules/OAuth/Sources/OAuthMocks/MockBackgroundTaskService.swift
@@ -3,13 +3,13 @@
 import Foundation
 import OAuth
 
-/// Hand-rolled mock for `BackgroundTaskServicing`.
+/// Hand-rolled mock for `BackgroundTaskService`.
 ///
 /// Returns an incrementing identifier from `beginBackgroundTask` and tracks
 /// begin/end calls. Set `stubBeginResult` to `nil` to simulate the system
 /// refusing to start a background task.
 @MainActor
-public final class MockBackgroundTaskService: BackgroundTaskServicing {
+public final class MockBackgroundTaskService: BackgroundTaskService {
 
     public init() {}
 

--- a/Modules/Presets/Sources/Presets/PresetManager.swift
+++ b/Modules/Presets/Sources/Presets/PresetManager.swift
@@ -11,7 +11,7 @@ import os
 /// Manages AI text processing presets with persistence in App Group UserDefaults.
 ///
 /// Handles both built-in and custom presets. Built-in presets are editable but not deletable.
-/// Custom presets are synced to CloudKit via a `PresetSyncing` implementation supplied by
+/// Custom presets are synced to CloudKit via a `PresetSync` implementation supplied by
 /// the app target (the package itself does not depend on SwiftData/CloudKit).
 ///
 /// ## Storage
@@ -34,7 +34,7 @@ public class PresetManager {
 
     /// Sync service for writing preset changes to SwiftData/CloudKit. The
     /// concrete implementation lives in the app target.
-    public var syncService: (any PresetSyncing)?
+    public var syncService: (any PresetSync)?
 
     public init(userDefaults: UserDefaults,
                 storageKey: String = "Presets_v1",

--- a/Modules/Presets/Sources/Presets/PresetSync.swift
+++ b/Modules/Presets/Sources/Presets/PresetSync.swift
@@ -1,5 +1,5 @@
 //
-//  PresetSyncing.swift
+//  PresetSync.swift
 //  Presets
 //
 //  Created by Anton Novoselov on 2026.05.15
@@ -11,7 +11,7 @@ import Foundation
 /// changes. The concrete implementation lives in the app target (where the
 /// `ModelContainer` and CloudKit container are configured); the package only
 /// depends on this protocol so `PresetManager` can be tested with a mock.
-public protocol PresetSyncing: AnyObject {
+public protocol PresetSync: AnyObject {
     func createPresetRecord(from preset: Preset)
     func updatePresetRecord(from preset: Preset)
     func deletePresetRecord(presetId: String)

--- a/Modules/Presets/Sources/PresetsMocks/MockPresetSync.swift
+++ b/Modules/Presets/Sources/PresetsMocks/MockPresetSync.swift
@@ -1,5 +1,5 @@
 //
-//  MockPresetSyncing.swift
+//  MockPresetSync.swift
 //  PresetsMocks
 //
 //  Created by Anton Novoselov on 2026.05.15
@@ -8,12 +8,12 @@
 import Foundation
 import Presets
 
-/// Hand-rolled mock for `PresetSyncing`. Tracks call counts and the records
+/// Hand-rolled mock for `PresetSync`. Tracks call counts and the records
 /// the production code under test wrote, but does not actually persist
 /// anything. Each method also exposes an after-side-effect callback so tests
 /// can fulfill expectations only after the production code has finished
 /// touching the mock.
-public final class MockPresetSyncing: PresetSyncing, @unchecked Sendable {
+public final class MockPresetSync: PresetSync, @unchecked Sendable {
 
     public init() {}
 

--- a/Modules/Presets/Tests/PresetsTests/MockPresetSyncTests.swift
+++ b/Modules/Presets/Tests/PresetsTests/MockPresetSyncTests.swift
@@ -10,11 +10,11 @@ import Testing
 import Presets
 import PresetsMocks
 
-@Suite("MockPresetSyncing contract")
+@Suite("MockPresetSync contract")
 struct MockPresetSyncingTests {
 
     @Test func tracksCreatePresetRecord() {
-        let sut = MockPresetSyncing()
+        let sut = MockPresetSync()
         let preset = PresetCatalog.regular
         sut.createPresetRecord(from: preset)
 
@@ -23,7 +23,7 @@ struct MockPresetSyncingTests {
     }
 
     @Test func tracksDeletePresetRecord() {
-        let sut = MockPresetSyncing()
+        let sut = MockPresetSync()
         sut.deletePresetRecord(presetId: "custom_xyz")
 
         #expect(sut.deletePresetRecordCallCount == 1)
@@ -31,7 +31,7 @@ struct MockPresetSyncingTests {
     }
 
     @Test func tracksFavoriteSync() {
-        let sut = MockPresetSyncing()
+        let sut = MockPresetSync()
         sut.syncFavoriteState(presetId: "summary", isFavorite: true)
 
         #expect(sut.syncFavoriteStateCallCount == 1)
@@ -40,7 +40,7 @@ struct MockPresetSyncingTests {
     }
 
     @Test func didCallbackFiresAfterMutation() {
-        let sut = MockPresetSyncing()
+        let sut = MockPresetSync()
         var observedCount: Int?
         sut.didCreatePresetRecord = {
             observedCount = sut.createPresetRecordCallCount

--- a/VivaDicta/AppDelegate.swift
+++ b/VivaDicta/AppDelegate.swift
@@ -17,7 +17,7 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         logger.logInfo("🚀 didFinishLaunchingWithOptions - state: \(application.applicationState.debugDescription)")
         FirebaseApp.configure()
-        BackgroundTaskService.registerBGTaskHandler()
+        BackgroundTaskManager.registerBGTaskHandler()
         return true
     }
 

--- a/VivaDicta/AppState.swift
+++ b/VivaDicta/AppState.swift
@@ -77,7 +77,7 @@ class AppState {
     var watchConnectivityService: PhoneWatchConnectivityService!
 
     /// Service for managing background task protection.
-    var backgroundTaskService: BackgroundTaskService!
+    var backgroundTaskService: BackgroundTaskManager!
 
 
     // MARK: - Navigation State
@@ -179,7 +179,7 @@ class AppState {
         )
 
         // Set up background task service
-        backgroundTaskService = BackgroundTaskService(modelContainer: modelContainer)
+        backgroundTaskService = BackgroundTaskManager(modelContainer: modelContainer)
         backgroundTaskService.configure(watchAudioProcessor: watchProcessor)
 
         watchConnectivityService = PhoneWatchConnectivityService()

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -170,7 +170,7 @@ class AIService {
     private let userDefaults: UserDefaults
     private let modesStorageKey: String
     private let selectedModeStorageKey: String
-    private let keychain: any KeychainServicing
+    private let keychain: any KeychainService
     private let baseTimeout: TimeInterval = 300
 
     /// Service for Apple's on-device Foundation Models (type-erased for iOS version compatibility)
@@ -186,7 +186,7 @@ class AIService {
         return service
     }
 
-    init(keychain: any KeychainServicing = KeychainServiceImpl()) {
+    init(keychain: any KeychainService = KeychainServiceImpl()) {
         self.keychain = keychain
         self.userDefaults = UserDefaultsStorage.shared
         self.modesStorageKey = AppGroupCoordinator.vivaModesKey
@@ -227,7 +227,7 @@ class AIService {
     }
 
     /// Test-only initializer with injectable UserDefaults and no network side effects.
-    init(userDefaults: UserDefaults, modesStorageKey: String = "VivaModes", selectedModeStorageKey: String = "selectedVivaMode", keychain: any KeychainServicing = KeychainServiceImpl()) {
+    init(userDefaults: UserDefaults, modesStorageKey: String = "VivaModes", selectedModeStorageKey: String = "selectedVivaMode", keychain: any KeychainService = KeychainServiceImpl()) {
         self.keychain = keychain
         self.userDefaults = userDefaults
         self.modesStorageKey = modesStorageKey

--- a/VivaDicta/Services/AIEnhance/ExaWebSearchTool.swift
+++ b/VivaDicta/Services/AIEnhance/ExaWebSearchTool.swift
@@ -261,7 +261,7 @@ private enum ExaError: LocalizedError {
 
 enum ExaAPIKeyManager {
     static let keychainKey = "exaAPIKey"
-    private static let keychain: any KeychainServicing = KeychainServiceImpl()
+    private static let keychain: any KeychainService = KeychainServiceImpl()
 
     static var apiKey: String? {
         keychain.getString(forKey: keychainKey)

--- a/VivaDicta/Services/AIEnhance/VivAgentsClient.swift
+++ b/VivaDicta/Services/AIEnhance/VivAgentsClient.swift
@@ -12,7 +12,7 @@ import os
 enum VivAgentsClient {
 
     private static let logger = Logger(category: .vivAgentsClient)
-    private static let keychain: any KeychainServicing = KeychainServiceImpl()
+    private static let keychain: any KeychainService = KeychainServiceImpl()
 
     struct EnhanceRequest: Encodable {
         let text: String

--- a/VivaDicta/Services/AIProvider+APIKey.swift
+++ b/VivaDicta/Services/AIProvider+APIKey.swift
@@ -12,7 +12,7 @@ import Keychain
 // without forcing every consumer of `AIProvider.apiKey` to inject one.
 // `AIProvider` is a domain enum used in non-DI contexts (data models,
 // view models) that don't have a ready `AppDependencies` reference.
-private let keychain: any KeychainServicing = KeychainServiceImpl()
+private let keychain: any KeychainService = KeychainServiceImpl()
 
 extension AIProvider {
     /// Reads this provider's API key from the Keychain.

--- a/VivaDicta/Services/APIKeyMigrationService.swift
+++ b/VivaDicta/Services/APIKeyMigrationService.swift
@@ -14,11 +14,11 @@ import os
 final class APIKeyMigrationService: Sendable {
     static let shared = APIKeyMigrationService(keychain: KeychainServiceImpl())
 
-    private let keychain: any KeychainServicing
+    private let keychain: any KeychainService
     private let logger = Logger(category: .keychainService)
     private let migrationCompletedKey = "HasMigratedAPIKeysToKeychain"
 
-    init(keychain: any KeychainServicing) {
+    init(keychain: any KeychainService) {
         self.keychain = keychain
     }
 

--- a/VivaDicta/Services/BackgroundTaskManager.swift
+++ b/VivaDicta/Services/BackgroundTaskManager.swift
@@ -1,5 +1,5 @@
 //
-//  BackgroundTaskService.swift
+//  BackgroundTaskManager.swift
 //  VivaDicta
 //
 //  Created by Anton Novoselov on 2026.04.04
@@ -19,11 +19,11 @@ import os
 /// The primary use case is protecting Watch audio processing, which happens
 /// entirely in background when the iPhone receives files via WatchConnectivity.
 @MainActor
-final class BackgroundTaskService {
+final class BackgroundTaskManager {
     nonisolated static let bgTaskIdentifier = "com.antonnovoselov.VivaDicta.transcription-processing"
 
     /// Live instance reference for the BGTask handler to dispatch to.
-    static nonisolated(unsafe) weak var shared: BackgroundTaskService?
+    static nonisolated(unsafe) weak var shared: BackgroundTaskManager?
 
     private let logger = Logger(category: .backgroundTask)
     private nonisolated(unsafe) let queue: BackgroundTaskQueue
@@ -107,7 +107,7 @@ final class BackgroundTaskService {
     /// Registers the BGProcessingTask handler. Must be called during `didFinishLaunching`.
     ///
     /// The handler dispatches to the live `shared` instance. By the time iOS delivers
-    /// a BGProcessingTask, AppState (and thus BackgroundTaskService) is always initialized
+    /// a BGProcessingTask, AppState (and thus BackgroundTaskManager) is always initialized
     /// because the task is scheduled from within the running app.
     static func registerBGTaskHandler() {
         BGTaskScheduler.shared.register(

--- a/VivaDicta/Services/LiveTranslation/LiveTranslationService.swift
+++ b/VivaDicta/Services/LiveTranslation/LiveTranslationService.swift
@@ -30,7 +30,7 @@ final class LiveTranslationService {
     }
 
     private let logger = Logger(category: .liveTranslationService)
-    private let keychain: any KeychainServicing
+    private let keychain: any KeychainService
     private let audio: LiveTranslationAudio
     private let sttClient = SonioxRealtimeSTTClient()
     private var ttsClient: SonioxRealtimeTTSClient?
@@ -61,7 +61,7 @@ final class LiveTranslationService {
     private var sessionStartedAt: Date?
     private(set) var sessionTargetLanguage: LiveTranslationLanguage = .english
 
-    init(keychain: any KeychainServicing = KeychainServiceImpl()) {
+    init(keychain: any KeychainService = KeychainServiceImpl()) {
         self.keychain = keychain
         self.audio = LiveTranslationAudio()
         self.audio.playbackRate = LiveTranslationPreferences.ttsRate

--- a/VivaDicta/Services/OAuth/BackgroundTaskServiceAdapter.swift
+++ b/VivaDicta/Services/OAuth/BackgroundTaskServiceAdapter.swift
@@ -4,11 +4,11 @@ import Foundation
 import UIKit
 import OAuth
 
-/// App-target adapter that bridges the OAuth module's `BackgroundTaskServicing`
-/// protocol to the concrete `BackgroundTaskService` singleton.
-struct BackgroundTaskServiceAdapter: BackgroundTaskServicing {
+/// App-target adapter that bridges the OAuth module's `BackgroundTaskService`
+/// protocol to the concrete `BackgroundTaskManager` singleton.
+struct BackgroundTaskServiceAdapter: BackgroundTaskService {
     func beginBackgroundTask(name: String, onExpiration: @escaping @Sendable () -> Void) -> UInt? {
-        guard let identifier = BackgroundTaskService.shared?.beginBackgroundTask(name: name, onExpiration: onExpiration) else {
+        guard let identifier = BackgroundTaskManager.shared?.beginBackgroundTask(name: name, onExpiration: onExpiration) else {
             return nil
         }
         guard identifier != .invalid else { return nil }
@@ -16,6 +16,6 @@ struct BackgroundTaskServiceAdapter: BackgroundTaskServicing {
     }
 
     func endBackgroundTask(_ identifier: UInt) {
-        BackgroundTaskService.shared?.endBackgroundTask(UIBackgroundTaskIdentifier(rawValue: Int(identifier)))
+        BackgroundTaskManager.shared?.endBackgroundTask(UIBackgroundTaskIdentifier(rawValue: Int(identifier)))
     }
 }

--- a/VivaDicta/Services/PhoneWatchConnectivityService.swift
+++ b/VivaDicta/Services/PhoneWatchConnectivityService.swift
@@ -17,12 +17,12 @@ final class PhoneWatchConnectivityService: NSObject {
     private var audioProcessor: WatchAudioProcessor?
 
     /// Service for background task protection.
-    private var backgroundTaskService: BackgroundTaskService?
+    private var backgroundTaskService: BackgroundTaskManager?
 
     /// Modes to sync to watch once session activates.
     private var pendingModes: [VivaMode]?
 
-    func configure(audioProcessor: WatchAudioProcessor, backgroundTaskService: BackgroundTaskService) {
+    func configure(audioProcessor: WatchAudioProcessor, backgroundTaskService: BackgroundTaskManager) {
         self.audioProcessor = audioProcessor
         self.backgroundTaskService = backgroundTaskService
     }

--- a/VivaDicta/Services/PresetSyncService.swift
+++ b/VivaDicta/Services/PresetSyncService.swift
@@ -22,7 +22,7 @@ import Presets
 /// - **Migration**: One-time migration of existing custom presets and old
 ///   ``CustomRewritePreset`` records to the new `RewritePreset` model.
 @Observable
-class PresetSyncService: PresetSyncing {
+class PresetSyncService: PresetSync {
     private let logger = Logger(category: .presetSync)
     private var modelContext: ModelContext?
 

--- a/VivaDicta/Services/Transcription/CustomTranscription/CustomTranscriptionModelManager.swift
+++ b/VivaDicta/Services/Transcription/CustomTranscription/CustomTranscriptionModelManager.swift
@@ -16,7 +16,7 @@ final class CustomTranscriptionModelManager {
     static let shared = CustomTranscriptionModelManager(keychain: KeychainServiceImpl())
 
     private let logger = Logger(category: .customTranscriptionService)
-    private let keychain: any KeychainServicing
+    private let keychain: any KeychainService
 
     /// The single custom transcription model configuration
     private(set) var customModel: CustomTranscriptionModel
@@ -27,7 +27,7 @@ final class CustomTranscriptionModelManager {
     /// Fixed model ID for the singleton custom model
     private static let fixedModelId = UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
 
-    init(keychain: any KeychainServicing) {
+    init(keychain: any KeychainService) {
         self.keychain = keychain
         // Initialize with empty model first
         customModel = CustomTranscriptionModel(


### PR DESCRIPTION
## Summary

Cleanup PR. Renames the gerund-form protocol names to the plain noun form that the Bev reference uses (`BeerAPI`/`BeerAPIImpl` pattern).

| Before | After |
|---|---|
| `KeychainServicing` | `KeychainService` |
| `BackgroundTaskServicing` | `BackgroundTaskService` |
| `PresetSyncing` | `PresetSync` |
| `MockPresetSyncing` | `MockPresetSync` |

`OAuthProvider` already used the noun form correctly - no change.

## Name collision resolved

The app target had its own concrete `BackgroundTaskService` class (the `UIApplication` background-task wrapper). The protocol now claims that name, so the app's class is renamed to `BackgroundTaskManager` - which describes what it actually does. The OAuth module's `BackgroundTaskServiceAdapter` still adapts the protocol; the adapter just forwards to `BackgroundTaskManager.shared` now.

## Why

The original `-ing` form was a Swift community convention (gerund/-able for protocols, noun for impls) but it read awkwardly and diverged from the Bev reference we cited in the modularization plan. `KeychainService` reads as "an object that provides keychain service"; `KeychainServicing` reads as "the act of servicing the keychain" - the noun form is clearer.

## Test plan

- [x] `swift test --package-path Modules/Keychain` - 6 tests pass
- [x] `swift test --package-path Modules/OAuth` - 11 tests pass (1 known issue by design)
- [x] `swift test --package-path Modules/Presets` - 4 tests pass
- [x] iOS app build green