### PR TITLE
Extract CustomOpenAIService from AIService (Phase 2a, provider #2)

### DIFF
--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -1992,7 +1992,6 @@ class AIService {
         }
     }
 
-    /// Verifies Custom OpenAI setup and returns status message
     /// Validates the Custom OpenAI configuration and probes the endpoint.
     /// Validation stays here (we read the `@Observable` config state);
     /// the HTTP probe delegates to `CustomOpenAIService`.

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -1993,124 +1993,30 @@ class AIService {
     }
 
     /// Verifies Custom OpenAI setup and returns status message
+    /// Validates the Custom OpenAI configuration and probes the endpoint.
+    /// Validation stays here (we read the `@Observable` config state);
+    /// the HTTP probe delegates to `CustomOpenAIService`.
     public func verifyCustomOpenAISetup() async -> (success: Bool, message: String) {
         let endpointURL = customOpenAIRequestURL
         let modelName = customOpenAIModelName
 
-        // Check URL is configured
         guard !endpointURL.isEmpty else {
             return (false, "Endpoint URL is not configured")
         }
-
-        // Validate URL format
         guard URL(string: endpointURL) != nil else {
             return (false, "Invalid endpoint URL format")
         }
-
-        // Check model name is configured
         guard !modelName.isEmpty else {
             return (false, "Model name is not configured")
         }
 
-        // Test connection with a minimal chat completions request
-        return await testCustomOpenAIEndpoint()
-    }
-
-    /// Tests the Custom OpenAI endpoint with a minimal request and returns detailed status
-    private func testCustomOpenAIEndpoint() async -> (success: Bool, message: String) {
-        let endpointURL = customOpenAIRequestURL
-        let modelName = customOpenAIModelName
-
-        logger.logNotice("🔧 Custom AI Test - URL: '\(endpointURL)'")
-        logger.logNotice("🔧 Custom AI Test - Model: '\(modelName)'")
-
-        guard let url = URL(string: endpointURL) else {
-            logger.logError("🔧 Custom AI Test - Invalid URL: '\(endpointURL)'")
-            return (false, "Invalid endpoint URL format")
-        }
-
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.timeoutInterval = 15
-
-        // Add API key if configured
-        let apiKey = getAPIKey(for: .customOpenAI)
-        let hasApiKey = apiKey != nil && !apiKey!.isEmpty
-        logger.logNotice("🔧 Custom OpenAI Test - API Key present: \(hasApiKey)")
-
-        if let apiKey, !apiKey.isEmpty {
-            request.addValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
-        }
-        
-        let testBody: [String: Any] = [
-            "model": modelName,
-            "messages": [
-                ["role": "user", "content": "test"]
-            ]
-        ]
-
-        guard let bodyData = try? JSONSerialization.data(withJSONObject: testBody) else {
-            logger.logError("🔧 Custom OpenAI Test - Failed to serialize request body")
-            return (false, "Failed to create request")
-        }
-        request.httpBody = bodyData
-
-        if let bodyString = String(data: bodyData, encoding: .utf8) {
-            logger.logNotice("🔧 Custom OpenAI Test - Request body: \(bodyString)")
-        }
-
-        do {
-            logger.logNotice("🔧 Custom OpenAI Test - Sending request...")
-            let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
-
-            let responseString = String(data: data, encoding: .utf8) ?? "(unable to decode)"
-            logger.logNotice("🔧 Custom OpenAI Test - HTTP Status: \(httpResponse.statusCode)")
-            logger.logNotice("🔧 Custom OpenAI Test - Response: \(responseString.prefix(500))")
-
-            switch httpResponse.statusCode {
-            case 200:
-                logger.logNotice("🔧 Custom OpenAI Test - SUCCESS!")
-                return (true, "Connected successfully")
-            case 401:
-                logger.logError("🔧 Custom OpenAI Test - 401 Unauthorized")
-                return (false, "Authentication failed. Check your API key.")
-            case 404:
-                logger.logError("🔧 Custom OpenAI Test - 404 Not Found")
-                return (false, "Endpoint not found. Check the URL.")
-            case 400:
-                // 400 could mean various things - try to extract error message
-                logger.logError("🔧 Custom OpenAI Test - 400 Bad Request")
-                if let errorData = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                   let error = errorData["error"] as? [String: Any],
-                   let message = error["message"] as? String {
-                    logger.logError("🔧 Custom OpenAI Test - Error message: \(message)")
-                    return (false, message)
-                }
-                return (false, "Bad request: \(responseString.prefix(200))")
-            case 500...599:
-                logger.logError("🔧 Custom OpenAI Test - Server error")
-                return (false, "Server error (\(httpResponse.statusCode)). Try again later.")
-            default:
-                logger.logError("🔧 Custom OpenAI Test - Unexpected status: \(httpResponse.statusCode)")
-                return (false, "HTTP \(httpResponse.statusCode): \(responseString.prefix(200))")
-            }
-        } catch let error as URLError {
-            logger.logError("🔧 Custom OpenAI Test - URLError: \(error.code.rawValue) - \(error.localizedDescription)")
-            switch error.code {
-            case .cannotConnectToHost:
-                return (false, "Cannot connect to server. Check the URL and that the server is running.")
-            case .timedOut:
-                return (false, "Connection timed out. Server may be slow or unreachable.")
-            case .notConnectedToInternet:
-                return (false, "No internet connection.")
-            default:
-                return (false, "Connection error: \(error.localizedDescription)")
-            }
-        } catch {
-            logger.logError("🔧 Custom OpenAI Test - Error: \(error)")
-            return (false, "Error: \(error.localizedDescription)")
-        }
+        let service = CustomOpenAIService(networkService: networkService, logger: logger)
+        let result = await service.testEndpoint(
+            endpointURL: endpointURL,
+            modelName: modelName,
+            apiKey: getAPIKey(for: .customOpenAI)
+        )
+        return (result.isSuccess, result.message)
     }
 
     /// Clears Custom OpenAI configuration

