### PR TITLE
Add xAI Speech-to-Text transcription provider

### DIFF
--- a/Modules/CloudTranscription/Sources/CloudTranscription/XaiTranscriptionService.swift
+++ b/Modules/CloudTranscription/Sources/CloudTranscription/XaiTranscriptionService.swift
@@ -1,0 +1,115 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import Networking
+import os
+import TranscriptionCore
+
+/// Pre-configured xAI Speech-to-Text client.
+///
+/// Endpoint: POST https://api.x.ai/v1/stt with multipart/form-data.
+/// The xAI STT API has no `model` field; the form fields are `format`,
+/// `language`, and `file` (file must be last per the docs).
+public struct XaiTranscriptionService: TranscriptionService, Sendable {
+    private let logger = Logger(cloudTranscriptionCategory: "XaiTranscription")
+
+    public struct Config: Sendable {
+        public let apiKey: String
+        public let language: String
+        /// When true the API returns naturally formatted text instead of
+        /// raw lowercased output. Defaults to true to match user expectations.
+        public let formatted: Bool
+
+        public init(apiKey: String, language: String = "auto", formatted: Bool = true) {
+            self.apiKey = apiKey
+            self.language = language
+            self.formatted = formatted
+        }
+    }
+
+    private let config: Config
+    private let urlSession: any URLSessionProtocol
+
+    public init(config: Config, urlSession: any URLSessionProtocol = URLSession.shared) {
+        self.config = config
+        self.urlSession = urlSession
+    }
+
+    public func transcribe(audioURL: URL) async throws -> TranscriptionServiceResult {
+        let text = try await NetworkRetry.withRetry(logger: logger) {
+            try await makeTranscriptionRequest(audioURL: audioURL)
+        }
+        return .plain(text)
+    }
+
+    private func makeTranscriptionRequest(audioURL: URL) async throws -> String {
+        guard !config.apiKey.isEmpty else {
+            throw CloudTranscriptionError.missingAPIKey
+        }
+        let apiURL = URL(string: "https://api.x.ai/v1/stt")!
+
+        let boundary = "Boundary-\(UUID().uuidString)"
+        var request = URLRequest(url: apiURL)
+        request.httpMethod = "POST"
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(config.apiKey)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = NetworkRetry.defaultTimeout
+
+        let body = try createRequestBody(audioURL: audioURL, boundary: boundary)
+
+        let (data, response) = try await urlSession.upload(for: request, from: body)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw CloudTranscriptionError.networkError(URLError(.badServerResponse))
+        }
+
+        if !(200...299).contains(httpResponse.statusCode) {
+            let errorMessage = String(data: data, encoding: .utf8) ?? "No error message"
+            logger.logError("xAI STT request failed with status \(httpResponse.statusCode): \(errorMessage)")
+            throw CloudTranscriptionError.apiRequestFailed(statusCode: httpResponse.statusCode, message: errorMessage)
+        }
+
+        do {
+            let transcriptionResponse = try JSONDecoder().decode(TranscriptionResponse.self, from: data)
+            return transcriptionResponse.text
+        } catch {
+            logger.logError("Failed to decode xAI STT response: \(error.localizedDescription)")
+            throw CloudTranscriptionError.noTranscriptionReturned
+        }
+    }
+
+    private func createRequestBody(audioURL: URL, boundary: String) throws -> Data {
+        var body = Data()
+        let crlf = "\r\n"
+
+        guard let audioData = try? Data(contentsOf: audioURL) else {
+            throw CloudTranscriptionError.audioFileNotFound
+        }
+
+        body.append("--\(boundary)\(crlf)".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"format\"\(crlf)\(crlf)".data(using: .utf8)!)
+        body.append((config.formatted ? "true" : "false").data(using: .utf8)!)
+        body.append(crlf.data(using: .utf8)!)
+
+        if config.language != "auto", !config.language.isEmpty {
+            body.append("--\(boundary)\(crlf)".data(using: .utf8)!)
+            body.append("Content-Disposition: form-data; name=\"language\"\(crlf)\(crlf)".data(using: .utf8)!)
+            body.append(config.language.data(using: .utf8)!)
+            body.append(crlf.data(using: .utf8)!)
+        }
+
+        // `file` must be the last field per xAI docs.
+        body.append("--\(boundary)\(crlf)".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"file\"; filename=\"\(audioURL.lastPathComponent)\"\(crlf)".data(using: .utf8)!)
+        body.append("Content-Type: \(audioURL.audioMIMEType)\(crlf)\(crlf)".data(using: .utf8)!)
+        body.append(audioData)
+        body.append(crlf.data(using: .utf8)!)
+
+        body.append("--\(boundary)--\(crlf)".data(using: .utf8)!)
+        return body
+    }
+
+    private struct TranscriptionResponse: Decodable {
+        let text: String
+    }
+}

