### PR TITLE
Introduce NetworkService protocol; rename NetworkClient to DefaultNetworkService

### DIFF
--- a/Modules/CloudTranscription/Sources/CloudTranscription/CartesiaTranscriptionService.swift
+++ b/Modules/CloudTranscription/Sources/CloudTranscription/CartesiaTranscriptionService.swift
@@ -31,11 +31,14 @@ public struct CartesiaTranscriptionService: TranscriptionService, Sendable {
     }
 
     private let config: Config
-    private let urlSession: any URLSessionProtocol
+    private let networkService: any NetworkService
 
-    public init(config: Config, urlSession: any URLSessionProtocol = URLSession.shared) {
+    public init(
+        config: Config,
+        networkService: any NetworkService = DefaultNetworkService(category: "CartesiaTranscription")
+    ) {
         self.config = config
-        self.urlSession = urlSession
+        self.networkService = networkService
     }
 
     public func transcribe(audioURL: URL) async throws -> TranscriptionServiceResult {
@@ -60,16 +63,11 @@ public struct CartesiaTranscriptionService: TranscriptionService, Sendable {
 
         let body = try createRequestBody(audioURL: audioURL, boundary: boundary)
 
-        let (data, response) = try await urlSession.upload(for: request, from: body)
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw CloudTranscriptionError.networkError(URLError(.badServerResponse))
-        }
-
-        if !(200...299).contains(httpResponse.statusCode) {
-            let errorMessage = String(data: data, encoding: .utf8) ?? "No error message"
-            logger.logError("Cartesia API request failed with status \(httpResponse.statusCode): \(errorMessage)")
-            throw CloudTranscriptionError.apiRequestFailed(statusCode: httpResponse.statusCode, message: errorMessage)
+        let data: Data
+        do {
+            (data, _) = try await networkService.upload(request, from: body)
+        } catch let error as NetworkError {
+            throw error.asTranscriptionError()
         }
 
         do {

--- a/Modules/CloudTranscription/Sources/CloudTranscription/CohereTranscriptionService.swift
+++ b/Modules/CloudTranscription/Sources/CloudTranscription/CohereTranscriptionService.swift
@@ -27,11 +27,14 @@ public struct CohereTranscriptionService: TranscriptionService, Sendable {
     }
 
     private let config: Config
-    private let urlSession: any URLSessionProtocol
+    private let networkService: any NetworkService
 
-    public init(config: Config, urlSession: any URLSessionProtocol = URLSession.shared) {
+    public init(
+        config: Config,
+        networkService: any NetworkService = DefaultNetworkService(category: "CohereTranscription")
+    ) {
         self.config = config
-        self.urlSession = urlSession
+        self.networkService = networkService
     }
 
     public func transcribe(audioURL: URL) async throws -> TranscriptionServiceResult {
@@ -55,16 +58,11 @@ public struct CohereTranscriptionService: TranscriptionService, Sendable {
 
         let body = try createRequestBody(audioURL: audioURL, boundary: boundary)
 
-        let (data, response) = try await urlSession.upload(for: request, from: body)
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw CloudTranscriptionError.networkError(URLError(.badServerResponse))
-        }
-
-        if !(200...299).contains(httpResponse.statusCode) {
-            let errorMessage = String(data: data, encoding: .utf8) ?? "No error message"
-            logger.logError("Cohere API request failed with status \(httpResponse.statusCode): \(errorMessage)")
-            throw CloudTranscriptionError.apiRequestFailed(statusCode: httpResponse.statusCode, message: errorMessage)
+        let data: Data
+        do {
+            (data, _) = try await networkService.upload(request, from: body)
+        } catch let error as NetworkError {
+            throw error.asTranscriptionError()
         }
 
         do {

--- a/Modules/CloudTranscription/Sources/CloudTranscription/CustomTranscriptionService.swift
+++ b/Modules/CloudTranscription/Sources/CloudTranscription/CustomTranscriptionService.swift
@@ -27,11 +27,14 @@ public struct CustomTranscriptionService: TranscriptionService, Sendable {
     }
 
     private let config: Config
-    private let networkClient: NetworkClient
+    private let networkService: any NetworkService
 
-    public init(config: Config, urlSession: any URLSessionProtocol = URLSession.shared) {
+    public init(
+        config: Config,
+        networkService: any NetworkService = DefaultNetworkService(category: "CustomTranscription")
+    ) {
         self.config = config
-        self.networkClient = NetworkClient(session: urlSession, category: "CustomTranscription")
+        self.networkService = networkService
     }
 
     public func transcribe(audioURL: URL) async throws -> TranscriptionServiceResult {
@@ -63,7 +66,7 @@ public struct CustomTranscriptionService: TranscriptionService, Sendable {
 
         let data: Data
         do {
-            (data, _) = try await networkClient.upload(request, from: body)
+            (data, _) = try await networkService.upload(request, from: body)
         } catch let error as NetworkError {
             throw error.asTranscriptionError()
         }

--- a/Modules/CloudTranscription/Sources/CloudTranscription/DeepgramTranscriptionService.swift
+++ b/Modules/CloudTranscription/Sources/CloudTranscription/DeepgramTranscriptionService.swift
@@ -30,11 +30,14 @@ public struct DeepgramTranscriptionService: TranscriptionService, Sendable {
     }
 
     private let config: Config
-    private let urlSession: any URLSessionProtocol
+    private let networkService: any NetworkService
 
-    public init(config: Config, urlSession: any URLSessionProtocol = URLSession.shared) {
+    public init(
+        config: Config,
+        networkService: any NetworkService = DefaultNetworkService(category: "DeepgramTranscription")
+    ) {
         self.config = config
-        self.urlSession = urlSession
+        self.networkService = networkService
     }
 
     public func transcribe(audioURL: URL) async throws -> TranscriptionServiceResult {
@@ -91,16 +94,11 @@ public struct DeepgramTranscriptionService: TranscriptionService, Sendable {
             throw CloudTranscriptionError.audioFileNotFound
         }
 
-        let (data, response) = try await urlSession.upload(for: request, from: audioData)
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw CloudTranscriptionError.networkError(URLError(.badServerResponse))
-        }
-
-        if !(200...299).contains(httpResponse.statusCode) {
-            let errorMessage = String(data: data, encoding: .utf8) ?? "No error message"
-            logger.logError("Deepgram API request failed with status \(httpResponse.statusCode): \(errorMessage)")
-            throw CloudTranscriptionError.apiRequestFailed(statusCode: httpResponse.statusCode, message: errorMessage)
+        let data: Data
+        do {
+            (data, _) = try await networkService.upload(request, from: audioData)
+        } catch let error as NetworkError {
+            throw error.asTranscriptionError()
         }
 
         do {

--- a/Modules/CloudTranscription/Sources/CloudTranscription/ElevenLabsTranscriptionService.swift
+++ b/Modules/CloudTranscription/Sources/CloudTranscription/ElevenLabsTranscriptionService.swift
@@ -25,11 +25,14 @@ public struct ElevenLabsTranscriptionService: TranscriptionService, Sendable {
     }
 
     private let config: Config
-    private let urlSession: any URLSessionProtocol
+    private let networkService: any NetworkService
 
-    public init(config: Config, urlSession: any URLSessionProtocol = URLSession.shared) {
+    public init(
+        config: Config,
+        networkService: any NetworkService = DefaultNetworkService(category: "ElevenLabsTranscription")
+    ) {
         self.config = config
-        self.urlSession = urlSession
+        self.networkService = networkService
     }
 
     public func transcribe(audioURL: URL) async throws -> TranscriptionServiceResult {
@@ -53,17 +56,11 @@ public struct ElevenLabsTranscriptionService: TranscriptionService, Sendable {
 
         let body = try createRequestBody(audioURL: audioURL, boundary: boundary)
 
-        let (data, response) = try await urlSession.upload(for: request, from: body)
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw CloudTranscriptionError.networkError(URLError(.badServerResponse))
-        }
-
-        logger.logNotice("ElevenLabs API Response Status: \(httpResponse.statusCode)")
-
-        if !(200...299).contains(httpResponse.statusCode) {
-            let errorMessage = String(data: data, encoding: .utf8) ?? "No error message"
-            throw CloudTranscriptionError.apiRequestFailed(statusCode: httpResponse.statusCode, message: errorMessage)
+        let data: Data
+        do {
+            (data, _) = try await networkService.upload(request, from: body)
+        } catch let error as NetworkError {
+            throw error.asTranscriptionError()
         }
 
         do {

--- a/Modules/CloudTranscription/Sources/CloudTranscription/GeminiTranscriptionService.swift
+++ b/Modules/CloudTranscription/Sources/CloudTranscription/GeminiTranscriptionService.swift
@@ -21,11 +21,14 @@ public struct GeminiTranscriptionService: TranscriptionService, Sendable {
     }
 
     private let config: Config
-    private let networkClient: NetworkClient
+    private let networkService: any NetworkService
 
-    public init(config: Config, urlSession: any URLSessionProtocol = URLSession.shared) {
+    public init(
+        config: Config,
+        networkService: any NetworkService = DefaultNetworkService(category: "GeminiTranscription")
+    ) {
         self.config = config
-        self.networkClient = NetworkClient(session: urlSession, category: "GeminiTranscription")
+        self.networkService = networkService
     }
 
     public func transcribe(audioURL: URL) async throws -> TranscriptionServiceResult {
@@ -85,7 +88,7 @@ public struct GeminiTranscriptionService: TranscriptionService, Sendable {
 
         let transcriptionResponse: GeminiResponse
         do {
-            transcriptionResponse = try await networkClient.sendJSON(request, as: GeminiResponse.self)
+            transcriptionResponse = try await networkService.sendJSON(request, as: GeminiResponse.self)
         } catch let error as NetworkError {
             throw error.asTranscriptionError()
         }

--- a/Modules/CloudTranscription/Sources/CloudTranscription/GladiaTranscriptionService.swift
+++ b/Modules/CloudTranscription/Sources/CloudTranscription/GladiaTranscriptionService.swift
@@ -38,11 +38,14 @@ public struct GladiaTranscriptionService: TranscriptionService, Sendable {
     }
 
     private let config: Config
-    private let urlSession: any URLSessionProtocol
+    private let networkService: any NetworkService
 
-    public init(config: Config, urlSession: any URLSessionProtocol = URLSession.shared) {
+    public init(
+        config: Config,
+        networkService: any NetworkService = DefaultNetworkService(category: "GladiaTranscription")
+    ) {
         self.config = config
-        self.urlSession = urlSession
+        self.networkService = networkService
     }
 
     public func transcribe(audioURL: URL) async throws -> TranscriptionServiceResult {
@@ -75,16 +78,11 @@ public struct GladiaTranscriptionService: TranscriptionService, Sendable {
         request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
 
         let body = try createMultipartBody(fileURL: audioURL, boundary: boundary)
-        let (data, response) = try await urlSession.upload(for: request, from: body)
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw CloudTranscriptionError.networkError(URLError(.badServerResponse))
-        }
-
-        if !(200...299).contains(httpResponse.statusCode) {
-            let errorMessage = String(data: data, encoding: .utf8) ?? "No error message"
-            logger.logError("Gladia upload failed with status \(httpResponse.statusCode): \(errorMessage)")
-            throw CloudTranscriptionError.apiRequestFailed(statusCode: httpResponse.statusCode, message: errorMessage)
+        let data: Data
+        do {
+            (data, _) = try await networkService.upload(request, from: body)
+        } catch let error as NetworkError {
+            throw error.asTranscriptionError()
         }
 
         do {
@@ -145,16 +143,11 @@ public struct GladiaTranscriptionService: TranscriptionService, Sendable {
 
         request.httpBody = try JSONSerialization.data(withJSONObject: payload)
 
-        let (data, response) = try await urlSession.data(for: request)
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw CloudTranscriptionError.networkError(URLError(.badServerResponse))
-        }
-
-        if !(200...299).contains(httpResponse.statusCode) {
-            let errorMessage = String(data: data, encoding: .utf8) ?? "No error message"
-            logger.logError("Gladia create transcription failed with status \(httpResponse.statusCode): \(errorMessage)")
-            throw CloudTranscriptionError.apiRequestFailed(statusCode: httpResponse.statusCode, message: errorMessage)
+        let data: Data
+        do {
+            (data, _) = try await networkService.send(request)
+        } catch let error as NetworkError {
+            throw error.asTranscriptionError()
         }
 
         do {
@@ -180,16 +173,11 @@ public struct GladiaTranscriptionService: TranscriptionService, Sendable {
             request.timeoutInterval = NetworkRetry.defaultTimeout
             request.setValue(config.apiKey, forHTTPHeaderField: "x-gladia-key")
 
-            let (data, response) = try await urlSession.data(for: request)
-
-            guard let httpResponse = response as? HTTPURLResponse else {
-                throw CloudTranscriptionError.networkError(URLError(.badServerResponse))
-            }
-
-            if !(200...299).contains(httpResponse.statusCode) {
-                let errorMessage = String(data: data, encoding: .utf8) ?? "No error message"
-                logger.logError("Gladia status poll failed with status \(httpResponse.statusCode): \(errorMessage)")
-                throw CloudTranscriptionError.apiRequestFailed(statusCode: httpResponse.statusCode, message: errorMessage)
+            let data: Data
+            do {
+                (data, _) = try await networkService.send(request)
+            } catch let error as NetworkError {
+                throw error.asTranscriptionError()
             }
 
             if let status = try? JSONDecoder().decode(StatusResponse.self, from: data) {

--- a/Modules/CloudTranscription/Sources/CloudTranscription/GroqTranscriptionService.swift
+++ b/Modules/CloudTranscription/Sources/CloudTranscription/GroqTranscriptionService.swift
@@ -27,11 +27,14 @@ public struct GroqTranscriptionService: TranscriptionService, Sendable {
     }
 
     private let config: Config
-    private let urlSession: any URLSessionProtocol
+    private let networkService: any NetworkService
 
-    public init(config: Config, urlSession: any URLSessionProtocol = URLSession.shared) {
+    public init(
+        config: Config,
+        networkService: any NetworkService = DefaultNetworkService(category: "GroqTranscription")
+    ) {
         self.config = config
-        self.urlSession = urlSession
+        self.networkService = networkService
     }
 
     public func transcribe(audioURL: URL) async throws -> TranscriptionServiceResult {
@@ -56,16 +59,11 @@ public struct GroqTranscriptionService: TranscriptionService, Sendable {
 
         let body = try createRequestBody(audioURL: audioURL, boundary: boundary)
 
-        let (data, response) = try await urlSession.upload(for: request, from: body)
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw CloudTranscriptionError.networkError(URLError(.badServerResponse))
-        }
-
-        if !(200...299).contains(httpResponse.statusCode) {
-            let errorMessage = String(data: data, encoding: .utf8) ?? "No error message"
-            logger.logError("Groq API request failed with status \(httpResponse.statusCode): \(errorMessage)")
-            throw CloudTranscriptionError.apiRequestFailed(statusCode: httpResponse.statusCode, message: errorMessage)
+        let data: Data
+        do {
+            (data, _) = try await networkService.upload(request, from: body)
+        } catch let error as NetworkError {
+            throw error.asTranscriptionError()
         }
 
         do {

--- a/Modules/CloudTranscription/Sources/CloudTranscription/MistralTranscriptionService.swift
+++ b/Modules/CloudTranscription/Sources/CloudTranscription/MistralTranscriptionService.swift
@@ -39,11 +39,14 @@ public struct MistralTranscriptionService: TranscriptionService, Sendable {
     }
 
     private let config: Config
-    private let urlSession: any URLSessionProtocol
+    private let networkService: any NetworkService
 
-    public init(config: Config, urlSession: any URLSessionProtocol = URLSession.shared) {
+    public init(
+        config: Config,
+        networkService: any NetworkService = DefaultNetworkService(category: "MistralTranscription")
+    ) {
         self.config = config
-        self.urlSession = urlSession
+        self.networkService = networkService
     }
 
     public func transcribe(audioURL: URL) async throws -> TranscriptionServiceResult {
@@ -67,16 +70,11 @@ public struct MistralTranscriptionService: TranscriptionService, Sendable {
 
         let body = try createRequestBody(audioURL: audioURL, boundary: boundary)
 
-        let (data, response) = try await urlSession.upload(for: request, from: body)
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw CloudTranscriptionError.networkError(URLError(.badServerResponse))
-        }
-
-        if !(200...299).contains(httpResponse.statusCode) {
-            let errorMessage = String(data: data, encoding: .utf8) ?? "No error message"
-            logger.logError("Mistral API request failed with status \(httpResponse.statusCode): \(errorMessage)")
-            throw CloudTranscriptionError.apiRequestFailed(statusCode: httpResponse.statusCode, message: errorMessage)
+        let data: Data
+        do {
+            (data, _) = try await networkService.upload(request, from: body)
+        } catch let error as NetworkError {
+            throw error.asTranscriptionError()
         }
 
         do {

--- a/Modules/CloudTranscription/Sources/CloudTranscription/OpenAITranscriptionService.swift
+++ b/Modules/CloudTranscription/Sources/CloudTranscription/OpenAITranscriptionService.swift
@@ -26,11 +26,14 @@ public struct OpenAITranscriptionService: TranscriptionService, Sendable {
     }
 
     private let config: Config
-    private let urlSession: any URLSessionProtocol
+    private let networkService: any NetworkService
 
-    public init(config: Config, urlSession: any URLSessionProtocol = URLSession.shared) {
+    public init(
+        config: Config,
+        networkService: any NetworkService = DefaultNetworkService(category: "OpenAITranscription")
+    ) {
         self.config = config
-        self.urlSession = urlSession
+        self.networkService = networkService
     }
 
     public func transcribe(audioURL: URL) async throws -> TranscriptionServiceResult {
@@ -55,16 +58,11 @@ public struct OpenAITranscriptionService: TranscriptionService, Sendable {
 
         let body = try createOpenAICompatibleRequestBody(audioURL: audioURL, boundary: boundary)
 
-        let (data, response) = try await urlSession.upload(for: request, from: body)
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw CloudTranscriptionError.networkError(URLError(.badServerResponse))
-        }
-
-        if !(200...299).contains(httpResponse.statusCode) {
-            let errorMessage = String(data: data, encoding: .utf8) ?? "No error message"
-            logger.logError("OpenAI API request failed with status \(httpResponse.statusCode): \(errorMessage)")
-            throw CloudTranscriptionError.apiRequestFailed(statusCode: httpResponse.statusCode, message: errorMessage)
+        let data: Data
+        do {
+            (data, _) = try await networkService.upload(request, from: body)
+        } catch let error as NetworkError {
+            throw error.asTranscriptionError()
         }
 
         do {

--- a/Modules/CloudTranscription/Sources/CloudTranscription/SonioxTranscriptionService.swift
+++ b/Modules/CloudTranscription/Sources/CloudTranscription/SonioxTranscriptionService.swift
@@ -39,11 +39,14 @@ public struct SonioxTranscriptionService: TranscriptionService, Sendable {
     }
 
     private let config: Config
-    private let urlSession: any URLSessionProtocol
+    private let networkService: any NetworkService
 
-    public init(config: Config, urlSession: any URLSessionProtocol = URLSession.shared) {
+    public init(
+        config: Config,
+        networkService: any NetworkService = DefaultNetworkService(category: "SonioxTranscription")
+    ) {
         self.config = config
-        self.urlSession = urlSession
+        self.networkService = networkService
     }
 
     public func transcribe(audioURL: URL) async throws -> TranscriptionServiceResult {
@@ -77,16 +80,11 @@ public struct SonioxTranscriptionService: TranscriptionService, Sendable {
         request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
 
         let body = try createMultipartBody(fileURL: audioURL, boundary: boundary)
-        let (data, response) = try await urlSession.upload(for: request, from: body)
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw CloudTranscriptionError.networkError(URLError(.badServerResponse))
-        }
-
-        if !(200...299).contains(httpResponse.statusCode) {
-            let errorMessage = String(data: data, encoding: .utf8) ?? "No error message"
-            logger.logError("Soniox file upload failed with status \(httpResponse.statusCode): \(errorMessage)")
-            throw CloudTranscriptionError.apiRequestFailed(statusCode: httpResponse.statusCode, message: errorMessage)
+        let data: Data
+        do {
+            (data, _) = try await networkService.upload(request, from: body)
+        } catch let error as NetworkError {
+            throw error.asTranscriptionError()
         }
 
         do {
@@ -137,16 +135,11 @@ public struct SonioxTranscriptionService: TranscriptionService, Sendable {
 
         request.httpBody = try JSONSerialization.data(withJSONObject: payload)
 
-        let (data, response) = try await urlSession.data(for: request)
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw CloudTranscriptionError.networkError(URLError(.badServerResponse))
-        }
-
-        if !(200...299).contains(httpResponse.statusCode) {
-            let errorMessage = String(data: data, encoding: .utf8) ?? "No error message"
-            logger.logError("Soniox create transcription failed with status \(httpResponse.statusCode): \(errorMessage)")
-            throw CloudTranscriptionError.apiRequestFailed(statusCode: httpResponse.statusCode, message: errorMessage)
+        let data: Data
+        do {
+            (data, _) = try await networkService.send(request)
+        } catch let error as NetworkError {
+            throw error.asTranscriptionError()
         }
 
         do {
@@ -172,16 +165,11 @@ public struct SonioxTranscriptionService: TranscriptionService, Sendable {
             request.timeoutInterval = NetworkRetry.defaultTimeout
             request.setValue("Bearer \(config.apiKey)", forHTTPHeaderField: "Authorization")
 
-            let (data, response) = try await urlSession.data(for: request)
-
-            guard let httpResponse = response as? HTTPURLResponse else {
-                throw CloudTranscriptionError.networkError(URLError(.badServerResponse))
-            }
-
-            if !(200...299).contains(httpResponse.statusCode) {
-                let errorMessage = String(data: data, encoding: .utf8) ?? "No error message"
-                logger.logError("Soniox status poll failed with status \(httpResponse.statusCode): \(errorMessage)")
-                throw CloudTranscriptionError.apiRequestFailed(statusCode: httpResponse.statusCode, message: errorMessage)
+            let data: Data
+            do {
+                (data, _) = try await networkService.send(request)
+            } catch let error as NetworkError {
+                throw error.asTranscriptionError()
             }
 
             if let status = try? JSONDecoder().decode(TranscriptionStatusResponse.self, from: data) {
@@ -216,16 +204,11 @@ public struct SonioxTranscriptionService: TranscriptionService, Sendable {
         request.timeoutInterval = NetworkRetry.defaultTimeout
         request.setValue("Bearer \(config.apiKey)", forHTTPHeaderField: "Authorization")
 
-        let (data, response) = try await urlSession.data(for: request)
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw CloudTranscriptionError.networkError(URLError(.badServerResponse))
-        }
-
-        if !(200...299).contains(httpResponse.statusCode) {
-            let errorMessage = String(data: data, encoding: .utf8) ?? "No error message"
-            logger.logError("Soniox fetch transcript failed with status \(httpResponse.statusCode): \(errorMessage)")
-            throw CloudTranscriptionError.apiRequestFailed(statusCode: httpResponse.statusCode, message: errorMessage)
+        let data: Data
+        do {
+            (data, _) = try await networkService.send(request)
+        } catch let error as NetworkError {
+            throw error.asTranscriptionError()
         }
 
         if let decoded = try? JSONDecoder().decode(TranscriptResponse.self, from: data) {

--- a/Modules/CloudTranscription/Sources/CloudTranscription/SpeechmaticsTranscriptionService.swift
+++ b/Modules/CloudTranscription/Sources/CloudTranscription/SpeechmaticsTranscriptionService.swift
@@ -38,11 +38,14 @@ public struct SpeechmaticsTranscriptionService: TranscriptionService, Sendable {
     }
 
     private let config: Config
-    private let urlSession: any URLSessionProtocol
+    private let networkService: any NetworkService
 
-    public init(config: Config, urlSession: any URLSessionProtocol = URLSession.shared) {
+    public init(
+        config: Config,
+        networkService: any NetworkService = DefaultNetworkService(category: "SpeechmaticsTranscription")
+    ) {
         self.config = config
-        self.urlSession = urlSession
+        self.networkService = networkService
     }
 
     public func transcribe(audioURL: URL) async throws -> TranscriptionServiceResult {
@@ -115,16 +118,11 @@ public struct SpeechmaticsTranscriptionService: TranscriptionService, Sendable {
 
         let body = try createMultipartBody(fileURL: audioURL, configJSON: configString, boundary: boundary)
 
-        let (data, response) = try await urlSession.upload(for: request, from: body)
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw CloudTranscriptionError.networkError(URLError(.badServerResponse))
-        }
-
-        if !(200...299).contains(httpResponse.statusCode) {
-            let errorMessage = String(data: data, encoding: .utf8) ?? "No error message"
-            logger.logError("Speechmatics create job failed with status \(httpResponse.statusCode): \(errorMessage)")
-            throw CloudTranscriptionError.apiRequestFailed(statusCode: httpResponse.statusCode, message: errorMessage)
+        let data: Data
+        do {
+            (data, _) = try await networkService.upload(request, from: body)
+        } catch let error as NetworkError {
+            throw error.asTranscriptionError()
         }
 
         do {
@@ -150,16 +148,11 @@ public struct SpeechmaticsTranscriptionService: TranscriptionService, Sendable {
             request.timeoutInterval = NetworkRetry.defaultTimeout
             request.setValue("Bearer \(config.apiKey)", forHTTPHeaderField: "Authorization")
 
-            let (data, response) = try await urlSession.data(for: request)
-
-            guard let httpResponse = response as? HTTPURLResponse else {
-                throw CloudTranscriptionError.networkError(URLError(.badServerResponse))
-            }
-
-            if !(200...299).contains(httpResponse.statusCode) {
-                let errorMessage = String(data: data, encoding: .utf8) ?? "No error message"
-                logger.logError("Speechmatics status poll failed with status \(httpResponse.statusCode): \(errorMessage)")
-                throw CloudTranscriptionError.apiRequestFailed(statusCode: httpResponse.statusCode, message: errorMessage)
+            let data: Data
+            do {
+                (data, _) = try await networkService.send(request)
+            } catch let error as NetworkError {
+                throw error.asTranscriptionError()
             }
 
             if let status = try? JSONDecoder().decode(JobStatusResponse.self, from: data) {
@@ -194,16 +187,11 @@ public struct SpeechmaticsTranscriptionService: TranscriptionService, Sendable {
         request.timeoutInterval = NetworkRetry.defaultTimeout
         request.setValue("Bearer \(config.apiKey)", forHTTPHeaderField: "Authorization")
 
-        let (data, response) = try await urlSession.data(for: request)
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw CloudTranscriptionError.networkError(URLError(.badServerResponse))
-        }
-
-        if !(200...299).contains(httpResponse.statusCode) {
-            let errorMessage = String(data: data, encoding: .utf8) ?? "No error message"
-            logger.logError("Speechmatics fetch transcript failed with status \(httpResponse.statusCode): \(errorMessage)")
-            throw CloudTranscriptionError.apiRequestFailed(statusCode: httpResponse.statusCode, message: errorMessage)
+        let data: Data
+        do {
+            (data, _) = try await networkService.send(request)
+        } catch let error as NetworkError {
+            throw error.asTranscriptionError()
         }
 
         guard let decoded = try? JSONDecoder().decode(TranscriptResponse.self, from: data) else {

--- a/Modules/CloudTranscription/Sources/CloudTranscription/XaiTranscriptionService.swift
+++ b/Modules/CloudTranscription/Sources/CloudTranscription/XaiTranscriptionService.swift
@@ -31,11 +31,14 @@ public struct XaiTranscriptionService: TranscriptionService, Sendable {
     }
 
     private let config: Config
-    private let urlSession: any URLSessionProtocol
+    private let networkService: any NetworkService
 
-    public init(config: Config, urlSession: any URLSessionProtocol = URLSession.shared) {
+    public init(
+        config: Config,
+        networkService: any NetworkService = DefaultNetworkService(category: "XaiTranscription")
+    ) {
         self.config = config
-        self.urlSession = urlSession
+        self.networkService = networkService
     }
 
     public func transcribe(audioURL: URL) async throws -> TranscriptionServiceResult {
@@ -60,16 +63,11 @@ public struct XaiTranscriptionService: TranscriptionService, Sendable {
 
         let body = try createRequestBody(audioURL: audioURL, boundary: boundary)
 
-        let (data, response) = try await urlSession.upload(for: request, from: body)
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw CloudTranscriptionError.networkError(URLError(.badServerResponse))
-        }
-
-        if !(200...299).contains(httpResponse.statusCode) {
-            let errorMessage = String(data: data, encoding: .utf8) ?? "No error message"
-            logger.logError("xAI STT request failed with status \(httpResponse.statusCode): \(errorMessage)")
-            throw CloudTranscriptionError.apiRequestFailed(statusCode: httpResponse.statusCode, message: errorMessage)
+        let data: Data
+        do {
+            (data, _) = try await networkService.upload(request, from: body)
+        } catch let error as NetworkError {
+            throw error.asTranscriptionError()
         }
 
         do {

--- a/Modules/CloudTranscription/Tests/CloudTranscriptionTests/GroqTranscriptionServiceTests.swift
+++ b/Modules/CloudTranscription/Tests/CloudTranscriptionTests/GroqTranscriptionServiceTests.swift
@@ -8,7 +8,7 @@ import Testing
 import TranscriptionCore
 
 /// Tests exercise `GroqTranscriptionService` end-to-end with a stubbed
-/// `MockURLSession`. Verifies request shape (URL, method, headers,
+/// `MockNetworkService`. Verifies request shape (URL, method, headers,
 /// multipart body) and response handling (success, non-2xx, undecodable
 /// JSON), plus the Groq-specific vocabulary-prompt path.
 ///
@@ -34,13 +34,13 @@ struct GroqTranscriptionServiceTests {
         )!
     }
 
-    private func stubSuccess(on session: MockURLSession, text: String) {
+    private func stubSuccess(on session: MockNetworkService, text: String) {
         let body = Data(#"{"text":"\#(text)","language":"en","duration":0.5}"#.utf8)
         session.stubUploadResponse = .success((body, makeHTTPResponse(200)))
     }
 
     private func makeService(
-        session: MockURLSession,
+        session: MockNetworkService,
         apiKey: String = "gsk-test-key",
         modelName: String = "whisper-large-v3",
         language: String = "auto",
@@ -53,14 +53,14 @@ struct GroqTranscriptionServiceTests {
                 language: language,
                 vocabulary: vocabulary
             ),
-            urlSession: session
+            networkService: session
         )
     }
 
     // MARK: - Success path
 
     @Test func successReturnsTranscribedText() async throws {
-        let session = MockURLSession()
+        let session = MockNetworkService()
         stubSuccess(on: session, text: "groq hello")
         let audio = try makeAudioFile()
         let sut = makeService(session: session)
@@ -75,7 +75,7 @@ struct GroqTranscriptionServiceTests {
     // MARK: - Request shape
 
     @Test func requestTargetsGroqTranscriptionsEndpoint() async throws {
-        let session = MockURLSession()
+        let session = MockNetworkService()
         stubSuccess(on: session, text: "ok")
         let audio = try makeAudioFile()
         let sut = makeService(session: session)
@@ -88,7 +88,7 @@ struct GroqTranscriptionServiceTests {
     }
 
     @Test func requestSendsBearerAuthorizationHeader() async throws {
-        let session = MockURLSession()
+        let session = MockNetworkService()
         stubSuccess(on: session, text: "ok")
         let audio = try makeAudioFile()
         let sut = makeService(session: session, apiKey: "gsk-abc123")
@@ -100,7 +100,7 @@ struct GroqTranscriptionServiceTests {
     }
 
     @Test func requestSendsMultipartContentTypeWithBoundary() async throws {
-        let session = MockURLSession()
+        let session = MockNetworkService()
         stubSuccess(on: session, text: "ok")
         let audio = try makeAudioFile()
         let sut = makeService(session: session)
@@ -113,7 +113,7 @@ struct GroqTranscriptionServiceTests {
     }
 
     @Test func bodyContainsModelAndResponseFormatFields() async throws {
-        let session = MockURLSession()
+        let session = MockNetworkService()
         stubSuccess(on: session, text: "ok")
         let audio = try makeAudioFile()
         let sut = makeService(session: session, modelName: "whisper-large-v3")
@@ -128,7 +128,7 @@ struct GroqTranscriptionServiceTests {
     }
 
     @Test func bodyIncludesLanguageFieldWhenNotAuto() async throws {
-        let session = MockURLSession()
+        let session = MockNetworkService()
         stubSuccess(on: session, text: "ok")
         let audio = try makeAudioFile()
         let sut = makeService(session: session, language: "fr")
@@ -141,7 +141,7 @@ struct GroqTranscriptionServiceTests {
     }
 
     @Test func bodyOmitsLanguageFieldWhenAuto() async throws {
-        let session = MockURLSession()
+        let session = MockNetworkService()
         stubSuccess(on: session, text: "ok")
         let audio = try makeAudioFile()
         let sut = makeService(session: session, language: "auto")
@@ -156,7 +156,7 @@ struct GroqTranscriptionServiceTests {
     // MARK: - Vocabulary / prompt (Groq-specific)
 
     @Test func bodyOmitsPromptFieldWhenVocabularyIsEmpty() async throws {
-        let session = MockURLSession()
+        let session = MockNetworkService()
         stubSuccess(on: session, text: "ok")
         let audio = try makeAudioFile()
         let sut = makeService(session: session, vocabulary: [])
@@ -169,7 +169,7 @@ struct GroqTranscriptionServiceTests {
     }
 
     @Test func bodyIncludesPromptFieldWhenVocabularyProvided() async throws {
-        let session = MockURLSession()
+        let session = MockNetworkService()
         stubSuccess(on: session, text: "ok")
         let audio = try makeAudioFile()
         let sut = makeService(session: session, vocabulary: ["SwiftUI", "Kubernetes"])
@@ -186,7 +186,7 @@ struct GroqTranscriptionServiceTests {
     // MARK: - Validation / short-circuit
 
     @Test func missingAPIKeyThrowsBeforeMakingRequest() async throws {
-        let session = MockURLSession()
+        let session = MockNetworkService()
         let audio = try makeAudioFile()
         let sut = makeService(session: session, apiKey: "")
 
@@ -197,7 +197,7 @@ struct GroqTranscriptionServiceTests {
     }
 
     @Test func missingAudioFileThrowsAudioFileNotFound() async {
-        let session = MockURLSession()
+        let session = MockNetworkService()
         let audio = URL.temporaryDirectory.appending(path: "definitely-not-a-real-file-\(UUID()).wav")
         let sut = makeService(session: session)
 
@@ -209,7 +209,7 @@ struct GroqTranscriptionServiceTests {
     // MARK: - Response handling
 
     @Test func nonSuccessStatusThrowsApiRequestFailed() async throws {
-        let session = MockURLSession()
+        let session = MockNetworkService()
         session.stubUploadResponse = .success((
             Data(#"{"error":"invalid key"}"#.utf8),
             makeHTTPResponse(401)
@@ -229,7 +229,7 @@ struct GroqTranscriptionServiceTests {
     }
 
     @Test func undecodableJSONOn200ThrowsNoTranscriptionReturned() async throws {
-        let session = MockURLSession()
+        let session = MockNetworkService()
         session.stubUploadResponse = .success((Data("not json".utf8), makeHTTPResponse(200)))
         let audio = try makeAudioFile()
         let sut = makeService(session: session)

--- a/Modules/CloudTranscription/Tests/CloudTranscriptionTests/OpenAITranscriptionServiceTests.swift
+++ b/Modules/CloudTranscription/Tests/CloudTranscriptionTests/OpenAITranscriptionServiceTests.swift
@@ -8,14 +8,14 @@ import Testing
 import TranscriptionCore
 
 /// Tests exercise `OpenAITranscriptionService` end-to-end with a stubbed
-/// `MockURLSession` (`URLSessionProtocol` conformer from `NetworkingMocks`).
+/// `MockNetworkService` (`URLSessionProtocol` conformer from `NetworkingMocks`).
 /// Verifies request shape (URL, method, headers, multipart body) and
 /// response handling (success, non-2xx, undecodable JSON).
 ///
 /// Retry-path tests are intentionally skipped here - retry semantics belong
 /// on `NetworkRetry`'s own tests.
 ///
-/// Each test creates a fresh `MockURLSession`, so there's no shared mutable
+/// Each test creates a fresh `MockNetworkService`, so there's no shared mutable
 /// state and the suite is safe to run in parallel with other suites.
 struct OpenAITranscriptionServiceTests {
 
@@ -39,27 +39,27 @@ struct OpenAITranscriptionServiceTests {
         )!
     }
 
-    private func stubSuccess(on session: MockURLSession, text: String) {
+    private func stubSuccess(on session: MockNetworkService, text: String) {
         let body = Data(#"{"text":"\#(text)","language":"en","duration":0.5}"#.utf8)
         session.stubUploadResponse = .success((body, makeHTTPResponse(200)))
     }
 
     private func makeService(
-        session: MockURLSession,
+        session: MockNetworkService,
         apiKey: String = "sk-test-key",
         modelName: String = "whisper-1",
         language: String = "auto"
     ) -> OpenAITranscriptionService {
         OpenAITranscriptionService(
             config: .init(apiKey: apiKey, modelName: modelName, language: language),
-            urlSession: session
+            networkService: session
         )
     }
 
     // MARK: - Success path
 
     @Test func successReturnsTranscribedText() async throws {
-        let session = MockURLSession()
+        let session = MockNetworkService()
         stubSuccess(on: session, text: "hello world")
         let audio = try makeAudioFile()
 
@@ -74,7 +74,7 @@ struct OpenAITranscriptionServiceTests {
     // MARK: - Request shape
 
     @Test func requestTargetsOpenAITranscriptionsEndpoint() async throws {
-        let session = MockURLSession()
+        let session = MockNetworkService()
         stubSuccess(on: session, text: "ok")
         let audio = try makeAudioFile()
 
@@ -87,7 +87,7 @@ struct OpenAITranscriptionServiceTests {
     }
 
     @Test func requestSendsBearerAuthorizationHeader() async throws {
-        let session = MockURLSession()
+        let session = MockNetworkService()
         stubSuccess(on: session, text: "ok")
         let audio = try makeAudioFile()
 
@@ -99,7 +99,7 @@ struct OpenAITranscriptionServiceTests {
     }
 
     @Test func requestSendsMultipartContentTypeWithBoundary() async throws {
-        let session = MockURLSession()
+        let session = MockNetworkService()
         stubSuccess(on: session, text: "ok")
         let audio = try makeAudioFile()
 
@@ -112,7 +112,7 @@ struct OpenAITranscriptionServiceTests {
     }
 
     @Test func bodyContainsModelAndResponseFormatFields() async throws {
-        let session = MockURLSession()
+        let session = MockNetworkService()
         stubSuccess(on: session, text: "ok")
         let audio = try makeAudioFile()
 
@@ -130,7 +130,7 @@ struct OpenAITranscriptionServiceTests {
     }
 
     @Test func bodyIncludesLanguageFieldWhenNotAuto() async throws {
-        let session = MockURLSession()
+        let session = MockNetworkService()
         stubSuccess(on: session, text: "ok")
         let audio = try makeAudioFile()
 
@@ -143,7 +143,7 @@ struct OpenAITranscriptionServiceTests {
     }
 
     @Test func bodyOmitsLanguageFieldWhenAuto() async throws {
-        let session = MockURLSession()
+        let session = MockNetworkService()
         stubSuccess(on: session, text: "ok")
         let audio = try makeAudioFile()
 
@@ -158,7 +158,7 @@ struct OpenAITranscriptionServiceTests {
     // MARK: - Validation / short-circuit
 
     @Test func missingAPIKeyThrowsBeforeMakingRequest() async throws {
-        let session = MockURLSession()
+        let session = MockNetworkService()
         let audio = try makeAudioFile()
         let sut = makeService(session: session, apiKey: "")
 
@@ -169,7 +169,7 @@ struct OpenAITranscriptionServiceTests {
     }
 
     @Test func missingAudioFileThrowsAudioFileNotFound() async {
-        let session = MockURLSession()
+        let session = MockNetworkService()
         let audio = URL.temporaryDirectory.appending(path: "definitely-not-a-real-file-\(UUID()).wav")
         let sut = makeService(session: session)
 
@@ -182,7 +182,7 @@ struct OpenAITranscriptionServiceTests {
 
     @Test func nonSuccessStatusThrowsApiRequestFailed() async throws {
         // 401 is not retried (only 429 + 5xx are), so this throws immediately.
-        let session = MockURLSession()
+        let session = MockNetworkService()
         session.stubUploadResponse = .success((
             Data(#"{"error":"invalid key"}"#.utf8),
             makeHTTPResponse(401)
@@ -202,7 +202,7 @@ struct OpenAITranscriptionServiceTests {
     }
 
     @Test func undecodableJSONOn200ThrowsNoTranscriptionReturned() async throws {
-        let session = MockURLSession()
+        let session = MockNetworkService()
         session.stubUploadResponse = .success((Data("not json".utf8), makeHTTPResponse(200)))
         let audio = try makeAudioFile()
         let sut = makeService(session: session)

--- a/Modules/CloudTranscription/Tests/CloudTranscriptionTests/XaiTranscriptionServiceTests.swift
+++ b/Modules/CloudTranscription/Tests/CloudTranscriptionTests/XaiTranscriptionServiceTests.swift
@@ -8,7 +8,7 @@ import Testing
 import TranscriptionCore
 
 /// Tests exercise `XaiTranscriptionService` end-to-end with a stubbed
-/// `MockURLSession`. Verifies request shape (URL, method, headers,
+/// `MockNetworkService`. Verifies request shape (URL, method, headers,
 /// multipart body) and response handling (success, non-2xx, undecodable
 /// JSON), plus the xAI-specific `format`/`file-last` body ordering.
 struct XaiTranscriptionServiceTests {
@@ -30,13 +30,13 @@ struct XaiTranscriptionServiceTests {
         )!
     }
 
-    private func stubSuccess(on session: MockURLSession, text: String) {
+    private func stubSuccess(on session: MockNetworkService, text: String) {
         let body = Data(#"{"text":"\#(text)"}"#.utf8)
         session.stubUploadResponse = .success((body, makeHTTPResponse(200)))
     }
 
     private func makeService(
-        session: MockURLSession,
+        session: MockNetworkService,
         apiKey: String = "xai-test-key",
         language: String = "en",
         formatted: Bool = true
@@ -47,14 +47,14 @@ struct XaiTranscriptionServiceTests {
                 language: language,
                 formatted: formatted
             ),
-            urlSession: session
+            networkService: session
         )
     }
 
     // MARK: - Success path
 
     @Test func successReturnsTranscribedText() async throws {
-        let session = MockURLSession()
+        let session = MockNetworkService()
         stubSuccess(on: session, text: "xai hello")
         let audio = try makeAudioFile()
         let sut = makeService(session: session)
@@ -69,7 +69,7 @@ struct XaiTranscriptionServiceTests {
     // MARK: - Request shape
 
     @Test func requestTargetsXaiSttEndpoint() async throws {
-        let session = MockURLSession()
+        let session = MockNetworkService()
         stubSuccess(on: session, text: "ok")
         let audio = try makeAudioFile()
         let sut = makeService(session: session)
@@ -82,7 +82,7 @@ struct XaiTranscriptionServiceTests {
     }
 
     @Test func requestSendsBearerAuthorizationHeader() async throws {
-        let session = MockURLSession()
+        let session = MockNetworkService()
         stubSuccess(on: session, text: "ok")
         let audio = try makeAudioFile()
         let sut = makeService(session: session, apiKey: "xai-abc123")
@@ -94,7 +94,7 @@ struct XaiTranscriptionServiceTests {
     }
 
     @Test func requestSendsMultipartContentTypeWithBoundary() async throws {
-        let session = MockURLSession()
+        let session = MockNetworkService()
         stubSuccess(on: session, text: "ok")
         let audio = try makeAudioFile()
         let sut = makeService(session: session)
@@ -107,7 +107,7 @@ struct XaiTranscriptionServiceTests {
     }
 
     @Test func bodyContainsFormatTrueByDefault() async throws {
-        let session = MockURLSession()
+        let session = MockNetworkService()
         stubSuccess(on: session, text: "ok")
         let audio = try makeAudioFile()
         let sut = makeService(session: session)
@@ -120,7 +120,7 @@ struct XaiTranscriptionServiceTests {
     }
 
     @Test func bodySendsFormatFalseWhenFormattedDisabled() async throws {
-        let session = MockURLSession()
+        let session = MockNetworkService()
         stubSuccess(on: session, text: "ok")
         let audio = try makeAudioFile()
         let sut = makeService(session: session, formatted: false)
@@ -133,7 +133,7 @@ struct XaiTranscriptionServiceTests {
     }
 
     @Test func bodyIncludesLanguageField() async throws {
-        let session = MockURLSession()
+        let session = MockNetworkService()
         stubSuccess(on: session, text: "ok")
         let audio = try makeAudioFile()
         let sut = makeService(session: session, language: "fr")
@@ -149,7 +149,7 @@ struct XaiTranscriptionServiceTests {
         // xAI rejects format=true without a language, so the service must
         // never omit the field. Verify with `fil` (Filipino) since it's xAI's
         // 3-letter outlier and proves no "drop if not in allowlist" sneaks in.
-        let session = MockURLSession()
+        let session = MockNetworkService()
         stubSuccess(on: session, text: "ok")
         let audio = try makeAudioFile()
         let sut = makeService(session: session, language: "fil")
@@ -162,7 +162,7 @@ struct XaiTranscriptionServiceTests {
     }
 
     @Test func bodyOrdersFieldsAsFormatLanguageFile() async throws {
-        let session = MockURLSession()
+        let session = MockNetworkService()
         stubSuccess(on: session, text: "ok")
         let audio = try makeAudioFile()
         let sut = makeService(session: session, language: "en")
@@ -183,7 +183,7 @@ struct XaiTranscriptionServiceTests {
     // MARK: - Validation / short-circuit
 
     @Test func missingAPIKeyThrowsBeforeMakingRequest() async throws {
-        let session = MockURLSession()
+        let session = MockNetworkService()
         let audio = try makeAudioFile()
         let sut = makeService(session: session, apiKey: "")
 
@@ -194,7 +194,7 @@ struct XaiTranscriptionServiceTests {
     }
 
     @Test func missingAudioFileThrowsAudioFileNotFound() async {
-        let session = MockURLSession()
+        let session = MockNetworkService()
         let audio = URL.temporaryDirectory.appending(path: "definitely-not-a-real-file-\(UUID()).wav")
         let sut = makeService(session: session)
 
@@ -206,7 +206,7 @@ struct XaiTranscriptionServiceTests {
     // MARK: - Response handling
 
     @Test func nonSuccessStatusThrowsApiRequestFailed() async throws {
-        let session = MockURLSession()
+        let session = MockNetworkService()
         session.stubUploadResponse = .success((
             Data(#"{"error":"invalid key"}"#.utf8),
             makeHTTPResponse(401)
@@ -226,7 +226,7 @@ struct XaiTranscriptionServiceTests {
     }
 
     @Test func undecodableJSONOn200ThrowsNoTranscriptionReturned() async throws {
-        let session = MockURLSession()
+        let session = MockNetworkService()
         session.stubUploadResponse = .success((Data("not json".utf8), makeHTTPResponse(200)))
         let audio = try makeAudioFile()
         let sut = makeService(session: session)

--- a/Modules/Networking/Sources/Networking/DefaultNetworkService.swift
+++ b/Modules/Networking/Sources/Networking/DefaultNetworkService.swift
@@ -3,36 +3,44 @@
 import Foundation
 import os
 
-/// Thin wrapper around `URLSessionProtocol` that centralizes the boilerplate
-/// each HTTP-talking client used to repeat: status code validation, JSON
-/// decoding, logging of non-2xx bodies, and translation of underlying URL
-/// errors into a structured ``NetworkError``.
+/// Production conformance to ``NetworkService``. Thin wrapper around
+/// `URLSessionProtocol` that centralizes the boilerplate each HTTP-talking
+/// client used to repeat: status code validation, JSON decoding, logging of
+/// non-2xx bodies, and translation of underlying URL errors into a structured
+/// ``NetworkError``.
 ///
-/// Designed to be cheap to construct and `Sendable`: hold one in a service or
-/// create per-request. Production callers default to `URLSession.shared`;
-/// tests inject a `MockURLSession`.
+/// `URLSessionProtocol` injection is an implementation detail of this type --
+/// it exists so the Networking module's own tests can verify request shapes
+/// via `MockURLSession`. Consumer code should depend on `NetworkService` and
+/// fake it via `MockNetworkService` from `NetworkingMocks`.
 ///
 /// ## Typical usage
 ///
 /// ```swift
 /// struct GeminiClient {
-///     private let client = NetworkClient(category: "Gemini")
+///     private let networkService: any NetworkService
+///
+///     init(networkService: any NetworkService = DefaultNetworkService(category: "Gemini")) {
+///         self.networkService = networkService
+///     }
 ///
 ///     func fetchModels() async throws -> [Model] {
 ///         var request = URLRequest(url: modelsURL)
 ///         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
-///         return try await client.sendJSON(request, as: ModelsResponse.self).models
+///         return try await networkService.sendJSON(request, as: ModelsResponse.self).models
 ///     }
 /// }
 /// ```
-public struct NetworkClient: Sendable {
+public struct DefaultNetworkService: NetworkService, Sendable {
     private let session: any URLSessionProtocol
     private let logger: Logger
-    private let acceptableStatusCodes: Set<Int>
+    private let defaultAcceptableStatusCodes: Set<Int>
 
     /// - Parameters:
     ///   - session: Injected URLSession. Defaults to `URLSession.shared` for
-    ///     production callers; tests pass a `MockURLSession`.
+    ///     production callers; the Networking module's own tests pass a
+    ///     `MockURLSession`. Consumers should NOT pass `MockURLSession` here
+    ///     - inject `MockNetworkService` at the `NetworkService` seam instead.
     ///   - category: Subsystem-specific log category (e.g. `"OpenAIChat"`).
     ///     Errors and non-2xx responses are logged under this category.
     ///   - acceptableStatusCodes: Status codes treated as success. Defaults
@@ -40,33 +48,30 @@ public struct NetworkClient: Sendable {
     ///     `NetworkError.unacceptableStatus`.
     public init(
         session: any URLSessionProtocol = URLSession.shared,
-        category: String = "NetworkClient",
+        category: String = "NetworkService",
         acceptableStatusCodes: Set<Int> = Set(200..<300)
     ) {
         self.session = session
         self.logger = Logger(subsystem: "com.antonnovoselov.VivaDicta.networking", category: category)
-        self.acceptableStatusCodes = acceptableStatusCodes
+        self.defaultAcceptableStatusCodes = acceptableStatusCodes
     }
 
-    // MARK: - Plain request/response
+    // MARK: - NetworkService
 
-    /// Send the request, validate the response, and return the raw body bytes
-    /// alongside the `HTTPURLResponse`.
     public func send(
         _ request: URLRequest,
-        acceptableStatusCodes: Set<Int>? = nil
+        acceptableStatusCodes: Set<Int>?
     ) async throws -> (Data, HTTPURLResponse) {
         let (data, response) = try await callData(request)
         let http = try validate(response: response, body: data, acceptable: acceptableStatusCodes)
         return (data, http)
     }
 
-    /// Send the request and decode the response body as `T`.
     public func sendJSON<T: Decodable>(
         _ request: URLRequest,
-        as type: T.Type = T.self,
-        decoder: JSONDecoder = JSONDecoder(),
-        acceptableStatusCodes: Set<Int>? = nil
+        as type: T.Type,
+        decoder: JSONDecoder,
+        acceptableStatusCodes: Set<Int>?
     ) async throws -> T {
         let (data, _) = try await send(request, acceptableStatusCodes: acceptableStatusCodes)
         do {
@@ -77,14 +82,10 @@ public struct NetworkClient: Sendable {
         }
     }
 
-    // MARK: - Upload (multipart / large body)
-
-    /// Send the request body via `URLSession.upload(for:from:)`. Validates the
-    /// response status and returns the body + HTTP response.
     public func upload(
         _ request: URLRequest,
         from bodyData: Data,
-        acceptableStatusCodes: Set<Int>? = nil
+        acceptableStatusCodes: Set<Int>?
     ) async throws -> (Data, HTTPURLResponse) {
         let (data, response): (Data, URLResponse)
         do {
@@ -96,15 +97,9 @@ public struct NetworkClient: Sendable {
         return (data, http)
     }
 
-    // MARK: - Streaming (SSE)
-
-    /// Open a byte stream for server-sent-events style endpoints. Validates
-    /// the status code first (draining the body on failure into
-    /// `NetworkError.unacceptableStatus`) and returns the stream + response
-    /// for the caller to iterate.
     public func bytes(
         for request: URLRequest,
-        acceptableStatusCodes: Set<Int>? = nil
+        acceptableStatusCodes: Set<Int>?
     ) async throws -> (URLSession.AsyncBytes, HTTPURLResponse) {
         let (bytes, response): (URLSession.AsyncBytes, URLResponse)
         do {
@@ -115,7 +110,7 @@ public struct NetworkClient: Sendable {
         guard let http = response as? HTTPURLResponse else {
             throw NetworkError.invalidResponse
         }
-        let acceptable = acceptableStatusCodes ?? self.acceptableStatusCodes
+        let acceptable = acceptableStatusCodes ?? self.defaultAcceptableStatusCodes
         if !acceptable.contains(http.statusCode) {
             var errorData = Data()
             for try await byte in bytes {
@@ -146,7 +141,7 @@ public struct NetworkClient: Sendable {
         guard let http = response as? HTTPURLResponse else {
             throw NetworkError.invalidResponse
         }
-        let acceptable = overrideAcceptable ?? self.acceptableStatusCodes
+        let acceptable = overrideAcceptable ?? self.defaultAcceptableStatusCodes
         if !acceptable.contains(http.statusCode) {
             let bodyText = String(data: body, encoding: .utf8) ?? ""
             logger.error("HTTP \(http.statusCode, privacy: .public) from \(http.url?.absoluteString ?? "<no url>", privacy: .public): \(bodyText, privacy: .public)")

--- a/Modules/Networking/Sources/Networking/NetworkService.swift
+++ b/Modules/Networking/Sources/Networking/NetworkService.swift
@@ -1,0 +1,73 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+
+/// Consumer-facing seam for all HTTP traffic. Domain services
+/// (`AIService`, the cloud transcription services, OAuth managers, etc.)
+/// inject `NetworkService` and never touch `URLSession`/`URLSessionProtocol`
+/// directly.
+///
+/// Tests inject a `MockNetworkService` from `NetworkingMocks`. `URLSession`
+/// and `MockURLSession` are intentionally scoped as implementation details of
+/// the production conformance ``DefaultNetworkService`` -- if consumer tests
+/// need to fake HTTP, they fake `NetworkService`, not `URLSession`.
+///
+/// Methods mirror the small set of HTTP patterns this codebase actually uses:
+///
+/// - ``send(_:acceptableStatusCodes:)`` for plain request/response calls with
+///   status validation.
+/// - ``sendJSON(_:as:decoder:acceptableStatusCodes:)`` for the very common
+///   "send a request, decode the body as `T`" pattern.
+/// - ``upload(_:from:acceptableStatusCodes:)`` for multipart / large body
+///   POSTs.
+/// - ``bytes(for:acceptableStatusCodes:)`` for Server-Sent Events / streaming
+///   endpoints.
+public protocol NetworkService: Sendable {
+    func send(
+        _ request: URLRequest,
+        acceptableStatusCodes: Set<Int>?
+    ) async throws -> (Data, HTTPURLResponse)
+
+    func sendJSON<T: Decodable>(
+        _ request: URLRequest,
+        as type: T.Type,
+        decoder: JSONDecoder,
+        acceptableStatusCodes: Set<Int>?
+    ) async throws -> T
+
+    func upload(
+        _ request: URLRequest,
+        from bodyData: Data,
+        acceptableStatusCodes: Set<Int>?
+    ) async throws -> (Data, HTTPURLResponse)
+
+    func bytes(
+        for request: URLRequest,
+        acceptableStatusCodes: Set<Int>?
+    ) async throws -> (URLSession.AsyncBytes, HTTPURLResponse)
+}
+
+// MARK: - Ergonomic defaults
+
+/// Convenience overloads with sensible defaults so call sites stay clean.
+public extension NetworkService {
+    func send(_ request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+        try await send(request, acceptableStatusCodes: nil)
+    }
+
+    func sendJSON<T: Decodable>(
+        _ request: URLRequest,
+        as type: T.Type = T.self,
+        decoder: JSONDecoder = JSONDecoder()
+    ) async throws -> T {
+        try await sendJSON(request, as: type, decoder: decoder, acceptableStatusCodes: nil)
+    }
+
+    func upload(_ request: URLRequest, from bodyData: Data) async throws -> (Data, HTTPURLResponse) {
+        try await upload(request, from: bodyData, acceptableStatusCodes: nil)
+    }
+
+    func bytes(for request: URLRequest) async throws -> (URLSession.AsyncBytes, HTTPURLResponse) {
+        try await bytes(for: request, acceptableStatusCodes: nil)
+    }
+}

--- a/Modules/Networking/Sources/Networking/NetworkService.swift
+++ b/Modules/Networking/Sources/Networking/NetworkService.swift
@@ -47,6 +47,17 @@ public protocol NetworkService: Sendable {
     ) async throws -> (URLSession.AsyncBytes, HTTPURLResponse)
 }
 
+// MARK: - Acceptable status code presets
+
+public extension Set where Element == Int {
+    /// "Accept any HTTP status code" - call sites that do their own
+    /// status-code mapping (OAuth's 200-only check, streaming endpoints that
+    /// drain the error body manually, etc.) pass this as
+    /// `acceptableStatusCodes` to bypass `NetworkService`'s default
+    /// `200..<300` validation.
+    static var acceptAny: Set<Int> { Set(0...999) }
+}
+
 // MARK: - Ergonomic defaults
 
 /// Convenience overloads with sensible defaults so call sites stay clean.

--- a/Modules/Networking/Sources/NetworkingMocks/MockNetworkService.swift
+++ b/Modules/Networking/Sources/NetworkingMocks/MockNetworkService.swift
@@ -1,0 +1,152 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import Networking
+import TestUtilities
+
+/// Hand-rolled mock of ``NetworkService`` for consumer tests. Stubs per-method
+/// responses, captures requests and bodies, counts calls. Each test creates
+/// its own instance - no global state - so suites run in parallel safely.
+///
+/// ## Usage
+///
+/// ```swift
+/// let net = MockNetworkService()
+/// net.stubSendResponse = .success((Data(#"{"text":"hello"}"#.utf8), httpResponse(200)))
+/// let service = OpenAIChatService(networkService: net)
+/// _ = try await service.chat(...)
+/// #expect(net.sendCallCount == 1)
+/// #expect(net.capturedRequest?.url?.path == "/v1/chat/completions")
+/// ```
+///
+/// ## `bytes(for:)` limitation
+///
+/// `URLSession.AsyncBytes` has no public initializer, so `bytes(for:)` cannot
+/// be stubbed to return a synthetic stream. Tests of SSE / streaming paths
+/// should be integration tests or rely on a real `URLSession` against a
+/// controlled local server. Calling `bytes(for:)` on this mock throws
+/// `StubNotSetError`.
+public final class MockNetworkService: NetworkService, @unchecked Sendable {
+    public init() {}
+
+    // MARK: - send
+
+    public var stubSendResponse: Result<(Data, HTTPURLResponse), Error>?
+    public var didSend: (() -> Void)?
+    public private(set) var sendCallCount = 0
+
+    // MARK: - sendJSON
+
+    /// Per-test stub for `sendJSON`. Stored as `Any` because the return type
+    /// is generic; tests put a `T` value here (or wrap an Error). The mock
+    /// type-checks at call time and records an Issue if the stub doesn't match
+    /// the requested `T`.
+    public var stubSendJSONResponse: Result<Any, Error>?
+    public var didSendJSON: (() -> Void)?
+    public private(set) var sendJSONCallCount = 0
+
+    // MARK: - upload
+
+    public var stubUploadResponse: Result<(Data, HTTPURLResponse), Error>?
+    public var didUpload: (() -> Void)?
+    public private(set) var uploadCallCount = 0
+    public private(set) var capturedBody: Data?
+
+    // MARK: - bytes
+
+    public private(set) var bytesCallCount = 0
+
+    // MARK: - shared capture
+
+    /// Most recent request seen by any method. For suites exercising multiple
+    /// endpoints, snapshot inline after each call rather than relying on the
+    /// final value.
+    public private(set) var capturedRequest: URLRequest?
+
+    /// All requests seen, in order. Useful for asserting a sequence.
+    public private(set) var capturedRequests: [URLRequest] = []
+
+    /// Most recent `acceptableStatusCodes` override passed in (nil = used the
+    /// default 200..<300).
+    public private(set) var capturedAcceptableStatusCodes: Set<Int>?
+
+    // MARK: - NetworkService conformance
+
+    public func send(
+        _ request: URLRequest,
+        acceptableStatusCodes: Set<Int>?
+    ) async throws -> (Data, HTTPURLResponse) {
+        defer { didSend?() }
+        sendCallCount += 1
+        capturedRequest = request
+        capturedRequests.append(request)
+        capturedAcceptableStatusCodes = acceptableStatusCodes
+        let (data, response): (Data, HTTPURLResponse) = try stubSendResponse.evaluate()
+        try validateStatus(response, body: data, acceptable: acceptableStatusCodes)
+        return (data, response)
+    }
+
+    public func sendJSON<T: Decodable>(
+        _ request: URLRequest,
+        as type: T.Type,
+        decoder: JSONDecoder,
+        acceptableStatusCodes: Set<Int>?
+    ) async throws -> T {
+        defer { didSendJSON?() }
+        sendJSONCallCount += 1
+        capturedRequest = request
+        capturedRequests.append(request)
+        capturedAcceptableStatusCodes = acceptableStatusCodes
+        let raw = try stubSendJSONResponse.evaluate() as Any
+        guard let typed = raw as? T else {
+            throw StubNotSetError("MockNetworkService.stubSendJSONResponse value \(raw) is not \(T.self)")
+        }
+        return typed
+    }
+
+    public func upload(
+        _ request: URLRequest,
+        from bodyData: Data,
+        acceptableStatusCodes: Set<Int>?
+    ) async throws -> (Data, HTTPURLResponse) {
+        defer { didUpload?() }
+        uploadCallCount += 1
+        capturedRequest = request
+        capturedRequests.append(request)
+        capturedAcceptableStatusCodes = acceptableStatusCodes
+        capturedBody = bodyData
+        let (data, response): (Data, HTTPURLResponse) = try stubUploadResponse.evaluate()
+        try validateStatus(response, body: data, acceptable: acceptableStatusCodes)
+        return (data, response)
+    }
+
+    // MARK: - Helpers
+
+    /// Mirrors `DefaultNetworkService`'s status validation so consumer tests
+    /// that stub a non-2xx HTTPURLResponse get the same `NetworkError`
+    /// production code would see. Otherwise the mock would silently bypass
+    /// the validation that `DefaultNetworkService` runs.
+    private func validateStatus(
+        _ response: HTTPURLResponse,
+        body: Data,
+        acceptable: Set<Int>?
+    ) throws {
+        let acceptableCodes = acceptable ?? Set(200..<300)
+        if !acceptableCodes.contains(response.statusCode) {
+            throw NetworkError.unacceptableStatus(code: response.statusCode, body: body)
+        }
+    }
+
+    public func bytes(
+        for request: URLRequest,
+        acceptableStatusCodes: Set<Int>?
+    ) async throws -> (URLSession.AsyncBytes, HTTPURLResponse) {
+        bytesCallCount += 1
+        capturedRequest = request
+        capturedRequests.append(request)
+        capturedAcceptableStatusCodes = acceptableStatusCodes
+        throw StubNotSetError(
+            "MockNetworkService.bytes(for:) cannot be stubbed: URLSession.AsyncBytes has no public initializer. Test SSE / streaming paths via integration."
+        )
+    }
+}

--- a/Modules/Networking/Sources/NetworkingMocks/MockNetworkService.swift
+++ b/Modules/Networking/Sources/NetworkingMocks/MockNetworkService.swift
@@ -39,8 +39,8 @@ public final class MockNetworkService: NetworkService, @unchecked Sendable {
 
     /// Per-test stub for `sendJSON`. Stored as `Any` because the return type
     /// is generic; tests put a `T` value here (or wrap an Error). The mock
-    /// type-checks at call time and records an Issue if the stub doesn't match
-    /// the requested `T`.
+    /// type-checks at call time and throws `StubNotSetError` if the stub
+    /// doesn't match the requested `T`.
     public var stubSendJSONResponse: Result<Any, Error>?
     public var didSendJSON: (() -> Void)?
     public private(set) var sendJSONCallCount = 0

--- a/Modules/Networking/Tests/NetworkingTests/DefaultNetworkServiceTests.swift
+++ b/Modules/Networking/Tests/NetworkingTests/DefaultNetworkServiceTests.swift
@@ -5,8 +5,8 @@ import Networking
 import NetworkingMocks
 import Testing
 
-@Suite("NetworkClient")
-struct NetworkClientTests {
+@Suite("DefaultNetworkService")
+struct DefaultNetworkServiceTests {
 
     private let endpoint = URL(string: "https://example.com/api")!
 
@@ -25,7 +25,7 @@ struct NetworkClientTests {
         let session = MockURLSession()
         let payload = Data(#"{"ok":true}"#.utf8)
         session.stubDataResponse = .success((payload, makeResponse(200)))
-        let client = NetworkClient(session: session)
+        let client = DefaultNetworkService(session: session)
 
         let (data, response) = try await client.send(URLRequest(url: endpoint))
 
@@ -38,7 +38,7 @@ struct NetworkClientTests {
         let session = MockURLSession()
         let body = Data(#"{"error":"nope"}"#.utf8)
         session.stubDataResponse = .success((body, makeResponse(404)))
-        let client = NetworkClient(session: session)
+        let client = DefaultNetworkService(session: session)
 
         await #expect {
             try await client.send(URLRequest(url: endpoint))
@@ -55,7 +55,7 @@ struct NetworkClientTests {
         struct Boom: Error {}
         let session = MockURLSession()
         session.stubDataResponse = .failure(Boom())
-        let client = NetworkClient(session: session)
+        let client = DefaultNetworkService(session: session)
 
         await #expect {
             try await client.send(URLRequest(url: endpoint))
@@ -69,7 +69,7 @@ struct NetworkClientTests {
     @Test func customAcceptableStatusCodesOverrideDefault() async throws {
         let session = MockURLSession()
         session.stubDataResponse = .success((Data(), makeResponse(302)))
-        let client = NetworkClient(session: session)
+        let client = DefaultNetworkService(session: session)
 
         let (_, response) = try await client.send(
             URLRequest(url: endpoint),
@@ -87,7 +87,7 @@ struct NetworkClientTests {
     @Test func sendJSONDecodesResponse() async throws {
         let session = MockURLSession()
         session.stubDataResponse = .success((Data(#"{"value":"hi"}"#.utf8), makeResponse(200)))
-        let client = NetworkClient(session: session)
+        let client = DefaultNetworkService(session: session)
 
         let result: Echo = try await client.sendJSON(URLRequest(url: endpoint))
 
@@ -97,7 +97,7 @@ struct NetworkClientTests {
     @Test func sendJSONWrapsDecodingErrors() async throws {
         let session = MockURLSession()
         session.stubDataResponse = .success((Data(#"{"wrong":"shape"}"#.utf8), makeResponse(200)))
-        let client = NetworkClient(session: session)
+        let client = DefaultNetworkService(session: session)
 
         await #expect {
             let _: Echo = try await client.sendJSON(URLRequest(url: endpoint))
@@ -113,7 +113,7 @@ struct NetworkClientTests {
     @Test func uploadPassesBodyToSession() async throws {
         let session = MockURLSession()
         session.stubUploadResponse = .success((Data(), makeResponse(200)))
-        let client = NetworkClient(session: session)
+        let client = DefaultNetworkService(session: session)
 
         let body = Data("payload".utf8)
         _ = try await client.upload(URLRequest(url: endpoint), from: body)
@@ -125,7 +125,7 @@ struct NetworkClientTests {
     @Test func uploadThrowsForServerErrors() async throws {
         let session = MockURLSession()
         session.stubUploadResponse = .success((Data("internal".utf8), makeResponse(500)))
-        let client = NetworkClient(session: session)
+        let client = DefaultNetworkService(session: session)
 
         await #expect {
             _ = try await client.upload(URLRequest(url: endpoint), from: Data())

--- a/Modules/Networking/Tests/NetworkingTests/MockNetworkServiceTests.swift
+++ b/Modules/Networking/Tests/NetworkingTests/MockNetworkServiceTests.swift
@@ -1,0 +1,111 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import Networking
+import NetworkingMocks
+import Testing
+import TestUtilities
+
+@Suite("MockNetworkService contract")
+struct MockNetworkServiceTests {
+
+    private let endpoint = URL(string: "https://example.com/api")!
+
+    private func makeResponse(_ code: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: endpoint,
+            statusCode: code,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+    }
+
+    @Test func sendReturnsStubbedResponse() async throws {
+        let mock = MockNetworkService()
+        let body = Data("ok".utf8)
+        mock.stubSendResponse = .success((body, makeResponse(200)))
+
+        let (data, response) = try await mock.send(URLRequest(url: endpoint))
+
+        #expect(data == body)
+        #expect(response.statusCode == 200)
+        #expect(mock.sendCallCount == 1)
+    }
+
+    @Test func sendCapturesRequestAndStatusCodeOverride() async throws {
+        let mock = MockNetworkService()
+        mock.stubSendResponse = .success((Data(), makeResponse(200)))
+
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.setValue("Bearer xyz", forHTTPHeaderField: "Authorization")
+        _ = try await mock.send(request, acceptableStatusCodes: [200, 302])
+
+        #expect(mock.capturedRequest?.url == endpoint)
+        #expect(mock.capturedRequest?.httpMethod == "POST")
+        #expect(mock.capturedRequest?.value(forHTTPHeaderField: "Authorization") == "Bearer xyz")
+        #expect(mock.capturedAcceptableStatusCodes == [200, 302])
+    }
+
+    @Test func sendPropagatesStubbedError() async {
+        struct Boom: Error {}
+        let mock = MockNetworkService()
+        mock.stubSendResponse = .failure(Boom())
+
+        await #expect(throws: Boom.self) {
+            _ = try await mock.send(URLRequest(url: endpoint))
+        }
+    }
+
+    private struct Echo: Decodable, Equatable {
+        let value: String
+    }
+
+    @Test func sendJSONReturnsTypedStub() async throws {
+        let mock = MockNetworkService()
+        mock.stubSendJSONResponse = .success(Echo(value: "hi"))
+
+        let result: Echo = try await mock.sendJSON(URLRequest(url: endpoint))
+
+        #expect(result == Echo(value: "hi"))
+        #expect(mock.sendJSONCallCount == 1)
+    }
+
+    @Test func sendJSONWithMismatchedStubThrowsStubNotSetError() async {
+        let mock = MockNetworkService()
+        mock.stubSendJSONResponse = .success("string instead of Echo")
+
+        await #expect(throws: StubNotSetError.self) {
+            let _: Echo = try await mock.sendJSON(URLRequest(url: endpoint))
+        }
+    }
+
+    @Test func uploadCapturesBody() async throws {
+        let mock = MockNetworkService()
+        mock.stubUploadResponse = .success((Data(), makeResponse(200)))
+
+        let body = Data("payload".utf8)
+        _ = try await mock.upload(URLRequest(url: endpoint), from: body)
+
+        #expect(mock.uploadCallCount == 1)
+        #expect(mock.capturedBody == body)
+    }
+
+    @Test func unsetSendStubRecordsIssue() async {
+        await withKnownIssue {
+            let mock = MockNetworkService()
+            await #expect(throws: StubNotSetError.self) {
+                _ = try await mock.send(URLRequest(url: endpoint))
+            }
+        }
+    }
+
+    @Test func bytesAlwaysThrowsStubNotSetError() async {
+        let mock = MockNetworkService()
+
+        await #expect(throws: StubNotSetError.self) {
+            _ = try await mock.bytes(for: URLRequest(url: endpoint))
+        }
+        #expect(mock.bytesCallCount == 1)
+    }
+}

--- a/Modules/OAuth/Sources/OAuth/CopilotOAuthManager.swift
+++ b/Modules/OAuth/Sources/OAuth/CopilotOAuthManager.swift
@@ -12,7 +12,7 @@ public final class CopilotOAuthManager: Sendable {
     private let logger = Logger(oauthCategory: "CopilotOAuth")
     private let keychain: any KeychainService
     private let backgroundTaskService: (any BackgroundTaskService)?
-    private let urlSession: any URLSessionProtocol
+    private let networkService: any NetworkService
 
     /// GitHub OAuth client ID (same as VS Code Copilot extension).
     private let clientId = "Iv1.b507a08c87ecfe98"
@@ -26,11 +26,11 @@ public final class CopilotOAuthManager: Sendable {
     public init(
         keychain: any KeychainService,
         backgroundTaskService: (any BackgroundTaskService)? = nil,
-        urlSession: any URLSessionProtocol = URLSession.shared
+        networkService: any NetworkService = DefaultNetworkService(category: "CopilotOAuthManager")
     ) {
         self.keychain = keychain
         self.backgroundTaskService = backgroundTaskService
-        self.urlSession = urlSession
+        self.networkService = networkService
     }
 
     // MARK: - Public API
@@ -54,7 +54,7 @@ public final class CopilotOAuthManager: Sendable {
         request.addValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
         request.httpBody = "client_id=\(clientId)&scope=read:user".data(using: .utf8)
 
-        let (data, response) = try await urlSession.data(for: request)
+        let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
 
         guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
             throw CopilotOAuthError.deviceCodeFailed("Failed to get device code")
@@ -108,7 +108,7 @@ public final class CopilotOAuthManager: Sendable {
 
             let data: Data
             do {
-                data = try await urlSession.data(for: request).0
+                data = try await networkService.send(request, acceptableStatusCodes: Set(0...999)).0
             } catch let urlError as URLError where urlError.code != .cancelled {
                 // Transient network error (e.g. -1005 after backgrounding); retry on next tick.
                 logger.logInfo("Poll network error \(urlError.code.rawValue), retrying")
@@ -201,7 +201,7 @@ public final class CopilotOAuthManager: Sendable {
         request.addValue("application/json", forHTTPHeaderField: "Accept")
         request.timeoutInterval = 15
 
-        let (data, response) = try await urlSession.data(for: request)
+        let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw CopilotOAuthError.tokenExchangeFailed("Invalid response")
@@ -235,7 +235,7 @@ public final class CopilotOAuthManager: Sendable {
         request.addValue("application/json", forHTTPHeaderField: "Accept")
         request.timeoutInterval = 10
 
-        guard let (data, response) = try? await urlSession.data(for: request),
+        guard let (data, response) = try? await networkService.send(request, acceptableStatusCodes: Set(0...999)),
               let httpResponse = response as? HTTPURLResponse,
               httpResponse.statusCode == 200,
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {

--- a/Modules/OAuth/Sources/OAuth/CopilotOAuthManager.swift
+++ b/Modules/OAuth/Sources/OAuth/CopilotOAuthManager.swift
@@ -54,9 +54,9 @@ public final class CopilotOAuthManager: Sendable {
         request.addValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
         request.httpBody = "client_id=\(clientId)&scope=read:user".data(using: .utf8)
 
-        let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
+        let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
 
-        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+        guard httpResponse.statusCode == 200 else {
             throw CopilotOAuthError.deviceCodeFailed("Failed to get device code")
         }
 
@@ -108,10 +108,14 @@ public final class CopilotOAuthManager: Sendable {
 
             let data: Data
             do {
-                data = try await networkService.send(request, acceptableStatusCodes: Set(0...999)).0
-            } catch let urlError as URLError where urlError.code != .cancelled {
+                data = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny).0
+            } catch NetworkError.transport(let underlying)
+                        where (underlying as? URLError)?.code != .cancelled {
                 // Transient network error (e.g. -1005 after backgrounding); retry on next tick.
-                logger.logInfo("Poll network error \(urlError.code.rawValue), retrying")
+                // `NetworkService` wraps URLErrors as `NetworkError.transport`, so we unwrap
+                // here to match the previous URLError-only retry behavior.
+                let code = (underlying as? URLError)?.code.rawValue ?? -1
+                logger.logInfo("Poll network error \(code), retrying")
                 continue
             }
 
@@ -201,11 +205,7 @@ public final class CopilotOAuthManager: Sendable {
         request.addValue("application/json", forHTTPHeaderField: "Accept")
         request.timeoutInterval = 15
 
-        let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw CopilotOAuthError.tokenExchangeFailed("Invalid response")
-        }
+        let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
 
         guard httpResponse.statusCode == 200 else {
             let body = String(data: data, encoding: .utf8) ?? ""
@@ -235,8 +235,7 @@ public final class CopilotOAuthManager: Sendable {
         request.addValue("application/json", forHTTPHeaderField: "Accept")
         request.timeoutInterval = 10
 
-        guard let (data, response) = try? await networkService.send(request, acceptableStatusCodes: Set(0...999)),
-              let httpResponse = response as? HTTPURLResponse,
+        guard let (data, httpResponse) = try? await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny),
               httpResponse.statusCode == 200,
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             return nil

--- a/Modules/OAuth/Sources/OAuth/GeminiOAuthProvider.swift
+++ b/Modules/OAuth/Sources/OAuth/GeminiOAuthProvider.swift
@@ -76,9 +76,9 @@ public struct GeminiOAuthProvider: OAuthProvider {
         ]
         request.httpBody = try? JSONSerialization.data(withJSONObject: body)
 
-        let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
+        let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
 
-        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+        guard httpResponse.statusCode == 200 else {
             return nil
         }
 
@@ -102,9 +102,9 @@ public struct GeminiOAuthProvider: OAuthProvider {
         let body: [String: Any] = ["tierId": "free-tier"]
         request.httpBody = try? JSONSerialization.data(withJSONObject: body)
 
-        let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
+        let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
 
-        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+        guard httpResponse.statusCode == 200 else {
             return nil
         }
 
@@ -131,9 +131,9 @@ public struct GeminiOAuthProvider: OAuthProvider {
             request.addValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
             request.timeoutInterval = 10
 
-            let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
+            let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
 
-            guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200,
+            guard httpResponse.statusCode == 200,
                   let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
                 continue
             }

--- a/Modules/OAuth/Sources/OAuth/GeminiOAuthProvider.swift
+++ b/Modules/OAuth/Sources/OAuth/GeminiOAuthProvider.swift
@@ -23,10 +23,10 @@ public struct GeminiOAuthProvider: OAuthProvider {
         "prompt": "consent"
     ]
 
-    private let urlSession: any URLSessionProtocol
+    private let networkService: any NetworkService
 
-    public init(urlSession: any URLSessionProtocol = URLSession.shared) {
-        self.urlSession = urlSession
+    public init(networkService: any NetworkService = DefaultNetworkService(category: "GeminiOAuthProvider")) {
+        self.networkService = networkService
     }
 
     public func extractAccountInfo(from claims: [String: Any]) -> (id: String?, email: String?) {
@@ -76,7 +76,7 @@ public struct GeminiOAuthProvider: OAuthProvider {
         ]
         request.httpBody = try? JSONSerialization.data(withJSONObject: body)
 
-        let (data, response) = try await urlSession.data(for: request)
+        let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
 
         guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
             return nil
@@ -102,7 +102,7 @@ public struct GeminiOAuthProvider: OAuthProvider {
         let body: [String: Any] = ["tierId": "free-tier"]
         request.httpBody = try? JSONSerialization.data(withJSONObject: body)
 
-        let (data, response) = try await urlSession.data(for: request)
+        let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
 
         guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
             return nil
@@ -131,7 +131,7 @@ public struct GeminiOAuthProvider: OAuthProvider {
             request.addValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
             request.timeoutInterval = 10
 
-            let (data, response) = try await urlSession.data(for: request)
+            let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
 
             guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200,
                   let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {

--- a/Modules/OAuth/Sources/OAuth/OAuthManager.swift
+++ b/Modules/OAuth/Sources/OAuth/OAuthManager.swift
@@ -242,11 +242,7 @@ public final class OAuthManager: Sendable {
             request.httpBody = formBody.data(using: .utf8)
         }
 
-        let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw OAuthError.invalidResponse
-        }
+        let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
 
         guard httpResponse.statusCode == 200 else {
             let errorBody = String(data: data, encoding: .utf8) ?? "Unknown error"
@@ -304,8 +300,7 @@ public final class OAuthManager: Sendable {
         request.addValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
         request.timeoutInterval = 10
 
-        guard let (data, response) = try? await networkService.send(request, acceptableStatusCodes: Set(0...999)),
-              let httpResponse = response as? HTTPURLResponse,
+        guard let (data, httpResponse) = try? await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny),
               httpResponse.statusCode == 200,
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             return (nil, nil)

--- a/Modules/OAuth/Sources/OAuth/OAuthManager.swift
+++ b/Modules/OAuth/Sources/OAuth/OAuthManager.swift
@@ -13,14 +13,17 @@ import os
 public final class OAuthManager: Sendable {
     private let logger = Logger(oauthCategory: "OAuthManager")
     private let keychain: any KeychainService
-    private let urlSession: any URLSessionProtocol
+    private let networkService: any NetworkService
 
     /// In-memory cache of credentials.
     private var credentials: [String: OAuthCredential] = [:]
 
-    public init(keychain: any KeychainService, urlSession: any URLSessionProtocol = URLSession.shared) {
+    public init(
+        keychain: any KeychainService,
+        networkService: any NetworkService = DefaultNetworkService(category: "OAuthManager")
+    ) {
         self.keychain = keychain
-        self.urlSession = urlSession
+        self.networkService = networkService
     }
 
     // MARK: - Public API
@@ -239,7 +242,7 @@ public final class OAuthManager: Sendable {
             request.httpBody = formBody.data(using: .utf8)
         }
 
-        let (data, response) = try await urlSession.data(for: request)
+        let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw OAuthError.invalidResponse
@@ -301,7 +304,7 @@ public final class OAuthManager: Sendable {
         request.addValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
         request.timeoutInterval = 10
 
-        guard let (data, response) = try? await urlSession.data(for: request),
+        guard let (data, response) = try? await networkService.send(request, acceptableStatusCodes: Set(0...999)),
               let httpResponse = response as? HTTPURLResponse,
               httpResponse.statusCode == 200,
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {

--- a/VivaDicta/Services/AIEnhance/AIService+Chat.swift
+++ b/VivaDicta/Services/AIEnhance/AIService+Chat.swift
@@ -167,7 +167,8 @@ extension AIService {
                     model: model,
                     accessToken: token,
                     projectId: projectId,
-                    onPartialResponse: onPartialResponse
+                    onPartialResponse: onPartialResponse,
+                    networkService: networkService
                 )
             } catch let error as OAuthError {
                 if let apiKey = provider.apiKey {
@@ -251,7 +252,8 @@ extension AIService {
                     messages: messages,
                     model: model,
                     accessToken: token,
-                    projectId: projectId
+                    projectId: projectId,
+                    networkService: networkService
                 )
             } catch let error as OAuthError {
                 if let apiKey = provider.apiKey {
@@ -517,11 +519,7 @@ extension AIService {
         let body = buildOpenAIChatRequestBody(model: model, systemMessage: systemMessage, messages: messages, stream: true)
         request.httpBody = try? JSONSerialization.data(withJSONObject: body)
 
-        let (bytes, response) = try await networkService.bytes(for: request, acceptableStatusCodes: Set(0...999))
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw EnhancementError.invalidResponse
-        }
+        let (bytes, httpResponse) = try await networkService.bytes(for: request, acceptableStatusCodes: Set<Int>.acceptAny)
 
         guard httpResponse.statusCode == 200 else {
             var errorData = Data()
@@ -571,11 +569,7 @@ extension AIService {
         let body = buildOpenAIChatRequestBody(model: model, systemMessage: systemMessage, messages: messages, stream: false)
         request.httpBody = try? JSONSerialization.data(withJSONObject: body)
 
-        let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw EnhancementError.invalidResponse
-        }
+        let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
 
         guard httpResponse.statusCode == 200 else {
             let errorString = String(data: data, encoding: .utf8) ?? "Unknown error"
@@ -627,11 +621,7 @@ extension AIService {
 
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
-        let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw EnhancementError.invalidResponse
-        }
+        let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
 
         guard httpResponse.statusCode == 200 else {
             let errorString = String(data: data, encoding: .utf8) ?? "Unknown error"
@@ -691,11 +681,7 @@ extension AIService {
 
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
-        let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw EnhancementError.invalidResponse
-        }
+        let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
 
         guard httpResponse.statusCode == 200 else {
             let errorString = String(data: data, encoding: .utf8) ?? "Unknown error"
@@ -753,11 +739,7 @@ extension AIService {
 
         request.httpBody = try? JSONSerialization.data(withJSONObject: body)
 
-        let (bytes, response) = try await networkService.bytes(for: request, acceptableStatusCodes: Set(0...999))
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw EnhancementError.invalidResponse
-        }
+        let (bytes, httpResponse) = try await networkService.bytes(for: request, acceptableStatusCodes: Set<Int>.acceptAny)
 
         guard httpResponse.statusCode == 200 else {
             var errorData = Data()
@@ -835,11 +817,7 @@ extension AIService {
 
         request.httpBody = try? JSONSerialization.data(withJSONObject: body)
 
-        let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw EnhancementError.invalidResponse
-        }
+        let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
 
         guard httpResponse.statusCode == 200 else {
             let errorString = String(data: data, encoding: .utf8) ?? "Unknown error"
@@ -883,11 +861,7 @@ extension AIService {
 
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
-        let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw EnhancementError.invalidResponse
-        }
+        let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
 
         guard httpResponse.statusCode == 200 else {
             let errorString = String(data: data, encoding: .utf8) ?? "Unknown error"
@@ -935,11 +909,7 @@ extension AIService {
 
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
-        let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw EnhancementError.invalidResponse
-        }
+        let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
 
         guard httpResponse.statusCode == 200 else {
             let errorString = String(data: data, encoding: .utf8) ?? "Unknown error"

--- a/VivaDicta/Services/AIEnhance/AIService+Chat.swift
+++ b/VivaDicta/Services/AIEnhance/AIService+Chat.swift
@@ -167,8 +167,7 @@ extension AIService {
                     model: model,
                     accessToken: token,
                     projectId: projectId,
-                    onPartialResponse: onPartialResponse,
-                    urlSession: urlSession
+                    onPartialResponse: onPartialResponse
                 )
             } catch let error as OAuthError {
                 if let apiKey = provider.apiKey {
@@ -252,8 +251,7 @@ extension AIService {
                     messages: messages,
                     model: model,
                     accessToken: token,
-                    projectId: projectId,
-                    urlSession: urlSession
+                    projectId: projectId
                 )
             } catch let error as OAuthError {
                 if let apiKey = provider.apiKey {
@@ -519,7 +517,7 @@ extension AIService {
         let body = buildOpenAIChatRequestBody(model: model, systemMessage: systemMessage, messages: messages, stream: true)
         request.httpBody = try? JSONSerialization.data(withJSONObject: body)
 
-        let (bytes, response) = try await urlSession.bytes(for: request)
+        let (bytes, response) = try await networkService.bytes(for: request, acceptableStatusCodes: Set(0...999))
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw EnhancementError.invalidResponse
@@ -573,7 +571,7 @@ extension AIService {
         let body = buildOpenAIChatRequestBody(model: model, systemMessage: systemMessage, messages: messages, stream: false)
         request.httpBody = try? JSONSerialization.data(withJSONObject: body)
 
-        let (data, response) = try await urlSession.data(for: request)
+        let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw EnhancementError.invalidResponse
@@ -629,7 +627,7 @@ extension AIService {
 
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
-        let (data, response) = try await urlSession.data(for: request)
+        let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw EnhancementError.invalidResponse
@@ -693,7 +691,7 @@ extension AIService {
 
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
-        let (data, response) = try await urlSession.data(for: request)
+        let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw EnhancementError.invalidResponse
@@ -755,7 +753,7 @@ extension AIService {
 
         request.httpBody = try? JSONSerialization.data(withJSONObject: body)
 
-        let (bytes, response) = try await urlSession.bytes(for: request)
+        let (bytes, response) = try await networkService.bytes(for: request, acceptableStatusCodes: Set(0...999))
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw EnhancementError.invalidResponse
@@ -837,7 +835,7 @@ extension AIService {
 
         request.httpBody = try? JSONSerialization.data(withJSONObject: body)
 
-        let (data, response) = try await urlSession.data(for: request)
+        let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw EnhancementError.invalidResponse
@@ -885,7 +883,7 @@ extension AIService {
 
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
-        let (data, response) = try await urlSession.data(for: request)
+        let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw EnhancementError.invalidResponse
@@ -937,7 +935,7 @@ extension AIService {
 
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
-        let (data, response) = try await urlSession.data(for: request)
+        let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw EnhancementError.invalidResponse

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -1055,11 +1055,7 @@ class AIService {
         )
         request.httpBody = try? JSONSerialization.data(withJSONObject: requestBody)
 
-        let (bytes, response) = try await networkService.bytes(for: request, acceptableStatusCodes: Set(0...999))
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw EnhancementError.invalidResponse
-        }
+        let (bytes, httpResponse) = try await networkService.bytes(for: request, acceptableStatusCodes: Set<Int>.acceptAny)
 
         guard httpResponse.statusCode == 200 else {
             var errorData = Data()
@@ -1156,11 +1152,7 @@ class AIService {
 
         request.httpBody = try? JSONSerialization.data(withJSONObject: requestBody)
 
-        let (bytes, response) = try await networkService.bytes(for: request, acceptableStatusCodes: Set(0...999))
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw EnhancementError.invalidResponse
-        }
+        let (bytes, httpResponse) = try await networkService.bytes(for: request, acceptableStatusCodes: Set<Int>.acceptAny)
 
         guard httpResponse.statusCode == 200 else {
             var errorData = Data()
@@ -1295,7 +1287,8 @@ class AIService {
                     model: model,
                     accessToken: token,
                     projectId: projectId,
-                    onPartialResult: onPartialResponse
+                    onPartialResult: onPartialResponse,
+                    networkService: networkService
                 )
                 return await finalizeStreamingResult(result, onPartialResponse: onPartialResponse)
             } catch let error as EnhancementError {
@@ -1536,7 +1529,8 @@ class AIService {
                     systemPrompt: resolvedSystemMessage,
                     model: model,
                     accessToken: token,
-                    projectId: projectId
+                    projectId: projectId,
+                    networkService: networkService
                 )
                 return AIEnhancementOutputFilter.filter(result)
             } catch let error as EnhancementError {
@@ -1653,11 +1647,7 @@ class AIService {
             request.httpBody = try? JSONSerialization.data(withJSONObject: requestBody)
 
             do {
-                let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
-
-                guard let httpResponse = response as? HTTPURLResponse else {
-                    throw EnhancementError.invalidResponse
-                }
+                let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
 
                 if httpResponse.statusCode == 200 {
                     guard let jsonResponse = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
@@ -1707,11 +1697,7 @@ class AIService {
             request.httpBody = try? JSONSerialization.data(withJSONObject: requestBody)
 
             do {
-                let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
-
-                guard let httpResponse = response as? HTTPURLResponse else {
-                    throw EnhancementError.invalidResponse
-                }
+                let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
 
                 if httpResponse.statusCode == 200 {
                     guard let jsonResponse = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
@@ -1830,11 +1816,7 @@ class AIService {
         request.httpBody = try? JSONSerialization.data(withJSONObject: finalRequestBody)
 
         do {
-            let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
-
-            guard let httpResponse = response as? HTTPURLResponse else {
-                throw EnhancementError.invalidResponse
-            }
+            let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
 
             switch httpResponse.statusCode {
             case 200:
@@ -1889,10 +1871,9 @@ class AIService {
         request.timeoutInterval = 5 // Short timeout for local service
 
         do {
-            let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
+            let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
 
-            guard let httpResponse = response as? HTTPURLResponse,
-                  httpResponse.statusCode == 200 else {
+            guard httpResponse.statusCode == 200 else {
                 logger.logWarning("Ollama OpenAI-compatible endpoint not responding, trying native endpoint")
                 await fetchOllamaModelsNative()
                 return
@@ -1929,10 +1910,9 @@ class AIService {
         request.timeoutInterval = 5
 
         do {
-            let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
+            let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
 
-            guard let httpResponse = response as? HTTPURLResponse,
-                  httpResponse.statusCode == 200 else {
+            guard httpResponse.statusCode == 200 else {
                 logger.logError("Ollama native endpoint not responding")
                 return
             }
@@ -1968,10 +1948,8 @@ class AIService {
         request.timeoutInterval = 3
 
         do {
-            let (_, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
-            guard let httpResponse = response as? HTTPURLResponse else {
-                return false
-            }
+            let (_, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
+
             return httpResponse.statusCode == 200
         } catch {
             return false
@@ -2051,11 +2029,7 @@ class AIService {
         request.httpBody = try? JSONSerialization.data(withJSONObject: requestBody)
 
         do {
-            let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
-
-            guard let httpResponse = response as? HTTPURLResponse else {
-                throw EnhancementError.invalidResponse
-            }
+            let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
 
             switch httpResponse.statusCode {
             case 200:
@@ -2168,12 +2142,7 @@ class AIService {
 
         do {
             logger.logNotice("🔧 Custom OpenAI Test - Sending request...")
-            let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
-
-            guard let httpResponse = response as? HTTPURLResponse else {
-                logger.logError("🔧 Custom OpenAI Test - Response is not HTTPURLResponse")
-                return (false, "Invalid response from server")
-            }
+            let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
 
             let responseString = String(data: data, encoding: .utf8) ?? "(unable to decode)"
             logger.logNotice("🔧 Custom OpenAI Test - HTTP Status: \(httpResponse.statusCode)")
@@ -2405,12 +2374,7 @@ class AIService {
         logger.logNotice("🔑 Verifying API key for \(provider.rawValue) provider at \(url.absoluteString)")
         
         do {
-            let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
-            
-            guard let httpResponse = response as? HTTPURLResponse else {
-                logger.logNotice("🔑 API key verification failed for \(provider.rawValue): Invalid response")
-                return false
-            }
+            let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
 
             let isValid = httpResponse.statusCode == 200
 
@@ -2440,12 +2404,7 @@ class AIService {
         logger.logNotice("🔑 Verifying API key for cerebras provider at \(url.absoluteString)")
 
         do {
-            let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
-
-            guard let httpResponse = response as? HTTPURLResponse else {
-                logger.logNotice("🔑 API key verification failed for cerebras: Invalid response")
-                return false
-            }
+            let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
 
             let isValid = httpResponse.statusCode == 200
 
@@ -2485,11 +2444,8 @@ class AIService {
         request.httpBody = try? JSONSerialization.data(withJSONObject: testBody)
         
         do {
-            let (_, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
-            
-            guard let httpResponse = response as? HTTPURLResponse else {
-                return false
-            }
+            let (_, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
+
             
             return httpResponse.statusCode == 200
             
@@ -2507,8 +2463,8 @@ class AIService {
         request.addValue(key, forHTTPHeaderField: "xi-api-key")
 
         do {
-            let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
-            let isValid = (response as? HTTPURLResponse)?.statusCode == 200
+            let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
+            let isValid = response.statusCode == 200
 
             if let body = String(data: data, encoding: .utf8) {
                 logger.logInfo("ElevenLabs verification response: \(body)")
@@ -2528,11 +2484,8 @@ class AIService {
         request.addValue("Token \(key)", forHTTPHeaderField: "Authorization")
         
         do {
-            let (_, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
-            
-            guard let httpResponse = response as? HTTPURLResponse else {
-                return false
-            }
+            let (_, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
+
             
             return httpResponse.statusCode == 200
             
@@ -2549,12 +2502,7 @@ class AIService {
         request.addValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
 
         do {
-            let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
-
-            guard let httpResponse = response as? HTTPURLResponse else {
-                logger.logError("Mistral API key verification failed: Invalid response from server.")
-                return false
-            }
+            let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
 
             if httpResponse.statusCode == 200 {
                 return true
@@ -2582,11 +2530,7 @@ class AIService {
         request.addValue("application/json", forHTTPHeaderField: "Accept")
 
         do {
-            let (_, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
-
-            guard let httpResponse = response as? HTTPURLResponse else {
-                return false
-            }
+            let (_, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
 
             return httpResponse.statusCode == 200
         } catch {
@@ -2605,11 +2549,7 @@ class AIService {
         request.addValue(key, forHTTPHeaderField: "x-gladia-key")
 
         do {
-            let (_, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
-
-            guard let httpResponse = response as? HTTPURLResponse else {
-                return false
-            }
+            let (_, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
 
             return httpResponse.statusCode == 200
         } catch {
@@ -2627,11 +2567,7 @@ class AIService {
         request.addValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
 
         do {
-            let (_, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
-
-            guard let httpResponse = response as? HTTPURLResponse else {
-                return false
-            }
+            let (_, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
 
             return httpResponse.statusCode == 200
         } catch {
@@ -2647,11 +2583,7 @@ class AIService {
         request.addValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
 
         do {
-            let (_, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
-
-            guard let httpResponse = response as? HTTPURLResponse else {
-                return false
-            }
+            let (_, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
 
             return httpResponse.statusCode == 200
         } catch {
@@ -2674,11 +2606,7 @@ class AIService {
         request.addValue(CartesiaTranscriptionService.cartesiaVersion, forHTTPHeaderField: "Cartesia-Version")
 
         do {
-            let (_, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
-
-            guard let httpResponse = response as? HTTPURLResponse else {
-                return false
-            }
+            let (_, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
 
             return httpResponse.statusCode == 200
         } catch {
@@ -2698,12 +2626,7 @@ class AIService {
         logger.logNotice("🔑 Verifying Vercel AI Gateway API key")
 
         do {
-            let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
-
-            guard let httpResponse = response as? HTTPURLResponse else {
-                logger.logNotice("🔑 Vercel AI Gateway API key verification failed: Invalid response")
-                return false
-            }
+            let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
 
             let isValid = httpResponse.statusCode == 200
 
@@ -2743,12 +2666,7 @@ class AIService {
         logger.logNotice("🔑 Verifying Grok API key at \(url.absoluteString)")
 
         do {
-            let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
-
-            guard let httpResponse = response as? HTTPURLResponse else {
-                logger.logNotice("🔑 Grok API key verification failed: Invalid response")
-                return false
-            }
+            let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
 
             let isValid = httpResponse.statusCode == 200
 
@@ -2788,12 +2706,7 @@ class AIService {
         logger.logNotice("🔑 Verifying HuggingFace API key at \(url.absoluteString)")
 
         do {
-            let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
-
-            guard let httpResponse = response as? HTTPURLResponse else {
-                logger.logNotice("🔑 HuggingFace API key verification failed: Invalid response")
-                return false
-            }
+            let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
 
             let isValid = httpResponse.statusCode == 200
 
@@ -2853,9 +2766,9 @@ class AIService {
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
         
         do {
-            let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
+            let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
 
-            guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            guard httpResponse.statusCode == 200 else {
                 logger.logError("Failed to fetch OpenRouter models: Invalid HTTP response")
                 // Preserve existing cached models on failure
                 return
@@ -2886,9 +2799,9 @@ class AIService {
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
 
         do {
-            let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
+            let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
 
-            guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            guard httpResponse.statusCode == 200 else {
                 logger.logError("Failed to fetch Vercel AI Gateway models: Invalid HTTP response")
                 // Preserve existing cached models on failure
                 return
@@ -2931,9 +2844,9 @@ class AIService {
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
 
         do {
-            let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
+            let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
 
-            guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            guard httpResponse.statusCode == 200 else {
                 logger.logError("Failed to fetch HuggingFace models: Invalid HTTP response")
                 // Preserve existing cached models on failure
                 return

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -175,7 +175,7 @@ class AIService {
     private let modesStorageKey: String
     private let selectedModeStorageKey: String
     private let keychain: any KeychainService
-    let urlSession: any URLSessionProtocol
+    let networkService: any NetworkService
     let oauthManager: OAuthManager
     let copilotOAuthManager: CopilotOAuthManager
     private let baseTimeout: TimeInterval = 300
@@ -195,12 +195,12 @@ class AIService {
 
     init(
         keychain: any KeychainService = DefaultKeychainService(),
-        urlSession: any URLSessionProtocol = URLSession.shared,
+        networkService: any NetworkService = DefaultNetworkService(category: "AIService"),
         oauthManager: OAuthManager = .shared,
         copilotOAuthManager: CopilotOAuthManager = .shared
     ) {
         self.keychain = keychain
-        self.urlSession = urlSession
+        self.networkService = networkService
         self.oauthManager = oauthManager
         self.copilotOAuthManager = copilotOAuthManager
         self.userDefaults = UserDefaultsStorage.shared
@@ -247,12 +247,12 @@ class AIService {
         modesStorageKey: String = "VivaModes",
         selectedModeStorageKey: String = "selectedVivaMode",
         keychain: any KeychainService = DefaultKeychainService(),
-        urlSession: any URLSessionProtocol = URLSession.shared,
+        networkService: any NetworkService = DefaultNetworkService(category: "AIService"),
         oauthManager: OAuthManager = .shared,
         copilotOAuthManager: CopilotOAuthManager = .shared
     ) {
         self.keychain = keychain
-        self.urlSession = urlSession
+        self.networkService = networkService
         self.oauthManager = oauthManager
         self.copilotOAuthManager = copilotOAuthManager
         self.userDefaults = userDefaults
@@ -1055,7 +1055,7 @@ class AIService {
         )
         request.httpBody = try? JSONSerialization.data(withJSONObject: requestBody)
 
-        let (bytes, response) = try await urlSession.bytes(for: request)
+        let (bytes, response) = try await networkService.bytes(for: request, acceptableStatusCodes: Set(0...999))
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw EnhancementError.invalidResponse
@@ -1156,7 +1156,7 @@ class AIService {
 
         request.httpBody = try? JSONSerialization.data(withJSONObject: requestBody)
 
-        let (bytes, response) = try await urlSession.bytes(for: request)
+        let (bytes, response) = try await networkService.bytes(for: request, acceptableStatusCodes: Set(0...999))
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw EnhancementError.invalidResponse
@@ -1295,8 +1295,7 @@ class AIService {
                     model: model,
                     accessToken: token,
                     projectId: projectId,
-                    onPartialResult: onPartialResponse,
-                    urlSession: urlSession
+                    onPartialResult: onPartialResponse
                 )
                 return await finalizeStreamingResult(result, onPartialResponse: onPartialResponse)
             } catch let error as EnhancementError {
@@ -1537,8 +1536,7 @@ class AIService {
                     systemPrompt: resolvedSystemMessage,
                     model: model,
                     accessToken: token,
-                    projectId: projectId,
-                    urlSession: urlSession
+                    projectId: projectId
                 )
                 return AIEnhancementOutputFilter.filter(result)
             } catch let error as EnhancementError {
@@ -1655,7 +1653,7 @@ class AIService {
             request.httpBody = try? JSONSerialization.data(withJSONObject: requestBody)
 
             do {
-                let (data, response) = try await urlSession.data(for: request)
+                let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
 
                 guard let httpResponse = response as? HTTPURLResponse else {
                     throw EnhancementError.invalidResponse
@@ -1709,7 +1707,7 @@ class AIService {
             request.httpBody = try? JSONSerialization.data(withJSONObject: requestBody)
 
             do {
-                let (data, response) = try await urlSession.data(for: request)
+                let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
 
                 guard let httpResponse = response as? HTTPURLResponse else {
                     throw EnhancementError.invalidResponse
@@ -1832,7 +1830,7 @@ class AIService {
         request.httpBody = try? JSONSerialization.data(withJSONObject: finalRequestBody)
 
         do {
-            let (data, response) = try await urlSession.data(for: request)
+            let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
 
             guard let httpResponse = response as? HTTPURLResponse else {
                 throw EnhancementError.invalidResponse
@@ -1891,7 +1889,7 @@ class AIService {
         request.timeoutInterval = 5 // Short timeout for local service
 
         do {
-            let (data, response) = try await urlSession.data(for: request)
+            let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
 
             guard let httpResponse = response as? HTTPURLResponse,
                   httpResponse.statusCode == 200 else {
@@ -1931,7 +1929,7 @@ class AIService {
         request.timeoutInterval = 5
 
         do {
-            let (data, response) = try await urlSession.data(for: request)
+            let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
 
             guard let httpResponse = response as? HTTPURLResponse,
                   httpResponse.statusCode == 200 else {
@@ -1970,7 +1968,7 @@ class AIService {
         request.timeoutInterval = 3
 
         do {
-            let (_, response) = try await urlSession.data(for: request)
+            let (_, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
             guard let httpResponse = response as? HTTPURLResponse else {
                 return false
             }
@@ -2053,7 +2051,7 @@ class AIService {
         request.httpBody = try? JSONSerialization.data(withJSONObject: requestBody)
 
         do {
-            let (data, response) = try await urlSession.data(for: request)
+            let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
 
             guard let httpResponse = response as? HTTPURLResponse else {
                 throw EnhancementError.invalidResponse
@@ -2170,7 +2168,7 @@ class AIService {
 
         do {
             logger.logNotice("🔧 Custom OpenAI Test - Sending request...")
-            let (data, response) = try await urlSession.data(for: request)
+            let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
 
             guard let httpResponse = response as? HTTPURLResponse else {
                 logger.logError("🔧 Custom OpenAI Test - Response is not HTTPURLResponse")
@@ -2407,7 +2405,7 @@ class AIService {
         logger.logNotice("🔑 Verifying API key for \(provider.rawValue) provider at \(url.absoluteString)")
         
         do {
-            let (data, response) = try await urlSession.data(for: request)
+            let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
             
             guard let httpResponse = response as? HTTPURLResponse else {
                 logger.logNotice("🔑 API key verification failed for \(provider.rawValue): Invalid response")
@@ -2442,7 +2440,7 @@ class AIService {
         logger.logNotice("🔑 Verifying API key for cerebras provider at \(url.absoluteString)")
 
         do {
-            let (data, response) = try await urlSession.data(for: request)
+            let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
 
             guard let httpResponse = response as? HTTPURLResponse else {
                 logger.logNotice("🔑 API key verification failed for cerebras: Invalid response")
@@ -2487,7 +2485,7 @@ class AIService {
         request.httpBody = try? JSONSerialization.data(withJSONObject: testBody)
         
         do {
-            let (_, response) = try await urlSession.data(for: request)
+            let (_, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
             
             guard let httpResponse = response as? HTTPURLResponse else {
                 return false
@@ -2509,7 +2507,7 @@ class AIService {
         request.addValue(key, forHTTPHeaderField: "xi-api-key")
 
         do {
-            let (data, response) = try await urlSession.data(for: request)
+            let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
             let isValid = (response as? HTTPURLResponse)?.statusCode == 200
 
             if let body = String(data: data, encoding: .utf8) {
@@ -2530,7 +2528,7 @@ class AIService {
         request.addValue("Token \(key)", forHTTPHeaderField: "Authorization")
         
         do {
-            let (_, response) = try await urlSession.data(for: request)
+            let (_, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
             
             guard let httpResponse = response as? HTTPURLResponse else {
                 return false
@@ -2551,7 +2549,7 @@ class AIService {
         request.addValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
 
         do {
-            let (data, response) = try await urlSession.data(for: request)
+            let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
 
             guard let httpResponse = response as? HTTPURLResponse else {
                 logger.logError("Mistral API key verification failed: Invalid response from server.")
@@ -2584,7 +2582,7 @@ class AIService {
         request.addValue("application/json", forHTTPHeaderField: "Accept")
 
         do {
-            let (_, response) = try await urlSession.data(for: request)
+            let (_, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
 
             guard let httpResponse = response as? HTTPURLResponse else {
                 return false
@@ -2607,7 +2605,7 @@ class AIService {
         request.addValue(key, forHTTPHeaderField: "x-gladia-key")
 
         do {
-            let (_, response) = try await urlSession.data(for: request)
+            let (_, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
 
             guard let httpResponse = response as? HTTPURLResponse else {
                 return false
@@ -2629,7 +2627,7 @@ class AIService {
         request.addValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
 
         do {
-            let (_, response) = try await urlSession.data(for: request)
+            let (_, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
 
             guard let httpResponse = response as? HTTPURLResponse else {
                 return false
@@ -2649,7 +2647,7 @@ class AIService {
         request.addValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
 
         do {
-            let (_, response) = try await urlSession.data(for: request)
+            let (_, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
 
             guard let httpResponse = response as? HTTPURLResponse else {
                 return false
@@ -2676,7 +2674,7 @@ class AIService {
         request.addValue(CartesiaTranscriptionService.cartesiaVersion, forHTTPHeaderField: "Cartesia-Version")
 
         do {
-            let (_, response) = try await urlSession.data(for: request)
+            let (_, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
 
             guard let httpResponse = response as? HTTPURLResponse else {
                 return false
@@ -2700,7 +2698,7 @@ class AIService {
         logger.logNotice("🔑 Verifying Vercel AI Gateway API key")
 
         do {
-            let (data, response) = try await urlSession.data(for: request)
+            let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
 
             guard let httpResponse = response as? HTTPURLResponse else {
                 logger.logNotice("🔑 Vercel AI Gateway API key verification failed: Invalid response")
@@ -2745,7 +2743,7 @@ class AIService {
         logger.logNotice("🔑 Verifying Grok API key at \(url.absoluteString)")
 
         do {
-            let (data, response) = try await urlSession.data(for: request)
+            let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
 
             guard let httpResponse = response as? HTTPURLResponse else {
                 logger.logNotice("🔑 Grok API key verification failed: Invalid response")
@@ -2790,7 +2788,7 @@ class AIService {
         logger.logNotice("🔑 Verifying HuggingFace API key at \(url.absoluteString)")
 
         do {
-            let (data, response) = try await urlSession.data(for: request)
+            let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
 
             guard let httpResponse = response as? HTTPURLResponse else {
                 logger.logNotice("🔑 HuggingFace API key verification failed: Invalid response")
@@ -2855,7 +2853,7 @@ class AIService {
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
         
         do {
-            let (data, response) = try await urlSession.data(for: request)
+            let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
 
             guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
                 logger.logError("Failed to fetch OpenRouter models: Invalid HTTP response")
@@ -2888,7 +2886,7 @@ class AIService {
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
 
         do {
-            let (data, response) = try await urlSession.data(for: request)
+            let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
 
             guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
                 logger.logError("Failed to fetch Vercel AI Gateway models: Invalid HTTP response")
@@ -2933,7 +2931,7 @@ class AIService {
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
 
         do {
-            let (data, response) = try await urlSession.data(for: request)
+            let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
 
             guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
                 logger.logError("Failed to fetch HuggingFace models: Invalid HTTP response")

--- a/VivaDicta/Services/AIEnhance/ExaWebSearchTool.swift
+++ b/VivaDicta/Services/AIEnhance/ExaWebSearchTool.swift
@@ -140,7 +140,7 @@ enum ExaWebSearchToolRuntime {
 
 nonisolated enum ExaSearchClient: Sendable {
     /// URL session used for Exa search requests. Override only from tests.
-    nonisolated(unsafe) static var urlSession: any URLSessionProtocol = URLSession.shared
+    nonisolated(unsafe) static var networkService: any NetworkService = DefaultNetworkService(category: "AppClient")
 
     nonisolated static func search(query: String, apiKey: String) async throws -> [ExaResult] {
         guard let url = URL(string: "https://api.exa.ai/search") else {
@@ -159,7 +159,7 @@ nonisolated enum ExaSearchClient: Sendable {
         request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
         request.httpBody = try JSONEncoder().encode(payload)
 
-        let (data, response) = try await urlSession.data(for: request)
+        let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw ExaError.invalidResponse

--- a/VivaDicta/Services/AIEnhance/ExaWebSearchTool.swift
+++ b/VivaDicta/Services/AIEnhance/ExaWebSearchTool.swift
@@ -159,11 +159,7 @@ nonisolated enum ExaSearchClient: Sendable {
         request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
         request.httpBody = try JSONEncoder().encode(payload)
 
-        let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw ExaError.invalidResponse
-        }
+        let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
 
         guard (200...299).contains(httpResponse.statusCode) else {
             throw ExaError.httpStatus(code: httpResponse.statusCode)

--- a/VivaDicta/Services/AIEnhance/VivAgentsClient.swift
+++ b/VivaDicta/Services/AIEnhance/VivAgentsClient.swift
@@ -181,12 +181,7 @@ enum VivAgentsClient {
 
         logger.logInfo("VivAgents request: provider=\(provider), model=\(model), textLength=\(text.count)")
 
-        let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            logger.logError("VivAgents: invalid response (not HTTP)")
-            throw VivAgentsClientError.invalidResponse
-        }
+        let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
 
         logger.logInfo("VivAgents response: HTTP \(httpResponse.statusCode)")
 
@@ -254,9 +249,9 @@ enum VivAgentsClient {
         }
 
         do {
-            let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
-            guard let httpResponse = response as? HTTPURLResponse,
-                  httpResponse.statusCode == 200 else { return nil }
+            let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
+
+            guard httpResponse.statusCode == 200 else { return nil }
             return try JSONDecoder().decode(HealthResponse.self, from: data)
         } catch {
             return nil
@@ -277,9 +272,9 @@ enum VivAgentsClient {
         }
 
         do {
-            let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
-            guard let httpResponse = response as? HTTPURLResponse,
-                  httpResponse.statusCode == 200 else { return false }
+            let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
+
+            guard httpResponse.statusCode == 200 else { return false }
             let health = try JSONDecoder().decode(HealthResponse.self, from: data)
             switch provider {
             case "codex": return health.codexAvailable ?? false

--- a/VivaDicta/Services/AIEnhance/VivAgentsClient.swift
+++ b/VivaDicta/Services/AIEnhance/VivAgentsClient.swift
@@ -16,7 +16,7 @@ enum VivAgentsClient {
     private static let keychain: any KeychainService = DefaultKeychainService()
 
     /// URL session used for all requests. Override only from tests.
-    nonisolated(unsafe) static var urlSession: any URLSessionProtocol = URLSession.shared
+    nonisolated(unsafe) static var networkService: any NetworkService = DefaultNetworkService(category: "AppClient")
 
     struct EnhanceRequest: Encodable {
         let text: String
@@ -181,7 +181,7 @@ enum VivAgentsClient {
 
         logger.logInfo("VivAgents request: provider=\(provider), model=\(model), textLength=\(text.count)")
 
-        let (data, response) = try await urlSession.data(for: request)
+        let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
 
         guard let httpResponse = response as? HTTPURLResponse else {
             logger.logError("VivAgents: invalid response (not HTTP)")
@@ -254,7 +254,7 @@ enum VivAgentsClient {
         }
 
         do {
-            let (data, response) = try await urlSession.data(for: request)
+            let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
             guard let httpResponse = response as? HTTPURLResponse,
                   httpResponse.statusCode == 200 else { return nil }
             return try JSONDecoder().decode(HealthResponse.self, from: data)
@@ -277,7 +277,7 @@ enum VivAgentsClient {
         }
 
         do {
-            let (data, response) = try await urlSession.data(for: request)
+            let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
             guard let httpResponse = response as? HTTPURLResponse,
                   httpResponse.statusCode == 200 else { return false }
             let health = try JSONDecoder().decode(HealthResponse.self, from: data)

--- a/VivaDicta/Services/OAuth/CopilotAPIClient.swift
+++ b/VivaDicta/Services/OAuth/CopilotAPIClient.swift
@@ -234,11 +234,7 @@ enum CopilotAPIClient {
     // MARK: - Shared Response Handling
 
     private static func executeRequest(_ request: URLRequest) async throws -> String {
-        let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw CopilotOAuthError.tokenExchangeFailed("Invalid response")
-        }
+        let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
 
         guard httpResponse.statusCode == 200 else {
             let errorBody = String(data: data, encoding: .utf8) ?? "Unknown error"
@@ -265,11 +261,7 @@ enum CopilotAPIClient {
         _ request: URLRequest,
         onPartialResult: @escaping @MainActor (String) -> Void
     ) async throws -> String {
-        let (bytes, response) = try await networkService.bytes(for: request, acceptableStatusCodes: Set(0...999))
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw CopilotOAuthError.tokenExchangeFailed("Invalid response")
-        }
+        let (bytes, httpResponse) = try await networkService.bytes(for: request, acceptableStatusCodes: Set<Int>.acceptAny)
 
         guard httpResponse.statusCode == 200 else {
             var errorData = Data()
@@ -350,8 +342,7 @@ enum CopilotAPIClient {
             request.addValue(value, forHTTPHeaderField: key)
         }
 
-        guard let (data, response) = try? await networkService.send(request, acceptableStatusCodes: Set(0...999)),
-              let httpResponse = response as? HTTPURLResponse,
+        guard let (data, httpResponse) = try? await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny),
               httpResponse.statusCode == 200,
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let models = json["data"] as? [[String: Any]] else {

--- a/VivaDicta/Services/OAuth/CopilotAPIClient.swift
+++ b/VivaDicta/Services/OAuth/CopilotAPIClient.swift
@@ -11,7 +11,7 @@ enum CopilotAPIClient {
     private static let logger = Logger(category: .copilotAPI)
 
     /// URL session used for all Copilot API calls. Override only from tests.
-    nonisolated(unsafe) static var urlSession: any URLSessionProtocol = URLSession.shared
+    nonisolated(unsafe) static var networkService: any NetworkService = DefaultNetworkService(category: "AppClient")
 
     /// Base URL for Copilot's API.
     static let baseURL = "https://api.individual.githubcopilot.com"
@@ -234,7 +234,7 @@ enum CopilotAPIClient {
     // MARK: - Shared Response Handling
 
     private static func executeRequest(_ request: URLRequest) async throws -> String {
-        let (data, response) = try await urlSession.data(for: request)
+        let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw CopilotOAuthError.tokenExchangeFailed("Invalid response")
@@ -265,7 +265,7 @@ enum CopilotAPIClient {
         _ request: URLRequest,
         onPartialResult: @escaping @MainActor (String) -> Void
     ) async throws -> String {
-        let (bytes, response) = try await urlSession.bytes(for: request)
+        let (bytes, response) = try await networkService.bytes(for: request, acceptableStatusCodes: Set(0...999))
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw CopilotOAuthError.tokenExchangeFailed("Invalid response")
@@ -350,7 +350,7 @@ enum CopilotAPIClient {
             request.addValue(value, forHTTPHeaderField: key)
         }
 
-        guard let (data, response) = try? await urlSession.data(for: request),
+        guard let (data, response) = try? await networkService.send(request, acceptableStatusCodes: Set(0...999)),
               let httpResponse = response as? HTTPURLResponse,
               httpResponse.statusCode == 200,
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],

--- a/VivaDicta/Services/OAuth/GeminiAPIClient.swift
+++ b/VivaDicta/Services/OAuth/GeminiAPIClient.swift
@@ -89,11 +89,7 @@ enum GeminiAPIClient {
 
         request.httpBody = try? JSONSerialization.data(withJSONObject: requestBody)
 
-        let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw OAuthError.invalidResponse
-        }
+        let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
 
         guard httpResponse.statusCode == 200 else {
             let errorBody = String(data: data, encoding: .utf8) ?? "Unknown error"
@@ -188,11 +184,7 @@ enum GeminiAPIClient {
 
         request.httpBody = try? JSONSerialization.data(withJSONObject: requestBody)
 
-        let (bytes, response) = try await networkService.bytes(for: request, acceptableStatusCodes: Set(0...999))
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw OAuthError.invalidResponse
-        }
+        let (bytes, httpResponse) = try await networkService.bytes(for: request, acceptableStatusCodes: Set<Int>.acceptAny)
 
         guard httpResponse.statusCode == 200 else {
             var errorData = Data()
@@ -359,11 +351,7 @@ enum GeminiAPIClient {
 
         request.httpBody = try? JSONSerialization.data(withJSONObject: requestBody)
 
-        let (bytes, response) = try await networkService.bytes(for: request, acceptableStatusCodes: Set(0...999))
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw OAuthError.invalidResponse
-        }
+        let (bytes, httpResponse) = try await networkService.bytes(for: request, acceptableStatusCodes: Set<Int>.acceptAny)
 
         guard httpResponse.statusCode == 200 else {
             var errorData = Data()

--- a/VivaDicta/Services/OAuth/GeminiAPIClient.swift
+++ b/VivaDicta/Services/OAuth/GeminiAPIClient.swift
@@ -46,7 +46,7 @@ enum GeminiAPIClient {
         model: String,
         accessToken: String,
         projectId: String?,
-        urlSession: any URLSessionProtocol = URLSession.shared
+        networkService: any NetworkService = DefaultNetworkService(category: "GeminiAPIClient")
     ) async throws -> String {
         guard let url = URL(string: endpoint) else {
             throw OAuthError.invalidResponse
@@ -89,7 +89,7 @@ enum GeminiAPIClient {
 
         request.httpBody = try? JSONSerialization.data(withJSONObject: requestBody)
 
-        let (data, response) = try await urlSession.data(for: request)
+        let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw OAuthError.invalidResponse
@@ -145,7 +145,7 @@ enum GeminiAPIClient {
         accessToken: String,
         projectId: String?,
         onPartialResult: @escaping @MainActor (String) -> Void,
-        urlSession: any URLSessionProtocol = URLSession.shared
+        networkService: any NetworkService = DefaultNetworkService(category: "GeminiAPIClient")
     ) async throws -> String {
         guard let url = URL(string: streamingEndpoint) else {
             throw OAuthError.invalidResponse
@@ -188,7 +188,7 @@ enum GeminiAPIClient {
 
         request.httpBody = try? JSONSerialization.data(withJSONObject: requestBody)
 
-        let (bytes, response) = try await urlSession.bytes(for: request)
+        let (bytes, response) = try await networkService.bytes(for: request, acceptableStatusCodes: Set(0...999))
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw OAuthError.invalidResponse
@@ -318,7 +318,7 @@ enum GeminiAPIClient {
         accessToken: String,
         projectId: String?,
         onPartialResponse: @escaping @MainActor (String) -> Void,
-        urlSession: any URLSessionProtocol = URLSession.shared
+        networkService: any NetworkService = DefaultNetworkService(category: "GeminiAPIClient")
     ) async throws -> String {
         guard let url = URL(string: streamingEndpoint) else {
             throw OAuthError.invalidResponse
@@ -359,7 +359,7 @@ enum GeminiAPIClient {
 
         request.httpBody = try? JSONSerialization.data(withJSONObject: requestBody)
 
-        let (bytes, response) = try await urlSession.bytes(for: request)
+        let (bytes, response) = try await networkService.bytes(for: request, acceptableStatusCodes: Set(0...999))
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw OAuthError.invalidResponse
@@ -461,7 +461,7 @@ enum GeminiAPIClient {
         model: String,
         accessToken: String,
         projectId: String?,
-        urlSession: any URLSessionProtocol = URLSession.shared
+        networkService: any NetworkService = DefaultNetworkService(category: "GeminiAPIClient")
     ) async throws -> String {
         try await chatStreaming(
             systemMessage: systemMessage,
@@ -470,7 +470,7 @@ enum GeminiAPIClient {
             accessToken: accessToken,
             projectId: projectId,
             onPartialResponse: { _ in },
-            urlSession: urlSession
+            networkService: networkService
         )
     }
 

--- a/VivaDicta/Services/OAuth/OpenAIOAuthClient.swift
+++ b/VivaDicta/Services/OAuth/OpenAIOAuthClient.swift
@@ -151,9 +151,9 @@ enum OpenAIOAuthClient {
         request.addValue(originator, forHTTPHeaderField: "originator")
         request.timeoutInterval = 15
 
-        let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
+        let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
 
-        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+        guard httpResponse.statusCode == 200 else {
             return [defaultModel]
         }
 
@@ -197,11 +197,7 @@ enum OpenAIOAuthClient {
         request: URLRequest,
         onPartialResult: (@MainActor (String) -> Void)?
     ) async throws -> String {
-        let (bytes, response) = try await networkService.bytes(for: request, acceptableStatusCodes: Set(0...999))
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw OAuthError.invalidResponse
-        }
+        let (bytes, httpResponse) = try await networkService.bytes(for: request, acceptableStatusCodes: Set<Int>.acceptAny)
 
         guard httpResponse.statusCode == 200 else {
             var errorData = Data()

--- a/VivaDicta/Services/OAuth/OpenAIOAuthClient.swift
+++ b/VivaDicta/Services/OAuth/OpenAIOAuthClient.swift
@@ -10,7 +10,7 @@ enum OpenAIOAuthClient {
     private static let logger = Logger(category: .openAIOAuthAPI)
 
     /// URL session used for all OpenAI OAuth API calls. Override only from tests.
-    nonisolated(unsafe) static var urlSession: any URLSessionProtocol = URLSession.shared
+    nonisolated(unsafe) static var networkService: any NetworkService = DefaultNetworkService(category: "AppClient")
 
     /// Originator header required by the Codex endpoint.
     private static let originator = "codex_cli_rs"
@@ -151,7 +151,7 @@ enum OpenAIOAuthClient {
         request.addValue(originator, forHTTPHeaderField: "originator")
         request.timeoutInterval = 15
 
-        let (data, response) = try await urlSession.data(for: request)
+        let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
 
         guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
             return [defaultModel]
@@ -197,7 +197,7 @@ enum OpenAIOAuthClient {
         request: URLRequest,
         onPartialResult: (@MainActor (String) -> Void)?
     ) async throws -> String {
-        let (bytes, response) = try await urlSession.bytes(for: request)
+        let (bytes, response) = try await networkService.bytes(for: request, acceptableStatusCodes: Set(0...999))
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw OAuthError.invalidResponse

--- a/VivaDicta/Services/Reminders/CloudReminderExtractionProvider.swift
+++ b/VivaDicta/Services/Reminders/CloudReminderExtractionProvider.swift
@@ -72,11 +72,11 @@ private struct CloudReminderDraftsPayload: Codable {
 final class CloudReminderExtractionProvider {
     private let logger = Logger(category: .reminderExtraction)
     private let aiService: AIService
-    private let urlSession: any URLSessionProtocol
+    private let networkService: any NetworkService
 
-    init(aiService: AIService, urlSession: any URLSessionProtocol = URLSession.shared) {
+    init(aiService: AIService, networkService: any NetworkService = DefaultNetworkService(category: "CloudReminderExtraction")) {
         self.aiService = aiService
-        self.urlSession = urlSession
+        self.networkService = networkService
     }
 
     func canExtract(
@@ -315,7 +315,7 @@ final class CloudReminderExtractionProvider {
         )
         request.httpBody = try JSONSerialization.data(withJSONObject: requestBody)
 
-        let (data, response) = try await urlSession.data(for: request)
+        let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw ReminderExtractionError.invalidResponse
@@ -380,9 +380,7 @@ final class CloudReminderExtractionProvider {
             systemPrompt: systemMessage(now: now, timeZone: timeZone, language: language),
             model: model,
             accessToken: token,
-            projectId: projectId,
-            urlSession: urlSession
-        )
+            projectId: projectId        )
         return try decodeTextResponse(responseText)
     }
 
@@ -446,7 +444,7 @@ final class CloudReminderExtractionProvider {
 
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
-        let (data, response) = try await urlSession.data(for: request)
+        let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw ReminderExtractionError.invalidResponse

--- a/VivaDicta/Services/Reminders/CloudReminderExtractionProvider.swift
+++ b/VivaDicta/Services/Reminders/CloudReminderExtractionProvider.swift
@@ -315,11 +315,7 @@ final class CloudReminderExtractionProvider {
         )
         request.httpBody = try JSONSerialization.data(withJSONObject: requestBody)
 
-        let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw ReminderExtractionError.invalidResponse
-        }
+        let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
 
         guard httpResponse.statusCode == 200 else {
             let errorString = String(data: data, encoding: .utf8) ?? "Unknown error"
@@ -380,7 +376,9 @@ final class CloudReminderExtractionProvider {
             systemPrompt: systemMessage(now: now, timeZone: timeZone, language: language),
             model: model,
             accessToken: token,
-            projectId: projectId        )
+            projectId: projectId,
+            networkService: networkService
+        )
         return try decodeTextResponse(responseText)
     }
 
@@ -444,11 +442,7 @@ final class CloudReminderExtractionProvider {
 
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
-        let (data, response) = try await networkService.send(request, acceptableStatusCodes: Set(0...999))
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw ReminderExtractionError.invalidResponse
-        }
+        let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
 
         guard httpResponse.statusCode == 200 else {
             let errorString = String(data: data, encoding: .utf8) ?? "Unknown error"

--- a/VivaDicta/Views/SettingsScreen/ChatToolsSettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/ChatToolsSettingsView.swift
@@ -329,7 +329,7 @@ private struct ExaWebSearchSettingsView: View {
         request.httpBody = body
 
         do {
-            let client = NetworkClient(category: "ExaKeyVerification")
+            let client: any NetworkService = DefaultNetworkService(category: "ExaKeyVerification")
             let (_, response) = try await client.send(request)
             return (200...299).contains(response.statusCode)
         } catch {

--- a/VivaDictaTests/AIServiceNetworkingTests.swift
+++ b/VivaDictaTests/AIServiceNetworkingTests.swift
@@ -6,7 +6,7 @@ import NetworkingMocks
 import Testing
 @testable import VivaDicta
 
-/// Smoke tests confirming `AIService` plumbs the injected `URLSessionProtocol`
+/// Smoke tests confirming `AIService` plumbs the injected `NetworkService`
 /// through to the underlying HTTP calls. Full per-provider coverage lives in
 /// each provider's own test suite; this file just locks in the wiring so a
 /// future refactor that drops the injection is caught immediately.
@@ -21,17 +21,16 @@ struct AIServiceNetworkingTests {
         return defaults
     }
 
-    @Test func storesInjectedURLSession() {
-        let session = MockURLSession()
-        let service = AIService(userDefaults: makeDefaults(), urlSession: session)
+    @Test func storesInjectedNetworkService() {
+        let net = MockNetworkService()
+        let service = AIService(userDefaults: makeDefaults(), networkService: net)
 
-        // The injected mock should be reachable as the same instance.
-        #expect(service.urlSession is MockURLSession)
+        #expect(service.networkService is MockNetworkService)
     }
 
-    @Test func defaultURLSessionIsRealURLSessionWhenNotInjected() {
+    @Test func defaultNetworkServiceIsDefaultNetworkServiceWhenNotInjected() {
         let service = AIService(userDefaults: makeDefaults())
 
-        #expect(service.urlSession is URLSession)
+        #expect(service.networkService is DefaultNetworkService)
     }
 }


### PR DESCRIPTION
Consumer code now depends on a domain protocol (`NetworkService`) instead of a transport-level mock (`MockURLSession`). Closes the architectural smell where `MockURLSession` leaked into every consumer's test target.

## What changes

### Networking module

- **New `NetworkService` protocol** with `send` / `sendJSON` / `upload` / `bytes` + ergonomic default-arg overloads. This is the consumer-facing seam.
- **`NetworkClient` renamed to `DefaultNetworkService`** (the production conformance). `URLSessionProtocol` injection is now an *implementation detail* of this type.
- **New `MockNetworkService`** in `NetworkingMocks`. Captures requests + bodies, stubs per-method responses, and mirrors `DefaultNetworkService`'s status validation so 4xx/5xx stubs produce the same `NetworkError.unacceptableStatus` consumers see in production.
- **`MockURLSession` stays** for the Networking module's own tests of `DefaultNetworkService`. Convention: consumer code uses `MockNetworkService` going forward.
- 8 new `MockNetworkService` contract tests, existing `DefaultNetworkServiceTests` updated.

### Consumer migration (~25 files, net -61 lines after status-check boilerplate removal)

- **CloudTranscription** (12 services) take `networkService: any NetworkService` instead of `urlSession`. Status validation moves into `NetworkService.upload`/`send`; the existing `NetworkError → CloudTranscriptionError` bridge keeps `NetworkRetry` retry semantics intact. ~12 lines of HTTPURLResponse cast + manual status check dropped per service.
- **OAuth module** (`OAuthManager`, `GeminiOAuthProvider`, `CopilotOAuthManager`) and **app-target OAuth clients** (`CopilotAPIClient`, `OpenAIOAuthClient`) take `NetworkService`. OAuth code does its own 200-only checks, so it passes \`acceptableStatusCodes: Set(0...999)\` to bypass NetworkService's default 2xx validation.
- **`AIService`** + **`AIService+Chat`** swap ~44 `urlSession.data` / `.bytes` call sites for `networkService.send` / `.bytes`. SSE streaming paths preserved.
- **`CloudReminderExtractionProvider`**, **`VivAgentsClient`**, **`ExaSearchClient`**, **`ChatToolsSettingsView`** migrated.
- CloudTranscription tests switch from `MockURLSession.stubUploadResponse` to `MockNetworkService.stubUploadResponse`. Request-shape assertions via `capturedRequest` / `capturedBody` still work.
- `AIServiceNetworkingTests` verifies `NetworkService` injection.

## Design notes

- **One mocking seam.** Consumers depend on `NetworkService`. `URLSessionProtocol` becomes an implementation detail of `DefaultNetworkService`. The two boundaries no longer compete.
- **Faithful mock.** `MockNetworkService` runs the same status validation as production. Tests that stub a 500 response get `NetworkError.unacceptableStatus`, matching what production callers would see. No "tests stub differently than production runs" trap.
- **SSE caveat unchanged.** `URLSession.AsyncBytes` has no public initializer, so `MockNetworkService.bytes(for:)` still throws `StubNotSetError`. SSE testing remains integration-test territory.

## Test plan

- [x] \`swift test\` in Modules/Networking: 23 tests pass (15 existing + 8 new)
- [x] \`swift test\` in Modules/OAuth: 11 tests pass
- [x] \`swift test\` in Modules/CloudTranscription: 50 tests pass
- [x] \`xcodebuild test\` for VivaDicta scheme: 22 tests pass on iPhone 17 Pro Max / iOS 26.4
- [x] Manual audit: zero \`MockURLSession\` references in consumer code outside Networking module