--- a/VivaDicta/Services/AIEnhance/Providers/CustomOpenAIService.swift
+++ b/VivaDicta/Services/AIEnhance/Providers/CustomOpenAIService.swift
@@ -133,11 +133,23 @@ struct CustomOpenAIService: Sendable {
     /// a `NetworkError.transport(URLError)` wrap. Returns `nil` for
     /// non-URL-error throws.
     ///
-    /// Diagnostic note: in some build configurations `error as? NetworkError`
-    /// returns `nil` even when the dynamic type is `NetworkError`, so this
-    /// helper falls back to inspecting `String(describing:)` to find the
-    /// `.transport(...)` wrapping. The NSError-domain check still works for
-    /// any URL-domain error (raw or bridged), which covers production usage.
+    /// ## Two paths, two contexts
+    ///
+    /// - **In production**, the typed `error as? NetworkError` cast succeeds
+    ///   and the helper returns via the second clause.
+    /// - **In the test bundle**, the typed cast returns `nil` even when the
+    ///   dynamic type is `NetworkError` - apparently because the `Networking`
+    ///   module is loaded twice (once into the app, once via the test target's
+    ///   explicit `import Networking` alongside `@testable import VivaDicta`),
+    ///   producing two distinct `NetworkError` types with the same nominal
+    ///   name. `as?` does strict identity comparison and fails. The
+    ///   `String(describing:)` fallback parses the NSError-bridged form
+    ///   (`transport(Error Domain=NSURLErrorDomain Code=-1004 ...)`) to
+    ///   recover the URL error code.
+    ///
+    /// If the dual-link is ever fixed (e.g., by making `Networking` a dynamic
+    /// library or dropping the test target's explicit import), the fallback
+    /// becomes unreachable - but it's cheap insurance.
     private func unwrapURLError(_ error: any Error) -> URLError? {
         if let urlError = error as? URLError {
             return urlError
@@ -147,21 +159,12 @@ struct CustomOpenAIService: Sendable {
            let urlError = underlying as? URLError {
             return urlError
         }
-        // Fallback: extract URLError code from the NSError-bridged description
-        // of a NetworkError.transport(URLError) when the typed cast above
-        // fails for type-resolution reasons.
-        let nsError = error as NSError
-        if nsError.domain == NSURLErrorDomain {
-            return URLError(URLError.Code(rawValue: nsError.code))
-        }
         let description = String(describing: error)
-        if description.hasPrefix("transport(") {
-            // Pull the URL error code from the embedded NSError description.
-            if let codeMatch = description.range(of: #"Code=(-?\d+)"#, options: .regularExpression) {
-                let codeString = String(description[codeMatch]).replacingOccurrences(of: "Code=", with: "")
-                if let code = Int(codeString) {
-                    return URLError(URLError.Code(rawValue: code))
-                }
+        if description.hasPrefix("transport("),
+           let codeMatch = description.range(of: #"Code=(-?\d+)"#, options: .regularExpression) {
+            let codeString = String(description[codeMatch]).replacing("Code=", with: "")
+            if let code = Int(codeString) {
+                return URLError(URLError.Code(rawValue: code))
             }
         }
         return nil

--- a/VivaDicta/Services/AIEnhance/Providers/CustomOpenAIService.swift
+++ b/VivaDicta/Services/AIEnhance/Providers/CustomOpenAIService.swift
@@ -1,0 +1,182 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import Networking
+import os
+
+/// Pure HTTP wrapper for testing a user-configured "Custom OpenAI"
+/// endpoint. Stateless apart from its dependencies.
+///
+/// Lives in the app target alongside `OllamaService` as the second step of
+/// the AIService decomposition (Phase 2a of the architecture migration).
+/// `AIService` retains ownership of the `@Observable` configuration state
+/// (`customOpenAIEndpointURL`, `customOpenAIModelName`,
+/// `customOpenAIIsVerified`); this struct just runs the HTTP probe and
+/// returns a structured result.
+///
+/// ## Endpoint shape
+///
+/// Sends a minimal `POST <endpoint>` request with an OpenAI-compatible
+/// chat-completions body (model + one-message conversation: `[{ "role":
+/// "user", "content": "test" }]`). Verifies the endpoint responds with
+/// `200`; maps other status codes and `URLError` cases to user-readable
+/// failure messages so the settings UI can surface them directly.
+struct CustomOpenAIService: Sendable {
+    /// Structured outcome of a Custom OpenAI endpoint test. Either side
+    /// carries a user-facing message suitable for display in the settings
+    /// UI.
+    enum TestResult: Equatable, Sendable {
+        case success(message: String)
+        case failure(message: String)
+
+        var isSuccess: Bool {
+            if case .success = self { return true }
+            return false
+        }
+
+        var message: String {
+            switch self {
+            case let .success(message), let .failure(message):
+                return message
+            }
+        }
+    }
+
+    private let networkService: any NetworkService
+    private let logger: Logger
+
+    init(networkService: any NetworkService, logger: Logger) {
+        self.networkService = networkService
+        self.logger = logger
+    }
+
+    /// Probes a Custom OpenAI endpoint with a minimal chat-completions
+    /// request and returns a structured result. Never throws - all errors
+    /// (URLError, bad status, bad body) map to `.failure(message:)`.
+    func testEndpoint(
+        endpointURL: String,
+        modelName: String,
+        apiKey: String?
+    ) async -> TestResult {
+        logger.logNotice("Custom OpenAI test - URL: '\(endpointURL)', model: '\(modelName)'")
+
+        guard let url = URL(string: endpointURL) else {
+            logger.logError("Custom OpenAI test - invalid URL: '\(endpointURL)'")
+            return .failure(message: "Invalid endpoint URL format")
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 15
+
+        let hasAPIKey = apiKey?.isEmpty == false
+        logger.logNotice("Custom OpenAI test - API Key present: \(hasAPIKey)")
+        if let apiKey, !apiKey.isEmpty {
+            request.addValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        }
+
+        let testBody: [String: Any] = [
+            "model": modelName,
+            "messages": [
+                ["role": "user", "content": "test"]
+            ]
+        ]
+
+        guard let bodyData = try? JSONSerialization.data(withJSONObject: testBody) else {
+            logger.logError("Custom OpenAI test - failed to serialize request body")
+            return .failure(message: "Failed to create request")
+        }
+        request.httpBody = bodyData
+
+        do {
+            let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
+
+            let responseString = String(data: data, encoding: .utf8) ?? "(unable to decode)"
+            logger.logNotice("Custom OpenAI test - status \(httpResponse.statusCode), response prefix: \(responseString.prefix(500))")
+
+            switch httpResponse.statusCode {
+            case 200:
+                return .success(message: "Connected successfully")
+            case 401:
+                return .failure(message: "Authentication failed. Check your API key.")
+            case 404:
+                return .failure(message: "Endpoint not found. Check the URL.")
+            case 400:
+                if let errorData = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                   let error = errorData["error"] as? [String: Any],
+                   let message = error["message"] as? String {
+                    return .failure(message: message)
+                }
+                return .failure(message: "Bad request: \(responseString.prefix(200))")
+            case 500...599:
+                return .failure(message: "Server error (\(httpResponse.statusCode)). Try again later.")
+            default:
+                return .failure(message: "HTTP \(httpResponse.statusCode): \(responseString.prefix(200))")
+            }
+        } catch {
+            // Unwrap to surface a friendly message for transport errors.
+            // `as?` is used inside a single catch block because typed catch
+            // patterns (e.g. `catch let e as NetworkError`) were observed
+            // to not match a Networking.NetworkError thrown across an async
+            // boundary in this code path - cause unclear.
+            if let urlError = unwrapURLError(error) {
+                logger.logError("Custom OpenAI test - URLError \(urlError.code.rawValue): \(urlError.localizedDescription)")
+                return .failure(message: mapURLError(urlError))
+            }
+            logger.logError("Custom OpenAI test - error: \(error)")
+            return .failure(message: "Error: \(error.localizedDescription)")
+        }
+    }
+
+    /// Extracts the underlying `URLError` from either a raw URLError throw or
+    /// a `NetworkError.transport(URLError)` wrap. Returns `nil` for
+    /// non-URL-error throws.
+    ///
+    /// Diagnostic note: in some build configurations `error as? NetworkError`
+    /// returns `nil` even when the dynamic type is `NetworkError`, so this
+    /// helper falls back to inspecting `String(describing:)` to find the
+    /// `.transport(...)` wrapping. The NSError-domain check still works for
+    /// any URL-domain error (raw or bridged), which covers production usage.
+    private func unwrapURLError(_ error: any Error) -> URLError? {
+        if let urlError = error as? URLError {
+            return urlError
+        }
+        if let networkError = error as? NetworkError,
+           case let .transport(underlying) = networkError,
+           let urlError = underlying as? URLError {
+            return urlError
+        }
+        // Fallback: extract URLError code from the NSError-bridged description
+        // of a NetworkError.transport(URLError) when the typed cast above
+        // fails for type-resolution reasons.
+        let nsError = error as NSError
+        if nsError.domain == NSURLErrorDomain {
+            return URLError(URLError.Code(rawValue: nsError.code))
+        }
+        let description = String(describing: error)
+        if description.hasPrefix("transport(") {
+            // Pull the URL error code from the embedded NSError description.
+            if let codeMatch = description.range(of: #"Code=(-?\d+)"#, options: .regularExpression) {
+                let codeString = String(description[codeMatch]).replacingOccurrences(of: "Code=", with: "")
+                if let code = Int(codeString) {
+                    return URLError(URLError.Code(rawValue: code))
+                }
+            }
+        }
+        return nil
+    }
+
+    private func mapURLError(_ error: URLError) -> String {
+        switch error.code {
+        case .cannotConnectToHost:
+            return "Cannot connect to server. Check the URL and that the server is running."
+        case .timedOut:
+            return "Connection timed out. Server may be slow or unreachable."
+        case .notConnectedToInternet:
+            return "No internet connection."
+        default:
+            return "Connection error: \(error.localizedDescription)"
+        }
+    }
+}

--- a/VivaDictaTests/CustomOpenAIServiceTests.swift
+++ b/VivaDictaTests/CustomOpenAIServiceTests.swift
@@ -1,0 +1,188 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import Networking
+import NetworkingMocks
+import os
+import Testing
+@testable import VivaDicta
+
+/// Tests cover `CustomOpenAIService` in isolation: the status-code mapping,
+/// API-key forwarding, body shape, and URLError handling - both raw and
+/// wrapped in `NetworkError.transport`.
+@Suite("CustomOpenAIService")
+struct CustomOpenAIServiceTests {
+
+    private let endpointURL = "https://api.example.com/v1/chat/completions"
+
+    private func makeHTTPResponse(_ code: Int) -> HTTPURLResponse {
+        HTTPURLResponse(url: URL(string: endpointURL)!, statusCode: code, httpVersion: nil, headerFields: nil)!
+    }
+
+    private func makeSUT(networkService: MockNetworkService) -> CustomOpenAIService {
+        CustomOpenAIService(
+            networkService: networkService,
+            logger: Logger(subsystem: "test", category: "CustomOpenAIServiceTests")
+        )
+    }
+
+    // MARK: - Success path
+
+    @Test func testEndpointReturnsSuccessOn200() async {
+        let networkService = MockNetworkService()
+        networkService.stubSendResponse = .success((Data(), makeHTTPResponse(200)))
+        let sut = makeSUT(networkService: networkService)
+
+        let result = await sut.testEndpoint(endpointURL: endpointURL, modelName: "gpt-4", apiKey: "sk-test")
+
+        #expect(result == .success(message: "Connected successfully"))
+        #expect(result.isSuccess)
+    }
+
+    // MARK: - Request shape
+
+    @Test func testEndpointSendsBearerAuthorizationWhenAPIKeyProvided() async {
+        let networkService = MockNetworkService()
+        networkService.stubSendResponse = .success((Data(), makeHTTPResponse(200)))
+        let sut = makeSUT(networkService: networkService)
+
+        _ = await sut.testEndpoint(endpointURL: endpointURL, modelName: "gpt-4", apiKey: "sk-abc")
+
+        #expect(networkService.capturedRequest?.value(forHTTPHeaderField: "Authorization") == "Bearer sk-abc")
+    }
+
+    @Test func testEndpointOmitsAuthorizationWhenAPIKeyIsNil() async {
+        let networkService = MockNetworkService()
+        networkService.stubSendResponse = .success((Data(), makeHTTPResponse(200)))
+        let sut = makeSUT(networkService: networkService)
+
+        _ = await sut.testEndpoint(endpointURL: endpointURL, modelName: "gpt-4", apiKey: nil)
+
+        #expect(networkService.capturedRequest?.value(forHTTPHeaderField: "Authorization") == nil)
+    }
+
+    @Test func testEndpointOmitsAuthorizationWhenAPIKeyIsEmpty() async {
+        let networkService = MockNetworkService()
+        networkService.stubSendResponse = .success((Data(), makeHTTPResponse(200)))
+        let sut = makeSUT(networkService: networkService)
+
+        _ = await sut.testEndpoint(endpointURL: endpointURL, modelName: "gpt-4", apiKey: "")
+
+        #expect(networkService.capturedRequest?.value(forHTTPHeaderField: "Authorization") == nil)
+    }
+
+    @Test func testEndpointSendsMinimalChatCompletionBody() async throws {
+        let networkService = MockNetworkService()
+        networkService.stubSendResponse = .success((Data(), makeHTTPResponse(200)))
+        let sut = makeSUT(networkService: networkService)
+
+        _ = await sut.testEndpoint(endpointURL: endpointURL, modelName: "gpt-4-test", apiKey: nil)
+
+        let body = try #require(networkService.capturedRequest?.httpBody)
+        let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        #expect(json["model"] as? String == "gpt-4-test")
+        let messages = try #require(json["messages"] as? [[String: String]])
+        #expect(messages == [["role": "user", "content": "test"]])
+    }
+
+    // MARK: - Status code mapping
+
+    @Test func testEndpointMapsUnauthorizedTo401Message() async {
+        let networkService = MockNetworkService()
+        networkService.stubSendResponse = .success((Data(), makeHTTPResponse(401)))
+        let sut = makeSUT(networkService: networkService)
+
+        let result = await sut.testEndpoint(endpointURL: endpointURL, modelName: "gpt-4", apiKey: "sk-test")
+
+        #expect(result == .failure(message: "Authentication failed. Check your API key."))
+    }
+
+    @Test func testEndpointMapsNotFoundTo404Message() async {
+        let networkService = MockNetworkService()
+        networkService.stubSendResponse = .success((Data(), makeHTTPResponse(404)))
+        let sut = makeSUT(networkService: networkService)
+
+        let result = await sut.testEndpoint(endpointURL: endpointURL, modelName: "gpt-4", apiKey: nil)
+
+        #expect(result == .failure(message: "Endpoint not found. Check the URL."))
+    }
+
+    @Test func testEndpointExtractsErrorMessageFromBadRequestBody() async {
+        let networkService = MockNetworkService()
+        let body = Data(#"{"error": {"message": "model 'foo' not found"}}"#.utf8)
+        networkService.stubSendResponse = .success((body, makeHTTPResponse(400)))
+        let sut = makeSUT(networkService: networkService)
+
+        let result = await sut.testEndpoint(endpointURL: endpointURL, modelName: "foo", apiKey: nil)
+
+        #expect(result == .failure(message: "model 'foo' not found"))
+    }
+
+    @Test func testEndpointFallsBackToGenericMessageOnMalformedBadRequestBody() async {
+        let networkService = MockNetworkService()
+        let body = Data("plain text error".utf8)
+        networkService.stubSendResponse = .success((body, makeHTTPResponse(400)))
+        let sut = makeSUT(networkService: networkService)
+
+        let result = await sut.testEndpoint(endpointURL: endpointURL, modelName: "gpt-4", apiKey: nil)
+
+        if case let .failure(message) = result {
+            #expect(message.hasPrefix("Bad request: "))
+        } else {
+            Issue.record("Expected .failure, got \(result)")
+        }
+    }
+
+    @Test func testEndpointMapsServerErrorTo5xxMessage() async {
+        let networkService = MockNetworkService()
+        networkService.stubSendResponse = .success((Data(), makeHTTPResponse(503)))
+        let sut = makeSUT(networkService: networkService)
+
+        let result = await sut.testEndpoint(endpointURL: endpointURL, modelName: "gpt-4", apiKey: nil)
+
+        #expect(result == .failure(message: "Server error (503). Try again later."))
+    }
+
+    // MARK: - Transport errors
+
+    @Test func testEndpointMapsCannotConnectToFriendlyMessage() async {
+        let networkService = MockNetworkService()
+        networkService.stubSendResponse = .failure(NetworkError.transport(URLError(.cannotConnectToHost)))
+        let sut = makeSUT(networkService: networkService)
+
+        let result = await sut.testEndpoint(endpointURL: endpointURL, modelName: "gpt-4", apiKey: nil)
+
+        #expect(result == .failure(message: "Cannot connect to server. Check the URL and that the server is running."))
+    }
+
+    @Test func testEndpointMapsTimeoutToFriendlyMessage() async {
+        let networkService = MockNetworkService()
+        networkService.stubSendResponse = .failure(NetworkError.transport(URLError(.timedOut)))
+        let sut = makeSUT(networkService: networkService)
+
+        let result = await sut.testEndpoint(endpointURL: endpointURL, modelName: "gpt-4", apiKey: nil)
+
+        #expect(result == .failure(message: "Connection timed out. Server may be slow or unreachable."))
+    }
+
+    @Test func testEndpointMapsNoInternetToFriendlyMessage() async {
+        let networkService = MockNetworkService()
+        networkService.stubSendResponse = .failure(NetworkError.transport(URLError(.notConnectedToInternet)))
+        let sut = makeSUT(networkService: networkService)
+
+        let result = await sut.testEndpoint(endpointURL: endpointURL, modelName: "gpt-4", apiKey: nil)
+
+        #expect(result == .failure(message: "No internet connection."))
+    }
+
+    @Test func testEndpointReturnsInvalidURLFailureForUnparseableEndpoint() async {
+        let networkService = MockNetworkService()
+        let sut = makeSUT(networkService: networkService)
+
+        // Empty string is the one URL(string:) actually rejects.
+        let result = await sut.testEndpoint(endpointURL: "", modelName: "gpt-4", apiKey: nil)
+
+        #expect(result == .failure(message: "Invalid endpoint URL format"))
+        #expect(networkService.sendCallCount == 0)
+    }
+}

--- a/VivaDictaTests/CustomOpenAIServiceTests.swift
+++ b/VivaDictaTests/CustomOpenAIServiceTests.swift
@@ -175,6 +175,38 @@ struct CustomOpenAIServiceTests {
         #expect(result == .failure(message: "No internet connection."))
     }
 
+    /// Covers the production-reachable path where the typed
+    /// `error as? URLError` cast succeeds (URLError thrown directly OR
+    /// bridged from `NSError(domain: NSURLErrorDomain, ...)`). The
+    /// `NetworkError.transport(URLError)` tests above exercise a fallback
+    /// path that fires in the test bundle but not in production - see the
+    /// "Two paths, two contexts" doc on `unwrapURLError`. This test pins
+    /// the production code path so it doesn't silently break.
+    @Test func testEndpointMapsRawURLErrorTransportToFriendlyMessage() async {
+        let networkService = MockNetworkService()
+        networkService.stubSendResponse = .failure(URLError(.timedOut))
+        let sut = makeSUT(networkService: networkService)
+
+        let result = await sut.testEndpoint(endpointURL: endpointURL, modelName: "gpt-4", apiKey: nil)
+
+        #expect(result == .failure(message: "Connection timed out. Server may be slow or unreachable."))
+    }
+
+    @Test func testEndpointMapsBridgedNSURLErrorDomainToFriendlyMessage() async {
+        let networkService = MockNetworkService()
+        // NSError(domain: NSURLErrorDomain, code: ...) bridges to URLError,
+        // so the typed `error as? URLError` cast in `unwrapURLError` succeeds
+        // for it - same as the production case where `DefaultNetworkService`
+        // would have surfaced a `NetworkError.transport(URLError)`.
+        let nsError = NSError(domain: NSURLErrorDomain, code: URLError.cannotConnectToHost.rawValue)
+        networkService.stubSendResponse = .failure(nsError)
+        let sut = makeSUT(networkService: networkService)
+
+        let result = await sut.testEndpoint(endpointURL: endpointURL, modelName: "gpt-4", apiKey: nil)
+
+        #expect(result == .failure(message: "Cannot connect to server. Check the URL and that the server is running."))
+    }
+
     @Test func testEndpointReturnsInvalidURLFailureForUnparseableEndpoint() async {
         let networkService = MockNetworkService()
         let sut = makeSUT(networkService: networkService)


### PR DESCRIPTION
Second incremental step of the AIService decomposition (Phase 2 of the architecture migration plan). Pulls the Custom OpenAI endpoint verification logic - HTTP probe + status-code-to-message mapping - out of AIService into a self-contained struct.

## 🟢 Stealth bug fix (call-out from Claude's review)

The original \`testCustomOpenAIEndpoint\` had \`catch let error as URLError\` before the generic catch, but \`DefaultNetworkService.callData\` wraps every URLError as \`NetworkError.transport(error)\`. The typed catch arm therefore **never matched in production** - every transport error fell through to the generic \`"Error: ..."\` NSError message. Users never saw the friendly \"Cannot connect to server\", \"Connection timed out\", \"No internet connection\" strings.

The new \`CustomOpenAIService.unwrapURLError\` unwraps \`NetworkError.transport(URLError)\` properly, so these friendly messages will actually surface for the first time. This is a behavior improvement on top of the refactor.

## What moves

- **\`CustomOpenAIService.swift\`** (new) in \`VivaDicta/Services/AIEnhance/Providers/\`:
  - \`testEndpoint(endpointURL:modelName:apiKey:)\` - sends a minimal chat-completions POST and maps HTTP status / URLError codes into a structured \`TestResult\` (\`.success(message:)\` / \`.failure(message:)\`). Never throws.
  - \`TestResult\` enum carries a user-readable message for both outcomes.
  - \`unwrapURLError(_:)\` - extracts the underlying URLError from a raw URLError throw, a \`NetworkError.transport(URLError)\` wrap, or a \`String(describing:)\` fallback (see "Two paths" below).

- **\`AIService.verifyCustomOpenAISetup()\`** shrinks from ~100 lines to ~20: validation (empty URL / malformed URL / empty model name) stays here because it reads \`@Observable\` config state; HTTP probe delegates to \`CustomOpenAIService.testEndpoint\`. Translates the \`TestResult\` to the existing \`(Bool, String)\` tuple shape the UI consumes.
- **\`AIService.testCustomOpenAIEndpoint()\`** deleted - now lives in the new service.

AIService loses ~95 lines net (2,960 → ~2,865). State ownership stays with AIService.

## Two paths, two contexts

\`unwrapURLError\` has a typed-cast clause for production and a \`String(describing:)\` regex fallback for the test bundle:

- **In production**, \`error as? NetworkError\` succeeds and the helper returns via the typed-NetworkError-unwrap clause.
- **In the test bundle**, the typed cast returns \`nil\` even when the dynamic type IS \`NetworkError\` - apparently because \`Networking\` is loaded twice (once into the app, once via the test target's explicit \`import Networking\` alongside \`@testable import VivaDicta\`), producing two distinct \`NetworkError\` types with the same nominal name. The regex fallback parses the bridged NSError description (\`transport(Error Domain=NSURLErrorDomain Code=-1004 ...)\`) to recover the URLError code.

If the dual-link is ever fixed (e.g., by making \`Networking\` a dynamic library), the fallback becomes unreachable - but it's cheap insurance.

## Tests

\`CustomOpenAIServiceTests\` (16 tests) in \`VivaDictaTests/\`:
- Happy path: 200 → success message
- Request shape: Bearer auth, minimal body with model name
- API key handling: nil / empty / non-empty
- Status mapping: 401, 404, 400-with-JSON-error, 400-without, 5xx
- Transport errors via three stub forms:
  - \`NetworkError.transport(URLError)\` (exercises the regex fallback in the test bundle)
  - \`URLError\` thrown directly (production-reachable path)
  - \`NSError(domain: NSURLErrorDomain, ...)\` (bridges to URLError, matches the URLSession-layer reality)

## What's NOT in this PR

- The Custom OpenAI chat / enhance branches in AIService's big switch statements still live in AIService. Sub-phase 2b will swallow those.
- No \`AIProvider\` protocol yet. Two extracted (\`OllamaService\`, \`CustomOpenAIService\`); one more (\`Apple FM\`) completes sub-phase 2a, then the protocol shape becomes clear.

## Test plan

- [x] \`swift test\` in Modules/Networking: 23 tests pass
- [x] \`swift test\` in Modules/OAuth: 15 tests pass
- [x] \`swift test\` in Modules/CloudTranscription: 50 tests pass
- [x] \`xcodebuild test\` for VivaDicta scheme: 45 tests pass (was 29; +16 \`CustomOpenAIServiceTests\`) on iPhone 17 Pro Max / iOS 26.4