### PR TITLE
Wire all 10 module test targets into the Xcode test plan

### DIFF
--- a/Modules/TranscriptionKit/Package.swift
+++ b/Modules/TranscriptionKit/Package.swift
@@ -15,6 +15,7 @@ let package = Package(
         .package(path: "../TranscriptionCore"),
         .package(path: "../CloudTranscription"),
         .package(path: "../LocalTranscription"),
+        .package(path: "../Networking"),
     ],
     targets: [
         .target(
@@ -23,6 +24,13 @@ let package = Package(
                 .product(name: "TranscriptionCore", package: "TranscriptionCore"),
                 .product(name: "CloudTranscription", package: "CloudTranscription"),
                 .product(name: "LocalTranscription", package: "LocalTranscription"),
+                // Direct dependency on Networking required so the linker can
+                // resolve the `URLSession: URLSessionProtocol` witness table
+                // referenced by CloudTranscription service initializers with
+                // their default `urlSession: URLSessionProtocol = URLSession.shared`.
+                // SPM doesn't propagate this transitive conformance link
+                // through the umbrella in every build context.
+                .product(name: "Networking", package: "Networking"),
             ]
         ),
         .testTarget(

--- a/VivaDicta/VivaDictaTestPlan.xctestplan
+++ b/VivaDicta/VivaDictaTestPlan.xctestplan
@@ -20,10 +20,81 @@
       }
     },
     {
+      "enabled" : false,
       "target" : {
         "containerPath" : "container:VivaDicta.xcodeproj",
         "identifier" : "187D20F22FB5011D004234D0",
         "name" : "VivaDictaUITests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Modules\/Presets",
+        "identifier" : "PresetsTests",
+        "name" : "PresetsTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Modules\/OAuth",
+        "identifier" : "OAuthTests",
+        "name" : "OAuthTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Modules\/CloudTranscription",
+        "identifier" : "CloudTranscriptionTests",
+        "name" : "CloudTranscriptionTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Modules\/TranscriptionKit",
+        "identifier" : "TranscriptionKitTests",
+        "name" : "TranscriptionKitTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Modules\/TranscriptionCore",
+        "identifier" : "TranscriptionCoreTests",
+        "name" : "TranscriptionCoreTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Modules\/TestUtilities",
+        "identifier" : "TestUtilitiesTests",
+        "name" : "TestUtilitiesTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Modules\/Keychain",
+        "identifier" : "KeychainTests",
+        "name" : "KeychainTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Modules\/Networking",
+        "identifier" : "NetworkingTests",
+        "name" : "NetworkingTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Modules\/LocalTranscription",
+        "identifier" : "LocalTranscriptionTests",
+        "name" : "LocalTranscriptionTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Modules\/AppGroup",
+        "identifier" : "AppGroupTests",
+        "name" : "AppGroupTests"
       }
     }
   ],

--- a/VivaDicta/VivaDictaTestPlan.xctestplan
+++ b/VivaDicta/VivaDictaTestPlan.xctestplan
@@ -20,7 +20,6 @@
       }
     },
     {
-      "enabled" : false,
       "target" : {
         "containerPath" : "container:VivaDicta.xcodeproj",
         "identifier" : "187D20F22FB5011D004234D0",


### PR DESCRIPTION
## Summary

Closes a long-standing CI gap: 380+ tests across our 10 SPM module test bundles were silently skipped on `unit-tests.yml` (Codex flagged this on PR #262).

### The problem

CI runs `xcodebuild test -scheme VivaDicta`, which executes whatever the scheme's test plan (`VivaDictaTestPlan.xctestplan`) lists. The plan only included:

- `VivaDictaTests` (242 tests)
- `VivaDictaUITests` (disabled)

Every module test bundle - 11 of them, accumulating 160+ tests we've added across this and prior sessions - was unreachable from the main scheme.

### The fix

Two changes:

**1. Add all 10 module test targets to the test plan**

Each module's `*Tests` target is now a top-level entry in `VivaDictaTestPlan.xctestplan`:

- `AppGroupTests` (22 tests)
- `CloudTranscriptionTests` (33 tests)
- `KeychainTests` (6 tests)
- `LocalTranscriptionTests` (10 tests)
- `NetworkingTests` (5 tests)
- `OAuthTests` (11 tests)
- `PresetsTests` (55 tests)
- `TranscriptionCoreTests` (10 tests)
- `TranscriptionKitTests` (5 tests)
- `TestUtilitiesTests` (3 tests)

Added through Xcode UI; reflected in the .xctestplan JSON.

**2. Add `Networking` as a direct dep of `TranscriptionKit`**

Running the full test plan exposed a hidden link issue: `TranscriptionKit.o` references the `URLSession: URLSessionProtocol` witness table from Networking, because `TranscriptionEngine` calls `OpenAITranscriptionService(config:)` (and other cloud services) using their default `urlSession: any URLSessionProtocol = URLSession.shared`. That default arg inlines a witness-table reference at the call site.

SPM doesn't auto-propagate this transitive conformance dep through the umbrella in every build context. The test-plan context specifically fails to link without an explicit dep on Networking from TranscriptionKit. Adding it explicitly resolves the link.

See the inline comment added in `TranscriptionKit/Package.swift`.

### After this PR

`xcodebuild test -scheme VivaDicta` now executes **all 402 tests across 11 test bundles**. Same for ⌘U in Xcode locally. CI's `unit-tests.yml` doesn't need any changes - it just calls the same command.

## Test plan
- [x] `xcodebuild test -scheme VivaDicta -workspace ./VivaDicta.xcodeproj/project.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max,OS=26.4'` passes: 402 tests across 11 bundles, 0 failures