### PR TITLE
Remove WhisperKit and FluidAudio from app target dependencies

### DIFF
--- a/Modules/LocalTranscription/Sources/LocalTranscription/LocalModelDownloader.swift
+++ b/Modules/LocalTranscription/Sources/LocalTranscription/LocalModelDownloader.swift
@@ -1,0 +1,116 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+@preconcurrency import FluidAudio
+import Foundation
+import TranscriptionCore
+import WhisperKit
+
+/// Stateless download helpers that wrap WhisperKit + FluidAudio. The app's
+/// `ModelDownloadManager` calls these instead of importing the SDKs directly,
+/// keeping `WhisperKit` and `FluidAudio` confined to this module.
+///
+/// Each download is a one-shot async function. Callers own all UI state
+/// (`@Observable` progress dicts, status enums, cancellation tasks). The
+/// helpers just translate SDK progress into a uniform `Double` (0.0...1.0).
+public enum LocalModelDownloader {
+    /// Receives normalized progress between 0.0 and 1.0.
+    public typealias ProgressHandler = @Sendable (Double) -> Void
+
+    // MARK: - Parakeet
+
+    /// Downloads (if not cached) and validates the Parakeet ASR model plus the
+    /// VAD model for the given version. Progress is unified across both
+    /// phases: ASR occupies 0.0...0.85, VAD occupies 0.85...1.0.
+    ///
+    /// Honors `Task.checkCancellation()` between phases.
+    public static func downloadParakeet(
+        version: ParakeetModelVersion,
+        onProgress: @escaping ProgressHandler
+    ) async throws {
+        let asrVersion = asrModelVersion(for: version)
+
+        _ = try await AsrModels.downloadAndLoad(
+            version: asrVersion,
+            progressHandler: { progress in
+                onProgress(progress.fractionCompleted * 0.85)
+            }
+        )
+
+        try Task.checkCancellation()
+
+        _ = try await VadManager(
+            progressHandler: { progress in
+                onProgress(0.85 + progress.fractionCompleted * 0.15)
+            }
+        )
+    }
+
+    // MARK: - WhisperKit
+
+    /// Phases the WhisperKit setup pipeline emits. Callers use them to drive
+    /// their own progress UI (e.g. animate between fixed checkpoints during
+    /// the long prewarm + load steps).
+    public enum WhisperKitPhase: Sendable {
+        /// File download in progress. `fractionCompleted` is 0.0...1.0 across
+        /// the network download only.
+        case downloading(fractionCompleted: Double)
+        /// Files are present on disk (either freshly downloaded or already
+        /// cached). Prewarm is about to start.
+        case prewarmStart
+        /// Prewarm finished; load is about to start.
+        case loadStart
+        /// Load finished; the model has been unloaded again to free memory.
+        case finished
+    }
+
+    public typealias WhisperKitPhaseHandler = @Sendable (WhisperKitPhase) -> Void
+
+    /// Downloads the WhisperKit model (if missing), prewarms it, loads it,
+    /// then unloads it again. This is the first-run setup flow - subsequent
+    /// transcriptions reload from the prewarmed Core ML cache and are fast.
+    ///
+    /// Honors `Task.checkCancellation()` at each phase boundary.
+    public static func downloadAndPrepareWhisperKit(
+        modelName: String,
+        onPhase: @escaping WhisperKitPhaseHandler
+    ) async throws {
+        let config = WhisperKitConfig(
+            verbose: false,
+            logLevel: .info,
+            prewarm: false,
+            load: false,
+            download: false
+        )
+
+        let whisperKit = try await WhisperKit(config)
+        try Task.checkCancellation()
+
+        let modelFolder = WhisperKitModelPath.directory(forModelName: modelName)
+
+        if FileManager.default.fileExists(atPath: modelFolder.path) {
+            whisperKit.modelFolder = modelFolder
+            onPhase(.downloading(fractionCompleted: 1.0))
+        } else {
+            let downloadedFolder = try await WhisperKit.download(
+                variant: modelName,
+                from: "argmaxinc/whisperkit-coreml",
+                progressCallback: { @Sendable progress in
+                    onPhase(.downloading(fractionCompleted: progress.fractionCompleted))
+                }
+            )
+            whisperKit.modelFolder = downloadedFolder
+        }
+
+        try Task.checkCancellation()
+        onPhase(.prewarmStart)
+        try await whisperKit.prewarmModels()
+        try Task.checkCancellation()
+
+        onPhase(.loadStart)
+        try await whisperKit.loadModels()
+        try Task.checkCancellation()
+
+        await whisperKit.unloadModels()
+        onPhase(.finished)
+    }
+}

