### PR TITLE
Route all URLSession traffic through Networking module

### DIFF
--- a/Modules/CloudTranscription/Sources/CloudTranscription/CartesiaTranscriptionService.swift
+++ b/Modules/CloudTranscription/Sources/CloudTranscription/CartesiaTranscriptionService.swift
@@ -1,6 +1,7 @@
 // Copyright © 2026 Anton Novoselov. All rights reserved.
 
 import Foundation
+import Networking
 import os
 import TranscriptionCore
 
@@ -30,9 +31,11 @@ public struct CartesiaTranscriptionService: TranscriptionService, Sendable {
     }
 
     private let config: Config
+    private let urlSession: any URLSessionProtocol
 
-    public init(config: Config) {
+    public init(config: Config, urlSession: any URLSessionProtocol = URLSession.shared) {
         self.config = config
+        self.urlSession = urlSession
     }
 
     public func transcribe(audioURL: URL) async throws -> TranscriptionServiceResult {
@@ -57,7 +60,7 @@ public struct CartesiaTranscriptionService: TranscriptionService, Sendable {
 
         let body = try createRequestBody(audioURL: audioURL, boundary: boundary)
 
-        let (data, response) = try await URLSession.shared.upload(for: request, from: body)
+        let (data, response) = try await urlSession.upload(for: request, from: body)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw CloudTranscriptionError.networkError(URLError(.badServerResponse))

--- a/Modules/CloudTranscription/Sources/CloudTranscription/CohereTranscriptionService.swift
+++ b/Modules/CloudTranscription/Sources/CloudTranscription/CohereTranscriptionService.swift
@@ -1,6 +1,7 @@
 // Copyright © 2026 Anton Novoselov. All rights reserved.
 
 import Foundation
+import Networking
 import os
 import TranscriptionCore
 
@@ -26,9 +27,11 @@ public struct CohereTranscriptionService: TranscriptionService, Sendable {
     }
 
     private let config: Config
+    private let urlSession: any URLSessionProtocol
 
-    public init(config: Config) {
+    public init(config: Config, urlSession: any URLSessionProtocol = URLSession.shared) {
         self.config = config
+        self.urlSession = urlSession
     }
 
     public func transcribe(audioURL: URL) async throws -> TranscriptionServiceResult {
@@ -52,7 +55,7 @@ public struct CohereTranscriptionService: TranscriptionService, Sendable {
 
         let body = try createRequestBody(audioURL: audioURL, boundary: boundary)
 
-        let (data, response) = try await URLSession.shared.upload(for: request, from: body)
+        let (data, response) = try await urlSession.upload(for: request, from: body)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw CloudTranscriptionError.networkError(URLError(.badServerResponse))

--- a/Modules/CloudTranscription/Sources/CloudTranscription/CustomTranscriptionService.swift
+++ b/Modules/CloudTranscription/Sources/CloudTranscription/CustomTranscriptionService.swift
@@ -1,6 +1,7 @@
 // Copyright © 2026 Anton Novoselov. All rights reserved.
 
 import Foundation
+import Networking
 import os
 import TranscriptionCore
 
@@ -26,9 +27,11 @@ public struct CustomTranscriptionService: TranscriptionService, Sendable {
     }
 
     private let config: Config
+    private let urlSession: any URLSessionProtocol
 
-    public init(config: Config) {
+    public init(config: Config, urlSession: any URLSessionProtocol = URLSession.shared) {
         self.config = config
+        self.urlSession = urlSession
     }
 
     public func transcribe(audioURL: URL) async throws -> TranscriptionServiceResult {
@@ -58,7 +61,7 @@ public struct CustomTranscriptionService: TranscriptionService, Sendable {
 
         logger.logInfo("Sending request to custom endpoint: \(config.apiEndpoint)")
 
-        let (data, response) = try await URLSession.shared.upload(for: request, from: body)
+        let (data, response) = try await urlSession.upload(for: request, from: body)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw CloudTranscriptionError.networkError(URLError(.badServerResponse))

--- a/Modules/CloudTranscription/Sources/CloudTranscription/DeepgramTranscriptionService.swift
+++ b/Modules/CloudTranscription/Sources/CloudTranscription/DeepgramTranscriptionService.swift
@@ -1,6 +1,7 @@
 // Copyright © 2026 Anton Novoselov. All rights reserved.
 
 import Foundation
+import Networking
 import os
 import TranscriptionCore
 
@@ -29,9 +30,11 @@ public struct DeepgramTranscriptionService: TranscriptionService, Sendable {
     }
 
     private let config: Config
+    private let urlSession: any URLSessionProtocol
 
-    public init(config: Config) {
+    public init(config: Config, urlSession: any URLSessionProtocol = URLSession.shared) {
         self.config = config
+        self.urlSession = urlSession
     }
 
     public func transcribe(audioURL: URL) async throws -> TranscriptionServiceResult {
@@ -88,7 +91,7 @@ public struct DeepgramTranscriptionService: TranscriptionService, Sendable {
             throw CloudTranscriptionError.audioFileNotFound
         }
 
-        let (data, response) = try await URLSession.shared.upload(for: request, from: audioData)
+        let (data, response) = try await urlSession.upload(for: request, from: audioData)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw CloudTranscriptionError.networkError(URLError(.badServerResponse))

--- a/Modules/CloudTranscription/Sources/CloudTranscription/ElevenLabsTranscriptionService.swift
+++ b/Modules/CloudTranscription/Sources/CloudTranscription/ElevenLabsTranscriptionService.swift
@@ -1,6 +1,7 @@
 // Copyright © 2026 Anton Novoselov. All rights reserved.
 
 import Foundation
+import Networking
 import os
 import TranscriptionCore
 
@@ -24,9 +25,11 @@ public struct ElevenLabsTranscriptionService: TranscriptionService, Sendable {
     }
 
     private let config: Config
+    private let urlSession: any URLSessionProtocol
 
-    public init(config: Config) {
+    public init(config: Config, urlSession: any URLSessionProtocol = URLSession.shared) {
         self.config = config
+        self.urlSession = urlSession
     }
 
     public func transcribe(audioURL: URL) async throws -> TranscriptionServiceResult {
@@ -50,7 +53,7 @@ public struct ElevenLabsTranscriptionService: TranscriptionService, Sendable {
 
         let body = try createRequestBody(audioURL: audioURL, boundary: boundary)
 
-        let (data, response) = try await URLSession.shared.upload(for: request, from: body)
+        let (data, response) = try await urlSession.upload(for: request, from: body)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw CloudTranscriptionError.networkError(URLError(.badServerResponse))

--- a/Modules/CloudTranscription/Sources/CloudTranscription/GeminiTranscriptionService.swift
+++ b/Modules/CloudTranscription/Sources/CloudTranscription/GeminiTranscriptionService.swift
@@ -1,6 +1,7 @@
 // Copyright © 2026 Anton Novoselov. All rights reserved.
 
 import Foundation
+import Networking
 import os
 import TranscriptionCore
 
@@ -20,9 +21,11 @@ public struct GeminiTranscriptionService: TranscriptionService, Sendable {
     }
 
     private let config: Config
+    private let urlSession: any URLSessionProtocol
 
-    public init(config: Config) {
+    public init(config: Config, urlSession: any URLSessionProtocol = URLSession.shared) {
         self.config = config
+        self.urlSession = urlSession
     }
 
     public func transcribe(audioURL: URL) async throws -> TranscriptionServiceResult {
@@ -80,7 +83,7 @@ public struct GeminiTranscriptionService: TranscriptionService, Sendable {
             throw CloudTranscriptionError.dataEncodingError
         }
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await urlSession.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw CloudTranscriptionError.networkError(URLError(.badServerResponse))

--- a/Modules/CloudTranscription/Sources/CloudTranscription/GladiaTranscriptionService.swift
+++ b/Modules/CloudTranscription/Sources/CloudTranscription/GladiaTranscriptionService.swift
@@ -1,6 +1,7 @@
 // Copyright © 2026 Anton Novoselov. All rights reserved.
 
 import Foundation
+import Networking
 import os
 import TranscriptionCore
 
@@ -37,9 +38,11 @@ public struct GladiaTranscriptionService: TranscriptionService, Sendable {
     }
 
     private let config: Config
+    private let urlSession: any URLSessionProtocol
 
-    public init(config: Config) {
+    public init(config: Config, urlSession: any URLSessionProtocol = URLSession.shared) {
         self.config = config
+        self.urlSession = urlSession
     }
 
     public func transcribe(audioURL: URL) async throws -> TranscriptionServiceResult {
@@ -72,7 +75,7 @@ public struct GladiaTranscriptionService: TranscriptionService, Sendable {
         request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
 
         let body = try createMultipartBody(fileURL: audioURL, boundary: boundary)
-        let (data, response) = try await URLSession.shared.upload(for: request, from: body)
+        let (data, response) = try await urlSession.upload(for: request, from: body)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw CloudTranscriptionError.networkError(URLError(.badServerResponse))
@@ -142,7 +145,7 @@ public struct GladiaTranscriptionService: TranscriptionService, Sendable {
 
         request.httpBody = try JSONSerialization.data(withJSONObject: payload)
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await urlSession.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw CloudTranscriptionError.networkError(URLError(.badServerResponse))
@@ -177,7 +180,7 @@ public struct GladiaTranscriptionService: TranscriptionService, Sendable {
             request.timeoutInterval = NetworkRetry.defaultTimeout
             request.setValue(config.apiKey, forHTTPHeaderField: "x-gladia-key")
 
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {
                 throw CloudTranscriptionError.networkError(URLError(.badServerResponse))

--- a/Modules/CloudTranscription/Sources/CloudTranscription/MistralTranscriptionService.swift
+++ b/Modules/CloudTranscription/Sources/CloudTranscription/MistralTranscriptionService.swift
@@ -1,6 +1,7 @@
 // Copyright © 2026 Anton Novoselov. All rights reserved.
 
 import Foundation
+import Networking
 import os
 import TranscriptionCore
 
@@ -38,9 +39,11 @@ public struct MistralTranscriptionService: TranscriptionService, Sendable {
     }
 
     private let config: Config
+    private let urlSession: any URLSessionProtocol
 
-    public init(config: Config) {
+    public init(config: Config, urlSession: any URLSessionProtocol = URLSession.shared) {
         self.config = config
+        self.urlSession = urlSession
     }
 
     public func transcribe(audioURL: URL) async throws -> TranscriptionServiceResult {
@@ -64,7 +67,7 @@ public struct MistralTranscriptionService: TranscriptionService, Sendable {
 
         let body = try createRequestBody(audioURL: audioURL, boundary: boundary)
 
-        let (data, response) = try await URLSession.shared.upload(for: request, from: body)
+        let (data, response) = try await urlSession.upload(for: request, from: body)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw CloudTranscriptionError.networkError(URLError(.badServerResponse))

--- a/Modules/CloudTranscription/Sources/CloudTranscription/SonioxTranscriptionService.swift
+++ b/Modules/CloudTranscription/Sources/CloudTranscription/SonioxTranscriptionService.swift
@@ -1,6 +1,7 @@
 // Copyright © 2026 Anton Novoselov. All rights reserved.
 
 import Foundation
+import Networking
 import os
 import TranscriptionCore
 
@@ -38,9 +39,11 @@ public struct SonioxTranscriptionService: TranscriptionService, Sendable {
     }
 
     private let config: Config
+    private let urlSession: any URLSessionProtocol
 
-    public init(config: Config) {
+    public init(config: Config, urlSession: any URLSessionProtocol = URLSession.shared) {
         self.config = config
+        self.urlSession = urlSession
     }
 
     public func transcribe(audioURL: URL) async throws -> TranscriptionServiceResult {
@@ -74,7 +77,7 @@ public struct SonioxTranscriptionService: TranscriptionService, Sendable {
         request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
 
         let body = try createMultipartBody(fileURL: audioURL, boundary: boundary)
-        let (data, response) = try await URLSession.shared.upload(for: request, from: body)
+        let (data, response) = try await urlSession.upload(for: request, from: body)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw CloudTranscriptionError.networkError(URLError(.badServerResponse))
@@ -134,7 +137,7 @@ public struct SonioxTranscriptionService: TranscriptionService, Sendable {
 
         request.httpBody = try JSONSerialization.data(withJSONObject: payload)
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await urlSession.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw CloudTranscriptionError.networkError(URLError(.badServerResponse))
@@ -169,7 +172,7 @@ public struct SonioxTranscriptionService: TranscriptionService, Sendable {
             request.timeoutInterval = NetworkRetry.defaultTimeout
             request.setValue("Bearer \(config.apiKey)", forHTTPHeaderField: "Authorization")
 
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {
                 throw CloudTranscriptionError.networkError(URLError(.badServerResponse))
@@ -213,7 +216,7 @@ public struct SonioxTranscriptionService: TranscriptionService, Sendable {
         request.timeoutInterval = NetworkRetry.defaultTimeout
         request.setValue("Bearer \(config.apiKey)", forHTTPHeaderField: "Authorization")
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await urlSession.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw CloudTranscriptionError.networkError(URLError(.badServerResponse))

--- a/Modules/CloudTranscription/Sources/CloudTranscription/SpeechmaticsTranscriptionService.swift
+++ b/Modules/CloudTranscription/Sources/CloudTranscription/SpeechmaticsTranscriptionService.swift
@@ -1,6 +1,7 @@
 // Copyright © 2026 Anton Novoselov. All rights reserved.
 
 import Foundation
+import Networking
 import os
 import TranscriptionCore
 
@@ -37,9 +38,11 @@ public struct SpeechmaticsTranscriptionService: TranscriptionService, Sendable {
     }
 
     private let config: Config
+    private let urlSession: any URLSessionProtocol
 
-    public init(config: Config) {
+    public init(config: Config, urlSession: any URLSessionProtocol = URLSession.shared) {
         self.config = config
+        self.urlSession = urlSession
     }
 
     public func transcribe(audioURL: URL) async throws -> TranscriptionServiceResult {
@@ -112,7 +115,7 @@ public struct SpeechmaticsTranscriptionService: TranscriptionService, Sendable {
 
         let body = try createMultipartBody(fileURL: audioURL, configJSON: configString, boundary: boundary)
 
-        let (data, response) = try await URLSession.shared.upload(for: request, from: body)
+        let (data, response) = try await urlSession.upload(for: request, from: body)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw CloudTranscriptionError.networkError(URLError(.badServerResponse))
@@ -147,7 +150,7 @@ public struct SpeechmaticsTranscriptionService: TranscriptionService, Sendable {
             request.timeoutInterval = NetworkRetry.defaultTimeout
             request.setValue("Bearer \(config.apiKey)", forHTTPHeaderField: "Authorization")
 
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {
                 throw CloudTranscriptionError.networkError(URLError(.badServerResponse))
@@ -191,7 +194,7 @@ public struct SpeechmaticsTranscriptionService: TranscriptionService, Sendable {
         request.timeoutInterval = NetworkRetry.defaultTimeout
         request.setValue("Bearer \(config.apiKey)", forHTTPHeaderField: "Authorization")
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await urlSession.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw CloudTranscriptionError.networkError(URLError(.badServerResponse))

--- a/Modules/Networking/Sources/Networking/NetworkClient.swift
+++ b/Modules/Networking/Sources/Networking/NetworkClient.swift
@@ -1,0 +1,157 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import os
+
+/// Thin wrapper around `URLSessionProtocol` that centralizes the boilerplate
+/// each HTTP-talking client used to repeat: status code validation, JSON
+/// decoding, logging of non-2xx bodies, and translation of underlying URL
+/// errors into a structured ``NetworkError``.
+///
+/// Designed to be cheap to construct and `Sendable`: hold one in a service or
+/// create per-request. Production callers default to `URLSession.shared`;
+/// tests inject a `MockURLSession`.
+///
+/// ## Typical usage
+///
+/// ```swift
+/// struct GeminiClient {
+///     private let client = NetworkClient(category: "Gemini")
+///
+///     func fetchModels() async throws -> [Model] {
+///         var request = URLRequest(url: modelsURL)
+///         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+///         return try await client.sendJSON(request, as: ModelsResponse.self).models
+///     }
+/// }
+/// ```
+public struct NetworkClient: Sendable {
+    private let session: any URLSessionProtocol
+    private let logger: Logger
+    private let acceptableStatusCodes: Set<Int>
+
+    /// - Parameters:
+    ///   - session: Injected URLSession. Defaults to `URLSession.shared` for
+    ///     production callers; tests pass a `MockURLSession`.
+    ///   - category: Subsystem-specific log category (e.g. `"OpenAIChat"`).
+    ///     Errors and non-2xx responses are logged under this category.
+    ///   - acceptableStatusCodes: Status codes treated as success. Defaults
+    ///     to `200..<300`. Anything else surfaces as
+    ///     `NetworkError.unacceptableStatus`.
+    public init(
+        session: any URLSessionProtocol = URLSession.shared,
+        category: String = "NetworkClient",
+        acceptableStatusCodes: Set<Int> = Set(200..<300)
+    ) {
+        self.session = session
+        self.logger = Logger(subsystem: "com.antonnovoselov.VivaDicta.networking", category: category)
+        self.acceptableStatusCodes = acceptableStatusCodes
+    }
+
+    // MARK: - Plain request/response
+
+    /// Send the request, validate the response, and return the raw body bytes
+    /// alongside the `HTTPURLResponse`.
+    public func send(
+        _ request: URLRequest,
+        acceptableStatusCodes: Set<Int>? = nil
+    ) async throws -> (Data, HTTPURLResponse) {
+        let (data, response) = try await callData(request)
+        let http = try validate(response: response, body: data, acceptable: acceptableStatusCodes)
+        return (data, http)
+    }
+
+    /// Send the request and decode the response body as `T`.
+    public func sendJSON<T: Decodable>(
+        _ request: URLRequest,
+        as type: T.Type = T.self,
+        decoder: JSONDecoder = JSONDecoder(),
+        acceptableStatusCodes: Set<Int>? = nil
+    ) async throws -> T {
+        let (data, _) = try await send(request, acceptableStatusCodes: acceptableStatusCodes)
+        do {
+            return try decoder.decode(T.self, from: data)
+        } catch {
+            logger.error("JSON decode failed for \(request.url?.absoluteString ?? "<no url>", privacy: .public): \(error.localizedDescription, privacy: .public)")
+            throw NetworkError.decodingFailed(error)
+        }
+    }
+
+    // MARK: - Upload (multipart / large body)
+
+    /// Send the request body via `URLSession.upload(for:from:)`. Validates the
+    /// response status and returns the body + HTTP response.
+    public func upload(
+        _ request: URLRequest,
+        from bodyData: Data,
+        acceptableStatusCodes: Set<Int>? = nil
+    ) async throws -> (Data, HTTPURLResponse) {
+        let (data, response): (Data, URLResponse)
+        do {
+            (data, response) = try await session.upload(for: request, from: bodyData)
+        } catch {
+            throw NetworkError.transport(error)
+        }
+        let http = try validate(response: response, body: data, acceptable: acceptableStatusCodes)
+        return (data, http)
+    }
+
+    // MARK: - Streaming (SSE)
+
+    /// Open a byte stream for server-sent-events style endpoints. Validates
+    /// the status code first (draining the body on failure into
+    /// `NetworkError.unacceptableStatus`) and returns the stream + response
+    /// for the caller to iterate.
+    public func bytes(
+        for request: URLRequest,
+        acceptableStatusCodes: Set<Int>? = nil
+    ) async throws -> (URLSession.AsyncBytes, HTTPURLResponse) {
+        let (bytes, response): (URLSession.AsyncBytes, URLResponse)
+        do {
+            (bytes, response) = try await session.bytes(for: request)
+        } catch {
+            throw NetworkError.transport(error)
+        }
+        guard let http = response as? HTTPURLResponse else {
+            throw NetworkError.invalidResponse
+        }
+        let acceptable = acceptableStatusCodes ?? self.acceptableStatusCodes
+        if !acceptable.contains(http.statusCode) {
+            var errorData = Data()
+            for try await byte in bytes {
+                errorData.append(byte)
+            }
+            let body = String(data: errorData, encoding: .utf8) ?? ""
+            logger.error("HTTP \(http.statusCode, privacy: .public) from \(request.url?.absoluteString ?? "<no url>", privacy: .public): \(body, privacy: .public)")
+            throw NetworkError.unacceptableStatus(code: http.statusCode, body: errorData)
+        }
+        return (bytes, http)
+    }
+
+    // MARK: - Private helpers
+
+    private func callData(_ request: URLRequest) async throws -> (Data, URLResponse) {
+        do {
+            return try await session.data(for: request)
+        } catch {
+            throw NetworkError.transport(error)
+        }
+    }
+
+    private func validate(
+        response: URLResponse,
+        body: Data,
+        acceptable overrideAcceptable: Set<Int>?
+    ) throws -> HTTPURLResponse {
+        guard let http = response as? HTTPURLResponse else {
+            throw NetworkError.invalidResponse
+        }
+        let acceptable = overrideAcceptable ?? self.acceptableStatusCodes
+        if !acceptable.contains(http.statusCode) {
+            let bodyText = String(data: body, encoding: .utf8) ?? ""
+            logger.error("HTTP \(http.statusCode, privacy: .public) from \(http.url?.absoluteString ?? "<no url>", privacy: .public): \(bodyText, privacy: .public)")
+            throw NetworkError.unacceptableStatus(code: http.statusCode, body: body)
+        }
+        return http
+    }
+}

--- a/Modules/Networking/Sources/Networking/NetworkError.swift
+++ b/Modules/Networking/Sources/Networking/NetworkError.swift
@@ -1,0 +1,40 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+
+/// Structured error surface for ``NetworkClient``. Callers can switch on this
+/// to translate into module-specific errors (e.g. `EnhancementError`,
+/// `CloudTranscriptionError`) without losing the raw status code or body.
+public enum NetworkError: Error, Sendable {
+    /// The response was not an `HTTPURLResponse`. Almost always indicates a
+    /// programming or test fixture problem rather than a real network event.
+    case invalidResponse
+
+    /// Server responded but the status code wasn't in the acceptable range.
+    /// `body` carries the raw response payload for richer error messages.
+    case unacceptableStatus(code: Int, body: Data)
+
+    /// JSON decoding failed for a typed `sendJSON` call.
+    case decodingFailed(any Error)
+
+    /// Underlying URLSession failure (network down, timeout, etc.).
+    case transport(any Error)
+
+    /// HTTP status code, if known. Useful for callers that need to special-case
+    /// `429`, `401` etc. without unwrapping the enum.
+    public var statusCode: Int? {
+        if case let .unacceptableStatus(code, _) = self { return code }
+        return nil
+    }
+
+    /// Raw response body bytes for non-2xx responses, empty otherwise.
+    public var bodyData: Data {
+        if case let .unacceptableStatus(_, body) = self { return body }
+        return Data()
+    }
+
+    /// UTF-8 decoded body, or an empty string if the body wasn't valid UTF-8.
+    public var bodyString: String {
+        String(data: bodyData, encoding: .utf8) ?? ""
+    }
+}

--- a/Modules/Networking/Sources/Networking/URLSessionProtocol.swift
+++ b/Modules/Networking/Sources/Networking/URLSessionProtocol.swift
@@ -7,11 +7,30 @@ import Foundation
 /// via the conformance extension below; tests inject a `MockURLSession`
 /// from `NetworkingMocks`.
 ///
-/// Methods are added on demand - only declare what some caller actually
-/// uses. Today only `upload(for:from:)` is needed for the cloud
-/// transcription services' multipart uploads.
+/// Methods mirror the small set of `URLSession` async APIs we actually use:
+///
+/// - ``data(for:)`` for plain request/response calls.
+/// - ``upload(for:from:)`` for multipart / large body POSTs.
+/// - ``bytes(for:)`` for streaming Server-Sent Events endpoints. The return
+///   type is `URLSession.AsyncBytes` because there is no constructible
+///   replacement; SSE-flavored code paths typically rely on integration
+///   tests rather than `MockURLSession` stubbing.
 public protocol URLSessionProtocol: Sendable {
+    func data(for request: URLRequest) async throws -> (Data, URLResponse)
     func upload(for request: URLRequest, from bodyData: Data) async throws -> (Data, URLResponse)
+    func bytes(for request: URLRequest) async throws -> (URLSession.AsyncBytes, URLResponse)
 }
 
-extension URLSession: URLSessionProtocol {}
+extension URLSession: URLSessionProtocol {
+    public func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        try await self.data(for: request, delegate: nil)
+    }
+
+    public func upload(for request: URLRequest, from bodyData: Data) async throws -> (Data, URLResponse) {
+        try await self.upload(for: request, from: bodyData, delegate: nil)
+    }
+
+    public func bytes(for request: URLRequest) async throws -> (URLSession.AsyncBytes, URLResponse) {
+        try await self.bytes(for: request, delegate: nil)
+    }
+}

--- a/Modules/Networking/Sources/NetworkingMocks/MockURLSession.swift
+++ b/Modules/Networking/Sources/NetworkingMocks/MockURLSession.swift
@@ -12,21 +12,51 @@ import TestUtilities
 ///
 /// ```swift
 /// let session = MockURLSession()
-/// session.stubUploadResponse = .success((Data(#"{"text":"hello"}"#.utf8), httpResponse(200)))
-/// let service = OpenAITranscriptionService(config: ..., urlSession: session)
-/// _ = try await service.transcribe(audioURL: audio)
-/// #expect(session.uploadCallCount == 1)
+/// session.stubDataResponse = .success((Data(#"{"text":"hello"}"#.utf8), httpResponse(200)))
+/// let service = SomeService(urlSession: session)
+/// _ = try await service.fetch()
+/// #expect(session.dataCallCount == 1)
 /// #expect(session.capturedRequest?.httpMethod == "POST")
-/// #expect(session.capturedBody == expectedBody)
 /// ```
+///
+/// `bytes(for:)` is intentionally unstubbable: there is no public initializer
+/// for `URLSession.AsyncBytes`, so SSE / streaming code paths should be tested
+/// via integration rather than `MockURLSession`. Calling `bytes(for:)` on the
+/// mock triggers a `StubNotSetError` issue.
 public final class MockURLSession: URLSessionProtocol, @unchecked Sendable {
     public init() {}
+
+    // MARK: data(for:)
+
+    public var stubDataResponse: Result<(Data, URLResponse), Error>?
+    public var didFetchData: (() -> Void)?
+    public private(set) var dataCallCount = 0
+
+    // MARK: upload(for:from:)
 
     public var stubUploadResponse: Result<(Data, URLResponse), Error>?
     public var didUpload: (() -> Void)?
     public private(set) var uploadCallCount = 0
-    public private(set) var capturedRequest: URLRequest?
     public private(set) var capturedBody: Data?
+
+    // MARK: bytes(for:)
+
+    public var stubBytesError: Error?
+    public private(set) var bytesCallCount = 0
+
+    // MARK: shared
+
+    /// Most recent request seen by any of `data`, `upload`, or `bytes`. For
+    /// suites that exercise multiple endpoints, snapshot it inline after each
+    /// call instead of relying on this property at the end.
+    public private(set) var capturedRequest: URLRequest?
+
+    public func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        defer { didFetchData?() }
+        dataCallCount += 1
+        capturedRequest = request
+        return try stubDataResponse.evaluate()
+    }
 
     public func upload(for request: URLRequest, from bodyData: Data) async throws -> (Data, URLResponse) {
         defer { didUpload?() }
@@ -34,5 +64,14 @@ public final class MockURLSession: URLSessionProtocol, @unchecked Sendable {
         capturedRequest = request
         capturedBody = bodyData
         return try stubUploadResponse.evaluate()
+    }
+
+    public func bytes(for request: URLRequest) async throws -> (URLSession.AsyncBytes, URLResponse) {
+        bytesCallCount += 1
+        capturedRequest = request
+        if let stubBytesError {
+            throw stubBytesError
+        }
+        throw StubNotSetError("MockURLSession.bytes(for:) cannot be stubbed: URLSession.AsyncBytes has no public initializer. Test streaming paths via integration or a real URLSession.")
     }
 }

--- a/Modules/Networking/Tests/NetworkingTests/NetworkClientTests.swift
+++ b/Modules/Networking/Tests/NetworkingTests/NetworkClientTests.swift
@@ -1,0 +1,149 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import Networking
+import NetworkingMocks
+import Testing
+
+@Suite("NetworkClient")
+struct NetworkClientTests {
+
+    private let endpoint = URL(string: "https://example.com/api")!
+
+    private func makeResponse(_ code: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: endpoint,
+            statusCode: code,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+    }
+
+    // MARK: send
+
+    @Test func sendReturnsBodyAndHTTPResponseOnSuccess() async throws {
+        let session = MockURLSession()
+        let payload = Data(#"{"ok":true}"#.utf8)
+        session.stubDataResponse = .success((payload, makeResponse(200)))
+        let client = NetworkClient(session: session)
+
+        let (data, response) = try await client.send(URLRequest(url: endpoint))
+
+        #expect(data == payload)
+        #expect(response.statusCode == 200)
+        #expect(session.dataCallCount == 1)
+    }
+
+    @Test func sendThrowsUnacceptableStatusFor4xx() async throws {
+        let session = MockURLSession()
+        let body = Data(#"{"error":"nope"}"#.utf8)
+        session.stubDataResponse = .success((body, makeResponse(404)))
+        let client = NetworkClient(session: session)
+
+        await #expect {
+            try await client.send(URLRequest(url: endpoint))
+        } throws: { error in
+            guard let net = error as? NetworkError,
+                  case let .unacceptableStatus(code, payload) = net else {
+                return false
+            }
+            return code == 404 && payload == body
+        }
+    }
+
+    @Test func sendWrapsTransportError() async throws {
+        struct Boom: Error {}
+        let session = MockURLSession()
+        session.stubDataResponse = .failure(Boom())
+        let client = NetworkClient(session: session)
+
+        await #expect {
+            try await client.send(URLRequest(url: endpoint))
+        } throws: { error in
+            guard let net = error as? NetworkError,
+                  case .transport = net else { return false }
+            return true
+        }
+    }
+
+    @Test func customAcceptableStatusCodesOverrideDefault() async throws {
+        let session = MockURLSession()
+        session.stubDataResponse = .success((Data(), makeResponse(302)))
+        let client = NetworkClient(session: session)
+
+        let (_, response) = try await client.send(
+            URLRequest(url: endpoint),
+            acceptableStatusCodes: [200, 302]
+        )
+        #expect(response.statusCode == 302)
+    }
+
+    // MARK: sendJSON
+
+    private struct Echo: Decodable, Equatable {
+        let value: String
+    }
+
+    @Test func sendJSONDecodesResponse() async throws {
+        let session = MockURLSession()
+        session.stubDataResponse = .success((Data(#"{"value":"hi"}"#.utf8), makeResponse(200)))
+        let client = NetworkClient(session: session)
+
+        let result: Echo = try await client.sendJSON(URLRequest(url: endpoint))
+
+        #expect(result == Echo(value: "hi"))
+    }
+
+    @Test func sendJSONWrapsDecodingErrors() async throws {
+        let session = MockURLSession()
+        session.stubDataResponse = .success((Data(#"{"wrong":"shape"}"#.utf8), makeResponse(200)))
+        let client = NetworkClient(session: session)
+
+        await #expect {
+            let _: Echo = try await client.sendJSON(URLRequest(url: endpoint))
+        } throws: { error in
+            guard let net = error as? NetworkError,
+                  case .decodingFailed = net else { return false }
+            return true
+        }
+    }
+
+    // MARK: upload
+
+    @Test func uploadPassesBodyToSession() async throws {
+        let session = MockURLSession()
+        session.stubUploadResponse = .success((Data(), makeResponse(200)))
+        let client = NetworkClient(session: session)
+
+        let body = Data("payload".utf8)
+        _ = try await client.upload(URLRequest(url: endpoint), from: body)
+
+        #expect(session.uploadCallCount == 1)
+        #expect(session.capturedBody == body)
+    }
+
+    @Test func uploadThrowsForServerErrors() async throws {
+        let session = MockURLSession()
+        session.stubUploadResponse = .success((Data("internal".utf8), makeResponse(500)))
+        let client = NetworkClient(session: session)
+
+        await #expect {
+            _ = try await client.upload(URLRequest(url: endpoint), from: Data())
+        } throws: { error in
+            (error as? NetworkError)?.statusCode == 500
+        }
+    }
+
+    // MARK: NetworkError accessors
+
+    @Test func statusAccessorsExposeBodyAndCode() {
+        let error = NetworkError.unacceptableStatus(code: 418, body: Data("teapot".utf8))
+        #expect(error.statusCode == 418)
+        #expect(error.bodyString == "teapot")
+    }
+
+    @Test func statusAccessorsReturnDefaultsForOtherCases() {
+        #expect(NetworkError.invalidResponse.statusCode == nil)
+        #expect(NetworkError.invalidResponse.bodyString == "")
+    }
+}

--- a/Modules/OAuth/Package.swift
+++ b/Modules/OAuth/Package.swift
@@ -14,6 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(path: "../Keychain"),
+        .package(path: "../Networking"),
         .package(path: "../TestUtilities"),
     ],
     targets: [
@@ -21,6 +22,7 @@ let package = Package(
             name: "OAuth",
             dependencies: [
                 .product(name: "Keychain", package: "Keychain"),
+                .product(name: "Networking", package: "Networking"),
             ]
         ),
         .target(
@@ -36,6 +38,7 @@ let package = Package(
                 "OAuth",
                 "OAuthMocks",
                 .product(name: "KeychainMocks", package: "Keychain"),
+                .product(name: "NetworkingMocks", package: "Networking"),
                 .product(name: "TestUtilities", package: "TestUtilities"),
             ]
         ),

--- a/Modules/OAuth/Sources/OAuth/CopilotOAuthManager.swift
+++ b/Modules/OAuth/Sources/OAuth/CopilotOAuthManager.swift
@@ -2,6 +2,7 @@
 
 import Foundation
 import Keychain
+import Networking
 import os
 
 /// Manages GitHub Copilot authentication using the device code flow.
@@ -11,6 +12,7 @@ public final class CopilotOAuthManager: Sendable {
     private let logger = Logger(oauthCategory: "CopilotOAuth")
     private let keychain: any KeychainService
     private let backgroundTaskService: (any BackgroundTaskService)?
+    private let urlSession: any URLSessionProtocol
 
     /// GitHub OAuth client ID (same as VS Code Copilot extension).
     private let clientId = "Iv1.b507a08c87ecfe98"
@@ -23,10 +25,12 @@ public final class CopilotOAuthManager: Sendable {
 
     public init(
         keychain: any KeychainService,
-        backgroundTaskService: (any BackgroundTaskService)? = nil
+        backgroundTaskService: (any BackgroundTaskService)? = nil,
+        urlSession: any URLSessionProtocol = URLSession.shared
     ) {
         self.keychain = keychain
         self.backgroundTaskService = backgroundTaskService
+        self.urlSession = urlSession
     }
 
     // MARK: - Public API
@@ -50,7 +54,7 @@ public final class CopilotOAuthManager: Sendable {
         request.addValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
         request.httpBody = "client_id=\(clientId)&scope=read:user".data(using: .utf8)
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await urlSession.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
             throw CopilotOAuthError.deviceCodeFailed("Failed to get device code")
@@ -104,7 +108,7 @@ public final class CopilotOAuthManager: Sendable {
 
             let data: Data
             do {
-                data = try await URLSession.shared.data(for: request).0
+                data = try await urlSession.data(for: request).0
             } catch let urlError as URLError where urlError.code != .cancelled {
                 // Transient network error (e.g. -1005 after backgrounding); retry on next tick.
                 logger.logInfo("Poll network error \(urlError.code.rawValue), retrying")
@@ -197,7 +201,7 @@ public final class CopilotOAuthManager: Sendable {
         request.addValue("application/json", forHTTPHeaderField: "Accept")
         request.timeoutInterval = 15
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await urlSession.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw CopilotOAuthError.tokenExchangeFailed("Invalid response")
@@ -231,7 +235,7 @@ public final class CopilotOAuthManager: Sendable {
         request.addValue("application/json", forHTTPHeaderField: "Accept")
         request.timeoutInterval = 10
 
-        guard let (data, response) = try? await URLSession.shared.data(for: request),
+        guard let (data, response) = try? await urlSession.data(for: request),
               let httpResponse = response as? HTTPURLResponse,
               httpResponse.statusCode == 200,
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {

--- a/Modules/OAuth/Sources/OAuth/GeminiOAuthProvider.swift
+++ b/Modules/OAuth/Sources/OAuth/GeminiOAuthProvider.swift
@@ -1,6 +1,7 @@
 // Copyright © 2026 Anton Novoselov. All rights reserved.
 
 import Foundation
+import Networking
 import os
 
 /// Google Gemini OAuth provider configuration.
@@ -22,7 +23,11 @@ public struct GeminiOAuthProvider: OAuthProvider {
         "prompt": "consent"
     ]
 
-    public init() {}
+    private let urlSession: any URLSessionProtocol
+
+    public init(urlSession: any URLSessionProtocol = URLSession.shared) {
+        self.urlSession = urlSession
+    }
 
     public func extractAccountInfo(from claims: [String: Any]) -> (id: String?, email: String?) {
         let id = claims["sub"] as? String
@@ -71,7 +76,7 @@ public struct GeminiOAuthProvider: OAuthProvider {
         ]
         request.httpBody = try? JSONSerialization.data(withJSONObject: body)
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await urlSession.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
             return nil
@@ -97,7 +102,7 @@ public struct GeminiOAuthProvider: OAuthProvider {
         let body: [String: Any] = ["tierId": "free-tier"]
         request.httpBody = try? JSONSerialization.data(withJSONObject: body)
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await urlSession.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
             return nil
@@ -126,7 +131,7 @@ public struct GeminiOAuthProvider: OAuthProvider {
             request.addValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
             request.timeoutInterval = 10
 
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200,
                   let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {

--- a/Modules/OAuth/Sources/OAuth/OAuthManager.swift
+++ b/Modules/OAuth/Sources/OAuth/OAuthManager.swift
@@ -4,6 +4,7 @@ import Foundation
 import AuthenticationServices
 import Keychain
 import Network
+import Networking
 import os
 
 /// Manages OAuth authentication flows - sign-in, token refresh, and credential storage.
@@ -12,12 +13,14 @@ import os
 public final class OAuthManager: Sendable {
     private let logger = Logger(oauthCategory: "OAuthManager")
     private let keychain: any KeychainService
+    private let urlSession: any URLSessionProtocol
 
     /// In-memory cache of credentials.
     private var credentials: [String: OAuthCredential] = [:]
 
-    public init(keychain: any KeychainService) {
+    public init(keychain: any KeychainService, urlSession: any URLSessionProtocol = URLSession.shared) {
         self.keychain = keychain
+        self.urlSession = urlSession
     }
 
     // MARK: - Public API
@@ -236,7 +239,7 @@ public final class OAuthManager: Sendable {
             request.httpBody = formBody.data(using: .utf8)
         }
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await urlSession.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw OAuthError.invalidResponse
@@ -298,7 +301,7 @@ public final class OAuthManager: Sendable {
         request.addValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
         request.timeoutInterval = 10
 
-        guard let (data, response) = try? await URLSession.shared.data(for: request),
+        guard let (data, response) = try? await urlSession.data(for: request),
               let httpResponse = response as? HTTPURLResponse,
               httpResponse.statusCode == 200,
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {

--- a/VivaDicta.xcodeproj/project.pbxproj
+++ b/VivaDicta.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		189C7A952F0C6822004BAFBF /* ShareExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 189C7A8B2F0C6822004BAFBF /* ShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		189C7AB02F0D84E2004BAFBF /* UniformTypeIdentifiers.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 189C7AAF2F0D84E2004BAFBF /* UniformTypeIdentifiers.framework */; };
 		189C7ABC2F0D84E2004BAFBF /* ActionExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 189C7AAE2F0D84E2004BAFBF /* ActionExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		18AABBCC0011223344556602 /* Networking in Frameworks */ = {isa = PBXBuildFile; productRef = 18AABBCC0011223344556601 /* Networking */; };
+		18AABBCC0011223344556604 /* NetworkingMocks in Frameworks */ = {isa = PBXBuildFile; productRef = 18AABBCC0011223344556603 /* NetworkingMocks */; };
 		18B497E52F26822400538830 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 18B497E42F26822400538830 /* Settings.bundle */; };
 		18B497E62F26822400538830 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 18B497E42F26822400538830 /* Settings.bundle */; };
 		18B497F02F268B2700538830 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 18B497EF2F268B2700538830 /* FirebaseAnalytics */; };
@@ -502,6 +504,7 @@
 				18F75FC02FB79A3200280269 /* CloudTranscription in Frameworks */,
 				18F7637F2FB7D5E300280269 /* LocalTranscription in Frameworks */,
 				186C057F2FB779AA00102432 /* Keychain in Frameworks */,
+				18AABBCC0011223344556602 /* Networking in Frameworks */,
 				18E1B4AD2E8C875000BE8A11 /* KeyboardKit in Frameworks */,
 				18F75FBE2FB79A2B00280269 /* TranscriptionCore in Frameworks */,
 				18B497F22F268B2700538830 /* FirebaseCrashlytics in Frameworks */,
@@ -520,6 +523,7 @@
 				186C05852FB779BA00102432 /* KeychainMocks in Frameworks */,
 				18F75FC62FB79A4B00280269 /* CloudTranscriptionMocks in Frameworks */,
 				186C0C9E2FB782A000102432 /* OAuthMocks in Frameworks */,
+				18AABBCC0011223344556604 /* NetworkingMocks in Frameworks */,
 				186C05832FB779BA00102432 /* Keychain in Frameworks */,
 				18F75FC22FB79A3E00280269 /* TranscriptionCore in Frameworks */,
 				18F76A342FB85C0B00280269 /* AppGroup in Frameworks */,
@@ -724,6 +728,7 @@
 				186C0C9B2FB7829A00102432 /* OAuth */,
 				18F75FBD2FB79A2B00280269 /* TranscriptionCore */,
 				18F75FBF2FB79A3200280269 /* CloudTranscription */,
+				18AABBCC0011223344556601 /* Networking */,
 				18F7637E2FB7D5E300280269 /* LocalTranscription */,
 				18F76A312FB85C0400280269 /* AppGroup */,
 				18B89BC22FB875530007FA96 /* TranscriptionKit */,
@@ -759,6 +764,7 @@
 				18F75FC12FB79A3E00280269 /* TranscriptionCore */,
 				18F75FC32FB79A4400280269 /* CloudTranscription */,
 				18F75FC52FB79A4B00280269 /* CloudTranscriptionMocks */,
+				18AABBCC0011223344556603 /* NetworkingMocks */,
 				18F76A332FB85C0B00280269 /* AppGroup */,
 				F4E0FCBD69B741548F9F6B15 /* TranscriptionKitMocks */,
 			);
@@ -2719,6 +2725,14 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 1879FD9E2F8C088E00952CF9 /* XCRemoteSwiftPackageReference "LumoKit" */;
 			productName = LumoKit;
+		};
+		18AABBCC0011223344556601 /* Networking */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Networking;
+		};
+		18AABBCC0011223344556603 /* NetworkingMocks */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = NetworkingMocks;
 		};
 		18B497EF2F268B2700538830 /* FirebaseAnalytics */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/VivaDicta/Services/AIEnhance/AIService+Chat.swift
+++ b/VivaDicta/Services/AIEnhance/AIService+Chat.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import FoundationModels
+import Networking
 import os
 import OAuth
 
@@ -516,7 +517,7 @@ extension AIService {
         let body = buildOpenAIChatRequestBody(model: model, systemMessage: systemMessage, messages: messages, stream: true)
         request.httpBody = try? JSONSerialization.data(withJSONObject: body)
 
-        let (bytes, response) = try await URLSession.shared.bytes(for: request)
+        let (bytes, response) = try await urlSession.bytes(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw EnhancementError.invalidResponse
@@ -570,7 +571,7 @@ extension AIService {
         let body = buildOpenAIChatRequestBody(model: model, systemMessage: systemMessage, messages: messages, stream: false)
         request.httpBody = try? JSONSerialization.data(withJSONObject: body)
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await urlSession.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw EnhancementError.invalidResponse
@@ -626,7 +627,7 @@ extension AIService {
 
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await urlSession.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw EnhancementError.invalidResponse
@@ -690,7 +691,7 @@ extension AIService {
 
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await urlSession.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw EnhancementError.invalidResponse
@@ -752,7 +753,7 @@ extension AIService {
 
         request.httpBody = try? JSONSerialization.data(withJSONObject: body)
 
-        let (bytes, response) = try await URLSession.shared.bytes(for: request)
+        let (bytes, response) = try await urlSession.bytes(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw EnhancementError.invalidResponse
@@ -834,7 +835,7 @@ extension AIService {
 
         request.httpBody = try? JSONSerialization.data(withJSONObject: body)
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await urlSession.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw EnhancementError.invalidResponse
@@ -882,7 +883,7 @@ extension AIService {
 
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await urlSession.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw EnhancementError.invalidResponse
@@ -934,7 +935,7 @@ extension AIService {
 
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await urlSession.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw EnhancementError.invalidResponse

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -6,6 +6,7 @@
 //
 
 import Keychain
+import Networking
 import Presets
 import SwiftUI
 import AppGroup
@@ -174,6 +175,7 @@ class AIService {
     private let modesStorageKey: String
     private let selectedModeStorageKey: String
     private let keychain: any KeychainService
+    let urlSession: any URLSessionProtocol
     private let baseTimeout: TimeInterval = 300
 
     /// Service for Apple's on-device Foundation Models (type-erased for iOS version compatibility)
@@ -189,8 +191,9 @@ class AIService {
         return service
     }
 
-    init(keychain: any KeychainService = DefaultKeychainService()) {
+    init(keychain: any KeychainService = DefaultKeychainService(), urlSession: any URLSessionProtocol = URLSession.shared) {
         self.keychain = keychain
+        self.urlSession = urlSession
         self.userDefaults = UserDefaultsStorage.shared
         self.modesStorageKey = AppGroupCoordinator.vivaModesKey
         self.selectedModeStorageKey = AppGroupCoordinator.selectedVivaModeKey
@@ -230,8 +233,9 @@ class AIService {
     }
 
     /// Test-only initializer with injectable UserDefaults and no network side effects.
-    init(userDefaults: UserDefaults, modesStorageKey: String = "VivaModes", selectedModeStorageKey: String = "selectedVivaMode", keychain: any KeychainService = DefaultKeychainService()) {
+    init(userDefaults: UserDefaults, modesStorageKey: String = "VivaModes", selectedModeStorageKey: String = "selectedVivaMode", keychain: any KeychainService = DefaultKeychainService(), urlSession: any URLSessionProtocol = URLSession.shared) {
         self.keychain = keychain
+        self.urlSession = urlSession
         self.userDefaults = userDefaults
         self.modesStorageKey = modesStorageKey
         self.selectedModeStorageKey = selectedModeStorageKey
@@ -1032,7 +1036,7 @@ class AIService {
         )
         request.httpBody = try? JSONSerialization.data(withJSONObject: requestBody)
 
-        let (bytes, response) = try await URLSession.shared.bytes(for: request)
+        let (bytes, response) = try await urlSession.bytes(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw EnhancementError.invalidResponse
@@ -1133,7 +1137,7 @@ class AIService {
 
         request.httpBody = try? JSONSerialization.data(withJSONObject: requestBody)
 
-        let (bytes, response) = try await URLSession.shared.bytes(for: request)
+        let (bytes, response) = try await urlSession.bytes(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw EnhancementError.invalidResponse
@@ -1630,7 +1634,7 @@ class AIService {
             request.httpBody = try? JSONSerialization.data(withJSONObject: requestBody)
 
             do {
-                let (data, response) = try await URLSession.shared.data(for: request)
+                let (data, response) = try await urlSession.data(for: request)
 
                 guard let httpResponse = response as? HTTPURLResponse else {
                     throw EnhancementError.invalidResponse
@@ -1684,7 +1688,7 @@ class AIService {
             request.httpBody = try? JSONSerialization.data(withJSONObject: requestBody)
 
             do {
-                let (data, response) = try await URLSession.shared.data(for: request)
+                let (data, response) = try await urlSession.data(for: request)
 
                 guard let httpResponse = response as? HTTPURLResponse else {
                     throw EnhancementError.invalidResponse
@@ -1807,7 +1811,7 @@ class AIService {
         request.httpBody = try? JSONSerialization.data(withJSONObject: finalRequestBody)
 
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {
                 throw EnhancementError.invalidResponse
@@ -1866,7 +1870,7 @@ class AIService {
         request.timeoutInterval = 5 // Short timeout for local service
 
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse,
                   httpResponse.statusCode == 200 else {
@@ -1906,7 +1910,7 @@ class AIService {
         request.timeoutInterval = 5
 
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse,
                   httpResponse.statusCode == 200 else {
@@ -1945,7 +1949,7 @@ class AIService {
         request.timeoutInterval = 3
 
         do {
-            let (_, response) = try await URLSession.shared.data(for: request)
+            let (_, response) = try await urlSession.data(for: request)
             guard let httpResponse = response as? HTTPURLResponse else {
                 return false
             }
@@ -2028,7 +2032,7 @@ class AIService {
         request.httpBody = try? JSONSerialization.data(withJSONObject: requestBody)
 
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {
                 throw EnhancementError.invalidResponse
@@ -2145,7 +2149,7 @@ class AIService {
 
         do {
             logger.logNotice("🔧 Custom OpenAI Test - Sending request...")
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {
                 logger.logError("🔧 Custom OpenAI Test - Response is not HTTPURLResponse")
@@ -2382,7 +2386,7 @@ class AIService {
         logger.logNotice("🔑 Verifying API key for \(provider.rawValue) provider at \(url.absoluteString)")
         
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await urlSession.data(for: request)
             
             guard let httpResponse = response as? HTTPURLResponse else {
                 logger.logNotice("🔑 API key verification failed for \(provider.rawValue): Invalid response")
@@ -2417,7 +2421,7 @@ class AIService {
         logger.logNotice("🔑 Verifying API key for cerebras provider at \(url.absoluteString)")
 
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {
                 logger.logNotice("🔑 API key verification failed for cerebras: Invalid response")
@@ -2462,7 +2466,7 @@ class AIService {
         request.httpBody = try? JSONSerialization.data(withJSONObject: testBody)
         
         do {
-            let (_, response) = try await URLSession.shared.data(for: request)
+            let (_, response) = try await urlSession.data(for: request)
             
             guard let httpResponse = response as? HTTPURLResponse else {
                 return false
@@ -2484,7 +2488,7 @@ class AIService {
         request.addValue(key, forHTTPHeaderField: "xi-api-key")
 
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await urlSession.data(for: request)
             let isValid = (response as? HTTPURLResponse)?.statusCode == 200
 
             if let body = String(data: data, encoding: .utf8) {
@@ -2505,7 +2509,7 @@ class AIService {
         request.addValue("Token \(key)", forHTTPHeaderField: "Authorization")
         
         do {
-            let (_, response) = try await URLSession.shared.data(for: request)
+            let (_, response) = try await urlSession.data(for: request)
             
             guard let httpResponse = response as? HTTPURLResponse else {
                 return false
@@ -2526,7 +2530,7 @@ class AIService {
         request.addValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
 
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {
                 logger.logError("Mistral API key verification failed: Invalid response from server.")
@@ -2559,7 +2563,7 @@ class AIService {
         request.addValue("application/json", forHTTPHeaderField: "Accept")
 
         do {
-            let (_, response) = try await URLSession.shared.data(for: request)
+            let (_, response) = try await urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {
                 return false
@@ -2582,7 +2586,7 @@ class AIService {
         request.addValue(key, forHTTPHeaderField: "x-gladia-key")
 
         do {
-            let (_, response) = try await URLSession.shared.data(for: request)
+            let (_, response) = try await urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {
                 return false
@@ -2604,7 +2608,7 @@ class AIService {
         request.addValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
 
         do {
-            let (_, response) = try await URLSession.shared.data(for: request)
+            let (_, response) = try await urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {
                 return false
@@ -2624,7 +2628,7 @@ class AIService {
         request.addValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
 
         do {
-            let (_, response) = try await URLSession.shared.data(for: request)
+            let (_, response) = try await urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {
                 return false
@@ -2651,7 +2655,7 @@ class AIService {
         request.addValue(CartesiaTranscriptionService.cartesiaVersion, forHTTPHeaderField: "Cartesia-Version")
 
         do {
-            let (_, response) = try await URLSession.shared.data(for: request)
+            let (_, response) = try await urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {
                 return false
@@ -2675,7 +2679,7 @@ class AIService {
         logger.logNotice("🔑 Verifying Vercel AI Gateway API key")
 
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {
                 logger.logNotice("🔑 Vercel AI Gateway API key verification failed: Invalid response")
@@ -2720,7 +2724,7 @@ class AIService {
         logger.logNotice("🔑 Verifying Grok API key at \(url.absoluteString)")
 
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {
                 logger.logNotice("🔑 Grok API key verification failed: Invalid response")
@@ -2765,7 +2769,7 @@ class AIService {
         logger.logNotice("🔑 Verifying HuggingFace API key at \(url.absoluteString)")
 
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {
                 logger.logNotice("🔑 HuggingFace API key verification failed: Invalid response")
@@ -2830,7 +2834,7 @@ class AIService {
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
         
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
                 logger.logError("Failed to fetch OpenRouter models: Invalid HTTP response")
@@ -2863,7 +2867,7 @@ class AIService {
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
 
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
                 logger.logError("Failed to fetch Vercel AI Gateway models: Invalid HTTP response")
@@ -2908,7 +2912,7 @@ class AIService {
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
 
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await urlSession.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
                 logger.logError("Failed to fetch HuggingFace models: Invalid HTTP response")

--- a/VivaDicta/Services/AIEnhance/ExaWebSearchTool.swift
+++ b/VivaDicta/Services/AIEnhance/ExaWebSearchTool.swift
@@ -8,6 +8,7 @@
 import Foundation
 import FoundationModels
 import Keychain
+import Networking
 import os
 
 enum WebSearchStatus: String, Sendable {
@@ -138,6 +139,9 @@ enum ExaWebSearchToolRuntime {
 // MARK: - API Client (nonisolated for Tool protocol compatibility)
 
 nonisolated enum ExaSearchClient: Sendable {
+    /// URL session used for Exa search requests. Override only from tests.
+    nonisolated(unsafe) static var urlSession: any URLSessionProtocol = URLSession.shared
+
     nonisolated static func search(query: String, apiKey: String) async throws -> [ExaResult] {
         guard let url = URL(string: "https://api.exa.ai/search") else {
             throw ExaError.invalidURL
@@ -155,7 +159,7 @@ nonisolated enum ExaSearchClient: Sendable {
         request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
         request.httpBody = try JSONEncoder().encode(payload)
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await urlSession.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw ExaError.invalidResponse

--- a/VivaDicta/Services/AIEnhance/VivAgentsClient.swift
+++ b/VivaDicta/Services/AIEnhance/VivAgentsClient.swift
@@ -7,12 +7,16 @@
 
 import Foundation
 import Keychain
+import Networking
 import os
 
 enum VivAgentsClient {
 
     private static let logger = Logger(category: .vivAgentsClient)
     private static let keychain: any KeychainService = DefaultKeychainService()
+
+    /// URL session used for all requests. Override only from tests.
+    nonisolated(unsafe) static var urlSession: any URLSessionProtocol = URLSession.shared
 
     struct EnhanceRequest: Encodable {
         let text: String
@@ -177,7 +181,7 @@ enum VivAgentsClient {
 
         logger.logInfo("VivAgents request: provider=\(provider), model=\(model), textLength=\(text.count)")
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await urlSession.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             logger.logError("VivAgents: invalid response (not HTTP)")
@@ -250,7 +254,7 @@ enum VivAgentsClient {
         }
 
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await urlSession.data(for: request)
             guard let httpResponse = response as? HTTPURLResponse,
                   httpResponse.statusCode == 200 else { return nil }
             return try JSONDecoder().decode(HealthResponse.self, from: data)
@@ -273,7 +277,7 @@ enum VivAgentsClient {
         }
 
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await urlSession.data(for: request)
             guard let httpResponse = response as? HTTPURLResponse,
                   httpResponse.statusCode == 200 else { return false }
             let health = try JSONDecoder().decode(HealthResponse.self, from: data)

--- a/VivaDicta/Services/OAuth/CopilotAPIClient.swift
+++ b/VivaDicta/Services/OAuth/CopilotAPIClient.swift
@@ -1,6 +1,7 @@
 // Copyright © 2026 Anton Novoselov. All rights reserved.
 
 import Foundation
+import Networking
 import os
 import OAuth
 
@@ -8,6 +9,9 @@ import OAuth
 /// Uses the Copilot token obtained via device code OAuth flow.
 enum CopilotAPIClient {
     private static let logger = Logger(category: .copilotAPI)
+
+    /// URL session used for all Copilot API calls. Override only from tests.
+    nonisolated(unsafe) static var urlSession: any URLSessionProtocol = URLSession.shared
 
     /// Base URL for Copilot's API.
     static let baseURL = "https://api.individual.githubcopilot.com"
@@ -230,7 +234,7 @@ enum CopilotAPIClient {
     // MARK: - Shared Response Handling
 
     private static func executeRequest(_ request: URLRequest) async throws -> String {
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await urlSession.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw CopilotOAuthError.tokenExchangeFailed("Invalid response")
@@ -261,7 +265,7 @@ enum CopilotAPIClient {
         _ request: URLRequest,
         onPartialResult: @escaping @MainActor (String) -> Void
     ) async throws -> String {
-        let (bytes, response) = try await URLSession.shared.bytes(for: request)
+        let (bytes, response) = try await urlSession.bytes(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw CopilotOAuthError.tokenExchangeFailed("Invalid response")
@@ -346,7 +350,7 @@ enum CopilotAPIClient {
             request.addValue(value, forHTTPHeaderField: key)
         }
 
-        guard let (data, response) = try? await URLSession.shared.data(for: request),
+        guard let (data, response) = try? await urlSession.data(for: request),
               let httpResponse = response as? HTTPURLResponse,
               httpResponse.statusCode == 200,
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],

--- a/VivaDicta/Services/OAuth/GeminiAPIClient.swift
+++ b/VivaDicta/Services/OAuth/GeminiAPIClient.swift
@@ -1,6 +1,7 @@
 // Copyright © 2026 Anton Novoselov. All rights reserved.
 
 import Foundation
+import Networking
 import os
 import OAuth
 
@@ -44,7 +45,8 @@ enum GeminiAPIClient {
         systemPrompt: String,
         model: String,
         accessToken: String,
-        projectId: String?
+        projectId: String?,
+        urlSession: any URLSessionProtocol = URLSession.shared
     ) async throws -> String {
         guard let url = URL(string: endpoint) else {
             throw OAuthError.invalidResponse
@@ -87,7 +89,7 @@ enum GeminiAPIClient {
 
         request.httpBody = try? JSONSerialization.data(withJSONObject: requestBody)
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await urlSession.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw OAuthError.invalidResponse
@@ -142,7 +144,8 @@ enum GeminiAPIClient {
         model: String,
         accessToken: String,
         projectId: String?,
-        onPartialResult: @escaping @MainActor (String) -> Void
+        onPartialResult: @escaping @MainActor (String) -> Void,
+        urlSession: any URLSessionProtocol = URLSession.shared
     ) async throws -> String {
         guard let url = URL(string: streamingEndpoint) else {
             throw OAuthError.invalidResponse
@@ -185,7 +188,7 @@ enum GeminiAPIClient {
 
         request.httpBody = try? JSONSerialization.data(withJSONObject: requestBody)
 
-        let (bytes, response) = try await URLSession.shared.bytes(for: request)
+        let (bytes, response) = try await urlSession.bytes(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw OAuthError.invalidResponse
@@ -314,7 +317,8 @@ enum GeminiAPIClient {
         model: String,
         accessToken: String,
         projectId: String?,
-        onPartialResponse: @escaping @MainActor (String) -> Void
+        onPartialResponse: @escaping @MainActor (String) -> Void,
+        urlSession: any URLSessionProtocol = URLSession.shared
     ) async throws -> String {
         guard let url = URL(string: streamingEndpoint) else {
             throw OAuthError.invalidResponse
@@ -355,7 +359,7 @@ enum GeminiAPIClient {
 
         request.httpBody = try? JSONSerialization.data(withJSONObject: requestBody)
 
-        let (bytes, response) = try await URLSession.shared.bytes(for: request)
+        let (bytes, response) = try await urlSession.bytes(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw OAuthError.invalidResponse
@@ -456,7 +460,8 @@ enum GeminiAPIClient {
         messages: [[String: String]],
         model: String,
         accessToken: String,
-        projectId: String?
+        projectId: String?,
+        urlSession: any URLSessionProtocol = URLSession.shared
     ) async throws -> String {
         try await chatStreaming(
             systemMessage: systemMessage,
@@ -464,7 +469,8 @@ enum GeminiAPIClient {
             model: model,
             accessToken: accessToken,
             projectId: projectId,
-            onPartialResponse: { _ in }
+            onPartialResponse: { _ in },
+            urlSession: urlSession
         )
     }
 

--- a/VivaDicta/Services/OAuth/OpenAIOAuthClient.swift
+++ b/VivaDicta/Services/OAuth/OpenAIOAuthClient.swift
@@ -1,12 +1,16 @@
 // Copyright © 2026 Anton Novoselov. All rights reserved.
 
 import Foundation
+import Networking
 import os
 import OAuth
 
 /// Client for OpenAI's backend API using OAuth tokens.
 enum OpenAIOAuthClient {
     private static let logger = Logger(category: .openAIOAuthAPI)
+
+    /// URL session used for all OpenAI OAuth API calls. Override only from tests.
+    nonisolated(unsafe) static var urlSession: any URLSessionProtocol = URLSession.shared
 
     /// Originator header required by the Codex endpoint.
     private static let originator = "codex_cli_rs"
@@ -147,7 +151,7 @@ enum OpenAIOAuthClient {
         request.addValue(originator, forHTTPHeaderField: "originator")
         request.timeoutInterval = 15
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await urlSession.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
             return [defaultModel]
@@ -193,7 +197,7 @@ enum OpenAIOAuthClient {
         request: URLRequest,
         onPartialResult: (@MainActor (String) -> Void)?
     ) async throws -> String {
-        let (bytes, response) = try await URLSession.shared.bytes(for: request)
+        let (bytes, response) = try await urlSession.bytes(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw OAuthError.invalidResponse

--- a/VivaDicta/Services/Reminders/CloudReminderExtractionProvider.swift
+++ b/VivaDicta/Services/Reminders/CloudReminderExtractionProvider.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Networking
 import os
 import OAuth
 
@@ -71,9 +72,11 @@ private struct CloudReminderDraftsPayload: Codable {
 final class CloudReminderExtractionProvider {
     private let logger = Logger(category: .reminderExtraction)
     private let aiService: AIService
+    private let urlSession: any URLSessionProtocol
 
-    init(aiService: AIService) {
+    init(aiService: AIService, urlSession: any URLSessionProtocol = URLSession.shared) {
         self.aiService = aiService
+        self.urlSession = urlSession
     }
 
     func canExtract(
@@ -312,7 +315,7 @@ final class CloudReminderExtractionProvider {
         )
         request.httpBody = try JSONSerialization.data(withJSONObject: requestBody)
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await urlSession.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw ReminderExtractionError.invalidResponse
@@ -442,7 +445,7 @@ final class CloudReminderExtractionProvider {
 
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await urlSession.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw ReminderExtractionError.invalidResponse

--- a/VivaDicta/Views/SettingsScreen/ChatToolsSettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/ChatToolsSettingsView.swift
@@ -5,6 +5,7 @@
 //  Created by Anton Novoselov on 2026.04.10
 //
 
+import Networking
 import SwiftUI
 
 /// Settings hub for chat tools such as automatic note search and web search.
@@ -328,9 +329,9 @@ private struct ExaWebSearchSettingsView: View {
         request.httpBody = body
 
         do {
-            let (_, response) = try await URLSession.shared.data(for: request)
-            guard let httpResponse = response as? HTTPURLResponse else { return false }
-            return (200...299).contains(httpResponse.statusCode)
+            let client = NetworkClient(category: "ExaKeyVerification")
+            let (_, response) = try await client.send(request)
+            return (200...299).contains(response.statusCode)
         } catch {
             return false
         }

--- a/VivaDictaTests/AIServiceNetworkingTests.swift
+++ b/VivaDictaTests/AIServiceNetworkingTests.swift
@@ -1,0 +1,37 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import Networking
+import NetworkingMocks
+import Testing
+@testable import VivaDicta
+
+/// Smoke tests confirming `AIService` plumbs the injected `URLSessionProtocol`
+/// through to the underlying HTTP calls. Full per-provider coverage lives in
+/// each provider's own test suite; this file just locks in the wiring so a
+/// future refactor that drops the injection is caught immediately.
+@MainActor
+struct AIServiceNetworkingTests {
+
+    private let suiteName = "AIServiceNetworkingTests.\(UUID().uuidString)"
+
+    private func makeDefaults() -> UserDefaults {
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+
+    @Test func storesInjectedURLSession() {
+        let session = MockURLSession()
+        let service = AIService(userDefaults: makeDefaults(), urlSession: session)
+
+        // The injected mock should be reachable as the same instance.
+        #expect(service.urlSession is MockURLSession)
+    }
+
+    @Test func defaultURLSessionIsRealURLSessionWhenNotInjected() {
+        let service = AIService(userDefaults: makeDefaults())
+
+        #expect(service.urlSession is URLSession)
+    }
+}


### PR DESCRIPTION
## Summary

- Replace scattered `URLSession.shared` calls across 22 files with injected `URLSessionProtocol`, unlocking testability everywhere HTTP is used.
- Expand the `Networking` module: `URLSessionProtocol` now covers `data`/`upload`/`bytes`; new `NetworkClient` wrapper centralizes status validation, JSON decoding, and structured `NetworkError` translation; `MockURLSession` gains `data` + `upload` stubs.
- Wire `Networking` + `NetworkingMocks` as direct Swift Package products on the main app target and test target (`VivaDicta.xcodeproj`).

## What changed where

**Foundation (Modules/Networking)**
- `URLSessionProtocol.swift` - extended to data/upload/bytes
- `NetworkClient.swift` (new) - send / sendJSON / upload / bytes with acceptable-status validation and optional logger
- `NetworkError.swift` (new) - invalidResponse / unacceptableStatus / decodingFailed / transport
- `MockURLSession.swift` - new `stubDataResponse` alongside existing upload stub
- `NetworkClientTests.swift` (new) - 9 tests; existing `MockURLSessionTests` updated

**Production migrations**
- `AIService` + `AIService+Chat` (cloud LLM and SSE streaming)
- Cloud transcription services: Cartesia, Cohere, Custom, Deepgram, ElevenLabs, Gemini, Gladia, Mistral, Soniox, Speechmatics
- OAuth: `OAuthManager`, `GeminiOAuthProvider`, `CopilotOAuthManager` (init-injected)
- App-level OAuth clients: `GeminiAPIClient` (per-method param), `CopilotAPIClient` + `OpenAIOAuthClient` (static-var override for enum namespaces)
- `VivAgentsClient`, `ExaSearchClient`, `CloudReminderExtractionProvider`
- `ChatToolsSettingsView.verifyExaKey` rewritten on top of `NetworkClient`

**Out of scope**
- `SonioxRealtimeSTTClient` / `SonioxRealtimeTTSClient` use `URLSessionWebSocketTask`, which isn't part of the data/upload/bytes contract.

## Design notes

- Two injection styles - init-injected `URLSessionProtocol` for instance types, `static var urlSession` for enum-namespace clients. The static-var path avoids threading a `urlSession` parameter through every internal helper.
- `NetworkClient` is intentionally a concrete struct (not a protocol). Tests mock at the lower `URLSessionProtocol` boundary so they exercise the real status validation / JSON decoding / logging.
- After the migration the only consumer of `NetworkClient` is `ChatToolsSettingsView`. Other call sites can opt-in opportunistically when they're already being touched.

## Test plan

- [x] `swift test` in `Modules/Networking` (15 tests passing)
- [x] `swift test` in `Modules/OAuth` (11 tests passing)
- [x] `swift test` in `Modules/CloudTranscription` (46 tests passing)
- [x] `xcodebuild test` for `VivaDicta` scheme on iPhone 17 Pro Max / iOS 26.4 (22 tests passing, including 2 new `AIServiceNetworkingTests`)
- [x] `xcodebuild build` clean on `VivaDicta` scheme
- [x] Grep audit: zero remaining `URLSession.shared.` HTTP usages outside tests