### PR TITLE
TagFilterBar: use DesignSystem.glassCapsule instead of private modifier

### DIFF
--- a/VivaDicta/Views/SettingsScreen/Tags/TagFilterBar.swift
+++ b/VivaDicta/Views/SettingsScreen/Tags/TagFilterBar.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import DesignSystem
 
 /// Horizontal scrollable filter bar with source tags and user tags.
 struct TagFilterBar: View {
@@ -82,7 +83,10 @@ struct TagFilterBar: View {
     }
 
     private func chipButton(label: String, icon: String?, isSelected: Bool, color: Color = .blue, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
+        let chipColor = color.opacity(colorScheme == .dark ? 0.6 : 1.0)
+        let chipFallback: Color = isSelected ? chipColor.opacity(0.2) : Color(.systemGray6)
+
+        return Button(action: action) {
             HStack(spacing: 4) {
                 if let icon {
                     Image(systemName: icon)
@@ -95,37 +99,8 @@ struct TagFilterBar: View {
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 6)
-            .chipBackground(isSelected: isSelected, color: color.opacity(colorScheme == .dark ? 0.6 : 1.0))
+            .glassCapsule(tint: isSelected ? chipColor : nil, fallback: chipFallback)
         }
         .buttonStyle(.plain)
-    }
-}
-
-// MARK: - Chip Background Modifier
-
-private struct ChipBackgroundModifier: ViewModifier {
-    let isSelected: Bool
-    let color: Color
-
-    func body(content: Content) -> some View {
-        if #available(iOS 26, *) {
-            content
-                .glassEffect(
-                    isSelected
-                    ? .regular.tint(color).interactive()
-                    : .regular.interactive(),
-                    in: .capsule
-                )
-        } else {
-            content
-                .background(isSelected ? color.opacity(0.2) : Color(.systemGray6))
-                .clipShape(.capsule)
-        }
-    }
-}
-
-extension View {
-    fileprivate func chipBackground(isSelected: Bool, color: Color) -> some View {
-        modifier(ChipBackgroundModifier(isSelected: isSelected, color: color))
     }
 }

--- a/VivaDicta/Views/SettingsScreen/Tags/TagFilterBar.swift
+++ b/VivaDicta/Views/SettingsScreen/Tags/TagFilterBar.swift
@@ -76,10 +76,6 @@ struct TagFilterBar: View {
             .padding(.horizontal)
         }
         .scrollIndicators(.hidden)
-//        .glassEffectOrMaterial()
-        
-        
-        
     }
 
     private func chipButton(label: String, icon: String?, isSelected: Bool, color: Color = .blue, action: @escaping () -> Void) -> some View {


### PR DESCRIPTION
## Summary

`TagFilterBar.swift` had a private `ChipBackgroundModifier` that was a byte-for-byte duplicate of the `glassCapsule(tint:fallback:)` helper in DesignSystem - same iOS 26 glass effect with optional tint, same capsule-shaped fallback. Removed the local modifier in favor of the DS helper.

Net: -25 LOC (private modifier + view extension deleted), file gains `import DesignSystem`.

Visual fidelity preserved:
- Dark-mode `color.opacity(0.6)` adjustment factored into a local `chipColor` constant inside `chipButton(...)`.
- Compound `.opacity(0.2)` fallback factored into `chipFallback` constant.
- Both feed `glassCapsule`'s `tint` and `fallback` parameters identically to the previous implementation.

## Why this matters

This is the first real-app consumer of `glassCapsule` since it landed in DesignSystem. Claude flagged the duplication in PR #265's review. Now DS earns its keep in TagFilterBar instead of just being declared next to it.

## Test plan
- [x] `xcodebuild build` for the main app passes
- [ ] Open Tags filter bar in light + dark mode, verify chip backgrounds render identically to before
- [ ] Tap a chip to select; confirm tint applies correctly on iOS 26