### PR TITLE
Relocate module-tests from app target into their owning modules

### DIFF
--- a/Modules/AppGroup/Tests/AppGroupTests/AppGroupCoordinatorSessionTests.swift
+++ b/Modules/AppGroup/Tests/AppGroupTests/AppGroupCoordinatorSessionTests.swift
@@ -6,9 +6,8 @@
 //
 
 import Foundation
-import AppGroup
 import Testing
-@testable import VivaDicta
+@testable import AppGroup
 
 struct AppGroupCoordinatorSessionTests {
 

--- a/Modules/AppGroup/Tests/AppGroupTests/AppGroupCoordinatorStateTests.swift
+++ b/Modules/AppGroup/Tests/AppGroupTests/AppGroupCoordinatorStateTests.swift
@@ -6,9 +6,8 @@
 //
 
 import Foundation
-import AppGroup
 import Testing
-@testable import VivaDicta
+@testable import AppGroup
 
 struct AppGroupCoordinatorStateTests {
 

--- a/Modules/Presets/Tests/PresetsTests/PresetCatalogTests.swift
+++ b/Modules/Presets/Tests/PresetsTests/PresetCatalogTests.swift
@@ -7,8 +7,7 @@
 
 import Foundation
 import Testing
-import Presets
-@testable import VivaDicta
+@testable import Presets
 
 struct PresetCatalogTests {
 

--- a/Modules/Presets/Tests/PresetsTests/PresetManagerTests.swift
+++ b/Modules/Presets/Tests/PresetsTests/PresetManagerTests.swift
@@ -7,8 +7,7 @@
 
 import Foundation
 import Testing
-import Presets
-@testable import VivaDicta
+@testable import Presets
 
 struct PresetManagerTests {
 

--- a/Modules/Presets/Tests/PresetsTests/PresetTests.swift
+++ b/Modules/Presets/Tests/PresetsTests/PresetTests.swift
@@ -7,8 +7,7 @@
 
 import Foundation
 import Testing
-import Presets
-@testable import VivaDicta
+@testable import Presets
 
 struct PresetTests {
 

--- a/Modules/TranscriptionCore/Tests/TranscriptionCoreTests/SpeakerDiarizationFormatterTests.swift
+++ b/Modules/TranscriptionCore/Tests/TranscriptionCoreTests/SpeakerDiarizationFormatterTests.swift
@@ -7,8 +7,7 @@
 
 import Foundation
 import Testing
-import TranscriptionCore
-@testable import VivaDicta
+@testable import TranscriptionCore
 
 struct SpeakerDiarizationFormatterTests {
 


### PR DESCRIPTION
## Summary

Six test files sat in `VivaDictaTests/` but exercised types living entirely inside SPM modules. Moved them to where their SUTs live so the test pyramid matches the production layering.

### Moves

| File | From | To | Tests |
|------|------|-----|-------|
| `AppGroupCoordinatorSessionTests.swift` | `VivaDictaTests/` | `Modules/AppGroup/Tests/AppGroupTests/` | 9 |
| `AppGroupCoordinatorStateTests.swift` | `VivaDictaTests/` | `Modules/AppGroup/Tests/AppGroupTests/` | 13 |
| `SpeakerDiarizationFormatterTests.swift` | `VivaDictaTests/` | `Modules/TranscriptionCore/Tests/TranscriptionCoreTests/` | 3 |
| `PresetCatalogTests.swift` | `VivaDictaTests/` | `Modules/Presets/Tests/PresetsTests/` | ~10 |
| `PresetManagerTests.swift` | `VivaDictaTests/` | `Modules/Presets/Tests/PresetsTests/` | ~25 |
| `PresetTests.swift` | `VivaDictaTests/` | `Modules/Presets/Tests/PresetsTests/` | ~12 |

### What changed in each file

- `git mv` to preserve history
- Dropped the dead `@testable import VivaDicta` line (no test referenced any app-target type - it was leftover from when these files predated the module extractions)
- Changed `import <Module>` to `@testable import <Module>` to keep access to internals consistent with the existing module-test pattern

### Results

- App test bundle: 21 → 15 files
- Each module's package tests now own their SUT's tests
- All 87 relocated tests pass in their new homes
- No production code touched

## Test plan
- [x] `swift test --package-path Modules/AppGroup` → 22 tests pass
- [x] `swift test --package-path Modules/TranscriptionCore` → 10 tests pass (3 newly added + 7 existing)
- [x] `swift test --package-path Modules/Presets` → 55 tests pass (47 newly added + 8 existing)
- [x] `xcodebuild build` for the main app passes