### PR TITLE
Adopt sut + networkService naming convention in tests

### DIFF
--- a/Modules/CloudTranscription/Tests/CloudTranscriptionTests/GroqTranscriptionServiceTests.swift
+++ b/Modules/CloudTranscription/Tests/CloudTranscriptionTests/GroqTranscriptionServiceTests.swift
@@ -34,13 +34,13 @@ struct GroqTranscriptionServiceTests {
         )!
     }
 
-    private func stubSuccess(on session: MockNetworkService, text: String) {
+    private func stubSuccess(on networkService: MockNetworkService, text: String) {
         let body = Data(#"{"text":"\#(text)","language":"en","duration":0.5}"#.utf8)
-        session.stubUploadResponse = .success((body, makeHTTPResponse(200)))
+        networkService.stubUploadResponse = .success((body, makeHTTPResponse(200)))
     }
 
     private func makeService(
-        session: MockNetworkService,
+        networkService: MockNetworkService,
         apiKey: String = "gsk-test-key",
         modelName: String = "whisper-large-v3",
         language: String = "auto",
@@ -53,74 +53,74 @@ struct GroqTranscriptionServiceTests {
                 language: language,
                 vocabulary: vocabulary
             ),
-            networkService: session
+            networkService: networkService
         )
     }
 
     // MARK: - Success path
 
     @Test func successReturnsTranscribedText() async throws {
-        let session = MockNetworkService()
-        stubSuccess(on: session, text: "groq hello")
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "groq hello")
         let audio = try makeAudioFile()
-        let sut = makeService(session: session)
+        let sut = makeService(networkService: networkService)
 
         let result = try await sut.transcribe(audioURL: audio)
 
         #expect(result.text == "groq hello")
         #expect(result.isSpeakerAttributed == false)
-        #expect(session.uploadCallCount == 1)
+        #expect(networkService.uploadCallCount == 1)
     }
 
     // MARK: - Request shape
 
     @Test func requestTargetsGroqTranscriptionsEndpoint() async throws {
-        let session = MockNetworkService()
-        stubSuccess(on: session, text: "ok")
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
         let audio = try makeAudioFile()
-        let sut = makeService(session: session)
+        let sut = makeService(networkService: networkService)
 
         _ = try await sut.transcribe(audioURL: audio)
 
-        let req = try #require(session.capturedRequest)
+        let req = try #require(networkService.capturedRequest)
         #expect(req.url?.absoluteString == "https://api.groq.com/openai/v1/audio/transcriptions")
         #expect(req.httpMethod == "POST")
     }
 
     @Test func requestSendsBearerAuthorizationHeader() async throws {
-        let session = MockNetworkService()
-        stubSuccess(on: session, text: "ok")
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
         let audio = try makeAudioFile()
-        let sut = makeService(session: session, apiKey: "gsk-abc123")
+        let sut = makeService(networkService: networkService, apiKey: "gsk-abc123")
 
         _ = try await sut.transcribe(audioURL: audio)
 
-        let req = try #require(session.capturedRequest)
+        let req = try #require(networkService.capturedRequest)
         #expect(req.value(forHTTPHeaderField: "Authorization") == "Bearer gsk-abc123")
     }
 
     @Test func requestSendsMultipartContentTypeWithBoundary() async throws {
-        let session = MockNetworkService()
-        stubSuccess(on: session, text: "ok")
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
         let audio = try makeAudioFile()
-        let sut = makeService(session: session)
+        let sut = makeService(networkService: networkService)
 
         _ = try await sut.transcribe(audioURL: audio)
 
-        let req = try #require(session.capturedRequest)
+        let req = try #require(networkService.capturedRequest)
         let contentType = try #require(req.value(forHTTPHeaderField: "Content-Type"))
         #expect(contentType.hasPrefix("multipart/form-data; boundary=Boundary-"))
     }
 
     @Test func bodyContainsModelAndResponseFormatFields() async throws {
-        let session = MockNetworkService()
-        stubSuccess(on: session, text: "ok")
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
         let audio = try makeAudioFile()
-        let sut = makeService(session: session, modelName: "whisper-large-v3")
+        let sut = makeService(networkService: networkService, modelName: "whisper-large-v3")
 
         _ = try await sut.transcribe(audioURL: audio)
 
-        let body = try #require(session.capturedBody)
+        let body = try #require(networkService.capturedBody)
         let bodyString = try #require(String(data: body, encoding: .utf8))
         #expect(bodyString.range(of: "name=\"model\"\\s*\\r\\n\\r\\nwhisper-large-v3", options: .regularExpression) != nil)
         #expect(bodyString.range(of: "name=\"response_format\"\\s*\\r\\n\\r\\njson", options: .regularExpression) != nil)
@@ -128,27 +128,27 @@ struct GroqTranscriptionServiceTests {
     }
 
     @Test func bodyIncludesLanguageFieldWhenNotAuto() async throws {
-        let session = MockNetworkService()
-        stubSuccess(on: session, text: "ok")
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
         let audio = try makeAudioFile()
-        let sut = makeService(session: session, language: "fr")
+        let sut = makeService(networkService: networkService, language: "fr")
 
         _ = try await sut.transcribe(audioURL: audio)
 
-        let body = try #require(session.capturedBody)
+        let body = try #require(networkService.capturedBody)
         let bodyString = try #require(String(data: body, encoding: .utf8))
         #expect(bodyString.range(of: "name=\"language\"\\s*\\r\\n\\r\\nfr", options: .regularExpression) != nil)
     }
 
     @Test func bodyOmitsLanguageFieldWhenAuto() async throws {
-        let session = MockNetworkService()
-        stubSuccess(on: session, text: "ok")
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
         let audio = try makeAudioFile()
-        let sut = makeService(session: session, language: "auto")
+        let sut = makeService(networkService: networkService, language: "auto")
 
         _ = try await sut.transcribe(audioURL: audio)
 
-        let body = try #require(session.capturedBody)
+        let body = try #require(networkService.capturedBody)
         let bodyString = try #require(String(data: body, encoding: .utf8))
         #expect(!bodyString.contains("name=\"language\""))
     }
@@ -156,27 +156,27 @@ struct GroqTranscriptionServiceTests {
     // MARK: - Vocabulary / prompt (Groq-specific)
 
     @Test func bodyOmitsPromptFieldWhenVocabularyIsEmpty() async throws {
-        let session = MockNetworkService()
-        stubSuccess(on: session, text: "ok")
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
         let audio = try makeAudioFile()
-        let sut = makeService(session: session, vocabulary: [])
+        let sut = makeService(networkService: networkService, vocabulary: [])
 
         _ = try await sut.transcribe(audioURL: audio)
 
-        let body = try #require(session.capturedBody)
+        let body = try #require(networkService.capturedBody)
         let bodyString = try #require(String(data: body, encoding: .utf8))
         #expect(!bodyString.contains("name=\"prompt\""))
     }
 
     @Test func bodyIncludesPromptFieldWhenVocabularyProvided() async throws {
-        let session = MockNetworkService()
-        stubSuccess(on: session, text: "ok")
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
         let audio = try makeAudioFile()
-        let sut = makeService(session: session, vocabulary: ["SwiftUI", "Kubernetes"])
+        let sut = makeService(networkService: networkService, vocabulary: ["SwiftUI", "Kubernetes"])
 
         _ = try await sut.transcribe(audioURL: audio)
 
-        let body = try #require(session.capturedBody)
+        let body = try #require(networkService.capturedBody)
         let bodyString = try #require(String(data: body, encoding: .utf8))
         #expect(bodyString.contains("name=\"prompt\""))
         #expect(bodyString.contains("SwiftUI, Kubernetes"))
@@ -186,20 +186,20 @@ struct GroqTranscriptionServiceTests {
     // MARK: - Validation / short-circuit
 
     @Test func missingAPIKeyThrowsBeforeMakingRequest() async throws {
-        let session = MockNetworkService()
+        let networkService = MockNetworkService()
         let audio = try makeAudioFile()
-        let sut = makeService(session: session, apiKey: "")
+        let sut = makeService(networkService: networkService, apiKey: "")
 
         await #expect(throws: CloudTranscriptionError.self) {
             _ = try await sut.transcribe(audioURL: audio)
         }
-        #expect(session.uploadCallCount == 0, "no network call should be made when API key is empty")
+        #expect(networkService.uploadCallCount == 0, "no network call should be made when API key is empty")
     }
 
     @Test func missingAudioFileThrowsAudioFileNotFound() async {
-        let session = MockNetworkService()
+        let networkService = MockNetworkService()
         let audio = URL.temporaryDirectory.appending(path: "definitely-not-a-real-file-\(UUID()).wav")
-        let sut = makeService(session: session)
+        let sut = makeService(networkService: networkService)
 
         await #expect(throws: CloudTranscriptionError.self) {
             _ = try await sut.transcribe(audioURL: audio)
@@ -209,13 +209,13 @@ struct GroqTranscriptionServiceTests {
     // MARK: - Response handling
 
     @Test func nonSuccessStatusThrowsApiRequestFailed() async throws {
-        let session = MockNetworkService()
-        session.stubUploadResponse = .success((
+        let networkService = MockNetworkService()
+        networkService.stubUploadResponse = .success((
             Data(#"{"error":"invalid key"}"#.utf8),
             makeHTTPResponse(401)
         ))
         let audio = try makeAudioFile()
-        let sut = makeService(session: session)
+        let sut = makeService(networkService: networkService)
 
         do {
             _ = try await sut.transcribe(audioURL: audio)
@@ -229,10 +229,10 @@ struct GroqTranscriptionServiceTests {
     }
 
     @Test func undecodableJSONOn200ThrowsNoTranscriptionReturned() async throws {
-        let session = MockNetworkService()
-        session.stubUploadResponse = .success((Data("not json".utf8), makeHTTPResponse(200)))
+        let networkService = MockNetworkService()
+        networkService.stubUploadResponse = .success((Data("not json".utf8), makeHTTPResponse(200)))
         let audio = try makeAudioFile()
-        let sut = makeService(session: session)
+        let sut = makeService(networkService: networkService)
 
         do {
             _ = try await sut.transcribe(audioURL: audio)

--- a/Modules/CloudTranscription/Tests/CloudTranscriptionTests/OpenAITranscriptionServiceTests.swift
+++ b/Modules/CloudTranscription/Tests/CloudTranscriptionTests/OpenAITranscriptionServiceTests.swift
@@ -39,87 +39,87 @@ struct OpenAITranscriptionServiceTests {
         )!
     }
 
-    private func stubSuccess(on session: MockNetworkService, text: String) {
+    private func stubSuccess(on networkService: MockNetworkService, text: String) {
         let body = Data(#"{"text":"\#(text)","language":"en","duration":0.5}"#.utf8)
-        session.stubUploadResponse = .success((body, makeHTTPResponse(200)))
+        networkService.stubUploadResponse = .success((body, makeHTTPResponse(200)))
     }
 
     private func makeService(
-        session: MockNetworkService,
+        networkService: MockNetworkService,
         apiKey: String = "sk-test-key",
         modelName: String = "whisper-1",
         language: String = "auto"
     ) -> OpenAITranscriptionService {
         OpenAITranscriptionService(
             config: .init(apiKey: apiKey, modelName: modelName, language: language),
-            networkService: session
+            networkService: networkService
         )
     }
 
     // MARK: - Success path
 
     @Test func successReturnsTranscribedText() async throws {
-        let session = MockNetworkService()
-        stubSuccess(on: session, text: "hello world")
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "hello world")
         let audio = try makeAudioFile()
 
-        let sut = makeService(session: session)
+        let sut = makeService(networkService: networkService)
         let result = try await sut.transcribe(audioURL: audio)
 
         #expect(result.text == "hello world")
         #expect(result.isSpeakerAttributed == false)
-        #expect(session.uploadCallCount == 1)
+        #expect(networkService.uploadCallCount == 1)
     }
 
     // MARK: - Request shape
 
     @Test func requestTargetsOpenAITranscriptionsEndpoint() async throws {
-        let session = MockNetworkService()
-        stubSuccess(on: session, text: "ok")
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
         let audio = try makeAudioFile()
 
-        let sut = makeService(session: session)
+        let sut = makeService(networkService: networkService)
         _ = try await sut.transcribe(audioURL: audio)
 
-        let req = try #require(session.capturedRequest)
+        let req = try #require(networkService.capturedRequest)
         #expect(req.url?.absoluteString == "https://api.openai.com/v1/audio/transcriptions")
         #expect(req.httpMethod == "POST")
     }
 
     @Test func requestSendsBearerAuthorizationHeader() async throws {
-        let session = MockNetworkService()
-        stubSuccess(on: session, text: "ok")
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
         let audio = try makeAudioFile()
 
-        let sut = makeService(session: session, apiKey: "sk-abc123")
+        let sut = makeService(networkService: networkService, apiKey: "sk-abc123")
         _ = try await sut.transcribe(audioURL: audio)
 
-        let req = try #require(session.capturedRequest)
+        let req = try #require(networkService.capturedRequest)
         #expect(req.value(forHTTPHeaderField: "Authorization") == "Bearer sk-abc123")
     }
 
     @Test func requestSendsMultipartContentTypeWithBoundary() async throws {
-        let session = MockNetworkService()
-        stubSuccess(on: session, text: "ok")
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
         let audio = try makeAudioFile()
 
-        let sut = makeService(session: session)
+        let sut = makeService(networkService: networkService)
         _ = try await sut.transcribe(audioURL: audio)
 
-        let req = try #require(session.capturedRequest)
+        let req = try #require(networkService.capturedRequest)
         let contentType = try #require(req.value(forHTTPHeaderField: "Content-Type"))
         #expect(contentType.hasPrefix("multipart/form-data; boundary=Boundary-"))
     }
 
     @Test func bodyContainsModelAndResponseFormatFields() async throws {
-        let session = MockNetworkService()
-        stubSuccess(on: session, text: "ok")
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
         let audio = try makeAudioFile()
 
-        let sut = makeService(session: session, modelName: "whisper-1")
+        let sut = makeService(networkService: networkService, modelName: "whisper-1")
         _ = try await sut.transcribe(audioURL: audio)
 
-        let body = try #require(session.capturedBody)
+        let body = try #require(networkService.capturedBody)
         let bodyString = try #require(String(data: body, encoding: .utf8))
         // Regex form (rather than separate `contains` checks) ensures each
         // value immediately follows its multipart field header, so a
@@ -130,27 +130,27 @@ struct OpenAITranscriptionServiceTests {
     }
 
     @Test func bodyIncludesLanguageFieldWhenNotAuto() async throws {
-        let session = MockNetworkService()
-        stubSuccess(on: session, text: "ok")
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
         let audio = try makeAudioFile()
 
-        let sut = makeService(session: session, language: "en")
+        let sut = makeService(networkService: networkService, language: "en")
         _ = try await sut.transcribe(audioURL: audio)
 
-        let body = try #require(session.capturedBody)
+        let body = try #require(networkService.capturedBody)
         let bodyString = try #require(String(data: body, encoding: .utf8))
         #expect(bodyString.range(of: "name=\"language\"\\s*\\r\\n\\r\\nen", options: .regularExpression) != nil)
     }
 
     @Test func bodyOmitsLanguageFieldWhenAuto() async throws {
-        let session = MockNetworkService()
-        stubSuccess(on: session, text: "ok")
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
         let audio = try makeAudioFile()
 
-        let sut = makeService(session: session, language: "auto")
+        let sut = makeService(networkService: networkService, language: "auto")
         _ = try await sut.transcribe(audioURL: audio)
 
-        let body = try #require(session.capturedBody)
+        let body = try #require(networkService.capturedBody)
         let bodyString = try #require(String(data: body, encoding: .utf8))
         #expect(!bodyString.contains("name=\"language\""))
     }
@@ -158,20 +158,20 @@ struct OpenAITranscriptionServiceTests {
     // MARK: - Validation / short-circuit
 
     @Test func missingAPIKeyThrowsBeforeMakingRequest() async throws {
-        let session = MockNetworkService()
+        let networkService = MockNetworkService()
         let audio = try makeAudioFile()
-        let sut = makeService(session: session, apiKey: "")
+        let sut = makeService(networkService: networkService, apiKey: "")
 
         await #expect(throws: CloudTranscriptionError.self) {
             _ = try await sut.transcribe(audioURL: audio)
         }
-        #expect(session.uploadCallCount == 0, "no network call should be made when API key is empty")
+        #expect(networkService.uploadCallCount == 0, "no network call should be made when API key is empty")
     }
 
     @Test func missingAudioFileThrowsAudioFileNotFound() async {
-        let session = MockNetworkService()
+        let networkService = MockNetworkService()
         let audio = URL.temporaryDirectory.appending(path: "definitely-not-a-real-file-\(UUID()).wav")
-        let sut = makeService(session: session)
+        let sut = makeService(networkService: networkService)
 
         await #expect(throws: CloudTranscriptionError.self) {
             _ = try await sut.transcribe(audioURL: audio)
@@ -182,13 +182,13 @@ struct OpenAITranscriptionServiceTests {
 
     @Test func nonSuccessStatusThrowsApiRequestFailed() async throws {
         // 401 is not retried (only 429 + 5xx are), so this throws immediately.
-        let session = MockNetworkService()
-        session.stubUploadResponse = .success((
+        let networkService = MockNetworkService()
+        networkService.stubUploadResponse = .success((
             Data(#"{"error":"invalid key"}"#.utf8),
             makeHTTPResponse(401)
         ))
         let audio = try makeAudioFile()
-        let sut = makeService(session: session)
+        let sut = makeService(networkService: networkService)
 
         do {
             _ = try await sut.transcribe(audioURL: audio)
@@ -202,10 +202,10 @@ struct OpenAITranscriptionServiceTests {
     }
 
     @Test func undecodableJSONOn200ThrowsNoTranscriptionReturned() async throws {
-        let session = MockNetworkService()
-        session.stubUploadResponse = .success((Data("not json".utf8), makeHTTPResponse(200)))
+        let networkService = MockNetworkService()
+        networkService.stubUploadResponse = .success((Data("not json".utf8), makeHTTPResponse(200)))
         let audio = try makeAudioFile()
-        let sut = makeService(session: session)
+        let sut = makeService(networkService: networkService)
 
         do {
             _ = try await sut.transcribe(audioURL: audio)

--- a/Modules/CloudTranscription/Tests/CloudTranscriptionTests/XaiTranscriptionServiceTests.swift
+++ b/Modules/CloudTranscription/Tests/CloudTranscriptionTests/XaiTranscriptionServiceTests.swift
@@ -30,13 +30,13 @@ struct XaiTranscriptionServiceTests {
         )!
     }
 
-    private func stubSuccess(on session: MockNetworkService, text: String) {
+    private func stubSuccess(on networkService: MockNetworkService, text: String) {
         let body = Data(#"{"text":"\#(text)"}"#.utf8)
-        session.stubUploadResponse = .success((body, makeHTTPResponse(200)))
+        networkService.stubUploadResponse = .success((body, makeHTTPResponse(200)))
     }
 
     private func makeService(
-        session: MockNetworkService,
+        networkService: MockNetworkService,
         apiKey: String = "xai-test-key",
         language: String = "en",
         formatted: Bool = true
@@ -47,100 +47,100 @@ struct XaiTranscriptionServiceTests {
                 language: language,
                 formatted: formatted
             ),
-            networkService: session
+            networkService: networkService
         )
     }
 
     // MARK: - Success path
 
     @Test func successReturnsTranscribedText() async throws {
-        let session = MockNetworkService()
-        stubSuccess(on: session, text: "xai hello")
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "xai hello")
         let audio = try makeAudioFile()
-        let sut = makeService(session: session)
+        let sut = makeService(networkService: networkService)
 
         let result = try await sut.transcribe(audioURL: audio)
 
         #expect(result.text == "xai hello")
         #expect(result.isSpeakerAttributed == false)
-        #expect(session.uploadCallCount == 1)
+        #expect(networkService.uploadCallCount == 1)
     }
 
     // MARK: - Request shape
 
     @Test func requestTargetsXaiSttEndpoint() async throws {
-        let session = MockNetworkService()
-        stubSuccess(on: session, text: "ok")
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
         let audio = try makeAudioFile()
-        let sut = makeService(session: session)
+        let sut = makeService(networkService: networkService)
 
         _ = try await sut.transcribe(audioURL: audio)
 
-        let req = try #require(session.capturedRequest)
+        let req = try #require(networkService.capturedRequest)
         #expect(req.url?.absoluteString == "https://api.x.ai/v1/stt")
         #expect(req.httpMethod == "POST")
     }
 
     @Test func requestSendsBearerAuthorizationHeader() async throws {
-        let session = MockNetworkService()
-        stubSuccess(on: session, text: "ok")
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
         let audio = try makeAudioFile()
-        let sut = makeService(session: session, apiKey: "xai-abc123")
+        let sut = makeService(networkService: networkService, apiKey: "xai-abc123")
 
         _ = try await sut.transcribe(audioURL: audio)
 
-        let req = try #require(session.capturedRequest)
+        let req = try #require(networkService.capturedRequest)
         #expect(req.value(forHTTPHeaderField: "Authorization") == "Bearer xai-abc123")
     }
 
     @Test func requestSendsMultipartContentTypeWithBoundary() async throws {
-        let session = MockNetworkService()
-        stubSuccess(on: session, text: "ok")
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
         let audio = try makeAudioFile()
-        let sut = makeService(session: session)
+        let sut = makeService(networkService: networkService)
 
         _ = try await sut.transcribe(audioURL: audio)
 
-        let req = try #require(session.capturedRequest)
+        let req = try #require(networkService.capturedRequest)
         let contentType = try #require(req.value(forHTTPHeaderField: "Content-Type"))
         #expect(contentType.hasPrefix("multipart/form-data; boundary=Boundary-"))
     }
 
     @Test func bodyContainsFormatTrueByDefault() async throws {
-        let session = MockNetworkService()
-        stubSuccess(on: session, text: "ok")
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
         let audio = try makeAudioFile()
-        let sut = makeService(session: session)
+        let sut = makeService(networkService: networkService)
 
         _ = try await sut.transcribe(audioURL: audio)
 
-        let body = try #require(session.capturedBody)
+        let body = try #require(networkService.capturedBody)
         let bodyString = try #require(String(data: body, encoding: .utf8))
         #expect(bodyString.range(of: "name=\"format\"\\s*\\r\\n\\r\\ntrue", options: .regularExpression) != nil)
     }
 
     @Test func bodySendsFormatFalseWhenFormattedDisabled() async throws {
-        let session = MockNetworkService()
-        stubSuccess(on: session, text: "ok")
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
         let audio = try makeAudioFile()
-        let sut = makeService(session: session, formatted: false)
+        let sut = makeService(networkService: networkService, formatted: false)
 
         _ = try await sut.transcribe(audioURL: audio)
 
-        let body = try #require(session.capturedBody)
+        let body = try #require(networkService.capturedBody)
         let bodyString = try #require(String(data: body, encoding: .utf8))
         #expect(bodyString.range(of: "name=\"format\"\\s*\\r\\n\\r\\nfalse", options: .regularExpression) != nil)
     }
 
     @Test func bodyIncludesLanguageField() async throws {
-        let session = MockNetworkService()
-        stubSuccess(on: session, text: "ok")
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
         let audio = try makeAudioFile()
-        let sut = makeService(session: session, language: "fr")
+        let sut = makeService(networkService: networkService, language: "fr")
 
         _ = try await sut.transcribe(audioURL: audio)
 
-        let body = try #require(session.capturedBody)
+        let body = try #require(networkService.capturedBody)
         let bodyString = try #require(String(data: body, encoding: .utf8))
         #expect(bodyString.range(of: "name=\"language\"\\s*\\r\\n\\r\\nfr", options: .regularExpression) != nil)
     }
@@ -149,27 +149,27 @@ struct XaiTranscriptionServiceTests {
         // xAI rejects format=true without a language, so the service must
         // never omit the field. Verify with `fil` (Filipino) since it's xAI's
         // 3-letter outlier and proves no "drop if not in allowlist" sneaks in.
-        let session = MockNetworkService()
-        stubSuccess(on: session, text: "ok")
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
         let audio = try makeAudioFile()
-        let sut = makeService(session: session, language: "fil")
+        let sut = makeService(networkService: networkService, language: "fil")
 
         _ = try await sut.transcribe(audioURL: audio)
 
-        let body = try #require(session.capturedBody)
+        let body = try #require(networkService.capturedBody)
         let bodyString = try #require(String(data: body, encoding: .utf8))
         #expect(bodyString.range(of: "name=\"language\"\\s*\\r\\n\\r\\nfil", options: .regularExpression) != nil)
     }
 
     @Test func bodyOrdersFieldsAsFormatLanguageFile() async throws {
-        let session = MockNetworkService()
-        stubSuccess(on: session, text: "ok")
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
         let audio = try makeAudioFile()
-        let sut = makeService(session: session, language: "en")
+        let sut = makeService(networkService: networkService, language: "en")
 
         _ = try await sut.transcribe(audioURL: audio)
 
-        let body = try #require(session.capturedBody)
+        let body = try #require(networkService.capturedBody)
         let bodyString = try #require(String(data: body, encoding: .utf8))
         let formatRange = try #require(bodyString.range(of: "name=\"format\""))
         let languageRange = try #require(bodyString.range(of: "name=\"language\""))
@@ -183,20 +183,20 @@ struct XaiTranscriptionServiceTests {
     // MARK: - Validation / short-circuit
 
     @Test func missingAPIKeyThrowsBeforeMakingRequest() async throws {
-        let session = MockNetworkService()
+        let networkService = MockNetworkService()
         let audio = try makeAudioFile()
-        let sut = makeService(session: session, apiKey: "")
+        let sut = makeService(networkService: networkService, apiKey: "")
 
         await #expect(throws: CloudTranscriptionError.self) {
             _ = try await sut.transcribe(audioURL: audio)
         }
-        #expect(session.uploadCallCount == 0, "no network call should be made when API key is empty")
+        #expect(networkService.uploadCallCount == 0, "no network call should be made when API key is empty")
     }
 
     @Test func missingAudioFileThrowsAudioFileNotFound() async {
-        let session = MockNetworkService()
+        let networkService = MockNetworkService()
         let audio = URL.temporaryDirectory.appending(path: "definitely-not-a-real-file-\(UUID()).wav")
-        let sut = makeService(session: session)
+        let sut = makeService(networkService: networkService)
 
         await #expect(throws: CloudTranscriptionError.self) {
             _ = try await sut.transcribe(audioURL: audio)
@@ -206,13 +206,13 @@ struct XaiTranscriptionServiceTests {
     // MARK: - Response handling
 
     @Test func nonSuccessStatusThrowsApiRequestFailed() async throws {
-        let session = MockNetworkService()
-        session.stubUploadResponse = .success((
+        let networkService = MockNetworkService()
+        networkService.stubUploadResponse = .success((
             Data(#"{"error":"invalid key"}"#.utf8),
             makeHTTPResponse(401)
         ))
         let audio = try makeAudioFile()
-        let sut = makeService(session: session)
+        let sut = makeService(networkService: networkService)
 
         do {
             _ = try await sut.transcribe(audioURL: audio)
@@ -226,10 +226,10 @@ struct XaiTranscriptionServiceTests {
     }
 
     @Test func undecodableJSONOn200ThrowsNoTranscriptionReturned() async throws {
-        let session = MockNetworkService()
-        session.stubUploadResponse = .success((Data("not json".utf8), makeHTTPResponse(200)))
+        let networkService = MockNetworkService()
+        networkService.stubUploadResponse = .success((Data("not json".utf8), makeHTTPResponse(200)))
         let audio = try makeAudioFile()
-        let sut = makeService(session: session)
+        let sut = makeService(networkService: networkService)
 
         do {
             _ = try await sut.transcribe(audioURL: audio)

--- a/Modules/Networking/Tests/NetworkingTests/DefaultNetworkServiceTests.swift
+++ b/Modules/Networking/Tests/NetworkingTests/DefaultNetworkServiceTests.swift
@@ -25,9 +25,9 @@ struct DefaultNetworkServiceTests {
         let session = MockURLSession()
         let payload = Data(#"{"ok":true}"#.utf8)
         session.stubDataResponse = .success((payload, makeResponse(200)))
-        let client = DefaultNetworkService(session: session)
+        let sut = DefaultNetworkService(session: session)
 
-        let (data, response) = try await client.send(URLRequest(url: endpoint))
+        let (data, response) = try await sut.send(URLRequest(url: endpoint))
 
         #expect(data == payload)
         #expect(response.statusCode == 200)
@@ -38,10 +38,10 @@ struct DefaultNetworkServiceTests {
         let session = MockURLSession()
         let body = Data(#"{"error":"nope"}"#.utf8)
         session.stubDataResponse = .success((body, makeResponse(404)))
-        let client = DefaultNetworkService(session: session)
+        let sut = DefaultNetworkService(session: session)
 
         await #expect {
-            try await client.send(URLRequest(url: endpoint))
+            try await sut.send(URLRequest(url: endpoint))
         } throws: { error in
             guard let net = error as? NetworkError,
                   case let .unacceptableStatus(code, payload) = net else {
@@ -55,10 +55,10 @@ struct DefaultNetworkServiceTests {
         struct Boom: Error {}
         let session = MockURLSession()
         session.stubDataResponse = .failure(Boom())
-        let client = DefaultNetworkService(session: session)
+        let sut = DefaultNetworkService(session: session)
 
         await #expect {
-            try await client.send(URLRequest(url: endpoint))
+            try await sut.send(URLRequest(url: endpoint))
         } throws: { error in
             guard let net = error as? NetworkError,
                   case .transport = net else { return false }
@@ -69,9 +69,9 @@ struct DefaultNetworkServiceTests {
     @Test func customAcceptableStatusCodesOverrideDefault() async throws {
         let session = MockURLSession()
         session.stubDataResponse = .success((Data(), makeResponse(302)))
-        let client = DefaultNetworkService(session: session)
+        let sut = DefaultNetworkService(session: session)
 
-        let (_, response) = try await client.send(
+        let (_, response) = try await sut.send(
             URLRequest(url: endpoint),
             acceptableStatusCodes: [200, 302]
         )
@@ -87,9 +87,9 @@ struct DefaultNetworkServiceTests {
     @Test func sendJSONDecodesResponse() async throws {
         let session = MockURLSession()
         session.stubDataResponse = .success((Data(#"{"value":"hi"}"#.utf8), makeResponse(200)))
-        let client = DefaultNetworkService(session: session)
+        let sut = DefaultNetworkService(session: session)
 
-        let result: Echo = try await client.sendJSON(URLRequest(url: endpoint))
+        let result: Echo = try await sut.sendJSON(URLRequest(url: endpoint))
 
         #expect(result == Echo(value: "hi"))
     }
@@ -97,10 +97,10 @@ struct DefaultNetworkServiceTests {
     @Test func sendJSONWrapsDecodingErrors() async throws {
         let session = MockURLSession()
         session.stubDataResponse = .success((Data(#"{"wrong":"shape"}"#.utf8), makeResponse(200)))
-        let client = DefaultNetworkService(session: session)
+        let sut = DefaultNetworkService(session: session)
 
         await #expect {
-            let _: Echo = try await client.sendJSON(URLRequest(url: endpoint))
+            let _: Echo = try await sut.sendJSON(URLRequest(url: endpoint))
         } throws: { error in
             guard let net = error as? NetworkError,
                   case .decodingFailed = net else { return false }
@@ -113,10 +113,10 @@ struct DefaultNetworkServiceTests {
     @Test func uploadPassesBodyToSession() async throws {
         let session = MockURLSession()
         session.stubUploadResponse = .success((Data(), makeResponse(200)))
-        let client = DefaultNetworkService(session: session)
+        let sut = DefaultNetworkService(session: session)
 
         let body = Data("payload".utf8)
-        _ = try await client.upload(URLRequest(url: endpoint), from: body)
+        _ = try await sut.upload(URLRequest(url: endpoint), from: body)
 
         #expect(session.uploadCallCount == 1)
         #expect(session.capturedBody == body)
@@ -125,10 +125,10 @@ struct DefaultNetworkServiceTests {
     @Test func uploadThrowsForServerErrors() async throws {
         let session = MockURLSession()
         session.stubUploadResponse = .success((Data("internal".utf8), makeResponse(500)))
-        let client = DefaultNetworkService(session: session)
+        let sut = DefaultNetworkService(session: session)
 
         await #expect {
-            _ = try await client.upload(URLRequest(url: endpoint), from: Data())
+            _ = try await sut.upload(URLRequest(url: endpoint), from: Data())
         } throws: { error in
             (error as? NetworkError)?.statusCode == 500
         }

--- a/Modules/Networking/Tests/NetworkingTests/MockNetworkServiceTests.swift
+++ b/Modules/Networking/Tests/NetworkingTests/MockNetworkServiceTests.swift
@@ -21,39 +21,39 @@ struct MockNetworkServiceTests {
     }
 
     @Test func sendReturnsStubbedResponse() async throws {
-        let mock = MockNetworkService()
+        let sut = MockNetworkService()
         let body = Data("ok".utf8)
-        mock.stubSendResponse = .success((body, makeResponse(200)))
+        sut.stubSendResponse = .success((body, makeResponse(200)))
 
-        let (data, response) = try await mock.send(URLRequest(url: endpoint))
+        let (data, response) = try await sut.send(URLRequest(url: endpoint))
 
         #expect(data == body)
         #expect(response.statusCode == 200)
-        #expect(mock.sendCallCount == 1)
+        #expect(sut.sendCallCount == 1)
     }
 
     @Test func sendCapturesRequestAndStatusCodeOverride() async throws {
-        let mock = MockNetworkService()
-        mock.stubSendResponse = .success((Data(), makeResponse(200)))
+        let sut = MockNetworkService()
+        sut.stubSendResponse = .success((Data(), makeResponse(200)))
 
         var request = URLRequest(url: endpoint)
         request.httpMethod = "POST"
         request.setValue("Bearer xyz", forHTTPHeaderField: "Authorization")
-        _ = try await mock.send(request, acceptableStatusCodes: [200, 302])
+        _ = try await sut.send(request, acceptableStatusCodes: [200, 302])
 
-        #expect(mock.capturedRequest?.url == endpoint)
-        #expect(mock.capturedRequest?.httpMethod == "POST")
-        #expect(mock.capturedRequest?.value(forHTTPHeaderField: "Authorization") == "Bearer xyz")
-        #expect(mock.capturedAcceptableStatusCodes == [200, 302])
+        #expect(sut.capturedRequest?.url == endpoint)
+        #expect(sut.capturedRequest?.httpMethod == "POST")
+        #expect(sut.capturedRequest?.value(forHTTPHeaderField: "Authorization") == "Bearer xyz")
+        #expect(sut.capturedAcceptableStatusCodes == [200, 302])
     }
 
     @Test func sendPropagatesStubbedError() async {
         struct Boom: Error {}
-        let mock = MockNetworkService()
-        mock.stubSendResponse = .failure(Boom())
+        let sut = MockNetworkService()
+        sut.stubSendResponse = .failure(Boom())
 
         await #expect(throws: Boom.self) {
-            _ = try await mock.send(URLRequest(url: endpoint))
+            _ = try await sut.send(URLRequest(url: endpoint))
         }
     }
 
@@ -62,50 +62,50 @@ struct MockNetworkServiceTests {
     }
 
     @Test func sendJSONReturnsTypedStub() async throws {
-        let mock = MockNetworkService()
-        mock.stubSendJSONResponse = .success(Echo(value: "hi"))
+        let sut = MockNetworkService()
+        sut.stubSendJSONResponse = .success(Echo(value: "hi"))
 
-        let result: Echo = try await mock.sendJSON(URLRequest(url: endpoint))
+        let result: Echo = try await sut.sendJSON(URLRequest(url: endpoint))
 
         #expect(result == Echo(value: "hi"))
-        #expect(mock.sendJSONCallCount == 1)
+        #expect(sut.sendJSONCallCount == 1)
     }
 
     @Test func sendJSONWithMismatchedStubThrowsStubNotSetError() async {
-        let mock = MockNetworkService()
-        mock.stubSendJSONResponse = .success("string instead of Echo")
+        let sut = MockNetworkService()
+        sut.stubSendJSONResponse = .success("string instead of Echo")
 
         await #expect(throws: StubNotSetError.self) {
-            let _: Echo = try await mock.sendJSON(URLRequest(url: endpoint))
+            let _: Echo = try await sut.sendJSON(URLRequest(url: endpoint))
         }
     }
 
     @Test func uploadCapturesBody() async throws {
-        let mock = MockNetworkService()
-        mock.stubUploadResponse = .success((Data(), makeResponse(200)))
+        let sut = MockNetworkService()
+        sut.stubUploadResponse = .success((Data(), makeResponse(200)))
 
         let body = Data("payload".utf8)
-        _ = try await mock.upload(URLRequest(url: endpoint), from: body)
+        _ = try await sut.upload(URLRequest(url: endpoint), from: body)
 
-        #expect(mock.uploadCallCount == 1)
-        #expect(mock.capturedBody == body)
+        #expect(sut.uploadCallCount == 1)
+        #expect(sut.capturedBody == body)
     }
 
     @Test func unsetSendStubRecordsIssue() async {
         await withKnownIssue {
-            let mock = MockNetworkService()
+            let sut = MockNetworkService()
             await #expect(throws: StubNotSetError.self) {
-                _ = try await mock.send(URLRequest(url: endpoint))
+                _ = try await sut.send(URLRequest(url: endpoint))
             }
         }
     }
 
     @Test func bytesAlwaysThrowsStubNotSetError() async {
-        let mock = MockNetworkService()
+        let sut = MockNetworkService()
 
         await #expect(throws: StubNotSetError.self) {
-            _ = try await mock.bytes(for: URLRequest(url: endpoint))
+            _ = try await sut.bytes(for: URLRequest(url: endpoint))
         }
-        #expect(mock.bytesCallCount == 1)
+        #expect(sut.bytesCallCount == 1)
     }
 }

--- a/VivaDictaTests/AIServiceNetworkingTests.swift
+++ b/VivaDictaTests/AIServiceNetworkingTests.swift
@@ -22,15 +22,15 @@ struct AIServiceNetworkingTests {
     }
 
     @Test func storesInjectedNetworkService() {
-        let net = MockNetworkService()
-        let service = AIService(userDefaults: makeDefaults(), networkService: net)
+        let networkService = MockNetworkService()
+        let sut = AIService(userDefaults: makeDefaults(), networkService: networkService)
 
-        #expect(service.networkService is MockNetworkService)
+        #expect(sut.networkService is MockNetworkService)
     }
 
     @Test func defaultNetworkServiceIsDefaultNetworkServiceWhenNotInjected() {
-        let service = AIService(userDefaults: makeDefaults())
+        let sut = AIService(userDefaults: makeDefaults())
 
-        #expect(service.networkService is DefaultNetworkService)
+        #expect(sut.networkService is DefaultNetworkService)
     }
 }


### PR DESCRIPTION
Tightens Swift Testing variable naming across the migrated test files.

## What changes

- **`sut`** ("system under test") for the type being tested:
  - \`DefaultNetworkServiceTests\`: \`let client = DefaultNetworkService(...)\` → \`let sut = ...\`
  - \`MockNetworkServiceTests\`: \`let mock = MockNetworkService()\` → \`let sut = ...\` (the mock itself is the subject here)
  - \`AIServiceNetworkingTests\`: \`let service = AIService(...)\` → \`let sut = ...\`

- **\`networkService\`** for the injected \`MockNetworkService\` dependency, matching the consumer's init parameter name. The old \`session\` naming was a holdover from when the mock was \`MockURLSession\` injected as \`urlSession\`:
  - \`OpenAITranscriptionServiceTests\`, \`GroqTranscriptionServiceTests\`, \`XaiTranscriptionServiceTests\`: \`let session = MockNetworkService()\` → \`let networkService = ...\` plus all helper params
  - \`AIServiceNetworkingTests\`: \`let net = ...\` → \`let networkService = ...\`

- **\`DefaultNetworkServiceTests\` keeps \`session\`** for the \`MockURLSession\` it passes to \`DefaultNetworkService(session:)\` - that variable name matches the init parameter and is correct.

## Convention

Documented in user-level CLAUDE.md:
- The variable holding the type under test is **\`sut\`**.
- Dependency mocks use **the consumer's init parameter name** (\`networkService\`, \`keychain\`, etc.).
- Test types are **\`struct\`** (not \`final class\`) - Swift Testing gives per-test isolation automatically.
- Hoist \`sut\` to a property + \`init()\` when SUT config is constant; use \`makeSUT(...)\` helpers when it varies per test.

## Test plan

- [x] \`swift test\` in Modules/Networking: 23 tests pass
- [x] \`swift test\` in Modules/CloudTranscription: 50 tests pass
- [x] \`xcodebuild test\` for VivaDicta scheme: 22 tests pass (iPhone 17 Pro Max / iOS 26.4)
- [x] No behavior changes - all renames are local variable / helper parameter