### PR TITLE
Extract AIChatService protocol + adopt Default<Name> naming

### DIFF
--- a/Modules/Keychain/Sources/Keychain/DefaultKeychainService.swift
+++ b/Modules/Keychain/Sources/Keychain/DefaultKeychainService.swift
@@ -1,5 +1,5 @@
 //
-//  KeychainServiceImpl.swift
+//  DefaultKeychainService.swift
 //  Keychain
 //
 //  Created by Anton Novoselov on 2026.05.15
@@ -12,14 +12,14 @@ import Security
 /// Production keychain implementation. The default `service` value must match
 /// the macOS VivaDicta app for iCloud Keychain sync to work; do not change it
 /// without coordinating across both platforms.
-public final class KeychainServiceImpl: KeychainService, Sendable {
+public final class DefaultKeychainService: KeychainService, Sendable {
 
     public static let defaultService = "com.antonnovoselov.VivaDicta"
 
     private let logger = Logger(subsystem: "com.antonnovoselov.VivaDicta", category: "KeychainService")
     private let service: String
 
-    public init(service: String = KeychainServiceImpl.defaultService) {
+    public init(service: String = DefaultKeychainService.defaultService) {
         self.service = service
     }
 

--- a/VivaDicta/Services/AIEnhance/AIChatService.swift
+++ b/VivaDicta/Services/AIEnhance/AIChatService.swift
@@ -1,0 +1,37 @@
+//
+//  AIChatService.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.05.17
+//
+
+import Foundation
+
+/// Narrow chat-request surface of ``AIService`` consumed by chat view models.
+///
+/// Carved out so chat view models can be unit-tested against a hand-rolled
+/// mock without spinning up a real ``AIService``. The protocol intentionally
+/// mirrors only the members the chat view models actually touch.
+@MainActor
+protocol AIChatService: AnyObject {
+    var selectedMode: VivaMode { get }
+
+    func isChatProviderReady(_ provider: AIProvider) -> Bool
+
+    func makeChatStreamingRequest(
+        provider: AIProvider,
+        model: String,
+        systemMessage: String,
+        messages: [[String: String]],
+        onPartialResponse: @escaping @MainActor (String) -> Void
+    ) async throws -> String
+
+    func makeChatRequest(
+        provider: AIProvider,
+        model: String,
+        systemMessage: String,
+        messages: [[String: String]]
+    ) async throws -> String
+}
+
+extension AIService: AIChatService {}

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -42,8 +42,11 @@ import CloudTranscription
 ///
 /// ## Thread Safety
 ///
-/// This class is marked with `@Observable` for SwiftUI integration. API key operations
-/// and provider refreshing should be performed on the main actor.
+/// This class is marked with `@Observable` for SwiftUI integration and is
+/// `@MainActor`-isolated: API key operations, provider refreshing, and all
+/// chat-routing methods must run on the main actor. The `AIChatService`
+/// protocol's `@MainActor` requirement matches this isolation.
+@MainActor
 @Observable
 class AIService {
     private let logger = Logger(category: .aiService)

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -186,7 +186,7 @@ class AIService {
         return service
     }
 
-    init(keychain: any KeychainService = KeychainServiceImpl()) {
+    init(keychain: any KeychainService = DefaultKeychainService()) {
         self.keychain = keychain
         self.userDefaults = UserDefaultsStorage.shared
         self.modesStorageKey = AppGroupCoordinator.vivaModesKey
@@ -227,7 +227,7 @@ class AIService {
     }
 
     /// Test-only initializer with injectable UserDefaults and no network side effects.
-    init(userDefaults: UserDefaults, modesStorageKey: String = "VivaModes", selectedModeStorageKey: String = "selectedVivaMode", keychain: any KeychainService = KeychainServiceImpl()) {
+    init(userDefaults: UserDefaults, modesStorageKey: String = "VivaModes", selectedModeStorageKey: String = "selectedVivaMode", keychain: any KeychainService = DefaultKeychainService()) {
         self.keychain = keychain
         self.userDefaults = userDefaults
         self.modesStorageKey = modesStorageKey

--- a/VivaDicta/Services/AIEnhance/ExaWebSearchTool.swift
+++ b/VivaDicta/Services/AIEnhance/ExaWebSearchTool.swift
@@ -261,7 +261,7 @@ private enum ExaError: LocalizedError {
 
 enum ExaAPIKeyManager {
     static let keychainKey = "exaAPIKey"
-    private static let keychain: any KeychainService = KeychainServiceImpl()
+    private static let keychain: any KeychainService = DefaultKeychainService()
 
     static var apiKey: String? {
         keychain.getString(forKey: keychainKey)

--- a/VivaDicta/Services/AIEnhance/SmartSearchQueryPlanner.swift
+++ b/VivaDicta/Services/AIEnhance/SmartSearchQueryPlanner.swift
@@ -46,7 +46,7 @@ enum SmartSearchQueryPlanner {
     private static let logger = Logger(category: .smartSearchChat)
 
     static func makePlan(
-        aiService: AIService,
+        aiService: any AIChatService,
         provider: AIProvider,
         model: String,
         recentMessages: [SmartSearchQueryPlannerMessage],
@@ -116,7 +116,7 @@ enum SmartSearchQueryPlanner {
     }
 
     private static func makeCloudPlan(
-        aiService: AIService,
+        aiService: any AIChatService,
         provider: AIProvider,
         model: String,
         recentMessages: [SmartSearchQueryPlannerMessage],

--- a/VivaDicta/Services/AIEnhance/VivAgentsClient.swift
+++ b/VivaDicta/Services/AIEnhance/VivAgentsClient.swift
@@ -12,7 +12,7 @@ import os
 enum VivAgentsClient {
 
     private static let logger = Logger(category: .vivAgentsClient)
-    private static let keychain: any KeychainService = KeychainServiceImpl()
+    private static let keychain: any KeychainService = DefaultKeychainService()
 
     struct EnhanceRequest: Encodable {
         let text: String

--- a/VivaDicta/Services/AIProvider+APIKey.swift
+++ b/VivaDicta/Services/AIProvider+APIKey.swift
@@ -12,7 +12,7 @@ import Keychain
 // without forcing every consumer of `AIProvider.apiKey` to inject one.
 // `AIProvider` is a domain enum used in non-DI contexts (data models,
 // view models) that don't have a ready `AppDependencies` reference.
-private let keychain: any KeychainService = KeychainServiceImpl()
+private let keychain: any KeychainService = DefaultKeychainService()
 
 extension AIProvider {
     /// Reads this provider's API key from the Keychain.

--- a/VivaDicta/Services/APIKeyMigrationService.swift
+++ b/VivaDicta/Services/APIKeyMigrationService.swift
@@ -12,7 +12,7 @@ import os
 
 /// One-time migration of API keys from UserDefaults (App Group) to Keychain (iCloud sync).
 final class APIKeyMigrationService: Sendable {
-    static let shared = APIKeyMigrationService(keychain: KeychainServiceImpl())
+    static let shared = APIKeyMigrationService(keychain: DefaultKeychainService())
 
     private let keychain: any KeychainService
     private let logger = Logger(category: .keychainService)

--- a/VivaDicta/Services/LiveTranslation/LiveTranslationService.swift
+++ b/VivaDicta/Services/LiveTranslation/LiveTranslationService.swift
@@ -61,7 +61,7 @@ final class LiveTranslationService {
     private var sessionStartedAt: Date?
     private(set) var sessionTargetLanguage: LiveTranslationLanguage = .english
 
-    init(keychain: any KeychainService = KeychainServiceImpl()) {
+    init(keychain: any KeychainService = DefaultKeychainService()) {
         self.keychain = keychain
         self.audio = LiveTranslationAudio()
         self.audio.playbackRate = LiveTranslationPreferences.ttsRate

--- a/VivaDicta/Services/OAuth/OAuthSingletons.swift
+++ b/VivaDicta/Services/OAuth/OAuthSingletons.swift
@@ -8,12 +8,12 @@ import OAuth
 /// live in `Modules/OAuth` and are dependency-injected; this file is the
 /// composition root for the convenience singletons used across the app.
 extension OAuthManager {
-    @MainActor public static let shared = OAuthManager(keychain: KeychainServiceImpl())
+    @MainActor public static let shared = OAuthManager(keychain: DefaultKeychainService())
 }
 
 extension CopilotOAuthManager {
     @MainActor public static let shared = CopilotOAuthManager(
-        keychain: KeychainServiceImpl(),
+        keychain: DefaultKeychainService(),
         backgroundTaskService: BackgroundTaskServiceAdapter()
     )
 }

--- a/VivaDicta/Services/Transcription/CustomTranscription/CustomTranscriptionModelManager.swift
+++ b/VivaDicta/Services/Transcription/CustomTranscription/CustomTranscriptionModelManager.swift
@@ -13,7 +13,7 @@ import os
 @Observable
 @MainActor
 final class CustomTranscriptionModelManager {
-    static let shared = CustomTranscriptionModelManager(keychain: KeychainServiceImpl())
+    static let shared = CustomTranscriptionModelManager(keychain: DefaultKeychainService())
 
     private let logger = Logger(category: .customTranscriptionService)
     private let keychain: any KeychainService

--- a/VivaDicta/Views/SmartSearch/SmartSearchChatViewModel.swift
+++ b/VivaDicta/Views/SmartSearch/SmartSearchChatViewModel.swift
@@ -105,7 +105,7 @@ final class SmartSearchChatViewModel {
     // MARK: - Dependencies
 
     let conversation: SmartSearchConversation
-    private let aiService: AIService
+    private let aiService: any AIChatService
     private let modelContext: ModelContext
     private var streamingTask: Task<Void, Never>?
     private var pendingUserMessage: ChatMessage?
@@ -114,7 +114,7 @@ final class SmartSearchChatViewModel {
 
     // MARK: - Init
 
-    init(conversation: SmartSearchConversation, aiService: AIService, modelContext: ModelContext) {
+    init(conversation: SmartSearchConversation, aiService: any AIChatService, modelContext: ModelContext) {
         self.conversation = conversation
         self.aiService = aiService
         self.modelContext = modelContext

--- a/VivaDictaTests/Mocks/MockAIChatService.swift
+++ b/VivaDictaTests/Mocks/MockAIChatService.swift
@@ -1,0 +1,88 @@
+//
+//  MockAIChatService.swift
+//  VivaDictaTests
+//
+//  Created by Anton Novoselov on 2026.05.17
+//
+
+import Foundation
+@testable import VivaDicta
+
+/// Hand-rolled mock for ``AIChatService`` following the Bev pattern:
+/// per-method `stub...` for return values, `...CallCount` for invocation
+/// counts, and a `last...` capture of the most recent arguments.
+@MainActor
+final class MockAIChatService: AIChatService {
+
+    // MARK: - selectedMode
+
+    var stubSelectedMode: VivaMode = .defaultMode
+    var selectedMode: VivaMode { stubSelectedMode }
+
+    // MARK: - isChatProviderReady
+
+    var stubIsChatProviderReady: Bool = true
+    var isChatProviderReadyCallCount = 0
+    var lastIsChatProviderReadyProvider: AIProvider?
+    func isChatProviderReady(_ provider: AIProvider) -> Bool {
+        isChatProviderReadyCallCount += 1
+        lastIsChatProviderReadyProvider = provider
+        return stubIsChatProviderReady
+    }
+
+    // MARK: - Captures (shared shape for both chat request methods)
+
+    struct ChatRequestCapture: Equatable {
+        let provider: AIProvider
+        let model: String
+        let systemMessage: String
+        let messages: [[String: String]]
+    }
+
+    // MARK: - makeChatRequest
+
+    var stubMakeChatRequestResult: Result<String, Error> = .success("")
+    var makeChatRequestCallCount = 0
+    var lastMakeChatRequestCapture: ChatRequestCapture?
+    func makeChatRequest(
+        provider: AIProvider,
+        model: String,
+        systemMessage: String,
+        messages: [[String: String]]
+    ) async throws -> String {
+        makeChatRequestCallCount += 1
+        lastMakeChatRequestCapture = ChatRequestCapture(
+            provider: provider,
+            model: model,
+            systemMessage: systemMessage,
+            messages: messages
+        )
+        return try stubMakeChatRequestResult.get()
+    }
+
+    // MARK: - makeChatStreamingRequest
+
+    var stubMakeChatStreamingRequestResult: Result<String, Error> = .success("")
+    var stubMakeChatStreamingRequestPartials: [String] = []
+    var makeChatStreamingRequestCallCount = 0
+    var lastMakeChatStreamingRequestCapture: ChatRequestCapture?
+    func makeChatStreamingRequest(
+        provider: AIProvider,
+        model: String,
+        systemMessage: String,
+        messages: [[String: String]],
+        onPartialResponse: @escaping @MainActor (String) -> Void
+    ) async throws -> String {
+        makeChatStreamingRequestCallCount += 1
+        lastMakeChatStreamingRequestCapture = ChatRequestCapture(
+            provider: provider,
+            model: model,
+            systemMessage: systemMessage,
+            messages: messages
+        )
+        for partial in stubMakeChatStreamingRequestPartials {
+            await onPartialResponse(partial)
+        }
+        return try stubMakeChatStreamingRequestResult.get()
+    }
+}

--- a/VivaDictaTests/SmartSearchChatViewModelTests.swift
+++ b/VivaDictaTests/SmartSearchChatViewModelTests.swift
@@ -1,0 +1,88 @@
+//
+//  SmartSearchChatViewModelTests.swift
+//  VivaDictaTests
+//
+//  Created by Anton Novoselov on 2026.05.17
+//
+
+import Foundation
+import SwiftData
+import Testing
+@testable import VivaDicta
+
+/// Proof-of-pattern: tests the real ``SmartSearchChatViewModel`` against a
+/// hand-rolled ``MockAIChatService`` injected through the ``AIChatService``
+/// protocol. This is the first app-target test class following the Bev
+/// dependency-injection-with-mocks pattern.
+@MainActor
+struct SmartSearchChatViewModelTests {
+
+    // MARK: - Test Infrastructure
+
+    private func makeContainer() throws -> ModelContainer {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        return try ModelContainer(
+            for: SmartSearchConversation.self, ChatMessage.self,
+            configurations: config
+        )
+    }
+
+    private func makeMode(provider: AIProvider?, model: String) -> VivaMode {
+        VivaMode(
+            id: UUID(),
+            name: "TestMode",
+            transcriptionProvider: .whisperKit,
+            transcriptionModel: "whisper-large",
+            aiProvider: provider,
+            aiModel: model,
+            aiEnhanceEnabled: true
+        )
+    }
+
+    private struct Fixture {
+        let sut: SmartSearchChatViewModel
+        let mockAIService: MockAIChatService
+        let container: ModelContainer
+    }
+
+    private func makeFixture(
+        stubMode: VivaMode = VivaMode.defaultMode
+    ) throws -> Fixture {
+        let container = try makeContainer()
+        let conversation = SmartSearchConversation()
+        container.mainContext.insert(conversation)
+
+        let mockAIService = MockAIChatService()
+        mockAIService.stubSelectedMode = stubMode
+
+        let sut = SmartSearchChatViewModel(
+            conversation: conversation,
+            aiService: mockAIService,
+            modelContext: container.mainContext
+        )
+        return Fixture(sut: sut, mockAIService: mockAIService, container: container)
+    }
+
+    // MARK: - selectedProvider / selectedModel pass-through
+
+    @Test func selectedProvider_reflectsMockSelectedMode() throws {
+        let fixture = try makeFixture(
+            stubMode: makeMode(provider: .openAI, model: "gpt-4")
+        )
+        #expect(fixture.sut.selectedProvider == .openAI)
+    }
+
+    @Test func selectedModel_returnsModelFromMockSelectedMode() throws {
+        let fixture = try makeFixture(
+            stubMode: makeMode(provider: .anthropic, model: "claude-sonnet-4-5")
+        )
+        #expect(fixture.sut.selectedModel == "claude-sonnet-4-5")
+    }
+
+    @Test func selectedModel_isNil_whenStubModelIsEmpty() throws {
+        let fixture = try makeFixture(
+            stubMode: makeMode(provider: .openAI, model: "")
+        )
+        #expect(fixture.sut.selectedModel == nil)
+    }
+}

--- a/VivaDictaUITests/VivaDictaUITestsLaunchTests.swift
+++ b/VivaDictaUITests/VivaDictaUITestsLaunchTests.swift
@@ -8,10 +8,6 @@
 import XCTest
 
 final class VivaDictaUITestsLaunchTests: XCTestCase {
-//
-//    override class var runsForEachTargetApplicationUIConfiguration: Bool {
-//        false
-//    }
 
     override func setUpWithError() throws {
         continueAfterFailure = false

--- a/VivaDictaUITests/VivaDictaUITestsLaunchTests.swift
+++ b/VivaDictaUITests/VivaDictaUITestsLaunchTests.swift
@@ -8,10 +8,10 @@
 import XCTest
 
 final class VivaDictaUITestsLaunchTests: XCTestCase {
-
-    override class var runsForEachTargetApplicationUIConfiguration: Bool {
-        false
-    }
+//
+//    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+//        false
+//    }
 
     override func setUpWithError() throws {
         continueAfterFailure = false


### PR DESCRIPTION
## Summary

- Extracts a narrow `AIChatService` protocol (4 members: `selectedMode`, `isChatProviderReady`, `makeChatStreamingRequest`, `makeChatRequest`) from the existing `AIService` class. `SmartSearchChatViewModel` and `SmartSearchQueryPlanner` now depend on `any AIChatService`; the existing `AIService` auto-conforms.
- First app-target test class following the Bev DI-with-mocks pattern: `MockAIChatService` + 3 `SmartSearchChatViewModelTests` injecting the mock through the protocol.
- Renames `KeychainServiceImpl` -> `DefaultKeychainService` across the `Keychain` module and 10 app-target call sites, adopting `Default<Name>` as the convention for concrete impls of a protocol.
- Simplifies the launch test: drops the explicit `runsForEachTargetApplicationUIConfiguration = false` override since `false` is already the `XCTestCase` default.

## Why

Production `AIService` is a 4167 LOC monolith. To unit-test view models that depend on it without spinning up a real `AIService`, we carve out narrow protocols per consumer. This is the first slice (chat-request surface). Pattern is intentionally incremental - more slices (`AIEnhancementService`, etc.) follow on demand without moving the impl.

`Default<Name>` is preferred over `Impl` suffix because it reads more naturally, parallels mock naming (`Default*` + `Mock*`), and is more Swift-idiomatic than the Java-style `Impl`.

## Files

**New (3):**
- `VivaDicta/Services/AIEnhance/AIChatService.swift` - protocol + conformance
- `VivaDictaTests/Mocks/MockAIChatService.swift` - Bev-style mock with stubs, callCounts, captures
- `VivaDictaTests/SmartSearchChatViewModelTests.swift` - 3 proof-of-pattern tests

**Renamed (1):**
- `Modules/Keychain/Sources/Keychain/KeychainServiceImpl.swift` -> `DefaultKeychainService.swift`

**Modified (11):** 10 app-target call sites updated to `DefaultKeychainService`, plus `SmartSearchChatViewModel` + `SmartSearchQueryPlanner` migrated to `any AIChatService`, plus the launch test simplification.

## Test plan

- [x] `xcodebuild ... build` - SUCCEEDED
- [x] `SmartSearchChatViewModelTests` - 3/3 passing
- [x] `KeychainTests` - 6/6 passing
- [ ] Full suite re-run after merge to confirm no regressions across 424 tests