--- a/Modules/LocalTranscription/Sources/LocalTranscription/ParakeetModelPath.swift
+++ b/Modules/LocalTranscription/Sources/LocalTranscription/ParakeetModelPath.swift
@@ -1,0 +1,31 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+@preconcurrency import FluidAudio
+import Foundation
+import TranscriptionCore
+
+/// Filesystem layout helper for Parakeet (FluidAudio) model packages.
+/// Centralized in `LocalTranscription` so the app's model catalog can ask
+/// "is this model downloaded?" without importing `FluidAudio` directly.
+public enum ParakeetModelPath {
+    /// Default cache directory FluidAudio uses for the given Parakeet model
+    /// version. Mirrors what `AsrModels.downloadAndLoad(version:)` writes to.
+    public static func directory(for version: ParakeetModelVersion) -> URL {
+        AsrModels.defaultCacheDirectory(for: asrModelVersion(for: version))
+    }
+
+    /// Whether all required model files for the given version are present in
+    /// FluidAudio's default cache directory.
+    public static func isDownloaded(version: ParakeetModelVersion) -> Bool {
+        let asrVersion = asrModelVersion(for: version)
+        return AsrModels.modelsExist(at: directory(for: version), version: asrVersion)
+    }
+}
+
+@inline(__always)
+internal func asrModelVersion(for version: ParakeetModelVersion) -> AsrModelVersion {
+    switch version {
+    case .v2: return .v2
+    case .v3: return .v3
+    }
+}

--- a/Modules/TranscriptionCore/Sources/TranscriptionCore/ParakeetModelVersion.swift
+++ b/Modules/TranscriptionCore/Sources/TranscriptionCore/ParakeetModelVersion.swift
@@ -1,0 +1,13 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+
+/// Identifies which Parakeet model family to load. Mirrors FluidAudio's
+/// `AsrModelVersion` but lives in TranscriptionCore so consumers (the
+/// app's `ParakeetModel` catalog, extensions that share it via folder-sync,
+/// and the `TranscriptionKit` engine) can name a version without pulling
+/// in FluidAudio.
+public enum ParakeetModelVersion: Sendable {
+    case v2
+    case v3
+}

--- a/Modules/TranscriptionKit/Sources/TranscriptionKit/TranscriptionProvider.swift
+++ b/Modules/TranscriptionKit/Sources/TranscriptionKit/TranscriptionProvider.swift
@@ -42,10 +42,6 @@ public enum TranscriptionProvider: Sendable {
     )
 }
 
-/// Identifies which Parakeet model family to load. Mirrors FluidAudio's
-/// `AsrModelVersion` but is owned by TranscriptionKit so consumers don't
-/// transitively pull in FluidAudio just to construct an enum case.
-public enum ParakeetModelVersion: Sendable {
-    case v2
-    case v3
-}
+// `ParakeetModelVersion` lives in `TranscriptionCore` so app-target model
+// catalogs (which are shared with extensions) can reference it without
+// linking TranscriptionKit.

--- a/VivaDicta.xcodeproj/project.pbxproj
+++ b/VivaDicta.xcodeproj/project.pbxproj
@@ -20,10 +20,8 @@
 		186C0C9E2FB782A000102432 /* OAuthMocks in Frameworks */ = {isa = PBXBuildFile; productRef = 186C0C9D2FB782A000102432 /* OAuthMocks */; };
 		1879FDA02F8C088E00952CF9 /* LumoKit in Frameworks */ = {isa = PBXBuildFile; productRef = 1879FD9F2F8C088E00952CF9 /* LumoKit */; };
 		189C7A952F0C6822004BAFBF /* ShareExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 189C7A8B2F0C6822004BAFBF /* ShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		189C7AA72F0D4A6E004BAFBF /* FluidAudio in Frameworks */ = {isa = PBXBuildFile; productRef = 189C7AA62F0D4A6E004BAFBF /* FluidAudio */; };
 		189C7AB02F0D84E2004BAFBF /* UniformTypeIdentifiers.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 189C7AAF2F0D84E2004BAFBF /* UniformTypeIdentifiers.framework */; };
 		189C7ABC2F0D84E2004BAFBF /* ActionExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 189C7AAE2F0D84E2004BAFBF /* ActionExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		189C7ACF2F0D8749004BAFBF /* FluidAudio in Frameworks */ = {isa = PBXBuildFile; productRef = 189C7ACE2F0D8749004BAFBF /* FluidAudio */; };
 		18B497E52F26822400538830 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 18B497E42F26822400538830 /* Settings.bundle */; };
 		18B497E62F26822400538830 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 18B497E42F26822400538830 /* Settings.bundle */; };
 		18B497F02F268B2700538830 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 18B497EF2F268B2700538830 /* FirebaseAnalytics */; };
@@ -39,10 +37,6 @@
 		18E1C7FC2E8E793E00BE8A11 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 18E1C7FB2E8E793E00BE8A11 /* WidgetKit.framework */; };
 		18E1C7FE2E8E793E00BE8A11 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 18E1C7FD2E8E793E00BE8A11 /* SwiftUI.framework */; };
 		18E1C80F2E8E793F00BE8A11 /* VivaDictaWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 18E1C7FA2E8E793E00BE8A11 /* VivaDictaWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		18E328F72E894C3D0026327D /* WhisperKit in Frameworks */ = {isa = PBXBuildFile; productRef = 18E328F62E894C3D0026327D /* WhisperKit */; };
