### PR TITLE
Phase 0: in-repo architecture conventions + ADR-001

### DIFF
--- a/documentation/adr/ADR-000-template.md
+++ b/documentation/adr/ADR-000-template.md
@@ -1,0 +1,37 @@
+# ADR-NNN: Title in present-tense imperative ("Adopt X", "Migrate to Y")
+
+**Date:** YYYY-MM-DD
+**Status:** Proposed | Accepted | Deprecated | Superseded by ADR-XXX
+
+## Context
+
+What situation requires a decision? Two-three sentences max. Stick to facts; don't editorialize.
+
+## Decision
+
+What is the change? Be specific - filenames, types, behaviors. If there's a longer plan elsewhere, link to it from here.
+
+## Consequences
+
+### Easier
+What becomes easier as a result of this decision?
+
+### Harder
+What becomes harder? Honest accounting of the cost.
+
+### Follow-up implied
+What other decisions or work does this trigger?
+
+### Explicitly not addressed
+What this decision deliberately leaves open. Future readers should know what's still on the table.
+
+## Alternatives considered
+
+1. **Alternative name.** One-line summary. Why rejected (or deferred).
+2. **Alternative name.** ...
+
+## References
+
+- Related ADRs (predecessors, related decisions)
+- Code files, migration plans, design docs
+- External references (blog posts, papers) if relevant - but per repo convention, avoid mentioning other people's projects by name

--- a/documentation/adr/ADR-001-modular-architecture.md
+++ b/documentation/adr/ADR-001-modular-architecture.md
@@ -1,0 +1,73 @@
+# ADR-001: Adopt incremental modular architecture migration
+
+**Date:** 2026-05-24
+**Status:** Accepted
+
+## Context
+
+VivaDicta has grown from a single-screen voice-to-text app into a multi-target product (iOS app, keyboard extension, widget + Live Activity, share extension, action extension) with a companion macOS app sharing CloudKit storage. The codebase currently:
+
+- Has a 4,030-line `AIService` god class orchestrating 16 LLM providers, OAuth flows, SSE streaming, mode management, and Apple Foundation Model integration.
+- Mixes app target organization (`Views/`, `Services/`) with adapter modules already extracted to SwiftPM (`Modules/Networking/`, `Modules/OAuth/`, etc.).
+- Has approximately 60% coverage of protocol-based DI seams across the modular shell, and approximately 0% in the app target proper.
+- Uses `AppState` as a mutable service locator (`var x: Service!`).
+
+This makes testing painful: view models and orchestration services can't be unit-tested without spinning up the full app, and adding a new AI provider requires editing the `AIService` god class.
+
+## Decision
+
+Adopt an incremental migration toward a modular, protocol-driven architecture, ordered by ROI and risk. The full plan lives in `llmtemp/architecture-migration-plan-v2-2026-05-24.md` and is summarized as:
+
+- **Phase 0:** Codify conventions in-repo (this ADR + `architecture-conventions.md`). ✅ Done.
+- **Phase 1b:** Protocol seams for the remaining concrete services (`TranscriptionManager`, `PresetSyncService`, `ModelDownloadManager`).
+- **Phase 2:** Decompose `AIService` into per-provider `AIProvider` conformances + a thin coordinator. The single highest-leverage refactor remaining.
+- **Phase 3:** Create a `VivaDictaDomain` package with pure value types and ports.
+- **Phase 4:** Extract the first feature package (`RecordFeature`) as a template.
+- **Phases 6-7:** Remaining feature packages + Composition Root refactor.
+- **Phases 5 (Decorators) and 8 (Persistence isolation): skip** unless a concrete need emerges. Decorators duplicate concerns already centralized in `NetworkClient` / `NetworkRetry`; persistence isolation carries CloudKit schema risk that outweighs the testability benefit.
+
+The migration is incremental, behavior-preserving, and explicitly stop-anywhere. Every phase boundary leaves the codebase strictly better than before.
+
+## Consequences
+
+### Easier
+
+- **Adding a new AI provider** becomes "write an `AIProvider` conformance, register it." No edits to existing provider code.
+- **Unit-testing view models** becomes possible once their dependencies are protocols with public mocks.
+- **Onboarding new collaborators** is easier with explicit module boundaries and the dependency rule documented.
+- **Reasoning about coupling** is easier - `swift build` enforces the layered dependency rule.
+
+### Harder
+
+- **More files, more SwiftPM packages.** Navigating the codebase requires understanding the module hierarchy.
+- **More wiring in Composition Root.** Constructing the dependency graph is explicit instead of implicit.
+- **Phase 2 (AIService decomposition) is 4-6 weeks of part-time work.** That's a substantial commitment for a solo developer.
+- **Multi-target migrations are tricky.** Each phase that touches code shared with the keyboard / widget / extensions has to verify all 5 targets still build and run.
+
+### Follow-up implied
+
+- Each phase ships as one or more PRs, not a big-bang refactor.
+- New ADRs accumulate in `documentation/adr/` as substantive structural decisions arise.
+- `documentation/Module-Architecture.html` is kept current.
+- After Phase 4 lands, a `documentation/feature-package-template.md` documents the feature-extraction pattern for Phase 6.
+
+### Explicitly not addressed
+
+- **Persistence isolation (Phase 8).** SwiftData models stay coupled to the persistence framework. Domain types in Phase 3 are parallel to (not replacements for) `Transcription` / `CustomRewritePreset` SwiftData entities.
+- **Decorator pattern (Phase 5).** Cross-cutting concerns (logging, retry, status validation) stay centralized in their respective services rather than as decorator wrappers.
+- **TCA or other architectural alternatives.** This decision commits to the MVVM + Services + protocols pattern.
+- **`VivaDictaMac` synchronization strategy.** The companion macOS app's relationship to the new `VivaDictaDomain` package is deferred until Phase 3 actually lands; at that point a separate ADR will pick between vendoring, git submodules, or a separate SPM repository.
+
+## Alternatives considered
+
+1. **Full rewrite (e.g., TCA migration).** Rejected: too costly for an indie app, and the current MVVM + Services pattern works - it just needs cleaner seams.
+2. **Big-bang refactor.** Rejected: contradicts the stop-anywhere principle and would put the app in a half-broken state for weeks.
+3. **Do nothing, keep current architecture.** Rejected: the testing pain is real and growing; `AIService` will only get larger as more providers are added.
+4. **Skip Phase 3 (VivaDictaDomain).** Deferred but not rejected. If after Phase 2 the testability win is good enough without pure domain types, skip Phase 3.
+
+## References
+
+- Migration plan: `llmtemp/architecture-migration-plan-v2-2026-05-24.md`
+- Current architecture diagram: `documentation/Module-Architecture.html`
+- Conventions: `documentation/architecture-conventions.md`
+- Predecessor (superseded) plan: `llmtemp/caio-architecture-migration-plan-2026-05-24.md`

