### PR TITLE
Extract TranscriptionEngine protocol + first app-target test using a module Mocks library

### DIFF
--- a/Modules/CloudTranscription/Sources/CloudTranscriptionMocks/MockOpenAITranscriptionService.swift
+++ b/Modules/CloudTranscription/Sources/CloudTranscriptionMocks/MockOpenAITranscriptionService.swift
@@ -9,7 +9,7 @@ import TestUtilities
 /// transcription services. Stub the result via `stubTranscribeResponse`.
 ///
 /// Conforms to `TranscriptionService` so it can be returned from a
-/// `TranscriptionEngine.ServiceFactory` to test engine-level routing.
+/// `DefaultTranscriptionEngine.ServiceFactory` to test engine-level routing.
 public final class MockTranscriptionService: TranscriptionService, @unchecked Sendable {
 
     public init() {}

--- a/Modules/LocalTranscription/Sources/LocalTranscriptionMocks/MockWhisperKitTranscriptionService.swift
+++ b/Modules/LocalTranscription/Sources/LocalTranscriptionMocks/MockWhisperKitTranscriptionService.swift
@@ -11,7 +11,7 @@ import TranscriptionCore
 ///
 /// Also conforms to `TranscriptionService` (the unified
 /// `transcribe(audioURL:)` entry point) so it can be returned from a
-/// `TranscriptionEngine.ServiceFactory` to test engine-level routing. The
+/// `DefaultTranscriptionEngine.ServiceFactory` to test engine-level routing. The
 /// protocol path delegates to the same stub as the type-specific signature
 /// but ignores the model/options captures.
 public final class MockWhisperKitTranscriptionService: TranscriptionService, @unchecked Sendable {

--- a/Modules/TranscriptionKit/Package.swift
+++ b/Modules/TranscriptionKit/Package.swift
@@ -10,12 +10,14 @@ let package = Package(
     ],
     products: [
         .library(name: "TranscriptionKit", targets: ["TranscriptionKit"]),
+        .library(name: "TranscriptionKitMocks", targets: ["TranscriptionKitMocks"]),
     ],
     dependencies: [
         .package(path: "../TranscriptionCore"),
         .package(path: "../CloudTranscription"),
         .package(path: "../LocalTranscription"),
         .package(path: "../Networking"),
+        .package(path: "../TestUtilities"),
     ],
     targets: [
         .target(
@@ -31,6 +33,14 @@ let package = Package(
                 // SPM doesn't propagate this transitive conformance link
                 // through the umbrella in every build context.
                 .product(name: "Networking", package: "Networking"),
+            ]
+        ),
+        .target(
+            name: "TranscriptionKitMocks",
+            dependencies: [
+                "TranscriptionKit",
+                .product(name: "TranscriptionCore", package: "TranscriptionCore"),
+                .product(name: "TestUtilities", package: "TestUtilities"),
             ]
         ),
         .testTarget(

--- a/Modules/TranscriptionKit/Sources/TranscriptionKit/DefaultTranscriptionEngine.swift
+++ b/Modules/TranscriptionKit/Sources/TranscriptionKit/DefaultTranscriptionEngine.swift
@@ -1,0 +1,168 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import CloudTranscription
+@preconcurrency import FluidAudio
+import Foundation
+import LocalTranscription
+import TranscriptionCore
+
+/// Production conformer of ``TranscriptionEngine`` and the unified entry
+/// point to VivaDicta's transcription stack. Pick a `TranscriptionProvider`
+/// describing where to transcribe; pass the audio URL; get text back.
+///
+/// Cloud providers are stateless - each call constructs a fresh service
+/// instance from the provider's config. Local providers (WhisperKit,
+/// Parakeet) are stateful - the engine caches a single instance of each so
+/// loaded models survive across calls. Call `unloadLocalModels()` when you
+/// want to free that memory.
+///
+/// ## Concurrency
+///
+/// `DefaultTranscriptionEngine` is an `actor`. Cache access (the WhisperKit /
+/// Parakeet service instances it holds) is serialized by the actor; the
+/// heavy work happens inside the awaited service calls, which are
+/// non-isolated async functions and run off the actor on the global
+/// executor.
+///
+/// The engine is deliberately not `@MainActor` so library consumers (CLI
+/// tools, server contexts, view models on other actors) can use it without
+/// being forced onto the main thread. Concurrent transcription requests
+/// against the same local model from different tasks are not supported
+/// (the underlying service holds a single loaded model).
+public actor DefaultTranscriptionEngine {
+    /// Maps a `TranscriptionProvider` to the concrete service that will
+    /// transcribe the audio. Injected at init for tests; `nil` in production
+    /// (the engine uses its built-in dispatch + local-service cache).
+    public typealias ServiceFactory = @Sendable (
+        TranscriptionProvider,
+        TranscriptionProgressHandler?
+    ) -> any TranscriptionService
+
+    private var whisperKitService: WhisperKitTranscriptionService?
+    private var parakeetService: ParakeetTranscriptionService?
+    private let serviceFactory: ServiceFactory?
+
+    /// Build an engine for production use. The default dispatch handles all
+    /// backends and caches local services across calls.
+    public init() {
+        self.serviceFactory = nil
+    }
+
+    /// Build an engine that routes every `transcribe` call through the
+    /// supplied factory instead of the built-in dispatch. Use this from tests
+    /// to inject mocks of `TranscriptionService` and verify routing without
+    /// touching real network/model code.
+    public init(serviceFactory: @escaping ServiceFactory) {
+        self.serviceFactory = serviceFactory
+    }
+
+    /// Transcribe `audioURL` using the backend described by `provider`.
+    ///
+    /// - Parameter progress: Optional callback for streaming progress updates.
+    ///   Currently only Parakeet emits progress events; other backends ignore
+    ///   the handler.
+    public func transcribe(
+        audioURL: URL,
+        using provider: TranscriptionProvider,
+        progress: TranscriptionProgressHandler? = nil
+    ) async throws -> TranscriptionServiceResult {
+        let service = serviceFactory?(provider, progress)
+            ?? makeService(for: provider, progress: progress)
+        return try await service.transcribe(audioURL: audioURL)
+    }
+
+    /// Preload a WhisperKit model in the engine's cached service. Best-effort;
+    /// failures are absorbed (the underlying service logs them).
+    public func preloadWhisperKitModel(named modelName: String) async {
+        await whisperKit().preloadModelIfNeeded(modelName: modelName)
+    }
+
+    /// Drop the cached WhisperKit/Parakeet services so their models leave
+    /// memory. The engine will rebuild them on next use.
+    public func unloadLocalModels() async {
+        // WhisperKit needs an explicit `unloadModel()` to release the
+        // WhisperKit + SpeakerKit instances it holds. Parakeet's
+        // `ParakeetTranscriptionService` releases its `AsrManager` after each
+        // transcription in `cleanupAfterTranscription`, so dropping the
+        // wrapper reference is sufficient.
+        await whisperKitService?.unloadModel()
+        whisperKitService = nil
+        parakeetService = nil
+    }
+
+    // MARK: - Private cache
+
+    /// Returns the engine's cached WhisperKit service, creating it lazily.
+    /// Private so the cache is owned entirely by the actor.
+    private func whisperKit() -> WhisperKitTranscriptionService {
+        if let whisperKitService { return whisperKitService }
+        let service = WhisperKitTranscriptionService()
+        whisperKitService = service
+        return service
+    }
+
+    /// Returns the engine's cached Parakeet service, creating it lazily.
+    private func parakeet() -> ParakeetTranscriptionService {
+        if let parakeetService { return parakeetService }
+        let service = ParakeetTranscriptionService()
+        parakeetService = service
+        return service
+    }
+
+    // MARK: - Dispatch
+
+    private func makeService(
+        for provider: TranscriptionProvider,
+        progress: TranscriptionProgressHandler?
+    ) -> any TranscriptionService {
+        switch provider {
+        case .openAI(let config):
+            return OpenAITranscriptionService(config: config)
+        case .gemini(let config):
+            return GeminiTranscriptionService(config: config)
+        case .groq(let config):
+            return GroqTranscriptionService(config: config)
+        case .elevenLabs(let config):
+            return ElevenLabsTranscriptionService(config: config)
+        case .cohere(let config):
+            return CohereTranscriptionService(config: config)
+        case .cartesia(let config):
+            return CartesiaTranscriptionService(config: config)
+        case .mistral(let config):
+            return MistralTranscriptionService(config: config)
+        case .deepgram(let config):
+            return DeepgramTranscriptionService(config: config)
+        case .soniox(let config):
+            return SonioxTranscriptionService(config: config)
+        case .gladia(let config):
+            return GladiaTranscriptionService(config: config)
+        case .speechmatics(let config):
+            return SpeechmaticsTranscriptionService(config: config)
+        case .xai(let config):
+            return XaiTranscriptionService(config: config)
+        case .custom(let config):
+            return CustomTranscriptionService(config: config)
+        case .whisperKit(let modelName, let displayName, let options):
+            return whisperKit().operation(
+                modelName: modelName,
+                displayName: displayName,
+                options: options
+            )
+        case .parakeet(let modelName, let displayName, let version, let options):
+            return parakeet().operation(
+                modelName: modelName,
+                displayName: displayName,
+                version: asrModelVersion(for: version),
+                options: options,
+                progressHandler: progress
+            )
+        }
+    }
+
+    private nonisolated func asrModelVersion(for version: ParakeetModelVersion) -> AsrModelVersion {
+        switch version {
+        case .v2: return .v2
+        case .v3: return .v3
+        }
+    }
+}

--- a/Modules/TranscriptionKit/Sources/TranscriptionKit/TranscriptionEngine.swift
+++ b/Modules/TranscriptionKit/Sources/TranscriptionKit/TranscriptionEngine.swift
@@ -1,168 +1,32 @@
 // Copyright © 2026 Anton Novoselov. All rights reserved.
 
-import CloudTranscription
-@preconcurrency import FluidAudio
 import Foundation
-import LocalTranscription
 import TranscriptionCore
 
-/// The unified entry point to VivaDicta's transcription stack. Pick a
-/// `TranscriptionProvider` describing where to transcribe; pass the audio
-/// URL; get text back.
+/// The transcription stack's entry-point abstraction.
 ///
-/// Cloud providers are stateless - each call constructs a fresh service
-/// instance from the provider's config. Local providers (WhisperKit,
-/// Parakeet) are stateful - the engine caches a single instance of each so
-/// loaded models survive across calls. Call `unloadLocalModels()` when you
-/// want to free that memory.
+/// Production code uses ``DefaultTranscriptionEngine``; tests can substitute
+/// a `MockTranscriptionEngine` (from `TranscriptionKitMocks`) injected
+/// through `any TranscriptionEngine`.
 ///
-/// ## Concurrency
-///
-/// `TranscriptionEngine` is an `actor`. Cache access (the WhisperKit /
-/// Parakeet service instances it holds) is serialized by the actor; the
-/// heavy work happens inside the awaited service calls, which are
-/// non-isolated async functions and run off the actor on the global
-/// executor.
-///
-/// The engine is deliberately not `@MainActor` so library consumers (CLI
-/// tools, server contexts, view models on other actors) can use it without
-/// being forced onto the main thread. Concurrent transcription requests
-/// against the same local model from different tasks are not supported
-/// (the underlying service holds a single loaded model).
-public actor TranscriptionEngine {
-    /// Maps a `TranscriptionProvider` to the concrete service that will
-    /// transcribe the audio. Injected at init for tests; `nil` in production
-    /// (the engine uses its built-in dispatch + local-service cache).
-    public typealias ServiceFactory = @Sendable (
-        TranscriptionProvider,
-        TranscriptionProgressHandler?
-    ) -> any TranscriptionService
-
-    private var whisperKitService: WhisperKitTranscriptionService?
-    private var parakeetService: ParakeetTranscriptionService?
-    private let serviceFactory: ServiceFactory?
-
-    /// Build an engine for production use. The default dispatch handles all
-    /// backends and caches local services across calls.
-    public init() {
-        self.serviceFactory = nil
-    }
-
-    /// Build an engine that routes every `transcribe` call through the
-    /// supplied factory instead of the built-in dispatch. Use this from tests
-    /// to inject mocks of `TranscriptionService` and verify routing without
-    /// touching real network/model code.
-    public init(serviceFactory: @escaping ServiceFactory) {
-        self.serviceFactory = serviceFactory
-    }
-
+/// The protocol is intentionally `Sendable` and not `@MainActor`-isolated:
+/// consumers on any actor (CLI tools, server contexts, view models on
+/// other actors) can use it without being forced onto the main thread.
+public protocol TranscriptionEngine: Sendable {
     /// Transcribe `audioURL` using the backend described by `provider`.
     ///
     /// - Parameter progress: Optional callback for streaming progress updates.
     ///   Currently only Parakeet emits progress events; other backends ignore
     ///   the handler.
-    public func transcribe(
+    func transcribe(
         audioURL: URL,
         using provider: TranscriptionProvider,
-        progress: TranscriptionProgressHandler? = nil
-    ) async throws -> TranscriptionServiceResult {
-        let service = serviceFactory?(provider, progress)
-            ?? makeService(for: provider, progress: progress)
-        return try await service.transcribe(audioURL: audioURL)
-    }
+        progress: TranscriptionProgressHandler?
+    ) async throws -> TranscriptionServiceResult
 
     /// Preload a WhisperKit model in the engine's cached service. Best-effort;
     /// failures are absorbed (the underlying service logs them).
-    public func preloadWhisperKitModel(named modelName: String) async {
-        await whisperKit().preloadModelIfNeeded(modelName: modelName)
-    }
-
-    /// Drop the cached WhisperKit/Parakeet services so their models leave
-    /// memory. The engine will rebuild them on next use.
-    public func unloadLocalModels() async {
-        // WhisperKit needs an explicit `unloadModel()` to release the
-        // WhisperKit + SpeakerKit instances it holds. Parakeet's
-        // `ParakeetTranscriptionService` releases its `AsrManager` after each
-        // transcription in `cleanupAfterTranscription`, so dropping the
-        // wrapper reference is sufficient.
-        await whisperKitService?.unloadModel()
-        whisperKitService = nil
-        parakeetService = nil
-    }
-
-    // MARK: - Private cache
-
-    /// Returns the engine's cached WhisperKit service, creating it lazily.
-    /// Private so the cache is owned entirely by the actor.
-    private func whisperKit() -> WhisperKitTranscriptionService {
-        if let whisperKitService { return whisperKitService }
-        let service = WhisperKitTranscriptionService()
-        whisperKitService = service
-        return service
-    }
-
-    /// Returns the engine's cached Parakeet service, creating it lazily.
-    private func parakeet() -> ParakeetTranscriptionService {
-        if let parakeetService { return parakeetService }
-        let service = ParakeetTranscriptionService()
-        parakeetService = service
-        return service
-    }
-
-    // MARK: - Dispatch
-
-    private func makeService(
-        for provider: TranscriptionProvider,
-        progress: TranscriptionProgressHandler?
-    ) -> any TranscriptionService {
-        switch provider {
-        case .openAI(let config):
-            return OpenAITranscriptionService(config: config)
-        case .gemini(let config):
-            return GeminiTranscriptionService(config: config)
-        case .groq(let config):
-            return GroqTranscriptionService(config: config)
-        case .elevenLabs(let config):
-            return ElevenLabsTranscriptionService(config: config)
-        case .cohere(let config):
-            return CohereTranscriptionService(config: config)
-        case .cartesia(let config):
-            return CartesiaTranscriptionService(config: config)
-        case .mistral(let config):
-            return MistralTranscriptionService(config: config)
-        case .deepgram(let config):
-            return DeepgramTranscriptionService(config: config)
-        case .soniox(let config):
-            return SonioxTranscriptionService(config: config)
-        case .gladia(let config):
-            return GladiaTranscriptionService(config: config)
-        case .speechmatics(let config):
-            return SpeechmaticsTranscriptionService(config: config)
-        case .xai(let config):
-            return XaiTranscriptionService(config: config)
-        case .custom(let config):
-            return CustomTranscriptionService(config: config)
-        case .whisperKit(let modelName, let displayName, let options):
-            return whisperKit().operation(
-                modelName: modelName,
-                displayName: displayName,
-                options: options
-            )
-        case .parakeet(let modelName, let displayName, let version, let options):
-            return parakeet().operation(
-                modelName: modelName,
-                displayName: displayName,
-                version: asrModelVersion(for: version),
-                options: options,
-                progressHandler: progress
-            )
-        }
-    }
-
-    private nonisolated func asrModelVersion(for version: ParakeetModelVersion) -> AsrModelVersion {
-        switch version {
-        case .v2: return .v2
-        case .v3: return .v3
-        }
-    }
+    func preloadWhisperKitModel(named modelName: String) async
 }
+
+extension DefaultTranscriptionEngine: TranscriptionEngine {}

--- a/Modules/TranscriptionKit/Sources/TranscriptionKit/TranscriptionEngine.swift
+++ b/Modules/TranscriptionKit/Sources/TranscriptionKit/TranscriptionEngine.swift
@@ -12,6 +12,12 @@ import TranscriptionCore
 /// The protocol is intentionally `Sendable` and not `@MainActor`-isolated:
 /// consumers on any actor (CLI tools, server contexts, view models on
 /// other actors) can use it without being forced onto the main thread.
+///
+/// The protocol surface intentionally excludes lifecycle/cache APIs such
+/// as `unloadLocalModels()`. Those live on ``DefaultTranscriptionEngine``
+/// directly - callers that need to manage the local-model cache should
+/// hold the concrete type. If a future consumer needs cache control
+/// through the protocol, add it here.
 public protocol TranscriptionEngine: Sendable {
     /// Transcribe `audioURL` using the backend described by `provider`.
     ///

--- a/Modules/TranscriptionKit/Sources/TranscriptionKitMocks/MockTranscriptionEngine.swift
+++ b/Modules/TranscriptionKit/Sources/TranscriptionKitMocks/MockTranscriptionEngine.swift
@@ -1,0 +1,47 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import TestUtilities
+import TranscriptionCore
+import TranscriptionKit
+
+/// Hand-rolled mock for ``TranscriptionEngine`` following the Bev pattern:
+/// per-method `stub...` for return values, `...CallCount` for invocation
+/// counts, and `last...` capture of the most recent arguments.
+///
+/// Use this from app-target tests to verify routing without touching real
+/// network or local-model code.
+public final class MockTranscriptionEngine: TranscriptionEngine, @unchecked Sendable {
+
+    public init() {}
+
+    // MARK: - transcribe
+
+    public var stubTranscribeResult: Result<TranscriptionServiceResult, Error>?
+    public private(set) var transcribeCallCount = 0
+    public private(set) var lastTranscribeAudioURL: URL?
+    public private(set) var lastTranscribeProvider: TranscriptionProvider?
+    public private(set) var lastTranscribeProgressWasNonNil = false
+
+    public func transcribe(
+        audioURL: URL,
+        using provider: TranscriptionProvider,
+        progress: TranscriptionProgressHandler?
+    ) async throws -> TranscriptionServiceResult {
+        transcribeCallCount += 1
+        lastTranscribeAudioURL = audioURL
+        lastTranscribeProvider = provider
+        lastTranscribeProgressWasNonNil = progress != nil
+        return try stubTranscribeResult.evaluate()
+    }
+
+    // MARK: - preloadWhisperKitModel
+
+    public private(set) var preloadWhisperKitModelCallCount = 0
+    public private(set) var lastPreloadWhisperKitModelName: String?
+
+    public func preloadWhisperKitModel(named modelName: String) async {
+        preloadWhisperKitModelCallCount += 1
+        lastPreloadWhisperKitModelName = modelName
+    }
+}

--- a/Modules/TranscriptionKit/Tests/TranscriptionKitTests/TranscriptionKitTests.swift
+++ b/Modules/TranscriptionKit/Tests/TranscriptionKitTests/TranscriptionKitTests.swift
@@ -15,7 +15,7 @@ struct TranscriptionEngineTests {
     /// constructed sut. Smoke test that hits the actor methods without
     /// touching real models.
     @Test func unloadOnFreshEngineDoesNotThrow() async {
-        let sut = TranscriptionEngine()
+        let sut = DefaultTranscriptionEngine()
         await sut.unloadLocalModels()
         // Second call should also be a no-op.
         await sut.unloadLocalModels()
@@ -28,7 +28,7 @@ struct TranscriptionEngineTests {
         let expectedAudio = URL(fileURLWithPath: "/tmp/test.wav")
         let received = ProviderCapture()
 
-        let sut = TranscriptionEngine { provider, progress in
+        let sut = DefaultTranscriptionEngine { provider, progress in
             received.set(provider: provider, progressIsNonNil: progress != nil)
             return mock
         }
@@ -50,7 +50,7 @@ struct TranscriptionEngineTests {
         mock.stubTranscribeResponse = .success(.plain("ok"))
 
         let capture = ProviderCapture()
-        let sut = TranscriptionEngine { provider, progress in
+        let sut = DefaultTranscriptionEngine { provider, progress in
             capture.set(provider: provider, progressIsNonNil: progress != nil)
             return mock
         }
@@ -73,7 +73,7 @@ struct TranscriptionEngineTests {
         let mock = MockTranscriptionService()
         mock.stubTranscribeResponse = .failure(StubError())
 
-        let sut = TranscriptionEngine { _, _ in mock }
+        let sut = DefaultTranscriptionEngine { _, _ in mock }
 
         await #expect(throws: StubError.self) {
             _ = try await sut.transcribe(
@@ -88,7 +88,7 @@ struct TranscriptionEngineTests {
         let mock = MockWhisperKitTranscriptionService()
         mock.stubTranscribeResponse = .success(.plain("whisper output"))
 
-        let sut = TranscriptionEngine { _, _ in mock }
+        let sut = DefaultTranscriptionEngine { _, _ in mock }
 
         let result = try await sut.transcribe(
             audioURL: URL(fileURLWithPath: "/tmp/wk.wav"),

--- a/VivaDicta.xcodeproj/project.pbxproj
+++ b/VivaDicta.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		18F76A3A2FB85C2300280269 /* AppGroup in Frameworks */ = {isa = PBXBuildFile; productRef = 18F76A392FB85C2300280269 /* AppGroup */; };
 		18F76A3C2FB85C2A00280269 /* AppGroup in Frameworks */ = {isa = PBXBuildFile; productRef = 18F76A3B2FB85C2A00280269 /* AppGroup */; };
 		18F76D862FB8617C00280269 /* AppGroup in Frameworks */ = {isa = PBXBuildFile; productRef = 18F76D852FB8617C00280269 /* AppGroup */; };
+		E1938683EE7E439ABF4FE3EA /* TranscriptionKitMocks in Frameworks */ = {isa = PBXBuildFile; productRef = F4E0FCBD69B741548F9F6B15 /* TranscriptionKitMocks */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -523,6 +524,7 @@
 				18F75FC22FB79A3E00280269 /* TranscriptionCore in Frameworks */,
 				18F76A342FB85C0B00280269 /* AppGroup in Frameworks */,
 				186C05892FB779BA00102432 /* PresetsMocks in Frameworks */,
+				E1938683EE7E439ABF4FE3EA /* TranscriptionKitMocks in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -758,6 +760,7 @@
 				18F75FC32FB79A4400280269 /* CloudTranscription */,
 				18F75FC52FB79A4B00280269 /* CloudTranscriptionMocks */,
 				18F76A332FB85C0B00280269 /* AppGroup */,
+				F4E0FCBD69B741548F9F6B15 /* TranscriptionKitMocks */,
 			);
 			productName = VivaDictaTests;
 			productReference = 18351E572E634FF000944940 /* VivaDictaTests.xctest */;
@@ -2796,6 +2799,10 @@
 		18F76D852FB8617C00280269 /* AppGroup */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = AppGroup;
+		};
+		F4E0FCBD69B741548F9F6B15 /* TranscriptionKitMocks */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = TranscriptionKitMocks;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/VivaDicta/Services/Transcription/TranscriptionManager.swift
+++ b/VivaDicta/Services/Transcription/TranscriptionManager.swift
@@ -33,7 +33,11 @@ import os
 class TranscriptionManager {
     private let logger = Logger(category: .transcriptionManager)
 
-    private let engine = TranscriptionEngine()
+    private let engine: any TranscriptionEngine
+
+    init(engine: any TranscriptionEngine = DefaultTranscriptionEngine()) {
+        self.engine = engine
+    }
 
     /// The currently active transcription mode determining which model to use.
     private(set) var currentMode: VivaMode = .defaultMode

--- a/VivaDictaTests/TranscriptionManagerTests.swift
+++ b/VivaDictaTests/TranscriptionManagerTests.swift
@@ -1,0 +1,88 @@
+//
+//  TranscriptionManagerTests.swift
+//  VivaDictaTests
+//
+//  Created by Anton Novoselov on 2026.05.17
+//
+
+import Foundation
+import Testing
+import TranscriptionCore
+import TranscriptionKitMocks
+@testable import VivaDicta
+
+/// First app-target test class importing a module Mocks library
+/// (`TranscriptionKitMocks`) to inject a `MockTranscriptionEngine` into
+/// `TranscriptionManager` through the `any TranscriptionEngine` protocol.
+///
+/// Coverage is intentionally narrow: the manager reads several singletons
+/// directly (`UserDefaultsStorage.shared`, `AppGroupCoordinator.shared`,
+/// `CustomTranscriptionModelManager.shared`) so end-to-end pipeline tests
+/// are out of scope until those are DI'd as well. These tests prove the
+/// protocol-DI wire and exercise the control-flow branches that don't
+/// touch app-wide state.
+@MainActor
+struct TranscriptionManagerTests {
+
+    private func makeMode(
+        provider: TranscriptionModelProvider,
+        model: String
+    ) -> VivaMode {
+        VivaMode(
+            id: UUID(),
+            name: "TestMode",
+            transcriptionProvider: provider,
+            transcriptionModel: model,
+            aiModel: "",
+            aiEnhanceEnabled: false
+        )
+    }
+
+    // MARK: - preloadWhisperKitModelIfNeeded
+
+    @Test func preloadWhisperKitModelIfNeeded_doesNothing_whenCurrentModeIsParakeet() async {
+        let mockEngine = MockTranscriptionEngine()
+        let sut = TranscriptionManager(engine: mockEngine)
+        sut.setCurrentMode(makeMode(provider: .parakeet, model: "parakeet-tdt-0.6b-v3"))
+
+        await sut.preloadWhisperKitModelIfNeeded()
+
+        #expect(mockEngine.preloadWhisperKitModelCallCount == 0)
+    }
+
+    @Test func preloadWhisperKitModelIfNeeded_doesNothing_whenCurrentModeIsCloudProvider() async {
+        let mockEngine = MockTranscriptionEngine()
+        let sut = TranscriptionManager(engine: mockEngine)
+        sut.setCurrentMode(makeMode(provider: .openAI, model: "whisper-1"))
+
+        await sut.preloadWhisperKitModelIfNeeded()
+
+        #expect(mockEngine.preloadWhisperKitModelCallCount == 0)
+    }
+
+    // MARK: - transcribe error path
+
+    @Test func transcribe_throws_andDoesNotInvokeEngine_whenCurrentModelIsUnknown() async {
+        let mockEngine = MockTranscriptionEngine()
+        let sut = TranscriptionManager(engine: mockEngine)
+        sut.setCurrentMode(makeMode(provider: .whisperKit, model: "nonexistent-model-xyz"))
+
+        let url = URL(fileURLWithPath: "/tmp/x.wav")
+        await #expect(throws: TranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: url)
+        }
+        #expect(mockEngine.transcribeCallCount == 0)
+    }
+
+    // MARK: - setCurrentMode
+
+    @Test func setCurrentMode_updatesCurrentMode() {
+        let mockEngine = MockTranscriptionEngine()
+        let sut = TranscriptionManager(engine: mockEngine)
+        let mode = makeMode(provider: .parakeet, model: "parakeet-tdt-0.6b-v3")
+
+        sut.setCurrentMode(mode)
+
+        #expect(sut.currentMode.id == mode.id)
+    }
+}


### PR DESCRIPTION
## Summary

- Carves the existing `actor TranscriptionEngine` into a protocol (`TranscriptionEngine`) + concrete conformer (`DefaultTranscriptionEngine`).
- Adds a `TranscriptionKitMocks` library shipping `MockTranscriptionEngine` (Bev-style stubs/callCounts/captures).
- Migrates `TranscriptionManager` to depend on `any TranscriptionEngine` via init, with `DefaultTranscriptionEngine()` as the default so existing call sites still work.
- Adds `VivaDictaTests/TranscriptionManagerTests.swift` - **the first app-target test class importing a module Mocks library** (`TranscriptionKitMocks`).

## Why

We've had module Mocks libraries (`KeychainMocks`, `PresetsMocks`, `OAuthMocks`, `CloudTranscriptionMocks`, `LocalTranscriptionMocks`, `NetworkingMocks`) for a while but no app-target test ever imported one. That gap is now closed.

## Naming convention

Follows the just-adopted `Default<Name>` rule (see `~/.claude/CLAUDE.md`):

- Protocol: `TranscriptionEngine`
- Concrete: `DefaultTranscriptionEngine`
- Mock: `MockTranscriptionEngine`

## Changes

- `Modules/TranscriptionKit`:
  - Renames the existing actor `TranscriptionEngine` -> `DefaultTranscriptionEngine` (file renamed too).
  - Adds new protocol `TranscriptionEngine` (transcribe, preloadWhisperKitModel) in a fresh `TranscriptionEngine.swift`.
  - `extension DefaultTranscriptionEngine: TranscriptionEngine {}` for the conformance.
  - Adds `TranscriptionKitMocks` library target shipping `MockTranscriptionEngine`.
- `Modules/TranscriptionKit/Tests`: 5 instantiation sites updated to `DefaultTranscriptionEngine()`.
- `Modules/{Cloud,Local}TranscriptionMocks`: doc comments updated to reference `DefaultTranscriptionEngine.ServiceFactory` (the typealias is concrete-only).
- `VivaDicta/Services/Transcription/TranscriptionManager.swift`: `private let engine: any TranscriptionEngine` + init taking the protocol with `DefaultTranscriptionEngine()` default.
- `VivaDicta.xcodeproj/project.pbxproj`: 4 surgical edits to link `TranscriptionKitMocks` into the `VivaDictaTests` target.
- `VivaDictaTests/TranscriptionManagerTests.swift`: 4 proof-of-pattern tests injecting `MockTranscriptionEngine`.

## Test scope (honest about limits)

Coverage is intentionally narrow because `TranscriptionManager` still reads `UserDefaultsStorage.shared`, `AppGroupCoordinator.shared`, and `CustomTranscriptionModelManager.shared` directly. The 4 tests exercise:

- `preloadWhisperKitModelIfNeeded` skips for `.parakeet` provider (engine never called)
- `preloadWhisperKitModelIfNeeded` skips for cloud provider (engine never called)
- `transcribe` throws `TranscriptionError` and doesn't invoke engine when current model is unknown
- `setCurrentMode` updates `currentMode`

The success path of `transcribe` (engine actually called with a constructed `TranscriptionProvider`) would require further DI of the singletons listed above - explicitly out of scope here.

## Test plan

- [x] `swift build --package-path Modules/TranscriptionKit` - SUCCEEDED
- [x] `xcodebuild ... build-for-testing` - SUCCEEDED
- [x] `xcodebuild ... test -only-testing:VivaDictaTests/TranscriptionManagerTests` - 4/4 passing
- [x] Full suite: **428 tests passing, 0 failures** (3 intentional known issues unchanged)