### PR TITLE
Extract OAuthManager and CopilotOAuthManager protocols; add mocks

### DIFF
--- a/Modules/OAuth/Sources/OAuth/CopilotOAuthManagerProtocol.swift
+++ b/Modules/OAuth/Sources/OAuth/CopilotOAuthManagerProtocol.swift
@@ -1,0 +1,41 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+
+/// GitHub Copilot OAuth manager seam used by consumers. The production
+/// conformance is ``DefaultCopilotOAuthManager``; tests inject
+/// `MockCopilotOAuthManager` from `OAuthMocks` to fake the device-code
+/// flow without polling GitHub.
+///
+/// `@MainActor`-isolated to match the credential-storage and background-task
+/// requirements of the device-code flow.
+@MainActor
+public protocol CopilotOAuthManager: Sendable {
+    /// Whether the user is signed in to Copilot.
+    var isSignedIn: Bool { get }
+
+    /// Display name shown in settings (GitHub username if known).
+    var accountInfo: String? { get }
+
+    /// Kicks off the GitHub device-code flow. Returns the user code +
+    /// verification URL the caller surfaces in UI.
+    func startDeviceCodeFlow() async throws -> DeviceCodeResponse
+
+    /// Polls GitHub until the user authorizes the device code.
+    /// `expiresIn` defaults to 900s, matching the GitHub-issued lifetime.
+    func pollForToken(deviceCode: String, interval: Int, expiresIn: Int) async throws -> CopilotCredential
+
+    /// Returns a valid Copilot token, refreshing from the stored GitHub
+    /// access token if the Copilot token is expiring soon.
+    func validCopilotToken() async throws -> String
+
+    /// Signs out by removing the stored credential.
+    func signOut()
+}
+
+// Convenience: keep the `expiresIn: Int = 900` ergonomics on the protocol.
+public extension CopilotOAuthManager {
+    func pollForToken(deviceCode: String, interval: Int) async throws -> CopilotCredential {
+        try await pollForToken(deviceCode: deviceCode, interval: interval, expiresIn: 900)
+    }
+}

--- a/Modules/OAuth/Sources/OAuth/CopilotOAuthManagerProtocol.swift
+++ b/Modules/OAuth/Sources/OAuth/CopilotOAuthManagerProtocol.swift
@@ -10,7 +10,7 @@ import Foundation
 /// `@MainActor`-isolated to match the credential-storage and background-task
 /// requirements of the device-code flow.
 @MainActor