--- a/Modules/CloudTranscription/Sources/CloudTranscription/XaiTranscriptionService.swift
+++ b/Modules/CloudTranscription/Sources/CloudTranscription/XaiTranscriptionService.swift
@@ -15,12 +15,15 @@ public struct XaiTranscriptionService: TranscriptionService, Sendable {
 
     public struct Config: Sendable {
         public let apiKey: String
+        /// One of xAI's 24 documented codes (e.g. "en", "fil"). xAI rejects
+        /// `format=true` without a `language`, so no default is provided -
+        /// callers must pass a concrete code (or pre-normalize "auto" → "en").
         public let language: String
-        /// When true the API returns naturally formatted text instead of
-        /// raw lowercased output. Defaults to true to match user expectations.
+        /// When true the API returns naturally formatted text with Inverse
+        /// Text Normalization (e.g. "$100" instead of "one hundred dollars").
         public let formatted: Bool
 
-        public init(apiKey: String, language: String = "auto", formatted: Bool = true) {
+        public init(apiKey: String, language: String, formatted: Bool = true) {
             self.apiKey = apiKey
             self.language = language
             self.formatted = formatted
@@ -91,12 +94,10 @@ public struct XaiTranscriptionService: TranscriptionService, Sendable {
         body.append((config.formatted ? "true" : "false").data(using: .utf8)!)
         body.append(crlf.data(using: .utf8)!)
 
-        if config.language != "auto", !config.language.isEmpty {
-            body.append("--\(boundary)\(crlf)".data(using: .utf8)!)
-            body.append("Content-Disposition: form-data; name=\"language\"\(crlf)\(crlf)".data(using: .utf8)!)
-            body.append(config.language.data(using: .utf8)!)
-            body.append(crlf.data(using: .utf8)!)
-        }
+        body.append("--\(boundary)\(crlf)".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"language\"\(crlf)\(crlf)".data(using: .utf8)!)
+        body.append(config.language.data(using: .utf8)!)
+        body.append(crlf.data(using: .utf8)!)
 
         // `file` must be the last field per xAI docs.
         body.append("--\(boundary)\(crlf)".data(using: .utf8)!)

--- a/Modules/CloudTranscription/Tests/CloudTranscriptionTests/XaiTranscriptionServiceTests.swift
+++ b/Modules/CloudTranscription/Tests/CloudTranscriptionTests/XaiTranscriptionServiceTests.swift
@@ -38,7 +38,7 @@ struct XaiTranscriptionServiceTests {
     private func makeService(
         session: MockURLSession,
         apiKey: String = "xai-test-key",
-        language: String = "auto",
+        language: String = "en",
         formatted: Bool = true
     ) -> XaiTranscriptionService {
         XaiTranscriptionService(
@@ -132,7 +132,7 @@ struct XaiTranscriptionServiceTests {
         #expect(bodyString.range(of: "name=\"format\"\\s*\\r\\n\\r\\nfalse", options: .regularExpression) != nil)
     }
 
-    @Test func bodyIncludesLanguageFieldWhenNotAuto() async throws {
+    @Test func bodyIncludesLanguageField() async throws {
         let session = MockURLSession()
         stubSuccess(on: session, text: "ok")
         let audio = try makeAudioFile()
@@ -145,20 +145,23 @@ struct XaiTranscriptionServiceTests {
         #expect(bodyString.range(of: "name=\"language\"\\s*\\r\\n\\r\\nfr", options: .regularExpression) != nil)
     }
 
-    @Test func bodyOmitsLanguageFieldWhenAuto() async throws {
+    @Test func bodyAlwaysSendsLanguageEvenForUnusualCodes() async throws {
+        // xAI rejects format=true without a language, so the service must
+        // never omit the field. Verify with `fil` (Filipino) since it's xAI's
+        // 3-letter outlier and proves no "drop if not in allowlist" sneaks in.
         let session = MockURLSession()
         stubSuccess(on: session, text: "ok")
         let audio = try makeAudioFile()
-        let sut = makeService(session: session, language: "auto")
+        let sut = makeService(session: session, language: "fil")
 
         _ = try await sut.transcribe(audioURL: audio)
 
         let body = try #require(session.capturedBody)
         let bodyString = try #require(String(data: body, encoding: .utf8))
-        #expect(!bodyString.contains("name=\"language\""))
+        #expect(bodyString.range(of: "name=\"language\"\\s*\\r\\n\\r\\nfil", options: .regularExpression) != nil)
     }
 
-    @Test func bodyPlacesFileFieldLastPerXaiSpec() async throws {
+    @Test func bodyOrdersFieldsAsFormatLanguageFile() async throws {
         let session = MockURLSession()
         stubSuccess(on: session, text: "ok")
         let audio = try makeAudioFile()
@@ -171,7 +174,9 @@ struct XaiTranscriptionServiceTests {
         let formatRange = try #require(bodyString.range(of: "name=\"format\""))
         let languageRange = try #require(bodyString.range(of: "name=\"language\""))
         let fileRange = try #require(bodyString.range(of: "name=\"file\""))
-        #expect(formatRange.lowerBound < fileRange.lowerBound)
+        // file MUST be last per xAI docs; strict ordering catches any future
+        // reshuffle that happens to keep file last but breaks the rest.
+        #expect(formatRange.lowerBound < languageRange.lowerBound)
         #expect(languageRange.lowerBound < fileRange.lowerBound)
     }
 

--- a/Modules/CloudTranscription/Tests/CloudTranscriptionTests/XaiTranscriptionServiceTests.swift
+++ b/Modules/CloudTranscription/Tests/CloudTranscriptionTests/XaiTranscriptionServiceTests.swift
@@ -1,0 +1,238 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import Networking
+import NetworkingMocks
+import Testing
+@testable import CloudTranscription
+import TranscriptionCore
+
+/// Tests exercise `XaiTranscriptionService` end-to-end with a stubbed
+/// `MockURLSession`. Verifies request shape (URL, method, headers,
+/// multipart body) and response handling (success, non-2xx, undecodable
+/// JSON), plus the xAI-specific `format`/`file-last` body ordering.
+struct XaiTranscriptionServiceTests {
+
+    // MARK: - Test Helpers
+
+    private func makeAudioFile() throws -> URL {
+        let url = URL.temporaryDirectory.appending(path: "\(UUID().uuidString).wav")
+        try Data([0x52, 0x49, 0x46, 0x46]).write(to: url) // "RIFF"
+        return url
+    }
+
+    private func makeHTTPResponse(_ statusCode: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: URL(string: "https://api.x.ai/v1/stt")!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/json"]
+        )!
+    }
+
+    private func stubSuccess(on session: MockURLSession, text: String) {
+        let body = Data(#"{"text":"\#(text)"}"#.utf8)
+        session.stubUploadResponse = .success((body, makeHTTPResponse(200)))
+    }
+
+    private func makeService(
+        session: MockURLSession,
+        apiKey: String = "xai-test-key",
+        language: String = "auto",
+        formatted: Bool = true
+    ) -> XaiTranscriptionService {
+        XaiTranscriptionService(
+            config: .init(
+                apiKey: apiKey,
+                language: language,
+                formatted: formatted
+            ),
+            urlSession: session
+        )
+    }
+
+    // MARK: - Success path
+
+    @Test func successReturnsTranscribedText() async throws {
+        let session = MockURLSession()
+        stubSuccess(on: session, text: "xai hello")
+        let audio = try makeAudioFile()
+        let sut = makeService(session: session)
+
+        let result = try await sut.transcribe(audioURL: audio)
+
+        #expect(result.text == "xai hello")
+        #expect(result.isSpeakerAttributed == false)
+        #expect(session.uploadCallCount == 1)
+    }
+
+    // MARK: - Request shape
+
+    @Test func requestTargetsXaiSttEndpoint() async throws {
+        let session = MockURLSession()
+        stubSuccess(on: session, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(session: session)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let req = try #require(session.capturedRequest)
+        #expect(req.url?.absoluteString == "https://api.x.ai/v1/stt")
+        #expect(req.httpMethod == "POST")
+    }
+
+    @Test func requestSendsBearerAuthorizationHeader() async throws {
+        let session = MockURLSession()
+        stubSuccess(on: session, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(session: session, apiKey: "xai-abc123")
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let req = try #require(session.capturedRequest)
+        #expect(req.value(forHTTPHeaderField: "Authorization") == "Bearer xai-abc123")
+    }
+
+    @Test func requestSendsMultipartContentTypeWithBoundary() async throws {
+        let session = MockURLSession()
+        stubSuccess(on: session, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(session: session)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let req = try #require(session.capturedRequest)
+        let contentType = try #require(req.value(forHTTPHeaderField: "Content-Type"))
+        #expect(contentType.hasPrefix("multipart/form-data; boundary=Boundary-"))
+    }
+
+    @Test func bodyContainsFormatTrueByDefault() async throws {
+        let session = MockURLSession()
+        stubSuccess(on: session, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(session: session)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let body = try #require(session.capturedBody)
+        let bodyString = try #require(String(data: body, encoding: .utf8))
+        #expect(bodyString.range(of: "name=\"format\"\\s*\\r\\n\\r\\ntrue", options: .regularExpression) != nil)
+    }
+
+    @Test func bodySendsFormatFalseWhenFormattedDisabled() async throws {
+        let session = MockURLSession()
+        stubSuccess(on: session, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(session: session, formatted: false)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let body = try #require(session.capturedBody)
+        let bodyString = try #require(String(data: body, encoding: .utf8))
+        #expect(bodyString.range(of: "name=\"format\"\\s*\\r\\n\\r\\nfalse", options: .regularExpression) != nil)
+    }
+
+    @Test func bodyIncludesLanguageFieldWhenNotAuto() async throws {
+        let session = MockURLSession()
+        stubSuccess(on: session, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(session: session, language: "fr")
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let body = try #require(session.capturedBody)
+        let bodyString = try #require(String(data: body, encoding: .utf8))
+        #expect(bodyString.range(of: "name=\"language\"\\s*\\r\\n\\r\\nfr", options: .regularExpression) != nil)
+    }
+
+    @Test func bodyOmitsLanguageFieldWhenAuto() async throws {
+        let session = MockURLSession()
+        stubSuccess(on: session, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(session: session, language: "auto")
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let body = try #require(session.capturedBody)
+        let bodyString = try #require(String(data: body, encoding: .utf8))
+        #expect(!bodyString.contains("name=\"language\""))
+    }
+
+    @Test func bodyPlacesFileFieldLastPerXaiSpec() async throws {
+        let session = MockURLSession()
+        stubSuccess(on: session, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(session: session, language: "en")
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let body = try #require(session.capturedBody)
+        let bodyString = try #require(String(data: body, encoding: .utf8))
+        let formatRange = try #require(bodyString.range(of: "name=\"format\""))
+        let languageRange = try #require(bodyString.range(of: "name=\"language\""))
+        let fileRange = try #require(bodyString.range(of: "name=\"file\""))
+        #expect(formatRange.lowerBound < fileRange.lowerBound)
+        #expect(languageRange.lowerBound < fileRange.lowerBound)
+    }
+
+    // MARK: - Validation / short-circuit
+
+    @Test func missingAPIKeyThrowsBeforeMakingRequest() async throws {
+        let session = MockURLSession()
+        let audio = try makeAudioFile()
+        let sut = makeService(session: session, apiKey: "")
+
+        await #expect(throws: CloudTranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: audio)
+        }
+        #expect(session.uploadCallCount == 0, "no network call should be made when API key is empty")
+    }
+
+    @Test func missingAudioFileThrowsAudioFileNotFound() async {
+        let session = MockURLSession()
+        let audio = URL.temporaryDirectory.appending(path: "definitely-not-a-real-file-\(UUID()).wav")
+        let sut = makeService(session: session)
+
+        await #expect(throws: CloudTranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: audio)
+        }
+    }
+
+    // MARK: - Response handling
+
+    @Test func nonSuccessStatusThrowsApiRequestFailed() async throws {
+        let session = MockURLSession()
+        session.stubUploadResponse = .success((
+            Data(#"{"error":"invalid key"}"#.utf8),
+            makeHTTPResponse(401)
+        ))
+        let audio = try makeAudioFile()
+        let sut = makeService(session: session)
+
+        do {
+            _ = try await sut.transcribe(audioURL: audio)
+            Issue.record("expected apiRequestFailed to throw")
+        } catch let CloudTranscriptionError.apiRequestFailed(statusCode, message) {
+            #expect(statusCode == 401)
+            #expect(message.contains("invalid key"))
+        } catch {
+            Issue.record("expected CloudTranscriptionError.apiRequestFailed, got \(error)")
+        }
+    }
+
+    @Test func undecodableJSONOn200ThrowsNoTranscriptionReturned() async throws {
+        let session = MockURLSession()
+        session.stubUploadResponse = .success((Data("not json".utf8), makeHTTPResponse(200)))
+        let audio = try makeAudioFile()
+        let sut = makeService(session: session)
+
+        do {
+            _ = try await sut.transcribe(audioURL: audio)
+            Issue.record("expected noTranscriptionReturned to throw")
+        } catch CloudTranscriptionError.noTranscriptionReturned {
+            // expected
+        } catch {
+            Issue.record("expected noTranscriptionReturned, got \(error)")
+        }
+    }
+}

--- a/Modules/TranscriptionKit/Sources/TranscriptionKit/TranscriptionEngine.swift
+++ b/Modules/TranscriptionKit/Sources/TranscriptionKit/TranscriptionEngine.swift
@@ -138,6 +138,8 @@ public actor TranscriptionEngine {
             return GladiaTranscriptionService(config: config)
         case .speechmatics(let config):
             return SpeechmaticsTranscriptionService(config: config)
+        case .xai(let config):
+            return XaiTranscriptionService(config: config)
         case .custom(let config):
             return CustomTranscriptionService(config: config)
         case .whisperKit(let modelName, let displayName, let options):

--- a/Modules/TranscriptionKit/Sources/TranscriptionKit/TranscriptionProvider.swift
+++ b/Modules/TranscriptionKit/Sources/TranscriptionKit/TranscriptionProvider.swift
@@ -28,6 +28,7 @@ public enum TranscriptionProvider: Sendable {
     case soniox(SonioxTranscriptionService.Config)
     case gladia(GladiaTranscriptionService.Config)
     case speechmatics(SpeechmaticsTranscriptionService.Config)
+    case xai(XaiTranscriptionService.Config)
     case custom(CustomTranscriptionService.Config)
     case whisperKit(
         modelName: String,

--- a/VivaDicta/Models/TranscriptionModelProvider.swift
+++ b/VivaDicta/Models/TranscriptionModelProvider.swift
@@ -471,10 +471,39 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
         return allLanguages.filter { codes.contains($0.key) }
     }()
 
-    /// xAI Speech-to-Text requires a non-empty `language` whenever `format=true`,
-    /// so the picker exposes the full Whisper-style set minus "auto". The service
-    /// falls back to "en" if the user previously had "auto" selected globally.
-    static let xaiLanguages: [String: String] = allLanguages.filter { $0.key != "auto" }
+    /// xAI Speech-to-Text documents exactly 24 supported language codes and
+    /// rejects everything else with a 400 when `format=true`. The list is
+    /// enumerated here (not derived from `allLanguages`) so a future Whisper
+    /// addition can't silently leak an unsupported code into the picker. Note
+    /// that xAI uses `fil` for Filipino, not Whisper's `tl`. No auto-detect:
+    /// the API requires a concrete language when ITN formatting is on.
+    static let xaiLanguages: [String: String] = [
+        "ar": "Arabic",
+        "cs": "Czech",
+        "da": "Danish",
+        "nl": "Dutch",
+        "en": "English",
+        "fil": "Filipino",
+        "fr": "French",
+        "de": "German",
+        "hi": "Hindi",
+        "id": "Indonesian",
+        "it": "Italian",
+        "ja": "Japanese",
+        "ko": "Korean",
+        "mk": "Macedonian",
+        "ms": "Malay",
+        "fa": "Persian",
+        "pl": "Polish",
+        "pt": "Portuguese",
+        "ro": "Romanian",
+        "ru": "Russian",
+        "es": "Spanish",
+        "sv": "Swedish",
+        "th": "Thai",
+        "tr": "Turkish",
+        "vi": "Vietnamese",
+    ]
 
     /// Soniox stt-async-v4 supports 60 languages plus auto-detect.
     /// Translation targets are the same set.
@@ -743,6 +772,7 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
         "et": "🇪🇪",
         "fo": "🇫🇴",
         "fi": "🇫🇮",
+        "fil": "🇵🇭",
         "fr": "🇫🇷",
         "gl": "🇪🇸",
         "ka": "🇬🇪",

--- a/VivaDicta/Models/TranscriptionModelProvider.swift
+++ b/VivaDicta/Models/TranscriptionModelProvider.swift
@@ -21,6 +21,7 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
     case speechmatics
     case cohere
     case cartesia
+    case xai
     case customTranscription
     
     var id: Self { self }
@@ -53,6 +54,8 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
             "Cohere"
         case .cartesia:
             "Cartesia"
+        case .xai:
+            "xAI"
         case .customTranscription:
             "Custom"
         }
@@ -74,6 +77,7 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
         .elevenLabs,
         .gemini,
         .openAI,
+        .xai,
         .customTranscription]
     
     var cloudTranscriptionModelsNames: [String] {
@@ -120,6 +124,7 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
         case .speechmatics: "speechmatics-batch-v2"
         case .cohere: "cohere-transcribe-03-2026"
         case .cartesia: "ink-whisper"
+        case .xai: "grok-stt"
         default: nil
         }
     }
@@ -148,6 +153,8 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
             return .cohere
         case .cartesia:
             return .cartesia
+        case .xai:
+            return .grok
         default:
             return nil
         }
@@ -398,6 +405,19 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
                 cost: 0.9,  // $0.006/min
                 supportManyLanguages: true,
                 supportedLanguages: allLanguages
+            ),
+
+            CloudModel(
+                name: "grok-stt",
+                displayName: "xAI Speech-to-Text",
+                description: "xAI's hosted speech-to-text endpoint with natural formatting and multilingual support. Uses the same xAI API key as Grok chat. No auto-detect - pick a language.",
+                provider: .xai,
+                recommended: true,
+                speed: 0.9,
+                accuracy: 0.95,
+                cost: 0.5,
+                supportManyLanguages: true,
+                supportedLanguages: xaiLanguages
             )
         ]
     }
@@ -450,6 +470,11 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
         ]
         return allLanguages.filter { codes.contains($0.key) }
     }()
+
+    /// xAI Speech-to-Text requires a non-empty `language` whenever `format=true`,
+    /// so the picker exposes the full Whisper-style set minus "auto". The service
+    /// falls back to "en" if the user previously had "auto" selected globally.
+    static let xaiLanguages: [String: String] = allLanguages.filter { $0.key != "auto" }
 
     /// Soniox stt-async-v4 supports 60 languages plus auto-detect.
     /// Translation targets are the same set.

--- a/VivaDicta/Services/Transcription/TranscriptionManager.swift
+++ b/VivaDicta/Services/Transcription/TranscriptionManager.swift
@@ -325,6 +325,19 @@ class TranscriptionManager {
             )
             return .cartesia(.init(apiKey: try requireAPIKey(model), modelName: model.name, language: language))
 
+        case .xai:
+            // xAI STT rejects `format=true` without a language, so fall back to
+            // "en" whenever the globally selected language is "auto".
+            let language = normalizedLanguage(
+                for: selectedLanguage,
+                supportedCodes: Set(TranscriptionModelProvider.xaiLanguages.keys),
+                fallback: "en"
+            )
+            return .xai(.init(
+                apiKey: try requireAPIKey(model),
+                language: language
+            ))
+
         case .customTranscription:
             guard let customModel = model as? CustomTranscriptionModel else {
                 throw CloudTranscriptionError.unsupportedProvider


### PR DESCRIPTION
## Summary
- Adds xAI Speech-to-Text (`https://api.x.ai/v1/stt`) as a cloud transcription provider, exposed as `grok-stt` ("xAI Speech-to-Text") in the model picker.
- Reuses the existing `AIProvider.grok` keychain entry (`grokAPIKey`) - users with an xAI key for Grok chat get transcription with no extra setup.
- xAI STT rejects `format=true` without a `language`, so xAI's language picker drops the "auto" option and `TranscriptionManager` falls back to `"en"` when the user has "auto" selected globally (same pattern Cartesia uses).
- Service implements file-LAST multipart ordering per the xAI docs and decodes the `{ "text": ... }` response, retried via `NetworkRetry`.

## Files changed
- `Modules/CloudTranscription/Sources/CloudTranscription/XaiTranscriptionService.swift` (new)
- `Modules/CloudTranscription/Tests/CloudTranscriptionTests/XaiTranscriptionServiceTests.swift` (new, 13 tests)
- `Modules/TranscriptionKit/Sources/TranscriptionKit/TranscriptionProvider.swift` - new `.xai` case
- `Modules/TranscriptionKit/Sources/TranscriptionKit/TranscriptionEngine.swift` - dispatch
- `VivaDicta/Models/TranscriptionModelProvider.swift` - `.xai` case, `xaiLanguages` set, `CloudModel(grok-stt)`, maps to `AIProvider.grok`
- `VivaDicta/Services/Transcription/TranscriptionManager.swift` - builds `.xai(.init(...))` with normalized language

## Test plan
- [x] `swift build` on `CloudTranscription` and `TranscriptionKit` - clean
- [x] `swift test --filter XaiTranscriptionServiceTests` - 13/13 passed
- [x] `xcodebuild` iOS app (Debug, iPhone 17 Pro Max, iOS 26.4) - 0 errors
- [ ] Manual: pick xAI in the model picker, confirm transcription works with `language=en` and a non-auto language
- [ ] Manual: confirm the picker no longer shows "Auto-detect" for the xAI provider