### PR TITLE
Update Gemini model lineup to May 2026 catalog

### DIFF
--- a/VivaDicta/Services/AIEnhance/AIProvider.swift
+++ b/VivaDicta/Services/AIEnhance/AIProvider.swift
@@ -305,7 +305,7 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
         case .groq:
             return "openai/gpt-oss-120b"
         case .gemini:
-            return "gemini-3-flash-preview"
+            return "gemini-3.5-flash"
         case .anthropic:
             return "claude-sonnet-4-6"
         case .openAI:
@@ -404,9 +404,10 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
         case .gemini:
             return [
                 "gemini-3.1-pro-preview",
-                "gemini-3.1-flash-lite-preview",
-                "gemini-3-pro-preview",
+                "gemini-3.5-flash",
                 "gemini-3-flash-preview",
+                "gemini-3.1-flash-lite",
+                "gemini-3.1-flash-lite-preview",
                 "gemini-2.5-pro",
                 "gemini-2.5-flash",
                 "gemini-2.5-flash-lite"

--- a/VivaDicta/Services/AIEnhance/ReasoningConfig.swift
+++ b/VivaDicta/Services/AIEnhance/ReasoningConfig.swift
@@ -14,11 +14,13 @@ struct ReasoningConfig {
         "gemini-2.5-flash-lite"
     ]
 
-    // These can't fully disable thinking — "minimal" is as low as they go
+    // These can't fully disable thinking - "minimal" is as low as they go
     static let geminiMinimalReasoningModels: Set<String> = [
         "gemini-2.5-pro",
         "gemini-3.1-pro-preview",
+        "gemini-3.5-flash",
         "gemini-3-flash-preview",
+        "gemini-3.1-flash-lite",
         "gemini-3.1-flash-lite-preview"
     ]
 

--- a/VivaDicta/Services/AIEnhance/VivaMode.swift
+++ b/VivaDicta/Services/AIEnhance/VivaMode.swift
@@ -149,9 +149,15 @@ struct VivaMode: Identifiable, Hashable, Codable {
         transcriptionLanguage = try container.decodeIfPresent(String.self, forKey: .transcriptionLanguage)
         translationTargetLanguage = try container.decodeIfPresent(String.self, forKey: .translationTargetLanguage)
         aiProvider = try container.decodeIfPresent(AIProvider.self, forKey: .aiProvider)
-        aiModel = try container.decode(String.self, forKey: .aiModel)
-        reminderExtractorProvider = try container.decodeIfPresent(AIProvider.self, forKey: .reminderExtractorProvider)
-        reminderExtractorModel = try container.decodeIfPresent(String.self, forKey: .reminderExtractorModel)
+        let decodedAIModel = try container.decode(String.self, forKey: .aiModel)
+        aiModel = VivaMode.normalizedModelID(decodedAIModel, provider: aiProvider)
+        let decodedReminderProvider = try container.decodeIfPresent(AIProvider.self, forKey: .reminderExtractorProvider)
+        reminderExtractorProvider = decodedReminderProvider
+        if let decodedReminderModel = try container.decodeIfPresent(String.self, forKey: .reminderExtractorModel) {
+            reminderExtractorModel = VivaMode.normalizedModelID(decodedReminderModel, provider: decodedReminderProvider)
+        } else {
+            reminderExtractorModel = nil
+        }
         aiEnhanceEnabled = try container.decode(Bool.self, forKey: .aiEnhanceEnabled)
         useClipboardContext = try container.decodeIfPresent(Bool.self, forKey: .useClipboardContext) ?? false
         isAutoTextFormattingEnabled = try container.decodeIfPresent(Bool.self, forKey: .isAutoTextFormattingEnabled) ?? true
@@ -171,6 +177,25 @@ struct VivaMode: Identifiable, Hashable, Codable {
             presetId = legacyPrompt?.title
         } else {
             presetId = nil
+        }
+    }
+
+    // MARK: - Model ID Normalization
+
+    /// Rewrites retired or renamed model IDs to their current replacements on decode,
+    /// so users who picked a model that has since been removed from `AIProvider.availableModels`
+    /// or `GeminiAPIClient.supportedModels` don't end up with a blank picker or a 404.
+    ///
+    /// Add new entries here whenever a model is removed from the available lists.
+    /// Mirror Google's deprecation table for Gemini.
+    static func normalizedModelID(_ modelID: String, provider: AIProvider?) -> String {
+        guard provider == .gemini else { return modelID }
+        switch modelID {
+        case "gemini-3-pro-preview":
+            // Retired by Google; superseded by gemini-3.1-pro-preview.
+            return "gemini-3.1-pro-preview"
+        default:
+            return modelID
         }
     }
 

--- a/VivaDicta/Services/OAuth/GeminiAPIClient.swift
+++ b/VivaDicta/Services/OAuth/GeminiAPIClient.swift
@@ -11,15 +11,21 @@ enum GeminiAPIClient {
     private static let logger = Logger(category: .geminiOAuthAPI)
 
     /// Default model for Gemini OAuth requests.
-    static let defaultModel = "gemini-2.5-flash"
+    /// Matches `AIProvider.gemini.defaultModel` so picker defaults agree across auth modes.
+    static let defaultModel = "gemini-3.5-flash"
 
-    /// Models available via Gemini OAuth.
+    /// Models available via Gemini OAuth (Cloud Code Assist endpoint).
+    /// Kept in sync with `AIProvider.gemini.availableModels` since the Cloud Code Assist
+    /// endpoint exposes the same generateContent surface as the standard API.
     static let supportedModels: [String] = [
+        "gemini-3.1-pro-preview",
+        "gemini-3.5-flash",
+        "gemini-3-flash-preview",
+        "gemini-3.1-flash-lite",
+        "gemini-3.1-flash-lite-preview",
         "gemini-2.5-pro",
         "gemini-2.5-flash",
-        "gemini-2.5-flash-lite",
-        "gemini-3-pro-preview",
-        "gemini-3-flash-preview"
+        "gemini-2.5-flash-lite"
     ]
 
     /// Cloud Code Assist endpoint (non-streaming).


### PR DESCRIPTION
## Summary

Refreshes the Gemini model list to match Google's [current model catalog](https://ai.google.dev/gemini-api/docs/models) as of May 2026, and switches the default off a preview model.

## Changes

**`VivaDicta/Services/AIEnhance/AIProvider.swift`**
- Add `gemini-3.5-flash` (stable) - successor to `gemini-2.5-flash`
- Add `gemini-3.1-flash-lite` (stable) - successor to `gemini-2.5-flash-lite`
- Remove `gemini-3-pro-preview` - retired by Google, superseded by `gemini-3.1-pro-preview`
- Change `defaultModel` for `.gemini` from `gemini-3-flash-preview` (preview) to `gemini-3.5-flash` (stable). Google warns preview models can be pulled with only "at least 2 weeks" notice - not a great default to bake into a shipped app.

**`VivaDicta/Services/AIEnhance/ReasoningConfig.swift`**
- Add `gemini-3.5-flash` and `gemini-3.1-flash-lite` to `geminiMinimalReasoningModels`, matching how every other 3.x variant is currently handled. Conservative choice - if Google's docs later confirm these support `none`, we can move them.

## Deprecation timeline (follow-up needed)

Per [Google's deprecation page](https://ai.google.dev/gemini-api/docs/deprecations), `gemini-2.5-pro`, `gemini-2.5-flash`, and `gemini-2.5-flash-lite` all shut down **2026-10-16**. They're left in the available list for this PR so users on those models don't lose them mid-cycle, but a follow-up before October should either remove them or auto-migrate user selections to:

| Old | New |
|---|---|
| `gemini-2.5-pro` | `gemini-3.1-pro-preview` |
| `gemini-2.5-flash` | `gemini-3.5-flash` |
| `gemini-2.5-flash-lite` | `gemini-3.1-flash-lite` |

## Out of scope

- `TranscriptionModelProvider.swift` Gemini transcription entries (separate code path, can update in a follow-up if desired)
- `GeminiAPIClient.swift` OAuth Cloud Code Assist endpoint model list (different surface, unclear whether the new stables are exposed there)

## Testing

- `xcodebuild build` clean: 0 errors, 0 new warnings.
- Existing tests reference `gemini-3-flash-preview` and `gemini-2.5-pro`, both still in the available models list - no test impact.