-		18EBD6B32ED1FBFB00C0041E /* FluidAudio in Frameworks */ = {isa = PBXBuildFile; productRef = 18EBD6B22ED1FBFB00C0041E /* FluidAudio */; };
-		18EBD7992ED1FCC600C0041E /* FluidAudio in Frameworks */ = {isa = PBXBuildFile; productRef = 18EBD7982ED1FCC600C0041E /* FluidAudio */; };
-		18F0AA4B2F90A11100A1B2C3 /* SpeakerKit in Frameworks */ = {isa = PBXBuildFile; productRef = 18F0AA4A2F90A11100A1B2C3 /* SpeakerKit */; };
 		18F75FBE2FB79A2B00280269 /* TranscriptionCore in Frameworks */ = {isa = PBXBuildFile; productRef = 18F75FBD2FB79A2B00280269 /* TranscriptionCore */; };
 		18F75FC02FB79A3200280269 /* CloudTranscription in Frameworks */ = {isa = PBXBuildFile; productRef = 18F75FBF2FB79A3200280269 /* CloudTranscription */; };
 		18F75FC22FB79A3E00280269 /* TranscriptionCore in Frameworks */ = {isa = PBXBuildFile; productRef = 18F75FC12FB79A3E00280269 /* TranscriptionCore */; };
@@ -503,13 +497,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				1879FDA02F8C088E00952CF9 /* LumoKit in Frameworks */,
-				18EBD6B32ED1FBFB00C0041E /* FluidAudio in Frameworks */,
-				18E328F72E894C3D0026327D /* WhisperKit in Frameworks */,
 				186C05812FB779AA00102432 /* Presets in Frameworks */,
 				18F76A322FB85C0400280269 /* AppGroup in Frameworks */,
 				186C0C9C2FB7829A00102432 /* OAuth in Frameworks */,
 				18F75FC02FB79A3200280269 /* CloudTranscription in Frameworks */,
-				18F0AA4B2F90A11100A1B2C3 /* SpeakerKit in Frameworks */,
 				18F7637F2FB7D5E300280269 /* LocalTranscription in Frameworks */,
 				186C057F2FB779AA00102432 /* Keychain in Frameworks */,
 				18E1B4AD2E8C875000BE8A11 /* KeyboardKit in Frameworks */,
@@ -547,7 +538,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				189C7AA72F0D4A6E004BAFBF /* FluidAudio in Frameworks */,
 				18F76A3A2FB85C2300280269 /* AppGroup in Frameworks */,
 				186C058B2FB779C200102432 /* Presets in Frameworks */,
 			);
@@ -558,7 +548,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				186C058D2FB779CB00102432 /* Presets in Frameworks */,
-				189C7ACF2F0D8749004BAFBF /* FluidAudio in Frameworks */,
 				18F76A3C2FB85C2A00280269 /* AppGroup in Frameworks */,
 				189C7AB02F0D84E2004BAFBF /* UniformTypeIdentifiers.framework in Frameworks */,
 			);
@@ -601,7 +590,6 @@
 				186C058F2FB779D200102432 /* Presets in Frameworks */,
 				18E1B4AF2E8C875A00BE8A11 /* KeyboardKit in Frameworks */,
 				18F76D862FB8617C00280269 /* AppGroup in Frameworks */,
-				18EBD7992ED1FCC600C0041E /* FluidAudio in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -725,10 +713,7 @@
 			);
 			name = VivaDicta;
 			packageProductDependencies = (
-				18E328F62E894C3D0026327D /* WhisperKit */,
-				18F0AA4A2F90A11100A1B2C3 /* SpeakerKit */,
 				18E1B4AC2E8C875000BE8A11 /* KeyboardKit */,
-				18EBD6B22ED1FBFB00C0041E /* FluidAudio */,
 				18B497EF2F268B2700538830 /* FirebaseAnalytics */,
 				18B497F12F268B2700538830 /* FirebaseCrashlytics */,
 				1879FD9F2F8C088E00952CF9 /* LumoKit */,
@@ -817,7 +802,6 @@
 			);
 			name = ShareExtension;
 			packageProductDependencies = (
-				189C7AA62F0D4A6E004BAFBF /* FluidAudio */,
 				186C058A2FB779C200102432 /* Presets */,
 				18F76A392FB85C2300280269 /* AppGroup */,
 			);
@@ -843,7 +827,6 @@
 			);
 			name = ActionExtension;
 			packageProductDependencies = (
-				189C7ACE2F0D8749004BAFBF /* FluidAudio */,
 				186C058C2FB779CB00102432 /* Presets */,
 				18F76A3B2FB85C2A00280269 /* AppGroup */,
 			);
@@ -961,7 +944,6 @@
 			name = VivaDictaKeyboard;
 			packageProductDependencies = (
 				18E1B4AE2E8C875A00BE8A11 /* KeyboardKit */,
-				18EBD7982ED1FCC600C0041E /* FluidAudio */,
 				186C058E2FB779D200102432 /* Presets */,
 				18F76D852FB8617C00280269 /* AppGroup */,
 			);
@@ -1051,9 +1033,7 @@
 			mainGroup = 181D04CE2E3E55E400D357A6;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				18E328F52E894C3D0026327D /* XCRemoteSwiftPackageReference "WhisperKit" */,
 				18E1B4AB2E8C875000BE8A11 /* XCRemoteSwiftPackageReference "KeyboardKit" */,