--- a/documentation/architecture-conventions.md
+++ b/documentation/architecture-conventions.md
@@ -1,0 +1,179 @@
+# Architecture Conventions
+
+This document codifies the in-repo conventions every new module, service, and test must follow. It exists alongside `~/.claude/CLAUDE.md` (which targets AI tooling) - this file targets humans collaborating on the codebase.
+
+For the broader migration plan these conventions support, see `llmtemp/architecture-migration-plan-v2-2026-05-24.md`.
+
+## Naming
+
+### Protocols
+
+Use the plain noun (`<Name>`) - **never** the `-ing` suffix.
+
+- ✅ `NetworkService`, `KeychainService`, `OAuthManager`, `TranscriptionService`, `AIProvider`
+- ❌ `NetworkServicing`, `KeychainServicing`, `OAuthManaging`, `Transcribing`
+
+### Concrete implementations
+
+When a protocol has a single canonical production conformance, name it `Default<Name>`.
+
+- ✅ `DefaultNetworkService`, `DefaultKeychainService`, `DefaultOAuthManager`
+- When the impl has personality (backend-specific etc.), prefer descriptive over `Default`: `URLSessionAIProvider`, `OpenAIBackedAIProvider`, `AVFoundationAudioRecorder`.
+- `Impl` suffix (`NetworkServiceImpl`) is acceptable but less Swift-idiomatic - it's a Java/C# carryover. Don't use it for new code.
+
+This convention applies to **new** services. For existing aggregated impls (like `AIService`, which conforms to multiple protocols), keep the existing name until decomposition. The `Default<Name>` rule is for one-protocol-one-impl situations.
+
+### Mocks
+
+Always `Mock<Name>`. Lives in a parallel `<Module>Mocks` target.
+
+- ✅ `MockNetworkService`, `MockOAuthManager`, `MockKeychainService`
+- ❌ `<Name>Mock`, `Fake<Name>`, `Stub<Name>`
+
+### Type-suffix naming (avoid generic `Manager`)
+
+For new types, prefer a specific suffix that names the responsibility:
+
+| Suffix | When to use | Example |
+|---|---|---|
+| `Service` | Provides functionality, often stateless or near-stateless | `KeychainService`, `AnalyticsService` |
+| `Repository` / `Store` | Owns persistence + retrieval of one entity | `PresetRepository`, `TranscriptionStore` |
+| `Coordinator` | Orchestrates flow between other components | `OnboardingCoordinator` |
+| `Engine` | Stateful long-running processor | `TranscriptionEngine` |
+| `Router` | Routes requests to the right handler | `URLRouter`, `DeepLinkRouter` |
+| `Provider` | Produces values on demand | `LocationProvider`, `AIProvider` |
+| `Player` | Plays / produces media | `HapticPlayer`, `AudioPlayer` |
+| `Downloader` | Fetches resources | `ModelDownloader` |
+| `Prompter` | Triggers user prompts | `RateAppPrompter` |
+| `Scheduler` | Schedules deferred work | `BackgroundTaskScheduler` |
+| `Manager` | **Only** when genuinely managing lifecycle of a system resource AND the responsibility is canonical enough that any alternative would obscure it | `FileManager`, `OAuthManager` (industry-standard) |
+
+**Don't rename existing `*Manager` types as a sweep.** Convert opportunistically when you're already touching the file and a better name is obvious.
+
+## Module organization
+
+### Layered dependency rule
+
+Inner-ring modules cannot import outer-ring modules. The rings are:
+
+```
+Layer 0 (core, no in-repo deps):
+  TestUtilities, Networking, Keychain, Presets, TranscriptionCore,
+  DesignSystem, AppGroup
+  + future: VivaDictaDomain
+
+Layer 1 (adapters - single concern: protocol + Default + Mock):
+  OAuth, CloudTranscription, LocalTranscription
+  + future: AIProviders/
+
+Layer 2 (orchestrators - compose multiple adapters):
+  TranscriptionKit
+  + future: feature packages' Core targets
+
+Layer 3 (features - UI + view models):
+  + future: Features/RecordFeature, Features/LibraryFeature, etc.
+
+Layer 4 (app):
+  VivaDicta main target, extensions
+```
+
+A module in layer N can import only modules in layers `0..<N`. A new module's `Package.swift` must reflect this.
+
+### `<Module>Mocks` target pattern
+
+Every module that exposes a mockable protocol ships a parallel `<Module>Mocks` library:
+
+```
+Modules/OAuth/
+├── Sources/
+│   ├── OAuth/                  ← production: protocol + Default impl
+│   └── OAuthMocks/             ← public: MockOAuthManager, etc.
+└── Tests/
+    └── OAuthTests/             ← imports both targets
+```
+
+- **`<Module>Mocks` imports `<Module>` + `TestUtilities`**, never the other way around.
+- **Consumer tests** import `<Module>Mocks` (e.g., `VivaDictaTests` imports `NetworkingMocks`).
+- **Production code never imports `*Mocks`.**
+
+### Mock fidelity
+
+Mocks must mirror production observable lifecycle. If `DefaultOAuthManager.signIn(...)` flips `isSignedIn(provider:)` to `true` on success, `MockOAuthManager.signIn(...)` must do the same. Otherwise tests stub behavior that diverges from production - a class of bug that's hard to spot.
+
+The `MockOAuthManagerLifecycleTests` in `Modules/OAuth/Tests` exists specifically to lock this in.
+
+## Testing
+
+### Test type shape
+
+Use Swift `struct` test types - never `final class` with `var x: T!` + `deinit` cleanup.
+
+Swift Testing creates a fresh struct per `@Test`, so per-test isolation is automatic.
+
+```swift
+// ✅ Correct
+struct OpenAITranscriptionServiceTests {
+    @Test func successReturnsText() async throws {
+        let networkService = MockNetworkService()
+        networkService.stubUploadResponse = .success(...)
+        let sut = makeSUT(networkService: networkService)
+        let result = try await sut.transcribe(audioURL: ...)
+        #expect(result.text == "hello")
+    }
+}
+
+// ❌ XCTest carry-over - don't write new code like this
+final class OpenAITranscriptionServiceTests {
+    var sut: OpenAITranscriptionService!
+    var networkService: MockNetworkService!
+    init() { ... }
+    deinit { sut = nil; networkService = nil }
+}
+```
+
+### `sut` variable name
+
+The variable holding the type under test is **always** `sut` (system under test).
+
+- ✅ `let sut = DefaultNetworkService(session: session)`
+- ❌ `let service = ...`, `let client = ...`, `let provider = ...`
+
+Mocks keep their explicit names (`networkService`, `keychain`, `mockRepo`) - only the SUT is `sut`. Reading a test, this makes the line being exercised vs. the dependencies being stubbed visually distinct.
+
+### Dependency variable naming
+
+The variable holding an injected dependency should match the consumer's init parameter name.
+
+- ✅ `let networkService = MockNetworkService()` (because consumer takes `init(networkService:)`)
+- ❌ `let session = MockNetworkService()` (when the parameter is `networkService:`)
+
+### Hoist `sut` to a property?
+
+- **Hoist** to a `let sut: X` property + `init()` when the SUT config is **constant across all tests** in the file.
+- **Construct per test** (often via a `makeSUT(...)` helper) when the SUT config **varies per test** (different API keys, different modes, etc.).
+
+Both shapes use `sut` as the variable name. The choice is about where you build it.
+
+## PR / commit hygiene
+
+### One concern per PR
+
+Don't bundle structural changes with feature work. Don't bundle naming conventions with bug fixes. Reviewers and `git bisect` both benefit from focused PRs.
+
+### Commit messages
+
+- Lead with what changed, not where.
+- Explain *why* if the diff doesn't make it obvious.
+- Don't include AI co-author attribution. Don't include "Generated with ... " footers.
+- Don't reference other people's projects or codebases (open-source samples, tutorial repos, etc.) in PR descriptions or commit messages. If you learned a pattern from elsewhere, describe the pattern on its own merits as if the decision originated here.
+
+### Architecture Decision Records (ADRs)
+
+When a structural decision is made that future readers should understand, record it in `documentation/adr/`. Template lives at `documentation/adr/ADR-000-template.md` (TODO: write).
+
+## Related documents
+
+- `Module-Architecture.html` - current module dependency graph and testing seams (visual)
+- `adr/ADR-001-modular-architecture.md` - decision to follow the modular pattern
+- `../llmtemp/architecture-migration-plan-v2-2026-05-24.md` - in-progress migration plan
+- `~/.claude/CLAUDE.md` (global, AI assistant) - the canonical source of these conventions for automated tooling


