### PR TITLE
Rename MockOpenAITranscriptionService.swift to match contained type

### DIFF
--- a/Modules/CloudTranscription/Sources/CloudTranscriptionMocks/MockTranscriptionService.swift
+++ b/Modules/CloudTranscription/Sources/CloudTranscriptionMocks/MockTranscriptionService.swift
@@ -5,11 +5,21 @@ import CloudTranscription
 import TranscriptionCore
 import TestUtilities
 
-/// Hand-rolled mock for the `transcribe(audioURL:)` shape used by cloud
-/// transcription services. Stub the result via `stubTranscribeResponse`.
+/// Generic mock conforming to `TranscriptionService`. Serves every provider
+/// (cloud + local) since the protocol surface is a single
+/// `transcribe(audioURL:)` method. Tests that need to assert per-provider
+/// routing create one `MockTranscriptionService` instance per route and
+/// hand them to the engine's `ServiceFactory`.
 ///
-/// Conforms to `TranscriptionService` so it can be returned from a
-/// `DefaultTranscriptionEngine.ServiceFactory` to test engine-level routing.
+/// ## Usage
+///
+/// ```swift
+/// let sut = MockTranscriptionService()
+/// sut.stubTranscribeResponse = .success(.plain("hello"))
+/// let result = try await sut.transcribe(audioURL: testFile)
+/// #expect(result.text == "hello")
+/// #expect(sut.transcribeCallCount == 1)
+/// ```
 public final class MockTranscriptionService: TranscriptionService, @unchecked Sendable {
 
     public init() {}


### PR DESCRIPTION
Cosmetic cleanup. The file \`MockOpenAITranscriptionService.swift\` contained a class named \`MockTranscriptionService\` - the file name was a leftover from when the mock was OpenAI-specific. The class is generic and already serves all 13 transcription providers (cloud + local) through the single-method \`TranscriptionService\` protocol.

Originally on the table as "complete CloudTranscription mocks" - but the generic mock is already in place, so this PR just makes the filename match.

## What changes

- \`git mv MockOpenAITranscriptionService.swift MockTranscriptionService.swift\` (preserves history)
- Doc comment updated: explicit "generic mock conforming to \`TranscriptionService\`" framing + usage snippet

## What didn't change

- No code rename - the class was already \`MockTranscriptionService\`
- No new mocks - the existing one serves every provider
- Consumer tests in \`CloudTranscriptionTests\` and \`TranscriptionKitTests\` keep using the same type

## Test plan

- [x] \`swift test\` in Modules/CloudTranscription: 50 tests pass