-				18EBD6B12ED1FBFB00C0041E /* XCRemoteSwiftPackageReference "FluidAudio" */,
 				18B497EE2F268B2700538830 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				1879FD9E2F8C088E00952CF9 /* XCRemoteSwiftPackageReference "LumoKit" */,
 			);
@@ -2683,22 +2663,6 @@
 				version = 10.3.1;
 			};
 		};
-		18E328F52E894C3D0026327D /* XCRemoteSwiftPackageReference "WhisperKit" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/argmaxinc/WhisperKit.git";
-			requirement = {
-				branch = main;
-				kind = branch;
-			};
-		};
-		18EBD6B12ED1FBFB00C0041E /* XCRemoteSwiftPackageReference "FluidAudio" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/FluidInference/FluidAudio";
-			requirement = {
-				kind = exactVersion;
-				version = 0.13.6;
-			};
-		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -2751,16 +2715,6 @@
 			package = 1879FD9E2F8C088E00952CF9 /* XCRemoteSwiftPackageReference "LumoKit" */;
 			productName = LumoKit;
 		};
-		189C7AA62F0D4A6E004BAFBF /* FluidAudio */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 18EBD6B12ED1FBFB00C0041E /* XCRemoteSwiftPackageReference "FluidAudio" */;
-			productName = FluidAudio;
-		};
-		189C7ACE2F0D8749004BAFBF /* FluidAudio */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 18EBD6B12ED1FBFB00C0041E /* XCRemoteSwiftPackageReference "FluidAudio" */;
-			productName = FluidAudio;
-		};
 		18B497EF2F268B2700538830 /* FirebaseAnalytics */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 18B497EE2F268B2700538830 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
@@ -2784,26 +2738,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 18E1B4AB2E8C875000BE8A11 /* XCRemoteSwiftPackageReference "KeyboardKit" */;
 			productName = KeyboardKit;
-		};
-		18E328F62E894C3D0026327D /* WhisperKit */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 18E328F52E894C3D0026327D /* XCRemoteSwiftPackageReference "WhisperKit" */;
-			productName = WhisperKit;
-		};
-		18EBD6B22ED1FBFB00C0041E /* FluidAudio */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 18EBD6B12ED1FBFB00C0041E /* XCRemoteSwiftPackageReference "FluidAudio" */;
-			productName = FluidAudio;
-		};
-		18EBD7982ED1FCC600C0041E /* FluidAudio */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 18EBD6B12ED1FBFB00C0041E /* XCRemoteSwiftPackageReference "FluidAudio" */;
-			productName = FluidAudio;
-		};
-		18F0AA4A2F90A11100A1B2C3 /* SpeakerKit */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 18E328F52E894C3D0026327D /* XCRemoteSwiftPackageReference "WhisperKit" */;
-			productName = SpeakerKit;
 		};
 		18F75FBD2FB79A2B00280269 /* TranscriptionCore */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/VivaDicta/Models/ParakeetModel+FileManagement.swift
+++ b/VivaDicta/Models/ParakeetModel+FileManagement.swift
@@ -1,0 +1,39 @@
+//
+//  ParakeetModel+FileManagement.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.05.16
+//
+
+import Foundation
+import LocalTranscription
+import TranscriptionCore
+
+// This extension lives in a main-target-only file because it depends on the
+// LocalTranscription package, which the extension targets do not link.
+// `ParakeetModel` itself is shared with extensions via folder-sync; this file
+// is not part of those extensions' folder-sync (the file is new and Xcode adds
+// new app-target files to the main target only).
+extension ParakeetModel {
+    var version: ParakeetModelVersion {
+        name.lowercased().contains("v2") ? .v2 : .v3
+    }
+
+    var modelsDirectory: URL {
+        ParakeetModelPath.directory(for: version)
+    }
+
+    private var hasCachedModelDirectory: Bool {
+        FileManager.default.fileExists(atPath: modelsDirectory.path)
+    }
+
+    var isDownloaded: Bool {
+        ParakeetModelPath.isDownloaded(version: version)
+    }
+
+    func deleteModel() throws {
+        if hasCachedModelDirectory {
+            try FileManager.default.removeItem(at: modelsDirectory)
+        }
+    }
+}