### PR DESCRIPTION
First milestone of the modular-architecture migration plan. Surfaces conventions that already exist in \`~/.claude/CLAUDE.md\` as in-repo documentation, so human collaborators find them without needing to know about the AI assistant's global config.

## What's in this PR

- **\`documentation/architecture-conventions.md\`** - protocol/mock/type naming, layered dependency rule, \`<Module>Mocks\` target pattern, mock-fidelity requirement, Swift Testing conventions (\`sut\`, \`struct\` test types), PR/commit hygiene.
- **\`documentation/adr/ADR-001-modular-architecture.md\`** - records the decision to follow the incremental migration plan. Explicit consequences (easier / harder / follow-up implied / explicitly not addressed) and alternatives considered. Status: Accepted.
- **\`documentation/adr/ADR-000-template.md\`** - template for future ADRs.

## What's NOT in this PR

- No code changes.
- The migration plan itself lives in \`llmtemp/\` (gitignored) - this is internal scratch.

## Why now

We've shipped 6 modular-architecture PRs today (NetworkService protocol, OAuth protocols, etc.) and informally been following conventions documented in \`~/.claude/CLAUDE.md\`. The codebase is at ~55-60% of the target modular architecture. Codifying the conventions in-repo before tackling the bigger phases (decomposing \`AIService\`, extracting feature packages) means the rest of the migration has a stable foundation to reference.

## Test plan

- [x] Files compile (they're markdown, but verified the structure)
- [x] Links between files resolve
- [x] No code changes - no tests run