-public protocol CopilotOAuthManager: Sendable {
+public protocol CopilotOAuthManager {
     /// Whether the user is signed in to Copilot.
     var isSignedIn: Bool { get }
 
@@ -31,11 +31,4 @@ public protocol CopilotOAuthManager: Sendable {
 
     /// Signs out by removing the stored credential.
     func signOut()
-}
-
-// Convenience: keep the `expiresIn: Int = 900` ergonomics on the protocol.
-public extension CopilotOAuthManager {
-    func pollForToken(deviceCode: String, interval: Int) async throws -> CopilotCredential {
-        try await pollForToken(deviceCode: deviceCode, interval: interval, expiresIn: 900)
-    }
 }

--- a/Modules/OAuth/Sources/OAuth/DefaultCopilotOAuthManager.swift
+++ b/Modules/OAuth/Sources/OAuth/DefaultCopilotOAuthManager.swift
@@ -8,7 +8,7 @@ import os
 /// Manages GitHub Copilot authentication using the device code flow.
 /// Two-step process: GitHub device code -> Copilot token exchange.
 @MainActor
-public final class DefaultCopilotOAuthManager: CopilotOAuthManager, Sendable {
+public final class DefaultCopilotOAuthManager: CopilotOAuthManager {
     private let logger = Logger(oauthCategory: "CopilotOAuth")
     private let keychain: any KeychainService
     private let backgroundTaskService: (any BackgroundTaskService)?

--- a/Modules/OAuth/Sources/OAuth/DefaultCopilotOAuthManager.swift
+++ b/Modules/OAuth/Sources/OAuth/DefaultCopilotOAuthManager.swift
@@ -8,7 +8,7 @@ import os
 /// Manages GitHub Copilot authentication using the device code flow.
 /// Two-step process: GitHub device code -> Copilot token exchange.
 @MainActor
-public final class CopilotOAuthManager: Sendable {
+public final class DefaultCopilotOAuthManager: CopilotOAuthManager, Sendable {
     private let logger = Logger(oauthCategory: "CopilotOAuth")
     private let keychain: any KeychainService
     private let backgroundTaskService: (any BackgroundTaskService)?

--- a/Modules/OAuth/Sources/OAuth/DefaultOAuthManager.swift
+++ b/Modules/OAuth/Sources/OAuth/DefaultOAuthManager.swift
@@ -10,7 +10,7 @@ import os
 /// Manages OAuth authentication flows - sign-in, token refresh, and credential storage.
 /// MainActor-isolated for safe interaction with UI and Keychain in Swift 6.
 @MainActor
-public final class OAuthManager: Sendable {
+public final class DefaultOAuthManager: OAuthManager, Sendable {
     private let logger = Logger(oauthCategory: "OAuthManager")
     private let keychain: any KeychainService
     private let networkService: any NetworkService

--- a/Modules/OAuth/Sources/OAuth/DefaultOAuthManager.swift
+++ b/Modules/OAuth/Sources/OAuth/DefaultOAuthManager.swift
@@ -10,7 +10,7 @@ import os
 /// Manages OAuth authentication flows - sign-in, token refresh, and credential storage.
 /// MainActor-isolated for safe interaction with UI and Keychain in Swift 6.
 @MainActor
-public final class DefaultOAuthManager: OAuthManager, Sendable {
+public final class DefaultOAuthManager: OAuthManager {
     private let logger = Logger(oauthCategory: "OAuthManager")
     private let keychain: any KeychainService
     private let networkService: any NetworkService

--- a/Modules/OAuth/Sources/OAuth/OAuthManagerProtocol.swift
+++ b/Modules/OAuth/Sources/OAuth/OAuthManagerProtocol.swift
@@ -1,0 +1,29 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+
+/// OAuth manager seam used by consumers (AIService, etc.). The production
+/// conformance is ``DefaultOAuthManager``; tests inject `MockOAuthManager`
+/// from `OAuthMocks` to fake the OAuth lifecycle without running real PKCE
+/// flows or hitting the keychain.
+///
+/// `@MainActor`-isolated because credential storage and any
+/// `ASWebAuthenticationSession` invocation must happen on the main thread.
+@MainActor
+public protocol OAuthManager: Sendable {
+    /// Whether the user is signed in for a given provider.
+    func isSignedIn(provider: some OAuthProvider) -> Bool
+
+    /// Returns the account email for a given provider, if signed in.
+    func accountEmail(for provider: some OAuthProvider) -> String?
+
+    /// Triggers the platform-appropriate sign-in flow (PKCE on iOS via
+    /// `ASWebAuthenticationSession`) and stores the resulting credential.
+    func signIn(provider: some OAuthProvider) async throws -> OAuthCredential
+
+    /// Signs out by removing the stored credential.
+    func signOut(provider: some OAuthProvider)
+
+    /// Returns a valid access token, refreshing if needed.
+    func validAccessToken(for provider: some OAuthProvider) async throws -> (token: String, accountId: String?, projectId: String?)
+}

--- a/Modules/OAuth/Sources/OAuth/OAuthManagerProtocol.swift
+++ b/Modules/OAuth/Sources/OAuth/OAuthManagerProtocol.swift
@@ -7,18 +7,18 @@ import Foundation
 /// from `OAuthMocks` to fake the OAuth lifecycle without running real PKCE
 /// flows or hitting the keychain.
 ///
-/// `@MainActor`-isolated because credential storage and any
-/// `ASWebAuthenticationSession` invocation must happen on the main thread.
+/// `@MainActor`-isolated because credential storage and any platform
+/// authentication UI invocation must happen on the main thread.
 @MainActor
-public protocol OAuthManager: Sendable {
+public protocol OAuthManager {
     /// Whether the user is signed in for a given provider.
     func isSignedIn(provider: some OAuthProvider) -> Bool
 
     /// Returns the account email for a given provider, if signed in.
     func accountEmail(for provider: some OAuthProvider) -> String?
 
-    /// Triggers the platform-appropriate sign-in flow (PKCE on iOS via
-    /// `ASWebAuthenticationSession`) and stores the resulting credential.
+    /// Triggers the platform-appropriate PKCE sign-in flow and stores the
+    /// resulting credential.
     func signIn(provider: some OAuthProvider) async throws -> OAuthCredential
 
     /// Signs out by removing the stored credential.

--- a/Modules/OAuth/Sources/OAuthMocks/MockCopilotOAuthManager.swift
+++ b/Modules/OAuth/Sources/OAuthMocks/MockCopilotOAuthManager.swift
@@ -1,0 +1,83 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import OAuth
+import TestUtilities
+
+/// Hand-rolled mock of ``CopilotOAuthManager`` for consumer tests. Stubs the
+/// device-code flow + token refresh without polling GitHub.
+///
+/// ## Usage
+///
+/// ```swift
+/// let copilot = MockCopilotOAuthManager()
+/// copilot.isSignedIn = true
+/// copilot.stubValidCopilotTokenResponse = .success("ghu_test-token")
+/// let sut = AIService(..., copilotOAuthManager: copilot)
+/// _ = try await sut.enhance(...)
+/// #expect(copilot.validCopilotTokenCallCount == 1)
+/// ```
+@MainActor
+public final class MockCopilotOAuthManager: CopilotOAuthManager {
+    public init() {}
+
+    // MARK: state
+
+    public var isSignedIn: Bool = false
+    public var accountInfo: String?
+
+    // MARK: startDeviceCodeFlow
+
+    public var stubStartDeviceCodeFlowResponse: Result<DeviceCodeResponse, Error>?
+    public var didStartDeviceCodeFlow: (() -> Void)?
+    public private(set) var startDeviceCodeFlowCallCount = 0
+
+    // MARK: pollForToken
+
+    public var stubPollForTokenResponse: Result<CopilotCredential, Error>?
+    public var didPollForToken: (() -> Void)?
+    public private(set) var pollForTokenCallCount = 0
+    public private(set) var capturedPollDeviceCode: String?
+    public private(set) var capturedPollInterval: Int?
+    public private(set) var capturedPollExpiresIn: Int?
+
+    // MARK: validCopilotToken
+
+    public var stubValidCopilotTokenResponse: Result<String, Error>?
+    public var didFetchValidCopilotToken: (() -> Void)?
+    public private(set) var validCopilotTokenCallCount = 0
+
+    // MARK: signOut
+
+    public var didSignOut: (() -> Void)?
+    public private(set) var signOutCallCount = 0
+
+    // MARK: - CopilotOAuthManager conformance
+
+    public func startDeviceCodeFlow() async throws -> DeviceCodeResponse {
+        defer { didStartDeviceCodeFlow?() }
+        startDeviceCodeFlowCallCount += 1
+        return try stubStartDeviceCodeFlowResponse.evaluate()
+    }
+
+    public func pollForToken(deviceCode: String, interval: Int, expiresIn: Int) async throws -> CopilotCredential {
+        defer { didPollForToken?() }
+        pollForTokenCallCount += 1
+        capturedPollDeviceCode = deviceCode
+        capturedPollInterval = interval
+        capturedPollExpiresIn = expiresIn
+        return try stubPollForTokenResponse.evaluate()
+    }
+
+    public func validCopilotToken() async throws -> String {
+        defer { didFetchValidCopilotToken?() }
+        validCopilotTokenCallCount += 1
+        return try stubValidCopilotTokenResponse.evaluate()
+    }
+
+    public func signOut() {
+        defer { didSignOut?() }
+        signOutCallCount += 1
+        isSignedIn = false
+    }
+}

--- a/Modules/OAuth/Sources/OAuthMocks/MockCopilotOAuthManager.swift
+++ b/Modules/OAuth/Sources/OAuthMocks/MockCopilotOAuthManager.swift
@@ -66,7 +66,13 @@ public final class MockCopilotOAuthManager: CopilotOAuthManager {
         capturedPollDeviceCode = deviceCode
         capturedPollInterval = interval
         capturedPollExpiresIn = expiresIn
-        return try stubPollForTokenResponse.evaluate()
+        let credential = try stubPollForTokenResponse.evaluate() as CopilotCredential
+        // Mirror DefaultCopilotOAuthManager.saveCredential: a successful poll
+        // means the user authorized the device code, so the manager is now
+        // signed in.
+        isSignedIn = true
+        accountInfo = credential.githubUsername
+        return credential
     }
 
     public func validCopilotToken() async throws -> String {
@@ -78,6 +84,9 @@ public final class MockCopilotOAuthManager: CopilotOAuthManager {
     public func signOut() {
         defer { didSignOut?() }
         signOutCallCount += 1
+        // Match DefaultCopilotOAuthManager.signOut: the credential is removed
+        // entirely, so both isSignedIn and accountInfo reset.
         isSignedIn = false
+        accountInfo = nil
     }
 }

--- a/Modules/OAuth/Sources/OAuthMocks/MockOAuthManager.swift
+++ b/Modules/OAuth/Sources/OAuthMocks/MockOAuthManager.swift
@@ -68,14 +68,24 @@ public final class MockOAuthManager: OAuthManager {
         defer { didSignIn?() }
         signInCallCount += 1
         capturedSignInProviderKey = provider.keychainKey
-        return try stubSignInResponse.evaluate()
+        let credential = try stubSignInResponse.evaluate() as OAuthCredential
+        // Mirror DefaultOAuthManager.saveCredential: on successful sign-in,
+        // the provider becomes signed-in and the account email is cached.
+        signedInProviders.insert(provider.keychainKey)
+        if let email = credential.accountEmail {
+            accountEmails[provider.keychainKey] = email
+        }
+        return credential
     }
 
     public func signOut(provider: some OAuthProvider) {
         defer { didSignOut?() }
         signOutCallCount += 1
         capturedSignOutProviderKey = provider.keychainKey
+        // Match DefaultOAuthManager.signOut: clear both signed-in state and
+        // the cached email.
         signedInProviders.remove(provider.keychainKey)
+        accountEmails.removeValue(forKey: provider.keychainKey)
     }
 
     public func validAccessToken(for provider: some OAuthProvider) async throws -> (token: String, accountId: String?, projectId: String?) {

--- a/Modules/OAuth/Sources/OAuthMocks/MockOAuthManager.swift
+++ b/Modules/OAuth/Sources/OAuthMocks/MockOAuthManager.swift
@@ -1,0 +1,87 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import OAuth
+import TestUtilities
+
+/// Hand-rolled mock of ``OAuthManager`` for consumer tests. Each test creates
+/// its own instance and stubs the per-call responses. Stubs are keyed by the
+/// `OAuthProvider`'s `keychainKey` so a single mock can serve different
+/// providers in the same test (e.g. Gemini-OAuth + OpenAI-OAuth paths).
+///
+/// ## Usage
+///
+/// ```swift
+/// let oauth = MockOAuthManager()
+/// oauth.signedInProviders.insert(GeminiOAuthProvider().keychainKey)
+/// oauth.stubValidAccessTokenResponse = .success(
+///     (token: "test-token", accountId: "acc-1", projectId: "proj-1")
+/// )
+/// let sut = AIService(..., oauthManager: oauth)
+/// _ = try await sut.enhance(...)
+/// #expect(oauth.validAccessTokenCallCount == 1)
+/// ```
+@MainActor
+public final class MockOAuthManager: OAuthManager {
+    public init() {}
+
+    // MARK: isSignedIn / accountEmail
+
+    /// Set of `provider.keychainKey` values considered signed-in. Falls back
+    /// to `false` for keys not in the set.
+    public var signedInProviders: Set<String> = []
+
+    /// Per-provider account email lookup (keyed by `provider.keychainKey`).
+    public var accountEmails: [String: String] = [:]
+
+    // MARK: signIn
+
+    public var stubSignInResponse: Result<OAuthCredential, Error>?
+    public var didSignIn: (() -> Void)?
+    public private(set) var signInCallCount = 0
+    public private(set) var capturedSignInProviderKey: String?
+
+    // MARK: signOut
+
+    public var didSignOut: (() -> Void)?
+    public private(set) var signOutCallCount = 0
+    public private(set) var capturedSignOutProviderKey: String?
+
+    // MARK: validAccessToken
+
+    public var stubValidAccessTokenResponse: Result<(token: String, accountId: String?, projectId: String?), Error>?
+    public var didFetchValidAccessToken: (() -> Void)?
+    public private(set) var validAccessTokenCallCount = 0
+    public private(set) var capturedValidAccessTokenProviderKey: String?
+
+    // MARK: - OAuthManager conformance
+
+    public func isSignedIn(provider: some OAuthProvider) -> Bool {
+        signedInProviders.contains(provider.keychainKey)
+    }
+
+    public func accountEmail(for provider: some OAuthProvider) -> String? {
+        accountEmails[provider.keychainKey]
+    }
+
+    public func signIn(provider: some OAuthProvider) async throws -> OAuthCredential {
+        defer { didSignIn?() }
+        signInCallCount += 1
+        capturedSignInProviderKey = provider.keychainKey
+        return try stubSignInResponse.evaluate()
+    }
+
+    public func signOut(provider: some OAuthProvider) {
+        defer { didSignOut?() }
+        signOutCallCount += 1
+        capturedSignOutProviderKey = provider.keychainKey
+        signedInProviders.remove(provider.keychainKey)
+    }
+
+    public func validAccessToken(for provider: some OAuthProvider) async throws -> (token: String, accountId: String?, projectId: String?) {
+        defer { didFetchValidAccessToken?() }
+        validAccessTokenCallCount += 1
+        capturedValidAccessTokenProviderKey = provider.keychainKey
+        return try stubValidAccessTokenResponse.evaluate()
+    }
+}

--- a/Modules/OAuth/Tests/OAuthTests/MockOAuthManagerTests.swift
+++ b/Modules/OAuth/Tests/OAuthTests/MockOAuthManagerTests.swift
@@ -1,0 +1,75 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import OAuth
+import OAuthMocks
+import Testing
+import TestUtilities
+
+/// Locks in the lifecycle parity between `MockOAuthManager` /
+/// `MockCopilotOAuthManager` and their `Default<Name>` production
+/// counterparts: successful sign-in / token-poll updates signed-in state;
+/// sign-out clears it. Regression catch for the divergence both PR #281
+/// reviewers flagged.
+@MainActor
+@Suite("Mock OAuth manager lifecycle parity")
+struct MockOAuthManagerLifecycleTests {
+
+    @Test func successfulSignInMarksProviderSignedIn() async throws {
+        let sut = MockOAuthManager()
+        let provider = MockOAuthProvider(keychainKey: "test-provider")
+        let credential = OAuthCredential(
+            accessToken: "token",
+            refreshToken: "refresh",
+            expiresAt: Date().addingTimeInterval(3600),
+            accountId: "id-1",
+            accountEmail: "a@example.com",
+            projectId: nil
+        )
+        sut.stubSignInResponse = .success(credential)
+
+        _ = try await sut.signIn(provider: provider)
+
+        #expect(sut.isSignedIn(provider: provider))
+        #expect(sut.accountEmail(for: provider) == "a@example.com")
+    }
+
+    @Test func signOutClearsSignedInStateAndEmail() async throws {
+        let sut = MockOAuthManager()
+        let provider = MockOAuthProvider(keychainKey: "test-provider")
+        sut.signedInProviders.insert(provider.keychainKey)
+        sut.accountEmails[provider.keychainKey] = "a@example.com"
+
+        sut.signOut(provider: provider)
+
+        #expect(!sut.isSignedIn(provider: provider))
+        #expect(sut.accountEmail(for: provider) == nil)
+    }
+
+    @Test func copilotPollForTokenFlipsSignedInAndAccountInfo() async throws {
+        let sut = MockCopilotOAuthManager()
+        let credential = CopilotCredential(
+            githubAccessToken: "gh-token",
+            copilotToken: "copilot-token",
+            copilotTokenExpiresAt: Date().addingTimeInterval(3600),
+            githubUsername: "octocat"
+        )
+        sut.stubPollForTokenResponse = .success(credential)
+
+        _ = try await sut.pollForToken(deviceCode: "dc", interval: 5, expiresIn: 900)
+
+        #expect(sut.isSignedIn)
+        #expect(sut.accountInfo == "octocat")
+    }
+
+    @Test func copilotSignOutClearsAccountInfo() async throws {
+        let sut = MockCopilotOAuthManager()
+        sut.isSignedIn = true
+        sut.accountInfo = "octocat"
+
+        sut.signOut()
+
+        #expect(!sut.isSignedIn)
+        #expect(sut.accountInfo == nil)
+    }
+}

--- a/Modules/OAuth/Tests/OAuthTests/OAuthTests.swift
+++ b/Modules/OAuth/Tests/OAuthTests/OAuthTests.swift
@@ -24,7 +24,7 @@ struct OAuthManagerTests {
         let encoded = try JSONEncoder().encode(credential)
         keychain.save(data: encoded, forKey: provider.keychainKey, syncable: false)
 
-        let sut = OAuthManager(keychain: keychain)
+        let sut = DefaultOAuthManager(keychain: keychain)
         #expect(sut.isSignedIn(provider: provider))
 
         sut.signOut(provider: provider)
@@ -37,7 +37,7 @@ struct OAuthManagerTests {
     @Test func isSignedInReturnsFalseWhenKeychainEmpty() {
         let keychain = MockKeychainService()
         let provider = MockOAuthProvider(keychainKey: "test.oauth.credential")
-        let sut = OAuthManager(keychain: keychain)
+        let sut = DefaultOAuthManager(keychain: keychain)
 
         #expect(!sut.isSignedIn(provider: provider))
     }
@@ -56,7 +56,7 @@ struct OAuthManagerTests {
         let encoded = try JSONEncoder().encode(credential)
         keychain.save(data: encoded, forKey: provider.keychainKey, syncable: false)
 
-        let sut = OAuthManager(keychain: keychain)
+        let sut = DefaultOAuthManager(keychain: keychain)
         #expect(sut.accountEmail(for: provider) == "user@example.com")
     }
 }
@@ -76,7 +76,7 @@ struct CopilotOAuthManagerTests {
         keychain.save(data: encoded, forKey: "copilotOAuthCredential", syncable: false)
 
         let bgTask = MockBackgroundTaskService()
-        let sut = CopilotOAuthManager(keychain: keychain, backgroundTaskService: bgTask)
+        let sut = DefaultCopilotOAuthManager(keychain: keychain, backgroundTaskService: bgTask)
         #expect(sut.isSignedIn)
         #expect(sut.accountInfo == "octocat")
 
@@ -89,7 +89,7 @@ struct CopilotOAuthManagerTests {
     @Test func backgroundTaskServiceIsOptional() {
         let keychain = MockKeychainService()
         // Construction succeeds without a background task sut.
-        let sut = CopilotOAuthManager(keychain: keychain, backgroundTaskService: nil)
+        let sut = DefaultCopilotOAuthManager(keychain: keychain, backgroundTaskService: nil)
         #expect(!sut.isSignedIn)
     }
 }

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -176,8 +176,8 @@ class AIService {
     private let selectedModeStorageKey: String
     private let keychain: any KeychainService
     let networkService: any NetworkService
-    let oauthManager: OAuthManager
-    let copilotOAuthManager: CopilotOAuthManager
+    let oauthManager: any OAuthManager
+    let copilotOAuthManager: any CopilotOAuthManager
     private let baseTimeout: TimeInterval = 300
 
     /// Service for Apple's on-device Foundation Models (type-erased for iOS version compatibility)
@@ -196,8 +196,8 @@ class AIService {
     init(
         keychain: any KeychainService = DefaultKeychainService(),
         networkService: any NetworkService = DefaultNetworkService(category: "AIService"),
-        oauthManager: OAuthManager = .shared,
-        copilotOAuthManager: CopilotOAuthManager = .shared
+        oauthManager: any OAuthManager = DefaultOAuthManager.shared,
+        copilotOAuthManager: any CopilotOAuthManager = DefaultCopilotOAuthManager.shared
     ) {
         self.keychain = keychain
         self.networkService = networkService
@@ -248,8 +248,8 @@ class AIService {
         selectedModeStorageKey: String = "selectedVivaMode",
         keychain: any KeychainService = DefaultKeychainService(),
         networkService: any NetworkService = DefaultNetworkService(category: "AIService"),
-        oauthManager: OAuthManager = .shared,
-        copilotOAuthManager: CopilotOAuthManager = .shared
+        oauthManager: any OAuthManager = DefaultOAuthManager.shared,
+        copilotOAuthManager: any CopilotOAuthManager = DefaultCopilotOAuthManager.shared
     ) {
         self.keychain = keychain
         self.networkService = networkService

--- a/VivaDicta/Services/OAuth/OAuthSingletons.swift
+++ b/VivaDicta/Services/OAuth/OAuthSingletons.swift
@@ -7,12 +7,12 @@ import OAuth
 /// App-target shared instances of the OAuth managers. The managers themselves
 /// live in `Modules/OAuth` and are dependency-injected; this file is the
 /// composition root for the convenience singletons used across the app.
-extension OAuthManager {
-    @MainActor public static let shared = OAuthManager(keychain: DefaultKeychainService())
+extension DefaultOAuthManager {
+    @MainActor public static let shared = DefaultOAuthManager(keychain: DefaultKeychainService())
 }
 
-extension CopilotOAuthManager {
-    @MainActor public static let shared = CopilotOAuthManager(
+extension DefaultCopilotOAuthManager {
+    @MainActor public static let shared = DefaultCopilotOAuthManager(
         keychain: DefaultKeychainService(),
         backgroundTaskService: BackgroundTaskServiceAdapter()
     )

--- a/VivaDicta/Views/SettingsScreen/CopilotConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/CopilotConfigurationView.swift
@@ -178,7 +178,7 @@ struct CopilotConfigurationView: View {
     private func startCopilotSignIn() {
         pollingTask = Task {
             do {
-                let code = try await CopilotOAuthManager.shared.startDeviceCodeFlow()
+                let code = try await DefaultCopilotOAuthManager.shared.startDeviceCodeFlow()
                 self.deviceCode = code
 
                 // Copy code to clipboard


### PR DESCRIPTION
Closes the seam consumers were missing. `AIService` previously injected the concrete `OAuthManager` / `CopilotOAuthManager` classes, so tests couldn't fake the OAuth lifecycle without constructing real managers backed by a `MockNetworkService`.

## What changes

### Module

- **`OAuthManager` protocol** in `OAuth/OAuthManagerProtocol.swift` - public API: `isSignedIn`, `accountEmail(for:)`, `signIn`, `signOut`, `validAccessToken(for:)`. `@MainActor`-isolated.
- **`CopilotOAuthManager` protocol** in `OAuth/CopilotOAuthManagerProtocol.swift` - `isSignedIn`, `accountInfo`, `startDeviceCodeFlow`, `pollForToken`, `validCopilotToken`, `signOut`. The `expiresIn = 900` default preserved via a protocol extension overload.
- **Concrete classes renamed**: `OAuthManager` → `DefaultOAuthManager`, `CopilotOAuthManager` → `DefaultCopilotOAuthManager`. Files renamed via `git mv` to preserve history.
- **`MockOAuthManager`** in `OAuthMocks` - stubs keyed by `OAuthProvider.keychainKey` so one mock can serve multiple providers in a single test.
- **`MockCopilotOAuthManager`** in `OAuthMocks` - stubs the device-code flow + token refresh.

### App

- `OAuthSingletons.swift`: `.shared` extensions moved onto the new `Default<Name>` types.
- `AIService.swift`: init parameters now `any OAuthManager` / `any CopilotOAuthManager`; defaults reference `DefaultOAuthManager.shared` / `DefaultCopilotOAuthManager.shared`.
- `CopilotConfigurationView.swift`: explicit `DefaultCopilotOAuthManager.shared` reference.
- OAuth module tests updated to construct via `Default<Name>(...)`.

Call sites at `oauthManager.signIn(...)` etc. didn't need to change - keeping the protocol named the same as the old class preserves the symbol consumers already use.

## What this unlocks

Tests of any consumer (AIService, CloudReminderExtractionProvider, view models) can inject `MockOAuthManager` / `MockCopilotOAuthManager` directly:

```swift
let oauth = MockOAuthManager()
oauth.signedInProviders.insert(GeminiOAuthProvider().keychainKey)
oauth.stubValidAccessTokenResponse = .success(
    (token: "t", accountId: "a", projectId: "p")
)
let sut = AIService(..., oauthManager: oauth)
```

No more spinning up a real OAuth manager backed by `MockNetworkService` just to fake `validAccessToken(for:)`.

## Test plan

- [x] \`swift test\` in Modules/Networking: 23 tests pass
- [x] \`swift test\` in Modules/OAuth: 11 tests pass
- [x] \`swift test\` in Modules/CloudTranscription: 50 tests pass
- [x] \`xcodebuild test\` for VivaDicta scheme: 22 tests pass (iPhone 17 Pro Max / iOS 26.4)