### PR TITLE
Inject OAuth managers + adopt NetworkClient in 2 transcription services

### DIFF
--- a/Modules/CloudTranscription/Sources/CloudTranscription/CustomTranscriptionService.swift
+++ b/Modules/CloudTranscription/Sources/CloudTranscription/CustomTranscriptionService.swift
@@ -27,11 +27,11 @@ public struct CustomTranscriptionService: TranscriptionService, Sendable {
     }
 
     private let config: Config
-    private let urlSession: any URLSessionProtocol
+    private let networkClient: NetworkClient
 
     public init(config: Config, urlSession: any URLSessionProtocol = URLSession.shared) {
         self.config = config
-        self.urlSession = urlSession
+        self.networkClient = NetworkClient(session: urlSession, category: "CustomTranscription")
     }
 
     public func transcribe(audioURL: URL) async throws -> TranscriptionServiceResult {
@@ -61,16 +61,11 @@ public struct CustomTranscriptionService: TranscriptionService, Sendable {
 
         logger.logInfo("Sending request to custom endpoint: \(config.apiEndpoint)")
 
-        let (data, response) = try await urlSession.upload(for: request, from: body)
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw CloudTranscriptionError.networkError(URLError(.badServerResponse))
-        }
-
-        if !(200...299).contains(httpResponse.statusCode) {
-            let errorMessage = String(data: data, encoding: .utf8) ?? "No error message"
-            logger.logError("Custom API request failed with status \(httpResponse.statusCode): \(errorMessage)")
-            throw CloudTranscriptionError.apiRequestFailed(statusCode: httpResponse.statusCode, message: errorMessage)
+        let data: Data
+        do {
+            (data, _) = try await networkClient.upload(request, from: body)
+        } catch let error as NetworkError {
+            throw error.asCloudTranscriptionError()
         }
 
         do {

--- a/Modules/CloudTranscription/Sources/CloudTranscription/CustomTranscriptionService.swift
+++ b/Modules/CloudTranscription/Sources/CloudTranscription/CustomTranscriptionService.swift
@@ -65,7 +65,7 @@ public struct CustomTranscriptionService: TranscriptionService, Sendable {
         do {
             (data, _) = try await networkClient.upload(request, from: body)
         } catch let error as NetworkError {
-            throw error.asCloudTranscriptionError()
+            throw error.asTranscriptionError()
         }
 
         do {

--- a/Modules/CloudTranscription/Sources/CloudTranscription/GeminiTranscriptionService.swift
+++ b/Modules/CloudTranscription/Sources/CloudTranscription/GeminiTranscriptionService.swift
@@ -21,11 +21,11 @@ public struct GeminiTranscriptionService: TranscriptionService, Sendable {
     }
 
     private let config: Config
-    private let urlSession: any URLSessionProtocol
+    private let networkClient: NetworkClient
 
     public init(config: Config, urlSession: any URLSessionProtocol = URLSession.shared) {
         self.config = config
-        self.urlSession = urlSession
+        self.networkClient = NetworkClient(session: urlSession, category: "GeminiTranscription")
     }
 
     public func transcribe(audioURL: URL) async throws -> TranscriptionServiceResult {
@@ -83,33 +83,20 @@ public struct GeminiTranscriptionService: TranscriptionService, Sendable {
             throw CloudTranscriptionError.dataEncodingError
         }
 
-        let (data, response) = try await urlSession.data(for: request)
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw CloudTranscriptionError.networkError(URLError(.badServerResponse))
-        }
-
-        if !(200...299).contains(httpResponse.statusCode) {
-            let errorMessage = String(data: data, encoding: .utf8) ?? "No error message"
-            logger.logError("Gemini API request failed with status \(httpResponse.statusCode): \(errorMessage)")
-            throw CloudTranscriptionError.apiRequestFailed(statusCode: httpResponse.statusCode, message: errorMessage)
-        }
-
+        let transcriptionResponse: GeminiResponse
         do {
-            let transcriptionResponse = try JSONDecoder().decode(GeminiResponse.self, from: data)
-            guard let candidate = transcriptionResponse.candidates.first,
-                  let part = candidate.content.parts.first,
-                  !part.text.isEmpty else {
-                logger.logError("No transcript found in Gemini response")
-                throw CloudTranscriptionError.noTranscriptionReturned
-            }
-            return part.text.trimmingCharacters(in: .whitespacesAndNewlines)
-        } catch let error as CloudTranscriptionError {
-            throw error
-        } catch {
-            logger.logError("Failed to decode Gemini API response: \(error.localizedDescription)")
+            transcriptionResponse = try await networkClient.sendJSON(request, as: GeminiResponse.self)
+        } catch let error as NetworkError {
+            throw error.asCloudTranscriptionError()
+        }
+
+        guard let candidate = transcriptionResponse.candidates.first,
+              let part = candidate.content.parts.first,
+              !part.text.isEmpty else {
+            logger.logError("No transcript found in Gemini response")
             throw CloudTranscriptionError.noTranscriptionReturned
         }
+        return part.text.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     private struct GeminiRequest: Codable {

--- a/Modules/CloudTranscription/Sources/CloudTranscription/GeminiTranscriptionService.swift
+++ b/Modules/CloudTranscription/Sources/CloudTranscription/GeminiTranscriptionService.swift
@@ -87,7 +87,7 @@ public struct GeminiTranscriptionService: TranscriptionService, Sendable {
         do {
             transcriptionResponse = try await networkClient.sendJSON(request, as: GeminiResponse.self)
         } catch let error as NetworkError {
-            throw error.asCloudTranscriptionError()
+            throw error.asTranscriptionError()
         }
 
         guard let candidate = transcriptionResponse.candidates.first,

--- a/Modules/CloudTranscription/Sources/CloudTranscription/NetworkError+CloudTranscription.swift
+++ b/Modules/CloudTranscription/Sources/CloudTranscription/NetworkError+CloudTranscription.swift
@@ -3,24 +3,30 @@
 import Foundation
 import Networking
 
-/// Bridges `NetworkError` (produced by `NetworkClient`) into the
-/// `CloudTranscriptionError` contract that `NetworkRetry.withRetry` already
-/// knows how to inspect for retry decisions (429 / 5xx / URLError).
+/// Bridges `NetworkError` (produced by `NetworkClient`) into the error type
+/// `NetworkRetry.withRetry` already knows how to inspect for retry decisions.
 ///
-/// Lets transcription services adopt `NetworkClient` without giving up the
-/// existing retry semantics.
+/// - `.invalidResponse` / `.unacceptableStatus` / `.decodingFailed` map to
+///   `CloudTranscriptionError` so the status-aware retry policy (5xx + 429)
+///   applies.
+/// - `.transport(URLError)` is **unwrapped** to the raw underlying error so
+///   `NetworkRetry.shouldRetryURLError`'s allowlist (`notConnected` /
+///   `timedOut` / `connectionLost` / `cannotConnectToHost`) makes the call.
+///   Wrapping these as `.networkError` would cause unconditional retry of
+///   non-retryable codes like `URLError.cancelled` -- a UX regression on
+///   user-initiated cancellation.
 extension NetworkError {
-    func asCloudTranscriptionError() -> CloudTranscriptionError {
+    func asTranscriptionError() -> any Error {
         switch self {
         case .invalidResponse:
-            return .networkError(URLError(.badServerResponse))
+            return CloudTranscriptionError.networkError(URLError(.badServerResponse))
         case let .unacceptableStatus(code, body):
             let message = String(data: body, encoding: .utf8) ?? "No error message"
-            return .apiRequestFailed(statusCode: code, message: message)
+            return CloudTranscriptionError.apiRequestFailed(statusCode: code, message: message)
         case let .transport(error):
-            return .networkError(error)
+            return error
         case .decodingFailed:
-            return .noTranscriptionReturned
+            return CloudTranscriptionError.noTranscriptionReturned
         }
     }
 }

--- a/Modules/CloudTranscription/Sources/CloudTranscription/NetworkError+CloudTranscription.swift
+++ b/Modules/CloudTranscription/Sources/CloudTranscription/NetworkError+CloudTranscription.swift
@@ -1,0 +1,26 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import Networking
+
+/// Bridges `NetworkError` (produced by `NetworkClient`) into the
+/// `CloudTranscriptionError` contract that `NetworkRetry.withRetry` already
+/// knows how to inspect for retry decisions (429 / 5xx / URLError).
+///
+/// Lets transcription services adopt `NetworkClient` without giving up the
+/// existing retry semantics.
+extension NetworkError {
+    func asCloudTranscriptionError() -> CloudTranscriptionError {
+        switch self {
+        case .invalidResponse:
+            return .networkError(URLError(.badServerResponse))
+        case let .unacceptableStatus(code, body):
+            let message = String(data: body, encoding: .utf8) ?? "No error message"
+            return .apiRequestFailed(statusCode: code, message: message)
+        case let .transport(error):
+            return .networkError(error)
+        case .decodingFailed:
+            return .noTranscriptionReturned
+        }
+    }
+}

--- a/Modules/CloudTranscription/Tests/CloudTranscriptionTests/NetworkErrorBridgeTests.swift
+++ b/Modules/CloudTranscription/Tests/CloudTranscriptionTests/NetworkErrorBridgeTests.swift
@@ -1,0 +1,59 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+@testable import CloudTranscription
+import Networking
+import Testing
+
+@Suite("NetworkError → transcription error bridge")
+struct NetworkErrorBridgeTests {
+
+    @Test func unacceptableStatusMapsToApiRequestFailed() {
+        let bridged = NetworkError.unacceptableStatus(code: 429, body: Data("rate limited".utf8))
+            .asTranscriptionError()
+
+        guard case let CloudTranscriptionError.apiRequestFailed(code, message) = bridged else {
+            Issue.record("Expected .apiRequestFailed, got \(bridged)")
+            return
+        }
+        #expect(code == 429)
+        #expect(message == "rate limited")
+    }
+
+    @Test func invalidResponseMapsToNetworkError() {
+        let bridged = NetworkError.invalidResponse.asTranscriptionError()
+
+        guard case CloudTranscriptionError.networkError = bridged else {
+            Issue.record("Expected .networkError, got \(bridged)")
+            return
+        }
+    }
+
+    @Test func decodingFailureMapsToNoTranscriptionReturned() {
+        struct Boom: Error {}
+        let bridged = NetworkError.decodingFailed(Boom()).asTranscriptionError()
+
+        guard case CloudTranscriptionError.noTranscriptionReturned = bridged else {
+            Issue.record("Expected .noTranscriptionReturned, got \(bridged)")
+            return
+        }
+    }
+
+    /// Regression test for the retry-on-cancel bug both reviewers flagged on
+    /// PR #278: `.transport` previously bridged to
+    /// `CloudTranscriptionError.networkError`, which `NetworkRetry` retries
+    /// unconditionally. The bridge now unwraps the underlying URLError so
+    /// `NetworkRetry.shouldRetryURLError` keeps gating on its allowlist.
+    @Test func transportUnwrapsToUnderlyingURLError() {
+        let original = URLError(.cancelled)
+        let bridged = NetworkError.transport(original).asTranscriptionError()
+
+        let urlError = bridged as? URLError
+        #expect(urlError?.code == .cancelled)
+        // Should NOT be wrapped as CloudTranscriptionError - that would force
+        // an unconditional retry path in NetworkRetry.
+        if case CloudTranscriptionError.networkError = bridged {
+            Issue.record(".transport must not bridge to .networkError - that re-introduces the retry-on-cancel regression")
+        }
+    }
+}

--- a/VivaDicta/Services/AIEnhance/AIService+Chat.swift
+++ b/VivaDicta/Services/AIEnhance/AIService+Chat.swift
@@ -86,7 +86,7 @@ extension AIService {
             )
 
         case .copilot:
-            let token = try await CopilotOAuthManager.shared.validCopilotToken()
+            let token = try await copilotOAuthManager.validCopilotToken()
             guard let url = URL(string: "\(CopilotAPIClient.baseURL)/chat/completions") else {
                 throw EnhancementError.customError("Invalid Copilot URL")
             }
@@ -134,7 +134,7 @@ extension AIService {
         case .openAIOAuth:
             do {
                 let oauthProvider = OpenAIOAuthProvider()
-                let (token, accountId, _) = try await OAuthManager.shared.validAccessToken(for: oauthProvider)
+                let (token, accountId, _) = try await oauthManager.validAccessToken(for: oauthProvider)
                 return try await OpenAIOAuthClient.chatStreaming(
                     systemMessage: systemMessage,
                     messages: messages,
@@ -160,14 +160,15 @@ extension AIService {
         case .geminiOAuth:
             do {
                 let oauthProvider = GeminiOAuthProvider()
-                let (token, _, projectId) = try await OAuthManager.shared.validAccessToken(for: oauthProvider)
+                let (token, _, projectId) = try await oauthManager.validAccessToken(for: oauthProvider)
                 return try await GeminiAPIClient.chatStreaming(
                     systemMessage: systemMessage,
                     messages: messages,
                     model: model,
                     accessToken: token,
                     projectId: projectId,
-                    onPartialResponse: onPartialResponse
+                    onPartialResponse: onPartialResponse,
+                    urlSession: urlSession
                 )
             } catch let error as OAuthError {
                 if let apiKey = provider.apiKey {
@@ -220,7 +221,7 @@ extension AIService {
         case .openAI where isOpenAISignedIn:
             do {
                 let oauthProvider = OpenAIOAuthProvider()
-                let (token, accountId, _) = try await OAuthManager.shared.validAccessToken(for: oauthProvider)
+                let (token, accountId, _) = try await oauthManager.validAccessToken(for: oauthProvider)
                 return try await OpenAIOAuthClient.chat(
                     systemMessage: systemMessage,
                     messages: messages,
@@ -245,13 +246,14 @@ extension AIService {
         case .gemini where isGeminiSignedIn:
             do {
                 let oauthProvider = GeminiOAuthProvider()
-                let (token, _, projectId) = try await OAuthManager.shared.validAccessToken(for: oauthProvider)
+                let (token, _, projectId) = try await oauthManager.validAccessToken(for: oauthProvider)
                 return try await GeminiAPIClient.chat(
                     systemMessage: systemMessage,
                     messages: messages,
                     model: model,
                     accessToken: token,
-                    projectId: projectId
+                    projectId: projectId,
+                    urlSession: urlSession
                 )
             } catch let error as OAuthError {
                 if let apiKey = provider.apiKey {
@@ -390,7 +392,7 @@ extension AIService {
     private func chatRequestConfig(for provider: AIProvider, model: String) async throws -> (URL, [String: String]) {
         switch provider {
         case .copilot:
-            let token = try await CopilotOAuthManager.shared.validCopilotToken()
+            let token = try await copilotOAuthManager.validCopilotToken()
             guard let url = URL(string: "\(CopilotAPIClient.baseURL)/chat/completions") else {
                 throw EnhancementError.customError("Invalid Copilot URL")
             }

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -176,6 +176,8 @@ class AIService {
     private let selectedModeStorageKey: String
     private let keychain: any KeychainService
     let urlSession: any URLSessionProtocol
+    let oauthManager: OAuthManager
+    let copilotOAuthManager: CopilotOAuthManager
     private let baseTimeout: TimeInterval = 300
 
     /// Service for Apple's on-device Foundation Models (type-erased for iOS version compatibility)
@@ -191,9 +193,16 @@ class AIService {
         return service
     }
 
-    init(keychain: any KeychainService = DefaultKeychainService(), urlSession: any URLSessionProtocol = URLSession.shared) {
+    init(
+        keychain: any KeychainService = DefaultKeychainService(),
+        urlSession: any URLSessionProtocol = URLSession.shared,
+        oauthManager: OAuthManager = .shared,
+        copilotOAuthManager: CopilotOAuthManager = .shared
+    ) {
         self.keychain = keychain
         self.urlSession = urlSession
+        self.oauthManager = oauthManager
+        self.copilotOAuthManager = copilotOAuthManager
         self.userDefaults = UserDefaultsStorage.shared
         self.modesStorageKey = AppGroupCoordinator.vivaModesKey
         self.selectedModeStorageKey = AppGroupCoordinator.selectedVivaModeKey
@@ -233,9 +242,19 @@ class AIService {
     }
 
     /// Test-only initializer with injectable UserDefaults and no network side effects.
-    init(userDefaults: UserDefaults, modesStorageKey: String = "VivaModes", selectedModeStorageKey: String = "selectedVivaMode", keychain: any KeychainService = DefaultKeychainService(), urlSession: any URLSessionProtocol = URLSession.shared) {
+    init(
+        userDefaults: UserDefaults,
+        modesStorageKey: String = "VivaModes",
+        selectedModeStorageKey: String = "selectedVivaMode",
+        keychain: any KeychainService = DefaultKeychainService(),
+        urlSession: any URLSessionProtocol = URLSession.shared,
+        oauthManager: OAuthManager = .shared,
+        copilotOAuthManager: CopilotOAuthManager = .shared
+    ) {
         self.keychain = keychain
         self.urlSession = urlSession
+        self.oauthManager = oauthManager
+        self.copilotOAuthManager = copilotOAuthManager
         self.userDefaults = userDefaults
         self.modesStorageKey = modesStorageKey
         self.selectedModeStorageKey = selectedModeStorageKey
@@ -1255,7 +1274,7 @@ class AIService {
                 onPartialResponse: onPartialResponse
             )
         case .copilot:
-            let token = try await CopilotOAuthManager.shared.validCopilotToken()
+            let token = try await copilotOAuthManager.validCopilotToken()
             let model = mode.aiModel.isEmpty ? CopilotAPIClient.defaultModel : mode.aiModel
             let result = try await CopilotAPIClient.enhanceStreaming(
                 text: userMsg,
@@ -1268,7 +1287,7 @@ class AIService {
         case .geminiOAuth:
             do {
                 let provider = GeminiOAuthProvider()
-                let (token, _, projectId) = try await OAuthManager.shared.validAccessToken(for: provider)
+                let (token, _, projectId) = try await oauthManager.validAccessToken(for: provider)
                 let model = mode.aiModel.isEmpty ? GeminiAPIClient.defaultModel : mode.aiModel
                 let result = try await GeminiAPIClient.enhanceStreaming(
                     text: userMsg,
@@ -1276,7 +1295,8 @@ class AIService {
                     model: model,
                     accessToken: token,
                     projectId: projectId,
-                    onPartialResult: onPartialResponse
+                    onPartialResult: onPartialResponse,
+                    urlSession: urlSession
                 )
                 return await finalizeStreamingResult(result, onPartialResponse: onPartialResponse)
             } catch let error as EnhancementError {
@@ -1292,7 +1312,7 @@ class AIService {
         case .openAIOAuth:
             do {
                 let provider = OpenAIOAuthProvider()
-                let (token, accountId, _) = try await OAuthManager.shared.validAccessToken(for: provider)
+                let (token, accountId, _) = try await oauthManager.validAccessToken(for: provider)
                 let model = mode.aiModel.isEmpty ? OpenAIOAuthClient.defaultModel : mode.aiModel
                 let result = try await OpenAIOAuthClient.enhance(
                     text: userMsg,
@@ -1484,7 +1504,7 @@ class AIService {
             lastUserMessageSent = formattedText
             do {
                 let provider = OpenAIOAuthProvider()
-                let (token, accountId, _) = try await OAuthManager.shared.validAccessToken(for: provider)
+                let (token, accountId, _) = try await oauthManager.validAccessToken(for: provider)
                 let model = mode.aiModel.isEmpty ? OpenAIOAuthClient.defaultModel : mode.aiModel
                 let result = try await OpenAIOAuthClient.enhance(
                     text: formattedText,
@@ -1510,14 +1530,15 @@ class AIService {
             lastUserMessageSent = formattedText
             do {
                 let provider = GeminiOAuthProvider()
-                let (token, _, projectId) = try await OAuthManager.shared.validAccessToken(for: provider)
+                let (token, _, projectId) = try await oauthManager.validAccessToken(for: provider)
                 let model = mode.aiModel.isEmpty ? GeminiAPIClient.defaultModel : mode.aiModel
                 let result = try await GeminiAPIClient.enhance(
                     text: formattedText,
                     systemPrompt: resolvedSystemMessage,
                     model: model,
                     accessToken: token,
-                    projectId: projectId
+                    projectId: projectId,
+                    urlSession: urlSession
                 )
                 return AIEnhancementOutputFilter.filter(result)
             } catch let error as EnhancementError {
@@ -1586,7 +1607,7 @@ class AIService {
             lastSystemMessageSent = resolvedSystemMessage
             lastUserMessageSent = formattedText
             do {
-                let token = try await CopilotOAuthManager.shared.validCopilotToken()
+                let token = try await copilotOAuthManager.validCopilotToken()
                 let model = mode.aiModel.isEmpty ? CopilotAPIClient.defaultModel : mode.aiModel
                 let result = try await CopilotAPIClient.enhance(
                     text: formattedText,
@@ -3026,8 +3047,8 @@ extension AIService {
     @MainActor
     func refreshOpenAIOAuthState() {
         let provider = OpenAIOAuthProvider()
-        isOpenAISignedIn = OAuthManager.shared.isSignedIn(provider: provider)
-        openAIEmail = OAuthManager.shared.accountEmail(for: provider)
+        isOpenAISignedIn = oauthManager.isSignedIn(provider: provider)
+        openAIEmail = oauthManager.accountEmail(for: provider)
     }
 
     /// Signs in to OpenAI via OAuth.
@@ -3037,7 +3058,7 @@ extension AIService {
         defer { isOpenAISigningIn = false }
 
         let provider = OpenAIOAuthProvider()
-        let credential = try await OAuthManager.shared.signIn(provider: provider)
+        let credential = try await oauthManager.signIn(provider: provider)
         isOpenAISignedIn = true
         openAIEmail = credential.accountEmail
         refreshConnectedProviders()
@@ -3047,7 +3068,7 @@ extension AIService {
     @MainActor
     func signOutFromOpenAI() {
         let provider = OpenAIOAuthProvider()
-        OAuthManager.shared.signOut(provider: provider)
+        oauthManager.signOut(provider: provider)
         isOpenAISignedIn = false
         openAIEmail = nil
         refreshConnectedProviders()
@@ -3061,8 +3082,8 @@ extension AIService {
     @MainActor
     func refreshGeminiOAuthState() {
         let provider = GeminiOAuthProvider()
-        isGeminiSignedIn = OAuthManager.shared.isSignedIn(provider: provider)
-        geminiEmail = OAuthManager.shared.accountEmail(for: provider)
+        isGeminiSignedIn = oauthManager.isSignedIn(provider: provider)
+        geminiEmail = oauthManager.accountEmail(for: provider)
     }
 
     /// Signs in to Gemini via OAuth.
@@ -3072,7 +3093,7 @@ extension AIService {
         defer { isGeminiSigningIn = false }
 
         let provider = GeminiOAuthProvider()
-        let credential = try await OAuthManager.shared.signIn(provider: provider)
+        let credential = try await oauthManager.signIn(provider: provider)
         isGeminiSignedIn = true
         geminiEmail = credential.accountEmail
         refreshConnectedProviders()
@@ -3082,7 +3103,7 @@ extension AIService {
     @MainActor
     func signOutFromGemini() {
         let provider = GeminiOAuthProvider()
-        OAuthManager.shared.signOut(provider: provider)
+        oauthManager.signOut(provider: provider)
         isGeminiSignedIn = false
         geminiEmail = nil
         refreshConnectedProviders()
@@ -3094,13 +3115,13 @@ extension AIService {
 extension AIService {
     @MainActor
     func refreshCopilotOAuthState() {
-        isCopilotSignedIn = CopilotOAuthManager.shared.isSignedIn
-        copilotUsername = CopilotOAuthManager.shared.accountInfo
+        isCopilotSignedIn = copilotOAuthManager.isSignedIn
+        copilotUsername = copilotOAuthManager.accountInfo
 
         // Fetch available models if signed in
         if isCopilotSignedIn {
             Task {
-                if let token = try? await CopilotOAuthManager.shared.validCopilotToken() {
+                if let token = try? await copilotOAuthManager.validCopilotToken() {
                     let models = await CopilotAPIClient.fetchModels(copilotToken: token)
                     self.copilotModels = models
                 }
@@ -3113,7 +3134,7 @@ extension AIService {
         isCopilotSigningIn = true
         defer { isCopilotSigningIn = false }
 
-        let credential = try await CopilotOAuthManager.shared.pollForToken(
+        let credential = try await copilotOAuthManager.pollForToken(
             deviceCode: deviceCode.deviceCode,
             interval: deviceCode.interval,
             expiresIn: deviceCode.expiresIn
@@ -3123,14 +3144,14 @@ extension AIService {
         refreshConnectedProviders()
 
         // Fetch models after sign-in
-        if let token = try? await CopilotOAuthManager.shared.validCopilotToken() {
+        if let token = try? await copilotOAuthManager.validCopilotToken() {
             copilotModels = await CopilotAPIClient.fetchModels(copilotToken: token)
         }
     }
 
     @MainActor
     func signOutFromCopilot() {
-        CopilotOAuthManager.shared.signOut()
+        copilotOAuthManager.signOut()
         isCopilotSignedIn = false
         copilotUsername = nil
         copilotModels = []

--- a/VivaDicta/Services/Reminders/CloudReminderExtractionProvider.swift
+++ b/VivaDicta/Services/Reminders/CloudReminderExtractionProvider.swift
@@ -355,7 +355,7 @@ final class CloudReminderExtractionProvider {
         language: String?
     ) async throws -> ReminderDraftsResponse {
         let provider = OpenAIOAuthProvider()
-        let (token, accountId, _) = try await OAuthManager.shared.validAccessToken(for: provider)
+        let (token, accountId, _) = try await aiService.oauthManager.validAccessToken(for: provider)
         let responseText = try await OpenAIOAuthClient.enhance(
             text: textTransportUserMessage(noteText: noteText, now: now, timeZone: timeZone, language: language),
             systemPrompt: systemMessage(now: now, timeZone: timeZone, language: language),
@@ -374,13 +374,14 @@ final class CloudReminderExtractionProvider {
         language: String?
     ) async throws -> ReminderDraftsResponse {
         let provider = GeminiOAuthProvider()
-        let (token, _, projectId) = try await OAuthManager.shared.validAccessToken(for: provider)
+        let (token, _, projectId) = try await aiService.oauthManager.validAccessToken(for: provider)
         let responseText = try await GeminiAPIClient.enhance(
             text: textTransportUserMessage(noteText: noteText, now: now, timeZone: timeZone, language: language),
             systemPrompt: systemMessage(now: now, timeZone: timeZone, language: language),
             model: model,
             accessToken: token,
-            projectId: projectId
+            projectId: projectId,
+            urlSession: urlSession
         )
         return try decodeTextResponse(responseText)
     }


### PR DESCRIPTION
Closes parts of #277.

## Summary

- **OAuth manager injection** - `AIService` now accepts `OAuthManager` + `CopilotOAuthManager` via init (defaults to `.shared`). All 29 internal `.shared` usages in `AIService` / `AIService+Chat` route through the injected instance. Tests can now fake OAuth managers end-to-end alongside the URLSession.
- **Thread `urlSession` through `GeminiAPIClient`** - the four `.enhance` / `.chat` / `.chatStreaming` / `.enhanceStreaming` call sites pass `urlSession` so a mock injected into `AIService` actually reaches the Cloud Code Assist endpoint. Closes the per-call mismatch flagged in #277's issue body.
- **NetworkClient adoption pilot** - `GeminiTranscriptionService` and `CustomTranscriptionService` now use `NetworkClient.sendJSON` / `NetworkClient.upload` for the HTTP step. Drops the manual `HTTPURLResponse` cast + status validation + ad-hoc logging at each site. New `NetworkError.asCloudTranscriptionError()` bridge keeps `NetworkRetry.withRetry` retry semantics intact.

## What's still using the singleton

Only `CopilotConfigurationView.startDeviceCodeFlow()` calls `CopilotOAuthManager.shared` directly. That's the intentional boundary - SwiftUI views can keep talking to the composition root. `OAuthSingletons.swift` stays as the canonical place to construct the single production instance.

## What's NOT in this PR

- **Static-var race fix** (#277 item #2) - deferred. No test currently overrides those statics, so the race doesn't exist today. Pre-emptive churn isn't justified.
- **Migrating the other 8 transcription services to NetworkClient** - Gemini + Custom prove the pattern; opportunistic adoption from here.

## Test plan

- [x] \`swift test\` in Modules/CloudTranscription: 46 tests pass (covers the migrated services - all stub URLSession via existing MockURLSession; tests still pass because NetworkClient transparently wraps the injected session)
- [x] \`xcodebuild test\` for VivaDicta scheme on iPhone 17 Pro Max / iOS 26.4: 22 tests pass (including \`AIServiceNetworkingTests\`)
- [x] Manual audit: only remaining \`OAuthManager.shared\` / \`CopilotOAuthManager.shared\` usage is in CopilotConfigurationView