--- a/VivaDicta/Models/ParakeetModel.swift
+++ b/VivaDicta/Models/ParakeetModel.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import FluidAudio
 
 struct ParakeetModel: @MainActor TranscriptionModel, Equatable {
     static func == (lhs: ParakeetModel, rhs: ParakeetModel) -> Bool {
@@ -22,7 +21,7 @@ struct ParakeetModel: @MainActor TranscriptionModel, Equatable {
     let speed: Double
     let accuracy: Double
     let ramUsage: Double
-    
+
     init(name: String,
          displayName: String,
          description: String,
@@ -48,31 +47,4 @@ struct ParakeetModel: @MainActor TranscriptionModel, Equatable {
     }
 
     let supportedLanguages: [String: String]
-}
-
-// MARK: - Download & File Management
-extension ParakeetModel {
-    var version: AsrModelVersion {
-        name.lowercased().contains("v2") ? .v2 : .v3
-    }
-
-    /// Returns FluidAudio's default cache directory for this model version.
-    /// This ensures consistency between download, validation, and loading.
-    var modelsDirectory: URL {
-        AsrModels.defaultCacheDirectory(for: version)
-    }
-
-    private var hasCachedModelDirectory: Bool {
-        FileManager.default.fileExists(atPath: modelsDirectory.path)
-    }
-
-    var isDownloaded: Bool {
-        AsrModels.modelsExist(at: modelsDirectory, version: version)
-    }
-
-    func deleteModel() throws {
-        if hasCachedModelDirectory {
-            try FileManager.default.removeItem(at: modelsDirectory)
-        }
-    }
 }

--- a/VivaDicta/Services/ModelDownloadManager.swift
+++ b/VivaDicta/Services/ModelDownloadManager.swift
@@ -5,9 +5,9 @@
 //  Created by Anton Novoselov on 2025.09.02
 //
 
+import LocalTranscription
 import SwiftUI
-import FluidAudio
-import WhisperKit
+import TranscriptionCore
 import os
 
 /// Status of a model download operation.
@@ -15,7 +15,7 @@ enum DownloadStatus: String {
     case download
     case downloading
     case downloaded
-    
+
     var actionButtonImage: String {
         switch self {
         case .download:
@@ -26,7 +26,7 @@ enum DownloadStatus: String {
             "trash.circle"
         }
     }
-    
+
     var actionButtonColor: Color {
         switch self {
         case .download:
@@ -42,7 +42,9 @@ enum DownloadStatus: String {
 /// Manager for downloading, tracking, and deleting on-device transcription models.
 ///
 /// `ModelDownloadManager` handles the download lifecycle for WhisperKit and Parakeet
-/// models, including progress tracking, cancellation, and cleanup.
+/// models, including progress tracking, cancellation, and cleanup. SDK-level work
+/// is delegated to `LocalTranscription.LocalModelDownloader` so this file does not
+/// import `WhisperKit` or `FluidAudio` directly.
 ///
 /// ## Overview
 ///
@@ -202,6 +204,7 @@ class ModelDownloadManager {
     }
 
     // MARK: - Parakeet Model Download
+
     private func downloadParakeetModel(_ model: ParakeetModel) async throws {
         try Task.checkCancellation()
 
@@ -210,77 +213,48 @@ class ModelDownloadManager {
 
         logger.logNotice("📥 Starting download of \(model.displayName)")
 
+        let modelName = model.name
+
         do {
-            let modelName = model.name
-
-            _ = try await AsrModels.downloadAndLoad(
+            try await LocalModelDownloader.downloadParakeet(
                 version: model.version,
-                progressHandler: { progress in
-                    self.updateParakeetDownloadProgress(
-                        for: modelName,
-                        progress: progress,
-                        within: 0.0 ... 0.85
-                    )
+                onProgress: { [weak self] progress in
+                    Task { @MainActor in
+                        guard let self else { return }
+                        guard self.downloadStatuses[modelName] == .downloading else { return }
+                        self.downloadProgress[modelName] = progress
+                    }
                 }
             )
 
             try Task.checkCancellation()
 
-            _ = try await VadManager(
-                progressHandler: { progress in
-                    self.updateParakeetDownloadProgress(
-                        for: modelName,
-                        progress: progress,
-                        within: 0.85 ... 1.0
-                    )
-                }
-            )
-
-            try Task.checkCancellation()
-
-            self.downloadProgress[model.name] = 1.0
-            self.downloadStatuses[model.name] = .downloaded
+            downloadProgress[model.name] = 1.0
+            downloadStatuses[model.name] = .downloaded
             logger.logNotice("✅ Successfully downloaded \(model.displayName)")
 
-            // Log model download to Firebase Analytics
             AnalyticsService.track(.modelDownloaded(name: model.displayName, type: "parakeet"))
 
             try? await Task.sleep(for: .seconds(0.5))
 
-            self.downloadProgress.removeValue(forKey: model.name)
-            self.onModelDownloaded?(model)
+            downloadProgress.removeValue(forKey: model.name)
+            onModelDownloaded?(model)
 
         } catch is CancellationError {
             logger.logNotice("🛑 Download of \(model.displayName) was cancelled")
             throw CancellationError()
         } catch {
-            self.downloadStatuses[model.name] = .download
-            self.downloadProgress.removeValue(forKey: model.name)
+            downloadStatuses[model.name] = .download
+            downloadProgress.removeValue(forKey: model.name)
 
             logger.logError("❌ Failed to download \(model.displayName): \(error.localizedDescription)")
             throw error
         }
     }
 
-    nonisolated private func updateParakeetDownloadProgress(
-        for modelName: String,
-        progress: DownloadUtils.DownloadProgress,
-        within range: ClosedRange<Double>
-    ) {
-        let boundedProgress =
-            range.lowerBound
-            + ((range.upperBound - range.lowerBound) * progress.fractionCompleted)
-
-        Task { @MainActor in
-            guard self.downloadStatuses[modelName] == .downloading else { return }
-            self.downloadProgress[modelName] = boundedProgress
-        }
-    }
-
     // MARK: - WhisperKit Model Download
 
     private func downloadWhisperKitModel(_ model: WhisperKitModel) async throws {
-        // Check for cancellation before starting
         try Task.checkCancellation()
 
         downloadStatuses[model.name] = .downloading
@@ -288,146 +262,124 @@ class ModelDownloadManager {
 
         logger.logNotice("📥 Starting download and preparation of \(model.displayName)")
 
+        let modelName = model.name
+        let displayName = model.displayName
+        let whisperKitModelName = model.whisperKitModelName
+
+        let phaseState = WhisperKitPhaseState()
+
         do {
-            // Initialize WhisperKit without auto-loading
-            let config = WhisperKitConfig(
-                verbose: false,
-                logLevel: .info,
-                prewarm: false,
-                load: false,
-                download: false
-            )
+            try await LocalModelDownloader.downloadAndPrepareWhisperKit(
+                modelName: whisperKitModelName,
+                onPhase: { [weak self] phase in
+                    Task { @MainActor in
+                        guard let self else { return }
+                        switch phase {
+                        case .downloading(let fractionCompleted):
+                            // First 70% of overall progress represents the download.
+                            self.downloadProgress[modelName] = fractionCompleted * 0.7
 
-            let whisperKit = try await WhisperKit(config)
-            
-            try Task.checkCancellation()
+                        case .prewarmStart:
+                            self.logger.logNotice("🔥 Prewarming model: \(whisperKitModelName)")
+                            self.downloadProgress[modelName] = 0.75
+                            phaseState.prewarmStart = Date()
+                            phaseState.prewarmProgressTask = Task { @MainActor [weak self] in
+                                self?.logger.logNotice("📊 Starting pre-warm progress animation from 75% to 90%")
+                                await self?.animateProgressExponentially(
+                                    for: modelName,
+                                    from: 0.75,
+                                    to: 0.9,
+                                    maxDuration: 240.0
+                                )
+                                self?.logger.logNotice("📊 Pre-warm progress animation completed or cancelled")
+                            }
 
-            // Check if model needs downloading using consolidated path
-            let modelFolder = WhisperKitModel.modelPath(for: model.whisperKitModelName)
+                        case .loadStart:
+                            if let prewarmStart = phaseState.prewarmStart {
+                                phaseState.prewarmDuration = Date().timeIntervalSince(prewarmStart)
+                                self.logger.logNotice("✅ Model prewarmed in \(phaseState.prewarmDuration.formatted(.number.precision(.fractionLength(2)))) seconds")
+                            }
+                            phaseState.prewarmProgressTask?.cancel()
+                            self.downloadProgress[modelName] = 0.9
+                            self.logger.logNotice("📚 Loading model: \(whisperKitModelName)")
+                            phaseState.loadStart = Date()
+                            phaseState.loadProgressTask = Task { @MainActor [weak self] in
+                                await self?.animateProgressExponentially(
+                                    for: modelName,
+                                    from: 0.9,
+                                    to: 0.99,
+                                    maxDuration: 60.0
+                                )
+                            }
 
-            if !FileManager.default.fileExists(atPath: modelFolder.path) {
-                logger.logNotice("📥 Downloading model: \(model.whisperKitModelName)")
-
-                // Download the model with real progress tracking
-                let downloadedFolder = try await WhisperKit.download(
-                    variant: model.whisperKitModelName,
-                    from: "argmaxinc/whisperkit-coreml",
-                    progressCallback: { @Sendable progress in
-                        let progressValue = progress.fractionCompleted * 0.7
-                        Task { @MainActor in
-                            // 70% of progress for download
-                            self.downloadProgress[model.name] = progressValue
+                        case .finished:
+                            if let loadStart = phaseState.loadStart {
+                                phaseState.loadDuration = Date().timeIntervalSince(loadStart)
+                                self.logger.logNotice("✅ Model loaded in \(phaseState.loadDuration.formatted(.number.precision(.fractionLength(2)))) seconds")
+                            }
+                            phaseState.loadProgressTask?.cancel()
                         }
                     }
-                )
-                
-                try Task.checkCancellation()
+                }
+            )
 
-                whisperKit.modelFolder = downloadedFolder
-            } else {
-                whisperKit.modelFolder = modelFolder
-                self.downloadProgress[model.name] = 0.7
-            }
-
-            // Check for cancellation before prewarm
             try Task.checkCancellation()
 
-            // Prewarm models with animated progress (critical for first-time performance)
-            logger.logNotice("🔥 Prewarming model: \(model.whisperKitModelName)")
-            self.downloadProgress[model.name] = 0.75
+            downloadProgress[model.name] = 1.0
+            downloadStatuses[model.name] = .downloaded
+            logger.logNotice("✅ Successfully downloaded and prepared \(displayName)")
+            logger.logNotice("⏱️ Preparation time: prewarm: \(phaseState.prewarmDuration.formatted(.number.precision(.fractionLength(2))))s, load: \(phaseState.loadDuration.formatted(.number.precision(.fractionLength(2))))s")
 
-            // Start progress animation for pre-warming phase
-            let progressTask = Task { @MainActor in
-                logger.logNotice("📊 Starting pre-warm progress animation from 75% to 90%")
-                await self.animateProgressExponentially(
-                    for: model.name,
-                    from: 0.75,
-                    to: 0.9,
-                    maxDuration: 240.0 // 4 minutes max
-                )
-                logger.logNotice("📊 Pre-warm progress animation completed or cancelled")
-            }
-
-            let prewarmStart = Date()
-            try await whisperKit.prewarmModels()
-            let prewarmDuration = Date().timeIntervalSince(prewarmStart)
-            logger.logNotice("✅ Model prewarmed in \(prewarmDuration.formatted(.number.precision(.fractionLength(2)))) seconds")
-
-            // Cancel the animation task and set final progress
-            progressTask.cancel()
-
-            // Check for cancellation after prewarm
-            try Task.checkCancellation()
-
-            self.downloadProgress[model.name] = 0.9
-
-            // Load models with animated progress
-            logger.logNotice("📚 Loading model: \(model.whisperKitModelName)")
-
-            // Start progress animation for loading phase
-            let loadProgressTask = Task {
-                await self.animateProgressExponentially(
-                    for: model.name,
-                    from: 0.9,
-                    to: 0.99,
-                    maxDuration: 60.0 // 1 minute max for loading
-                )
-            }
-
-            let loadStart = Date()
-            try await whisperKit.loadModels()
-            let loadDuration = Date().timeIntervalSince(loadStart)
-            logger.logNotice("✅ Model loaded in \(loadDuration.formatted(.number.precision(.fractionLength(2)))) seconds")
-
-            // Cancel the animation task and set final progress
-            loadProgressTask.cancel()
-
-            // Check for cancellation after load
-            try Task.checkCancellation()
-
-            self.downloadProgress[model.name] = 1.0
-            self.downloadStatuses[model.name] = .downloaded
-            logger.logNotice("✅ Successfully downloaded and prepared \(model.displayName)")
-            logger.logNotice("⏱️ Preparation time: prewarm: \(prewarmDuration.formatted(.number.precision(.fractionLength(2))))s, load: \(loadDuration.formatted(.number.precision(.fractionLength(2))))s")
-
-            // Log model download to Firebase Analytics
-            AnalyticsService.track(.modelDownloaded(name: model.displayName, type: "whisperkit"))
-
-            // Unload models after download to free memory
-            // They will be loaded again when needed for transcription
-            await whisperKit.unloadModels()
+            AnalyticsService.track(.modelDownloaded(name: displayName, type: "whisperkit"))
 
             try? await Task.sleep(for: .seconds(0.5))
 
-            self.downloadProgress.removeValue(forKey: model.name)
-            self.onModelDownloaded?(model)
+            downloadProgress.removeValue(forKey: model.name)
+            onModelDownloaded?(model)
 
         } catch is CancellationError {
-            logger.logNotice("🛑 Download of \(model.displayName) was cancelled")
+            phaseState.prewarmProgressTask?.cancel()
+            phaseState.loadProgressTask?.cancel()
+            logger.logNotice("🛑 Download of \(displayName) was cancelled")
             throw CancellationError()
         } catch {
-            self.downloadStatuses[model.name] = .download
-            self.downloadProgress.removeValue(forKey: model.name)
+            phaseState.prewarmProgressTask?.cancel()
+            phaseState.loadProgressTask?.cancel()
+            downloadStatuses[model.name] = .download
+            downloadProgress.removeValue(forKey: model.name)
 
-            logger.logError("❌ Failed to download \(model.displayName): \(error.localizedDescription)")
+            logger.logError("❌ Failed to download \(displayName): \(error.localizedDescription)")
             throw error
         }
     }
 
+    /// Mutable state shared between the WhisperKit phase callback and the
+    /// surrounding download orchestration. All reads/writes happen inside
+    /// `Task { @MainActor in ... }` blocks, so concurrent access is
+    /// serialized by the MainActor; that lets us mark it `@unchecked
+    /// Sendable` and capture it by reference from the `@Sendable` phase
+    /// closure.
+    private final class WhisperKitPhaseState: @unchecked Sendable {
+        var prewarmStart: Date?
+        var prewarmDuration: TimeInterval = 0
+        var loadStart: Date?
+        var loadDuration: TimeInterval = 0
+        var prewarmProgressTask: Task<Void, Never>?
+        var loadProgressTask: Task<Void, Never>?
+    }
+
     // MARK: - Progress Animation
 
-    /// Animates progress exponentially from current value to target value over a maximum duration
-    /// Uses exponential decay function for smooth, natural-looking progress animation
+    /// Animates progress exponentially from current value to target value over a maximum duration.
+    /// Uses exponential decay function for smooth, natural-looking progress animation.
     private func animateProgressExponentially(
         for modelName: String,
         from initialProgress: Float,
         to targetProgress: Float,
         maxDuration: TimeInterval
     ) async {
-        // Calculate decay constant for exponential approach to target
-        // We want to reach ~99% of the target progress range in maxDuration
         let progressRange = targetProgress - initialProgress
-        let decayConstant = -log(0.01) / Float(maxDuration) // -log(0.01) ≈ 4.605
+        let decayConstant = -log(0.01) / Float(maxDuration)
         let startTime = Date()
 
         logger.logInfo("🎯 Starting progress animation: \(initialProgress) -> \(targetProgress) over \(maxDuration)s")
@@ -436,24 +388,20 @@ class ModelDownloadManager {
         while !Task.isCancelled {
             let elapsedTime = Date().timeIntervalSince(startTime)
 
-            // Calculate progress using exponential decay
-            // This ensures smooth, continuous progress that asymptotically approaches target
             let decayFactor = exp(-decayConstant * Float(elapsedTime))
             let currentProgress = initialProgress + progressRange * (1 - decayFactor)
 
-            self.downloadProgress[modelName] = Double(currentProgress)
+            downloadProgress[modelName] = Double(currentProgress)
             updateCount += 1
-            if updateCount % 10 == 0 { // Log every 5 seconds (10 * 0.5s)
+            if updateCount % 10 == 0 {
                 logger.logInfo("📊 Progress update #\(updateCount): \((currentProgress * 100).formatted(.number.precision(.fractionLength(1))))%")
             }
 
-            // Stop when we're close enough to target or time limit exceeded
             if currentProgress >= targetProgress - 0.001 || elapsedTime >= maxDuration {
                 logger.logInfo("🏁 Animation ended: final progress \((currentProgress * 100).formatted(.number.precision(.fractionLength(1))))%")
                 break
             }
 
-            // Update every 0.5 seconds for smooth animation
             try? await Task.sleep(for: .milliseconds(500))
         }
     }

--- a/VivaDicta/Services/Transcription/TranscriptionManager.swift
+++ b/VivaDicta/Services/Transcription/TranscriptionManager.swift
@@ -8,7 +8,6 @@
 import Foundation
 import AppGroup
 import CloudTranscription
-@preconcurrency import FluidAudio
 import LocalTranscription
 import SwiftUI
 import TranscriptionCore
@@ -216,11 +215,10 @@ class TranscriptionManager {
             guard let parakeetModel = model as? ParakeetModel else {
                 throw TranscriptionError.unsupportedModel
             }
-            let version: ParakeetModelVersion = (parakeetModel.version == .v2) ? .v2 : .v3
             return .parakeet(
                 modelName: parakeetModel.name,
                 displayName: parakeetModel.displayName,
-                version: version,
+                version: parakeetModel.version,
                 options: .init(isVADEnabled: isVADEnabled, vocabulary: parakeetVocabularyIfEnabled())
             )
 


### PR DESCRIPTION
## Summary

The app target now consumes WhisperKit, SpeakerKit, and FluidAudio only transitively through the `LocalTranscription` SPM module - they're no longer direct package dependencies of the project.

### What moved
- New `LocalTranscription.LocalModelDownloader` wraps `WhisperKit` + `AsrModels` + `VadManager` behind Sendable helpers. `ModelDownloadManager` calls those instead of importing the SDKs directly.
- New `LocalTranscription.ParakeetModelPath` exposes `directory(for:)` + `isDownloaded(version:)` so the app's `ParakeetModel` doesn't need `AsrModels.defaultCacheDirectory` / `AsrModels.modelsExist`.
- `ParakeetModelVersion` moved from `TranscriptionKit` to `TranscriptionCore` so the app's model catalog (shared with extensions) can name a version without linking TranscriptionKit or FluidAudio.
- `ParakeetModel.swift` split into a Foundation-only core (compiled by extensions via folder-sync) + `ParakeetModel+FileManagement.swift` main-target-only file that imports `LocalTranscription`. Mirrors the existing `WhisperKitModel` / `WhisperKitModel+FileManagement.swift` pattern.
- `TranscriptionManager` dropped its `@preconcurrency import FluidAudio`; `parakeetModel.version` already returns the kit-owned enum.

### Removed from project.pbxproj
- `XCRemoteSwiftPackageReference` entries for `WhisperKit` and `FluidAudio`
- `XCSwiftPackageProductDependency` entries for `WhisperKit`, `SpeakerKit`, `FluidAudio` (4 targets: main app, keyboard, share, action)
- The corresponding `PBXBuildFile` / framework-link entries

### Notes
- Extensions (keyboard / share / action) previously linked FluidAudio as dead linkage; that's gone now.
- `LocalTranscription` still has WhisperKit + FluidAudio as its own SPM deps - this PR is about the project boundary, not vendor lock-in.
- A small `WhisperKitPhaseState` reference wrapper (Swift 6 strict concurrency) holds prewarm/load timing across the Sendable phase callback.

## Test plan
- [x] `xcodebuild build` for iPhone 17 Pro Max simulator passes
- [ ] Manual: open Settings → Models, download a Parakeet v2 / v3 model, confirm progress UI works through to 100%
- [ ] Manual: download a WhisperKit model, confirm the prewarm + load animated progress phases still render correctly
- [ ] Manual: transcribe with each on-device backend and confirm the engine still routes correctly