### PR TITLE
Update Gemini transcription lineup to May 2026 catalog

### DIFF
--- a/VivaDicta/Models/TranscriptionModelProvider.swift
+++ b/VivaDicta/Models/TranscriptionModelProvider.swift
@@ -115,7 +115,7 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
         switch self {
         case .groq: "whisper-large-v3-turbo"
         case .mistral: "voxtral-mini-latest"
-        case .gemini: "gemini-3-flash-preview"
+        case .gemini: "gemini-3.5-flash"
         case .deepgram: "nova-3"
         case .elevenLabs: "scribe_v2"
         case .openAI: "gpt-4o-mini-transcribe"
@@ -329,20 +329,42 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
 
             // Gemini Models
             CloudModel(
-                name: "gemini-3-pro-preview",
-                displayName: "Gemini 3 Pro",
-                description: "Google's latest multimodal model with enhanced transcription capabilities.",
+                name: "gemini-3.5-flash",
+                displayName: "Gemini 3.5 Flash",
+                description: "Google's latest stable fast multimodal model with strong transcription quality.",
                 provider: .gemini,
-                speed: 0.75,
+                speed: 0.92,
                 accuracy: 0.92,
                 cost: 0.3,  // $0.002/min - Free tier (15 RPM) + $300 Google Cloud credits for 90 days
                 supportManyLanguages: true,
                 supportedLanguages: allLanguages
             ),
             CloudModel(
+                name: "gemini-3.1-pro-preview",
+                displayName: "Gemini 3.1 Pro (Preview)",
+                description: "Google's most capable Gemini model with advanced multimodal understanding.",
+                provider: .gemini,
+                speed: 0.7,
+                accuracy: 0.94,
+                cost: 0.3,  // $0.002/min - Free tier (15 RPM) + $300 Google Cloud credits for 90 days
+                supportManyLanguages: true,
+                supportedLanguages: allLanguages
+            ),
+            CloudModel(
+                name: "gemini-3.1-flash-lite",
+                displayName: "Gemini 3.1 Flash Lite",
+                description: "Google's fastest and cheapest model, designed for high-volume transcription.",
+                provider: .gemini,
+                speed: 0.95,
+                accuracy: 0.85,
+                cost: 0.15,  // Cheapest Gemini tier - Free tier (15 RPM) + $300 Google Cloud credits for 90 days
+                supportManyLanguages: true,
+                supportedLanguages: allLanguages
+            ),
+            CloudModel(
                 name: "gemini-3-flash-preview",
-                displayName: "Gemini 3 Flash",
-                description: "Google's newest fast model combining intelligence with superior speed.",
+                displayName: "Gemini 3 Flash (Preview)",
+                description: "Earlier preview of Gemini 3 Flash combining intelligence with superior speed.",
                 provider: .gemini,
                 speed: 0.92,
                 accuracy: 0.9,
@@ -350,10 +372,12 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
                 supportManyLanguages: true,
                 supportedLanguages: allLanguages
             ),
+            // Gemini 2.5 family is scheduled for shutdown on 2026-10-16 per Google's deprecation page.
+            // Kept for backward compatibility; plan migration of user selections before October.
             CloudModel(
                 name: "gemini-2.5-pro",
                 displayName: "Gemini 2.5 Pro",
-                description: "Google's advanced model with superior noise filtering and speaker diarization. Free tier available + $300 Google Cloud credits",
+                description: "Google's advanced 2.5-generation model with superior noise filtering and speaker diarization. Scheduled for shutdown 2026-10-16.",
                 provider: .gemini,
                 speed: 0.7,
                 accuracy: 0.92,
@@ -364,7 +388,7 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
             CloudModel(
                 name: "gemini-2.5-flash",
                 displayName: "Gemini 2.5 Flash",
-                description: "Google's fastest model with 887 tokens/sec output and cost-effective batch processing. Free tier available + $300 Google Cloud credits",
+                description: "Google's fast 2.5-generation model with cost-effective batch processing. Scheduled for shutdown 2026-10-16.",
                 provider: .gemini,
                 speed: 0.9,
                 accuracy: 0.7,

--- a/VivaDicta/Services/AIEnhance/VivaMode.swift
+++ b/VivaDicta/Services/AIEnhance/VivaMode.swift
@@ -145,7 +145,8 @@ struct VivaMode: Identifiable, Hashable, Codable {
         id = try container.decode(UUID.self, forKey: .id)
         name = try container.decode(String.self, forKey: .name)
         transcriptionProvider = try container.decode(TranscriptionModelProvider.self, forKey: .transcriptionProvider)
-        transcriptionModel = try container.decode(String.self, forKey: .transcriptionModel)
+        let decodedTranscriptionModel = try container.decode(String.self, forKey: .transcriptionModel)
+        transcriptionModel = VivaMode.normalizedTranscriptionModelID(decodedTranscriptionModel, provider: transcriptionProvider)
         transcriptionLanguage = try container.decodeIfPresent(String.self, forKey: .transcriptionLanguage)
         translationTargetLanguage = try container.decodeIfPresent(String.self, forKey: .translationTargetLanguage)
         aiProvider = try container.decodeIfPresent(AIProvider.self, forKey: .aiProvider)
@@ -193,6 +194,20 @@ struct VivaMode: Identifiable, Hashable, Codable {
         switch modelID {
         case "gemini-3-pro-preview":
             // Retired by Google; superseded by gemini-3.1-pro-preview.
+            return "gemini-3.1-pro-preview"
+        default:
+            return modelID
+        }
+    }
+
+    /// Same rewrite logic as `normalizedModelID(_:provider:)` but for the transcription model.
+    /// Without this, a saved mode pinned to a retired transcription model would fail
+    /// `TranscriptionManager.getCurrentTranscriptionModel()`'s exact lookup in `allCloudModels`
+    /// and the user would get `TranscriptionError.transcriptionFailed` before any network call.
+    static func normalizedTranscriptionModelID(_ modelID: String, provider: TranscriptionModelProvider) -> String {
+        guard provider == .gemini else { return modelID }
+        switch modelID {
+        case "gemini-3-pro-preview":
             return "gemini-3.1-pro-preview"
         default:
             return modelID

--- a/VivaDictaTests/VivaModeModelNormalizationTests.swift
+++ b/VivaDictaTests/VivaModeModelNormalizationTests.swift
@@ -1,0 +1,90 @@
+//
+//  VivaModeModelNormalizationTests.swift
+//  VivaDictaTests
+//
+//  Created by Anton Novoselov on 2026.05.23
+//
+
+import Foundation
+import Testing
+@testable import VivaDicta
+
+struct VivaModeModelNormalizationTests {
+
+    // MARK: - AI model normalization
+
+    @Test func aiModel_geminiRetiredProPreview_isRewritten() {
+        let normalized = VivaMode.normalizedModelID("gemini-3-pro-preview", provider: .gemini)
+        #expect(normalized == "gemini-3.1-pro-preview")
+    }
+
+    @Test func aiModel_currentGeminiModel_isPassedThrough() {
+        let normalized = VivaMode.normalizedModelID("gemini-3.5-flash", provider: .gemini)
+        #expect(normalized == "gemini-3.5-flash")
+    }
+
+    @Test func aiModel_nonGeminiProvider_isNotRewritten() {
+        let normalized = VivaMode.normalizedModelID("gemini-3-pro-preview", provider: .openAI)
+        #expect(normalized == "gemini-3-pro-preview")
+    }
+
+    @Test func aiModel_nilProvider_isNotRewritten() {
+        let normalized = VivaMode.normalizedModelID("gemini-3-pro-preview", provider: nil)
+        #expect(normalized == "gemini-3-pro-preview")
+    }
+
+    // MARK: - Transcription model normalization
+
+    @Test func transcriptionModel_geminiRetiredProPreview_isRewritten() {
+        let normalized = VivaMode.normalizedTranscriptionModelID("gemini-3-pro-preview", provider: .gemini)
+        #expect(normalized == "gemini-3.1-pro-preview")
+    }
+
+    @Test func transcriptionModel_currentGeminiModel_isPassedThrough() {
+        let normalized = VivaMode.normalizedTranscriptionModelID("gemini-3.5-flash", provider: .gemini)
+        #expect(normalized == "gemini-3.5-flash")
+    }
+
+    @Test func transcriptionModel_nonGeminiProvider_isNotRewritten() {
+        let normalized = VivaMode.normalizedTranscriptionModelID("gemini-3-pro-preview", provider: .openAI)
+        #expect(normalized == "gemini-3-pro-preview")
+    }
+
+    // MARK: - Decoder integration
+
+    @Test func decoder_rewritesRetiredTranscriptionModelOnDecode() throws {
+        let modeID = UUID()
+        let payload: [String: Any] = [
+            "id": modeID.uuidString,
+            "name": "Legacy Gemini Mode",
+            "transcriptionProvider": "gemini",
+            "transcriptionModel": "gemini-3-pro-preview",
+            "aiProvider": "openAI",
+            "aiModel": "gpt-5",
+            "aiEnhanceEnabled": true
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload)
+
+        let decoded = try JSONDecoder().decode(VivaMode.self, from: data)
+
+        #expect(decoded.transcriptionModel == "gemini-3.1-pro-preview")
+    }
+
+    @Test func decoder_rewritesRetiredAIModelOnDecode() throws {
+        let modeID = UUID()
+        let payload: [String: Any] = [
+            "id": modeID.uuidString,
+            "name": "Legacy Gemini AI Mode",
+            "transcriptionProvider": "whisperKit",
+            "transcriptionModel": "whisper-base",
+            "aiProvider": "gemini",
+            "aiModel": "gemini-3-pro-preview",
+            "aiEnhanceEnabled": true
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload)
+
+        let decoded = try JSONDecoder().decode(VivaMode.self, from: data)
+
+        #expect(decoded.aiModel == "gemini-3.1-pro-preview")
+    }
+}


### PR DESCRIPTION
## Summary

Mirror PR #274's Gemini refresh on the transcription side, which was still pinned to the old AI lineup.

- Switch default Gemini transcription model from `gemini-3-flash-preview` (preview) to `gemini-3.5-flash` (stable), so users aren't pinned to a preview that can be deprecated with two weeks' notice.
- Drop `gemini-3-pro-preview` (no longer in Google's catalog per PR #274).
- Add stable `gemini-3.5-flash`, `gemini-3.1-pro-preview` (replacement for the retired pro), and `gemini-3.1-flash-lite` (cheapest tier, explicitly marketed for transcription).
- Keep `gemini-3-flash-preview` for parity with the AI list.
- Flag the 2026-10-16 shutdown of `gemini-2.5-pro` / `gemini-2.5-flash` in their model descriptions.

## Audio Modality Verification

Every added model was checked against Google's docs for audio input support:

| Model | Audio input |
|---|---|
| `gemini-3.5-flash` | ✅ |
| `gemini-3.1-pro-preview` | ✅ |
| `gemini-3.1-flash-lite` | ✅ (Google markets it for transcription) |

Sources:
- https://ai.google.dev/gemini-api/docs/models/gemini-3.1-flash-lite
- https://ai.google.dev/gemini-api/docs/models/gemini-3.1-pro-preview
- https://ai.google.dev/gemini-api/docs/audio

## Follow-up

`gemini-2.5-pro` and `gemini-2.5-flash` shut down on 2026-10-16. Migration of stored user selections should land before October.

## Test plan

- [x] `xcodebuild` Debug build for iOS Simulator (iPhone 17 Pro Max, OS 26.4) passes
- [ ] Manually verify the Gemini provider picker in Settings shows the new list and `Gemini 3.5 Flash` is the default
- [ ] Manually verify transcription works end-to-end against each newly added model with a real API key