### PR TITLE
Add DesignSystem SPM module + move GlowShape into it

### DIFF
--- a/Modules/DesignSystem/.gitignore
+++ b/Modules/DesignSystem/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Modules/DesignSystem/Package.swift
+++ b/Modules/DesignSystem/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version: 6.2
+
+import PackageDescription
+
+let package = Package(
+    name: "DesignSystem",
+    platforms: [
+        .iOS(.v18),
+        .macOS(.v14),
+    ],
+    products: [
+        .library(name: "DesignSystem", targets: ["DesignSystem"]),
+    ],
+    targets: [
+        .target(name: "DesignSystem"),
+    ],
+    swiftLanguageModes: [.v6]
+)

--- a/Modules/DesignSystem/Sources/DesignSystem/GlowShape.swift
+++ b/Modules/DesignSystem/Sources/DesignSystem/GlowShape.swift
@@ -1,33 +1,26 @@
-//
-//  GlowShape.swift
-//  VivaDicta
-//
-//  Created by Anton Novoselov on 2025.12.03
-//
+// Copyright © 2026 Anton Novoselov. All rights reserved.
 
 import SwiftUI
 
-extension View {
+/// Adds a multi-layered animated rainbow glow around a shape.
+///
+/// Apply with `.glowBackground(in: .capsule)` or `.glowOverlay(in: .capsule)`
+/// on any view. The glow re-randomizes its gradient stops at a fixed
+/// interval, animating between them. Honors `accessibilityReduceMotion` by
+/// suppressing the animation when enabled.
+public extension View {
     @MainActor
-    func glowBackground<S: InsettableShape>(
-        in shape: S
-    ) -> some View {
-        background(
-            shape.glowStroke()
-        )
+    func glowBackground<S: InsettableShape>(in shape: S) -> some View {
+        background(shape.glowStroke())
     }
-    
+
     @MainActor
-    func glowOverlay<S: InsettableShape>(
-        in shape: S
-    ) -> some View {
-        overlay(
-            shape.glowStroke()
-        )
+    func glowOverlay<S: InsettableShape>(in shape: S) -> some View {
+        overlay(shape.glowStroke())
     }
 }
 
-extension InsettableShape {
+public extension InsettableShape {
     @MainActor
     func glowStroke(
         lineWidths: [CGFloat] = [6, 9, 11, 15],
@@ -86,7 +79,9 @@ private struct GlowStrokeView<S: InsettableShape>: View {
     }
 }
 
-private extension Array where Element == Gradient.Stop {
+public extension Array where Element == Gradient.Stop {
+    /// VivaDicta's brand glow gradient - six branded colors at randomized
+    /// positions. Re-evaluated each `updateInterval` to drive the animation.
     static var glowStyle: [Gradient.Stop] {
         [
             Color(red: 188/255, green: 130/255, blue: 243/255),
@@ -101,7 +96,7 @@ private extension Array where Element == Gradient.Stop {
     }
 }
 
-#Preview {
+#Preview("Glow background") {
     VStack(spacing: 30) {
         Text("Some text here")
             .padding(22)
@@ -111,4 +106,5 @@ private extension Array where Element == Gradient.Stop {
             .padding(22)
             .glowOverlay(in: .capsule)
     }
+    .padding()
 }

--- a/VivaDicta.xcodeproj/project.pbxproj
+++ b/VivaDicta.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		18B497F02F268B2700538830 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 18B497EF2F268B2700538830 /* FirebaseAnalytics */; };
 		18B497F22F268B2700538830 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = 18B497F12F268B2700538830 /* FirebaseCrashlytics */; };
 		18B89BC32FB875530007FA96 /* TranscriptionKit in Frameworks */ = {isa = PBXBuildFile; productRef = 18B89BC22FB875530007FA96 /* TranscriptionKit */; };
+		18B8BEB12FB8BD7D0007FA96 /* DesignSystem in Frameworks */ = {isa = PBXBuildFile; productRef = 18B8BEB02FB8BD7D0007FA96 /* DesignSystem */; };
 		18BA24132F7ED0D700C4F68B /* VivaDictaWatch Watch App.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 18BA23F32F7ED0D500C4F68B /* VivaDictaWatch Watch App.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		18BA29262F7F29FD00C4F68B /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 18E1C7FB2E8E793E00BE8A11 /* WidgetKit.framework */; };
 		18BA29272F7F29FD00C4F68B /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 18E1C7FD2E8E793E00BE8A11 /* SwiftUI.framework */; };
@@ -208,6 +209,7 @@
 			membershipExceptions = (
 				AppGroup,
 				CloudTranscription,
+				DesignSystem,
 				Keychain,
 				LocalTranscription,
 				Networking,
@@ -224,6 +226,7 @@
 			membershipExceptions = (
 				AppGroup,
 				CloudTranscription,
+				DesignSystem,
 				Keychain,
 				LocalTranscription,
 				Networking,
@@ -354,7 +357,6 @@
 				PrivacyInfo.xcprivacy,
 				Utilities/LoggerExtension.swift,
 				"Utils/Extensions/Color+Ext.swift",
-				Utils/Extensions/GlowShape.swift,
 				"Utils/Extensions/View+Ext.swift",
 			);
 			target = 18E1C7F92E8E793E00BE8A11 /* VivaDictaWidgetExtension */;
@@ -386,7 +388,6 @@
 				Utilities/LoggerExtension.swift,
 				Utils/ClipboardManager.swift,
 				"Utils/Extensions/Color+Ext.swift",
-				Utils/Extensions/GlowShape.swift,
 				"Utils/Extensions/View+Ext.swift",
 				Utils/HapticManager.swift,
 				Views/HudView.swift,
@@ -510,6 +511,7 @@
 				18B497F22F268B2700538830 /* FirebaseCrashlytics in Frameworks */,
 				18B497F02F268B2700538830 /* FirebaseAnalytics in Frameworks */,
 				18B89BC32FB875530007FA96 /* TranscriptionKit in Frameworks */,
+				18B8BEB12FB8BD7D0007FA96 /* DesignSystem in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -727,6 +729,7 @@
 				18F7637E2FB7D5E300280269 /* LocalTranscription */,
 				18F76A312FB85C0400280269 /* AppGroup */,
 				18B89BC22FB875530007FA96 /* TranscriptionKit */,
+				18B8BEB02FB8BD7D0007FA96 /* DesignSystem */,
 			);
 			productName = VivaDicta;
 			productReference = 181D04D72E3E55E400D357A6 /* VivaDicta.app */;
@@ -2730,6 +2733,10 @@
 		18B89BC22FB875530007FA96 /* TranscriptionKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = TranscriptionKit;
+		};
+		18B8BEB02FB8BD7D0007FA96 /* DesignSystem */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = DesignSystem;
 		};
 		18E1B4AC2E8C875000BE8A11 /* KeyboardKit */ = {
 			isa = XCSwiftPackageProductDependency;


### PR DESCRIPTION
## Summary

First skeleton PR for a `DesignSystem` SPM module. Two goals:

1. **Faster SwiftUI previews** - a module's previews compile against just the module's deps, not the full ~62K-LOC app target. Real iteration-speed win once visual components live here.
2. **A clean home for reusable visual building blocks** - color tokens, view extensions, custom shapes, branded components.

### What moves in this PR

Just one file: `GlowShape.swift`. Chosen because:

- **Zero app callers** - the only consumer of `glowBackground` / `glowOverlay` was its own `#Preview`. Verified with `grep`. So moving it has no import-ripple.
- **Self-contained** - no app-target dependencies, only SwiftUI.
- **Already has a preview** - demonstrates the speed win immediately.

Public API exposed by the module:

- `View.glowBackground(in:)` / `View.glowOverlay(in:)`
- `InsettableShape.glowStroke(lineWidths:blurs:updateInterval:animationDurations:gradientGenerator:)`
- `[Gradient.Stop].glowStyle` (brand glow gradient tokens)

### Module shape

```
Modules/DesignSystem/
├── Package.swift            # library: DesignSystem (no test target yet - no DS-specific tests)
└── Sources/DesignSystem/
    └── GlowShape.swift
```

Single product, single target. Test target removed from `Package.swift` for now (no design-system tests yet; will add when something testable lands).

### Targets

Linked to the main `VivaDicta` target only. As we move shared visual content from `Shared/` in follow-up PRs (e.g. `MicButton`, `AnimatedMeshGradient`, `RippleEffect`), we'll add DesignSystem to the extension targets that need it.

### pbxproj cleanup

Two stale `Utils/Extensions/GlowShape.swift` references removed from `membershipExceptions` (`VivaDictaWidgetExtension` + `VivaDictaKeyboard` folder-sync exception sets). Those were trying to include the file at its old path; no longer applicable now that it's in the module.

### Follow-up direction

PRs after this incrementally move visual content into DesignSystem:

1. `Color+Ext.swift` (tiny, 1 internal user)
2. `View+Ext.swift` (~13 app-target import additions, many APIs to publicize)
3. `Shared/MicButton.swift`, `AnimatedMeshGradient.swift`, `RippleEffect.metal`, etc. (extension targets get DesignSystem linked too)

## Test plan
- [x] `swift build --package-path Modules/DesignSystem` succeeds
- [x] `xcodebuild build` for the main app passes
- [ ] Open `GlowShape.swift` in Xcode, hit Resume on the canvas: preview should render and rebuild faster than equivalent previews inside the app target