### PR TITLE
Extract OpenAICompatibleService from AIService (Phase 2b kickoff)

### DIFF
--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -997,32 +997,12 @@ class AIService {
         userMessage: String,
         stream: Bool
     ) -> [String: Any] {
-        let messages: [[String: Any]] = [
-            ["role": "system", "content": systemMessage],
-            ["role": "user", "content": userMessage]
-        ]
-
-        var requestBody: [String: Any] = [
-            "model": modelName,
-            "messages": messages,
-            "stream": stream
-        ]
-
-        if modelName.lowercased().hasPrefix("gpt-5") == false {
-            requestBody["temperature"] = 0.3
-        }
-
-        if let reasoningEffort = ReasoningConfig.getReasoningParameter(for: modelName) {
-            requestBody["reasoning_effort"] = reasoningEffort
-        }
-
-        if let extraBody = ReasoningConfig.getExtraBodyParameters(for: modelName) {
-            for (key, value) in extraBody {
-                requestBody[key] = value
-            }
-        }
-
-        return requestBody
+        OpenAICompatibleService.buildRequestBody(
+            modelName: modelName,
+            systemMessage: systemMessage,
+            userMessage: userMessage,
+            stream: stream
+        )
     }
 
     private func makeOpenAICompatibleStreamingRequest(
@@ -1037,92 +1017,23 @@ class AIService {
         unauthorizedMessage: String? = nil,
         onPartialResponse: @escaping @MainActor (String) -> Void
     ) async throws -> String {
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.addValue("text/event-stream", forHTTPHeaderField: "Accept")
-        request.timeoutInterval = timeout
-
-        for (key, value) in headers {
-            request.addValue(value, forHTTPHeaderField: key)
-        }
-
-        let requestBody = buildOpenAICompatibleRequestBody(
+        let service = OpenAICompatibleService(networkService: networkService, logger: logger)
+        return try await service.enhanceStreaming(
+            url: url,
             modelName: modelName,
             systemMessage: systemMessage,
             userMessage: userMessage,
-            stream: true
+            headers: headers,
+            timeout: timeout,
+            errorPrefix: errorPrefix,
+            notFoundMessage: notFoundMessage,
+            unauthorizedMessage: unauthorizedMessage,
+            onPartialResponse: onPartialResponse
         )
-        request.httpBody = try? JSONSerialization.data(withJSONObject: requestBody)
-
-        let (bytes, httpResponse) = try await networkService.bytes(for: request, acceptableStatusCodes: Set<Int>.acceptAny)
-
-        guard httpResponse.statusCode == 200 else {
-            var errorData = Data()
-            for try await byte in bytes {
-                errorData.append(byte)
-            }
-            let errorString = String(data: errorData, encoding: .utf8) ?? "Unknown error"
-
-            switch httpResponse.statusCode {
-            case 401 where unauthorizedMessage != nil:
-                throw EnhancementError.customError(unauthorizedMessage ?? errorString)
-            case 404 where notFoundMessage != nil:
-                throw EnhancementError.customError(notFoundMessage ?? errorString)
-            case 429:
-                throw EnhancementError.rateLimitExceeded
-            case 500...599:
-                throw EnhancementError.serverError
-            default:
-                throw EnhancementError.customError("\(errorPrefix) (HTTP \(httpResponse.statusCode)): \(errorString)")
-            }
-        }
-
-        var aggregatedText = ""
-        for try await line in bytes.lines {
-            if let delta = Self.openAICompatibleStreamingDelta(from: line) {
-                aggregatedText += delta
-                onPartialResponse(aggregatedText)
-            }
-        }
-
-        guard !aggregatedText.isEmpty else {
-            throw EnhancementError.enhancementFailed
-        }
-
-        return await finalizeStreamingResult(aggregatedText, onPartialResponse: onPartialResponse)
     }
 
     static func openAICompatibleStreamingDelta(from line: String) -> String? {
-        guard line.hasPrefix("data:") else {
-            return nil
-        }
-
-        let payload = String(line.dropFirst(5)).trimmingCharacters(in: .whitespaces)
-        guard payload.isEmpty == false, payload != "[DONE]",
-              let data = payload.data(using: .utf8),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let choices = json["choices"] as? [[String: Any]],
-              let firstChoice = choices.first else {
-            return nil
-        }
-
-        if let delta = firstChoice["delta"] as? [String: Any] {
-            if let content = delta["content"] as? String, content.isEmpty == false {
-                return content
-            }
-
-            if let contentItems = delta["content"] as? [[String: Any]] {
-                let text = contentItems.compactMap { $0["text"] as? String }.joined()
-                return text.isEmpty ? nil : text
-            }
-        }
-
-        if let text = firstChoice["text"] as? String, text.isEmpty == false {
-            return text
-        }
-
-        return nil
+        OpenAICompatibleService.streamingDelta(from: line)
     }
 
     private func makeAnthropicStreamingRequest(
@@ -1570,55 +1481,15 @@ class AIService {
             )
 
         default:
-            let url = URL(string: aiProvider.baseURL)!
-            var request = URLRequest(url: url)
-            
-            request.httpMethod = "POST"
-            request.addValue("application/json", forHTTPHeaderField: "Content-Type")
-            request.addValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
-            request.timeoutInterval = baseTimeout
-
-            let requestBody = buildOpenAICompatibleRequestBody(
+            let service = OpenAICompatibleService(networkService: networkService, logger: logger)
+            return try await service.enhance(
+                url: URL(string: aiProvider.baseURL)!,
                 modelName: mode.aiModel,
                 systemMessage: resolvedSystemMessage,
                 userMessage: formattedText,
-                stream: false
+                headers: ["Authorization": "Bearer \(apiKey)"],
+                timeout: baseTimeout
             )
-
-            request.httpBody = try? JSONSerialization.data(withJSONObject: requestBody)
-
-            do {
-                let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
-
-                if httpResponse.statusCode == 200 {
-                    guard let jsonResponse = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                          let choices = jsonResponse["choices"] as? [[String: Any]],
-                          let firstChoice = choices.first,
-                          let message = firstChoice["message"] as? [String: Any],
-                          let enhancedText = message["content"] as? String else {
-                        throw EnhancementError.enhancementFailed
-                    }
-
-                    let filteredText = AIEnhancementOutputFilter.filter(enhancedText.trimmingCharacters(in: .whitespacesAndNewlines))
-                    return filteredText
-                } else if httpResponse.statusCode == 429 {
-                    throw EnhancementError.rateLimitExceeded
-                } else if (500...599).contains(httpResponse.statusCode) {
-                    throw EnhancementError.serverError
-                } else {
-                    let errorString = String(data: data, encoding: .utf8) ?? "Could not decode error response."
-                    throw EnhancementError.customError("HTTP \(httpResponse.statusCode): \(errorString)")
-                }
-
-            } catch is CancellationError {
-                throw CancellationError()
-            } catch let error as EnhancementError {
-                throw error
-            } catch let error as URLError {
-                throw error
-            } catch {
-                throw EnhancementError.customError(error.localizedDescription)
-            }
         }
     }
 
@@ -2072,43 +1943,13 @@ class AIService {
     }
     
     private func verifyOpenAICompatibleAPIKey(_ key: String, provider: AIProvider) async -> Bool {
-        let url = URL(string: provider.baseURL)!
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.addValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
-        
-        let testBody: [String: Any] = [
-            "model": provider.defaultModel,
-            "messages": [
-                ["role": "user", "content": "test"]
-            ]
-        ]
-        
-        request.httpBody = try? JSONSerialization.data(withJSONObject: testBody)
-        
-        logger.logNotice("🔑 Verifying API key for \(provider.rawValue) provider at \(url.absoluteString)")
-        
-        do {
-            let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
-
-            let isValid = httpResponse.statusCode == 200
-
-            if !isValid {
-                // Log the exact API error response
-                if let exactAPIError = String(data: data, encoding: .utf8) {
-                    logger.logNotice("🔑 API key verification failed for \(provider.rawValue) - Status: \(httpResponse.statusCode) - \(exactAPIError)")
-                } else {
-                    logger.logNotice("🔑 API key verification failed for \(provider.rawValue) - Status: \(httpResponse.statusCode)")
-                }
-            }
-            
-            return isValid
-            
-        } catch {
-            logger.logNotice("🔑 API key verification failed for \(provider.rawValue): \(error.localizedDescription)")
-            return false
-        }
+        let service = OpenAICompatibleService(networkService: networkService, logger: logger)
+        return await service.verifyChatCompletionsAPIKey(
+            key,
+            baseURL: provider.baseURL,
+            defaultModel: provider.defaultModel,
+            providerName: provider.rawValue
+        )
     }
     
     private func verifyCerebrasAPIKey(_ key: String) async -> Bool {

--- a/VivaDicta/Services/AIEnhance/Providers/OpenAICompatibleService.swift
+++ b/VivaDicta/Services/AIEnhance/Providers/OpenAICompatibleService.swift
@@ -1,0 +1,326 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import Networking
+import os
+
+/// Pure HTTP wrapper for OpenAI-compatible chat-completions endpoints
+/// (`POST /v1/chat/completions` with Bearer auth and standard `messages`
+/// body). Stateless apart from its dependencies.
+///
+/// The fourth provider service in Phase 2a/2b of the AIService
+/// decomposition. Used by ~10 cloud providers (OpenAI, Groq, Cerebras,
+/// Mistral, xAI/Grok, OpenRouter, Z.AI, Kimi, Vercel AI Gateway,
+/// HuggingFace) that all share the OpenAI shape. Indirectly used by
+/// Ollama and Custom OpenAI through the static `buildRequestBody` and
+/// `streamingDelta` helpers - those callers do their own status-code
+/// mapping for provider-specific friendly errors and so call the static
+/// helpers directly rather than going through `enhance` / `enhanceStreaming`.
+///
+/// ## Why static helpers + instance methods
+///
+/// The shared utilities (`buildRequestBody`, `streamingDelta`) are static
+/// because callers like Ollama and Custom OpenAI build their own
+/// `URLRequest` with custom timeouts and error mapping, then just need
+/// the body shape and the SSE delta parser. Cloud providers that match
+/// the standard 429/5xx/default error mapping can call the instance
+/// `enhance` / `enhanceStreaming` methods directly.
+struct OpenAICompatibleService: Sendable {
+    private let networkService: any NetworkService
+    private let logger: Logger
+
+    init(networkService: any NetworkService, logger: Logger) {
+        self.networkService = networkService
+        self.logger = logger
+    }
+
+    // MARK: - Static utilities (also called by non-cloud paths)
+
+    /// Builds an OpenAI-compatible chat-completions body. Applies model
+    /// quirks: GPT-5 series omits `temperature` (uses `reasoning_effort`
+    /// instead); reasoning models pick up extra body parameters from
+    /// `ReasoningConfig`.
+    static func buildRequestBody(
+        modelName: String,
+        systemMessage: String,
+        userMessage: String,
+        stream: Bool
+    ) -> [String: Any] {
+        let messages: [[String: Any]] = [
+            ["role": "system", "content": systemMessage],
+            ["role": "user", "content": userMessage]
+        ]
+
+        var requestBody: [String: Any] = [
+            "model": modelName,
+            "messages": messages,
+            "stream": stream
+        ]
+
+        if modelName.lowercased().hasPrefix("gpt-5") == false {
+            requestBody["temperature"] = 0.3
+        }
+
+        if let reasoningEffort = ReasoningConfig.getReasoningParameter(for: modelName) {
+            requestBody["reasoning_effort"] = reasoningEffort
+        }
+
+        if let extraBody = ReasoningConfig.getExtraBodyParameters(for: modelName) {
+            for (key, value) in extraBody {
+                requestBody[key] = value
+            }
+        }
+
+        return requestBody
+    }
+
+    /// Parses one SSE `data:` line from an OpenAI-compatible streaming
+    /// response and returns the text delta if present. Returns `nil` for
+    /// non-data lines, the `[DONE]` sentinel, or malformed payloads.
+    /// Handles both string-content deltas and the newer array-of-text
+    /// deltas (responses-API shape).
+    static func streamingDelta(from line: String) -> String? {
+        guard line.hasPrefix("data:") else {
+            return nil
+        }
+
+        let payload = String(line.dropFirst(5)).trimmingCharacters(in: .whitespaces)
+        guard payload.isEmpty == false, payload != "[DONE]",
+              let data = payload.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let choices = json["choices"] as? [[String: Any]],
+              let firstChoice = choices.first else {
+            return nil
+        }
+
+        if let delta = firstChoice["delta"] as? [String: Any] {
+            if let content = delta["content"] as? String, content.isEmpty == false {
+                return content
+            }
+
+            if let contentItems = delta["content"] as? [[String: Any]] {
+                let text = contentItems.compactMap { $0["text"] as? String }.joined()
+                return text.isEmpty ? nil : text
+            }
+        }
+
+        if let text = firstChoice["text"] as? String, text.isEmpty == false {
+            return text
+        }
+
+        return nil
+    }
+
+    // MARK: - Non-streaming enhance
+
+    /// Non-streaming chat-completions request. Standard 429/5xx error
+    /// mapping; non-200 non-429 non-5xx maps to
+    /// `.customError("HTTP <status>: <body>")`.
+    ///
+    /// Returns the filtered/trimmed `choices[0].message.content`. Throws
+    /// `.enhancementFailed` on a malformed 200 body.
+    func enhance(
+        url: URL,
+        modelName: String,
+        systemMessage: String,
+        userMessage: String,
+        headers: [String: String],
+        timeout: TimeInterval
+    ) async throws -> String {
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = timeout
+
+        for (key, value) in headers {
+            request.addValue(value, forHTTPHeaderField: key)
+        }
+
+        let requestBody = Self.buildRequestBody(
+            modelName: modelName,
+            systemMessage: systemMessage,
+            userMessage: userMessage,
+            stream: false
+        )
+        request.httpBody = try? JSONSerialization.data(withJSONObject: requestBody)
+
+        do {
+            let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
+
+            if httpResponse.statusCode == 200 {
+                guard let jsonResponse = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                      let choices = jsonResponse["choices"] as? [[String: Any]],
+                      let firstChoice = choices.first,
+                      let message = firstChoice["message"] as? [String: Any],
+                      let enhancedText = message["content"] as? String else {
+                    logger.logError("OpenAI-compatible enhance - malformed 200 body")
+                    throw EnhancementError.enhancementFailed
+                }
+
+                let filteredText = AIEnhancementOutputFilter.filter(enhancedText.trimmingCharacters(in: .whitespacesAndNewlines))
+                return filteredText
+            } else if httpResponse.statusCode == 429 {
+                logger.logWarning("OpenAI-compatible enhance - rate limit exceeded (429)")
+                throw EnhancementError.rateLimitExceeded
+            } else if (500...599).contains(httpResponse.statusCode) {
+                logger.logError("OpenAI-compatible enhance - server error \(httpResponse.statusCode)")
+                throw EnhancementError.serverError
+            } else {
+                let errorString = String(data: data, encoding: .utf8) ?? "Could not decode error response."
+                logger.logError("OpenAI-compatible enhance - HTTP \(httpResponse.statusCode): \(errorString.prefix(500))")
+                throw EnhancementError.customError("HTTP \(httpResponse.statusCode): \(errorString)")
+            }
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch let error as EnhancementError {
+            throw error
+        } catch let error as URLError {
+            logger.logError("OpenAI-compatible enhance - URLError \(error.code.rawValue): \(error.localizedDescription)")
+            throw error
+        } catch {
+            logger.logError("OpenAI-compatible enhance - error: \(error.localizedDescription)")
+            throw EnhancementError.customError(error.localizedDescription)
+        }
+    }
+
+    // MARK: - Streaming enhance
+
+    /// Streaming chat-completions request via SSE. `errorPrefix` is
+    /// prepended to the default error message; `notFoundMessage` /
+    /// `unauthorizedMessage` override the 404 / 401 default messages
+    /// when provided (used by Ollama and Custom OpenAI to surface
+    /// model-name and auth hints).
+    ///
+    /// Calls `onPartialResponse` on the main actor as each SSE delta
+    /// arrives. Returns the filtered/trimmed final text. Throws
+    /// `.enhancementFailed` if no deltas arrived.
+    func enhanceStreaming(
+        url: URL,
+        modelName: String,
+        systemMessage: String,
+        userMessage: String,
+        headers: [String: String],
+        timeout: TimeInterval,
+        errorPrefix: String,
+        notFoundMessage: String? = nil,
+        unauthorizedMessage: String? = nil,
+        onPartialResponse: @escaping @MainActor (String) -> Void
+    ) async throws -> String {
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addValue("text/event-stream", forHTTPHeaderField: "Accept")
+        request.timeoutInterval = timeout
+
+        for (key, value) in headers {
+            request.addValue(value, forHTTPHeaderField: key)
+        }
+
+        let requestBody = Self.buildRequestBody(
+            modelName: modelName,
+            systemMessage: systemMessage,
+            userMessage: userMessage,
+            stream: true
+        )
+        request.httpBody = try? JSONSerialization.data(withJSONObject: requestBody)
+
+        let (bytes, httpResponse) = try await networkService.bytes(for: request, acceptableStatusCodes: Set<Int>.acceptAny)
+
+        guard httpResponse.statusCode == 200 else {
+            var errorData = Data()
+            for try await byte in bytes {
+                errorData.append(byte)
+            }
+            let errorString = String(data: errorData, encoding: .utf8) ?? "Unknown error"
+
+            switch httpResponse.statusCode {
+            case 401 where unauthorizedMessage != nil:
+                logger.logError("OpenAI-compatible streaming - 401: \(errorString.prefix(500))")
+                throw EnhancementError.customError(unauthorizedMessage ?? errorString)
+            case 404 where notFoundMessage != nil:
+                logger.logError("OpenAI-compatible streaming - 404: \(errorString.prefix(500))")
+                throw EnhancementError.customError(notFoundMessage ?? errorString)
+            case 429:
+                logger.logWarning("OpenAI-compatible streaming - rate limit exceeded (429)")
+                throw EnhancementError.rateLimitExceeded
+            case 500...599:
+                logger.logError("OpenAI-compatible streaming - server error \(httpResponse.statusCode)")
+                throw EnhancementError.serverError
+            default:
+                logger.logError("OpenAI-compatible streaming - HTTP \(httpResponse.statusCode): \(errorString.prefix(500))")
+                throw EnhancementError.customError("\(errorPrefix) (HTTP \(httpResponse.statusCode)): \(errorString)")
+            }
+        }
+
+        var aggregatedText = ""
+        for try await line in bytes.lines {
+            if let delta = Self.streamingDelta(from: line) {
+                aggregatedText += delta
+                await onPartialResponse(aggregatedText)
+            }
+        }
+
+        guard !aggregatedText.isEmpty else {
+            logger.logError("OpenAI-compatible streaming - finished with empty aggregated text")
+            throw EnhancementError.enhancementFailed
+        }
+
+        let trimmed = aggregatedText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let filtered = AIEnhancementOutputFilter.filter(trimmed)
+        if filtered != aggregatedText {
+            await onPartialResponse(filtered)
+        }
+        return filtered
+    }
+
+    // MARK: - API key verification
+
+    /// Probes an OpenAI-compatible chat-completions endpoint with a
+    /// minimal `messages: [{ "role": "user", "content": "test" }]`
+    /// request and returns `true` if the response is 200. Used by
+    /// providers whose verify path is "send a tiny chat completion and
+    /// see if it succeeds" - currently the generic AIService fallback
+    /// for OpenAI, Groq, OpenRouter, Z.AI, Kimi, Vercel AI Gateway.
+    ///
+    /// Never throws. `providerName` is used only for log lines.
+    func verifyChatCompletionsAPIKey(
+        _ key: String,
+        baseURL: String,
+        defaultModel: String,
+        providerName: String
+    ) async -> Bool {
+        let url = URL(string: baseURL)!
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
+
+        let testBody: [String: Any] = [
+            "model": defaultModel,
+            "messages": [
+                ["role": "user", "content": "test"]
+            ]
+        ]
+        request.httpBody = try? JSONSerialization.data(withJSONObject: testBody)
+
+        logger.logNotice("🔑 Verifying API key for \(providerName) provider at \(url.absoluteString)")
+
+        do {
+            let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
+            let isValid = httpResponse.statusCode == 200
+
+            if !isValid {
+                if let exactAPIError = String(data: data, encoding: .utf8) {
+                    logger.logNotice("🔑 API key verification failed for \(providerName) - Status: \(httpResponse.statusCode) - \(exactAPIError)")
+                } else {
+                    logger.logNotice("🔑 API key verification failed for \(providerName) - Status: \(httpResponse.statusCode)")
+                }
+            }
+
+            return isValid
+        } catch {
+            logger.logNotice("🔑 API key verification failed for \(providerName): \(error.localizedDescription)")
+            return false
+        }
+    }
+}

--- a/VivaDictaTests/OpenAICompatibleServiceTests.swift
+++ b/VivaDictaTests/OpenAICompatibleServiceTests.swift
@@ -264,6 +264,28 @@ struct OpenAICompatibleServiceTests {
         }
     }
 
+    @Test func enhanceRethrowsURLErrorTransport() async {
+        let networkService = MockNetworkService()
+        networkService.stubSendResponse = .failure(URLError(.timedOut))
+        let sut = makeSUT(networkService: networkService)
+
+        do {
+            _ = try await sut.enhance(
+                url: URL(string: endpointURL)!,
+                modelName: "m",
+                systemMessage: "s",
+                userMessage: "u",
+                headers: [:],
+                timeout: 30
+            )
+            Issue.record("Expected URLError")
+        } catch let error as URLError {
+            #expect(error.code == .timedOut)
+        } catch {
+            Issue.record("Expected URLError, got \(error)")
+        }
+    }
+
     @Test func enhanceMapsOtherStatusToCustomError() async {
         let networkService = MockNetworkService()
         let body = Data(#"{"error":"unauthorized"}"#.utf8)

--- a/VivaDictaTests/OpenAICompatibleServiceTests.swift
+++ b/VivaDictaTests/OpenAICompatibleServiceTests.swift
@@ -1,0 +1,393 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import Networking
+import NetworkingMocks
+import os
+import Testing
+@testable import VivaDicta
+
+/// Tests cover `OpenAICompatibleService` in isolation: the static body
+/// builder and SSE delta parser (pure functions, fully exercised),
+/// the instance `enhance` non-streaming path (success, 429, 5xx,
+/// other, malformed body, request shape), the instance
+/// `verifyChatCompletionsAPIKey` probe, and the streaming request
+/// shape (full SSE parsing is not testable via MockNetworkService;
+/// see the comment near the streaming tests).
+@Suite("OpenAICompatibleService")
+struct OpenAICompatibleServiceTests {
+
+    private let endpointURL = "https://api.example.com/v1/chat/completions"
+
+    private func makeHTTPResponse(_ code: Int) -> HTTPURLResponse {
+        HTTPURLResponse(url: URL(string: endpointURL)!, statusCode: code, httpVersion: nil, headerFields: nil)!
+    }
+
+    private func makeSUT(networkService: MockNetworkService) -> OpenAICompatibleService {
+        OpenAICompatibleService(
+            networkService: networkService,
+            logger: Logger(subsystem: "test", category: "OpenAICompatibleServiceTests")
+        )
+    }
+
+    // MARK: - Static buildRequestBody
+
+    @Test func buildRequestBodyIncludesStandardFields() throws {
+        let body = OpenAICompatibleService.buildRequestBody(
+            modelName: "gpt-4",
+            systemMessage: "you are a helper",
+            userMessage: "rewrite this",
+            stream: false
+        )
+
+        #expect(body["model"] as? String == "gpt-4")
+        #expect(body["stream"] as? Bool == false)
+        let messages = try #require(body["messages"] as? [[String: String]])
+        #expect(messages == [
+            ["role": "system", "content": "you are a helper"],
+            ["role": "user", "content": "rewrite this"]
+        ])
+    }
+
+    @Test func buildRequestBodyIncludesTemperatureForNonGPT5() {
+        let body = OpenAICompatibleService.buildRequestBody(
+            modelName: "gpt-4",
+            systemMessage: "s",
+            userMessage: "u",
+            stream: false
+        )
+
+        #expect(body["temperature"] as? Double == 0.3)
+    }
+
+    @Test func buildRequestBodyOmitsTemperatureForGPT5() {
+        let body = OpenAICompatibleService.buildRequestBody(
+            modelName: "gpt-5-mini",
+            systemMessage: "s",
+            userMessage: "u",
+            stream: false
+        )
+
+        #expect(body["temperature"] == nil)
+    }
+
+    @Test func buildRequestBodyOmitsTemperatureForUppercaseGPT5() {
+        // The check is case-insensitive (`.lowercased().hasPrefix("gpt-5")`).
+        let body = OpenAICompatibleService.buildRequestBody(
+            modelName: "GPT-5-Mini",
+            systemMessage: "s",
+            userMessage: "u",
+            stream: false
+        )
+
+        #expect(body["temperature"] == nil)
+    }
+
+    @Test func buildRequestBodyPassesStreamFlag() {
+        let streamingBody = OpenAICompatibleService.buildRequestBody(
+            modelName: "gpt-4",
+            systemMessage: "s",
+            userMessage: "u",
+            stream: true
+        )
+
+        #expect(streamingBody["stream"] as? Bool == true)
+    }
+
+    // MARK: - Static streamingDelta
+
+    @Test func streamingDeltaIgnoresNonDataLines() {
+        #expect(OpenAICompatibleService.streamingDelta(from: "event: ping") == nil)
+        #expect(OpenAICompatibleService.streamingDelta(from: "") == nil)
+    }
+
+    @Test func streamingDeltaIgnoresDoneSentinel() {
+        #expect(OpenAICompatibleService.streamingDelta(from: "data: [DONE]") == nil)
+    }
+
+    @Test func streamingDeltaIgnoresMalformedJSON() {
+        #expect(OpenAICompatibleService.streamingDelta(from: "data: not-json") == nil)
+    }
+
+    @Test func streamingDeltaExtractsStringContent() {
+        let line = #"data: {"choices":[{"delta":{"content":"hello"}}]}"#
+        #expect(OpenAICompatibleService.streamingDelta(from: line) == "hello")
+    }
+
+    @Test func streamingDeltaExtractsArrayContent() {
+        let line = #"data: {"choices":[{"delta":{"content":[{"text":"foo"},{"text":"bar"}]}}]}"#
+        #expect(OpenAICompatibleService.streamingDelta(from: line) == "foobar")
+    }
+
+    @Test func streamingDeltaExtractsLegacyTextField() {
+        let line = #"data: {"choices":[{"text":"legacy"}]}"#
+        #expect(OpenAICompatibleService.streamingDelta(from: line) == "legacy")
+    }
+
+    @Test func streamingDeltaReturnsNilForEmptyContent() {
+        let line = #"data: {"choices":[{"delta":{"content":""}}]}"#
+        #expect(OpenAICompatibleService.streamingDelta(from: line) == nil)
+    }
+
+    // MARK: - enhance non-streaming success
+
+    @Test func enhanceReturnsTextFromChoicesArray() async throws {
+        let networkService = MockNetworkService()
+        let body = Data(#"{"choices":[{"message":{"content":"  enhanced output  "}}]}"#.utf8)
+        networkService.stubSendResponse = .success((body, makeHTTPResponse(200)))
+        let sut = makeSUT(networkService: networkService)
+
+        let result = try await sut.enhance(
+            url: URL(string: endpointURL)!,
+            modelName: "gpt-4",
+            systemMessage: "s",
+            userMessage: "u",
+            headers: ["Authorization": "Bearer sk-test"],
+            timeout: 30
+        )
+
+        // Whitespace is trimmed and output filter is applied.
+        #expect(result == "enhanced output")
+    }
+
+    @Test func enhanceSendsBearerAuthorizationHeader() async throws {
+        let networkService = MockNetworkService()
+        let body = Data(#"{"choices":[{"message":{"content":"ok"}}]}"#.utf8)
+        networkService.stubSendResponse = .success((body, makeHTTPResponse(200)))
+        let sut = makeSUT(networkService: networkService)
+
+        _ = try await sut.enhance(
+            url: URL(string: endpointURL)!,
+            modelName: "gpt-4",
+            systemMessage: "s",
+            userMessage: "u",
+            headers: ["Authorization": "Bearer sk-test"],
+            timeout: 30
+        )
+
+        let request = try #require(networkService.capturedRequest)
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer sk-test")
+        #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/json")
+    }
+
+    @Test func enhanceSendsChatCompletionsBody() async throws {
+        let networkService = MockNetworkService()
+        let body = Data(#"{"choices":[{"message":{"content":"ok"}}]}"#.utf8)
+        networkService.stubSendResponse = .success((body, makeHTTPResponse(200)))
+        let sut = makeSUT(networkService: networkService)
+
+        _ = try await sut.enhance(
+            url: URL(string: endpointURL)!,
+            modelName: "gpt-4",
+            systemMessage: "you are helpful",
+            userMessage: "rewrite this",
+            headers: [:],
+            timeout: 30
+        )
+
+        let httpBody = try #require(networkService.capturedRequest?.httpBody)
+        let json = try #require(try JSONSerialization.jsonObject(with: httpBody) as? [String: Any])
+        #expect(json["model"] as? String == "gpt-4")
+        #expect(json["stream"] as? Bool == false)
+        let messages = try #require(json["messages"] as? [[String: String]])
+        #expect(messages == [
+            ["role": "system", "content": "you are helpful"],
+            ["role": "user", "content": "rewrite this"]
+        ])
+    }
+
+    // MARK: - enhance error mapping
+
+    @Test func enhanceThrowsEnhancementFailedOnMalformedBody() async {
+        let networkService = MockNetworkService()
+        let body = Data(#"{"unexpected":"shape"}"#.utf8)
+        networkService.stubSendResponse = .success((body, makeHTTPResponse(200)))
+        let sut = makeSUT(networkService: networkService)
+
+        await #expect(throws: EnhancementError.self) {
+            _ = try await sut.enhance(
+                url: URL(string: self.endpointURL)!,
+                modelName: "gpt-4",
+                systemMessage: "s",
+                userMessage: "u",
+                headers: [:],
+                timeout: 30
+            )
+        }
+    }
+
+    @Test func enhanceMaps429ToRateLimitExceeded() async {
+        let networkService = MockNetworkService()
+        networkService.stubSendResponse = .success((Data(), makeHTTPResponse(429)))
+        let sut = makeSUT(networkService: networkService)
+
+        do {
+            _ = try await sut.enhance(
+                url: URL(string: endpointURL)!,
+                modelName: "m",
+                systemMessage: "s",
+                userMessage: "u",
+                headers: [:],
+                timeout: 30
+            )
+            Issue.record("Expected rateLimitExceeded")
+        } catch let error as EnhancementError {
+            if case .rateLimitExceeded = error {} else {
+                Issue.record("Expected .rateLimitExceeded, got \(error)")
+            }
+        } catch {
+            Issue.record("Expected EnhancementError, got \(error)")
+        }
+    }
+
+    @Test func enhanceMaps5xxToServerError() async {
+        let networkService = MockNetworkService()
+        networkService.stubSendResponse = .success((Data(), makeHTTPResponse(502)))
+        let sut = makeSUT(networkService: networkService)
+
+        do {
+            _ = try await sut.enhance(
+                url: URL(string: endpointURL)!,
+                modelName: "m",
+                systemMessage: "s",
+                userMessage: "u",
+                headers: [:],
+                timeout: 30
+            )
+            Issue.record("Expected serverError")
+        } catch let error as EnhancementError {
+            if case .serverError = error {} else {
+                Issue.record("Expected .serverError, got \(error)")
+            }
+        } catch {
+            Issue.record("Expected EnhancementError, got \(error)")
+        }
+    }
+
+    @Test func enhanceMapsOtherStatusToCustomError() async {
+        let networkService = MockNetworkService()
+        let body = Data(#"{"error":"unauthorized"}"#.utf8)
+        networkService.stubSendResponse = .success((body, makeHTTPResponse(401)))
+        let sut = makeSUT(networkService: networkService)
+
+        do {
+            _ = try await sut.enhance(
+                url: URL(string: endpointURL)!,
+                modelName: "m",
+                systemMessage: "s",
+                userMessage: "u",
+                headers: [:],
+                timeout: 30
+            )
+            Issue.record("Expected customError")
+        } catch let error as EnhancementError {
+            if case let .customError(message) = error {
+                #expect(message.hasPrefix("HTTP 401"))
+            } else {
+                Issue.record("Expected .customError, got \(error)")
+            }
+        } catch {
+            Issue.record("Expected EnhancementError, got \(error)")
+        }
+    }
+
+    // MARK: - verifyChatCompletionsAPIKey
+
+    @Test func verifyChatCompletionsAPIKeyReturnsTrueOn200() async {
+        let networkService = MockNetworkService()
+        networkService.stubSendResponse = .success((Data(), makeHTTPResponse(200)))
+        let sut = makeSUT(networkService: networkService)
+
+        let valid = await sut.verifyChatCompletionsAPIKey(
+            "sk-test",
+            baseURL: endpointURL,
+            defaultModel: "gpt-4",
+            providerName: "openai"
+        )
+
+        #expect(valid)
+    }
+
+    @Test func verifyChatCompletionsAPIKeyReturnsFalseOn401() async {
+        let networkService = MockNetworkService()
+        networkService.stubSendResponse = .success((Data(), makeHTTPResponse(401)))
+        let sut = makeSUT(networkService: networkService)
+
+        let valid = await sut.verifyChatCompletionsAPIKey(
+            "sk-bad",
+            baseURL: endpointURL,
+            defaultModel: "gpt-4",
+            providerName: "openai"
+        )
+
+        #expect(!valid)
+    }
+
+    @Test func verifyChatCompletionsAPIKeyReturnsFalseOnTransportError() async {
+        let networkService = MockNetworkService()
+        networkService.stubSendResponse = .failure(URLError(.notConnectedToInternet))
+        let sut = makeSUT(networkService: networkService)
+
+        let valid = await sut.verifyChatCompletionsAPIKey(
+            "sk-test",
+            baseURL: endpointURL,
+            defaultModel: "gpt-4",
+            providerName: "openai"
+        )
+
+        #expect(!valid)
+    }
+
+    @Test func verifyChatCompletionsAPIKeySendsBearerAndMinimalBody() async throws {
+        let networkService = MockNetworkService()
+        networkService.stubSendResponse = .success((Data(), makeHTTPResponse(200)))
+        let sut = makeSUT(networkService: networkService)
+
+        _ = await sut.verifyChatCompletionsAPIKey(
+            "sk-probe",
+            baseURL: endpointURL,
+            defaultModel: "gpt-4-mini",
+            providerName: "openai"
+        )
+
+        let request = try #require(networkService.capturedRequest)
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer sk-probe")
+        let body = try #require(request.httpBody)
+        let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        #expect(json["model"] as? String == "gpt-4-mini")
+        let messages = try #require(json["messages"] as? [[String: String]])
+        #expect(messages == [["role": "user", "content": "test"]])
+    }
+
+    // MARK: - Streaming request shape
+    //
+    // `MockNetworkService.bytes(for:)` cannot return a real
+    // `URLSession.AsyncBytes`, so it throws `StubNotSetError` before any
+    // SSE bytes are yielded. We can still verify the outgoing request
+    // shape (headers, body, stream flag) - the SSE parser itself is
+    // exercised by the static `streamingDelta(from:)` tests above.
+
+    @Test func enhanceStreamingSendsCorrectHeadersAndBody() async throws {
+        let networkService = MockNetworkService()
+        let sut = makeSUT(networkService: networkService)
+
+        _ = try? await sut.enhanceStreaming(
+            url: URL(string: endpointURL)!,
+            modelName: "gpt-4",
+            systemMessage: "s",
+            userMessage: "u",
+            headers: ["Authorization": "Bearer sk-stream"],
+            timeout: 60,
+            errorPrefix: "test",
+            onPartialResponse: { _ in }
+        )
+
+        let request = try #require(networkService.capturedRequest)
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer sk-stream")
+        #expect(request.value(forHTTPHeaderField: "Accept") == "text/event-stream")
+        let body = try #require(request.httpBody)
+        let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        #expect(json["stream"] as? Bool == true)
+        #expect(json["model"] as? String == "gpt-4")
+    }
+}


### PR DESCRIPTION
## Summary

- Kicks off Phase 2b of the AIService decomposition. Moves the shared OpenAI-compatible chat-completions HTTP (used by ~10 cloud providers and indirectly by Ollama / Custom OpenAI / the chat methods) into \`OpenAICompatibleService.swift\` in \`Providers/\`.
- AIService loses **159 lines net** (2,762 → 2,603). Behavior unchanged.
- Same architectural pattern as the prior three extractions (Ollama, Custom OpenAI, Anthropic): pure-HTTP struct that takes \`NetworkService\` + \`Logger\` via init, no observable state.

## What moved

| Before (in AIService) | After (in OpenAICompatibleService) |
|---|---|
| \`buildOpenAICompatibleRequestBody\` | \`OpenAICompatibleService.buildRequestBody\` (static) |
| \`openAICompatibleStreamingDelta\` | \`OpenAICompatibleService.streamingDelta\` (static) |
| \`makeOpenAICompatibleStreamingRequest\` | \`service.enhanceStreaming\` (instance) |
| \`default:\` branch of non-streaming \`makeRequest\` | \`service.enhance\` (instance) |
| \`verifyOpenAICompatibleAPIKey\` | \`service.verifyChatCompletionsAPIKey\` (instance) |

The three AIService methods that other code calls (\`buildOpenAICompatibleRequestBody\`, \`makeOpenAICompatibleStreamingRequest\`, \`openAICompatibleStreamingDelta\`) are kept as thin shims that delegate to the new service. That keeps the diff scoped and lets follow-up PRs migrate the call sites (Ollama wrapper, Custom OpenAI wrapper, \`AIService+Chat.swift\`) incrementally.

## Why static helpers + instance methods

Ollama and Custom OpenAI need the same body shape and SSE delta parser but want their own status-code mapping (friendly \"model not found - run \`ollama pull <model>\`\" messages, custom auth hints). The static \`buildRequestBody\` and \`streamingDelta\` helpers let those callers reuse the shared logic without going through the opinionated \`enhance\` / \`enhanceStreaming\` flow.

## Test coverage (24 new tests)

- **Static \`buildRequestBody\`** (5 tests): standard fields, temperature applied for non-GPT-5, temperature omitted for \`gpt-5-mini\` and \`GPT-5-Mini\` (case-insensitive), stream flag pass-through.
- **Static \`streamingDelta\`** (7 tests): non-data lines, \`[DONE]\` sentinel, malformed JSON, string content delta, array-of-text content delta (responses-API shape), legacy \`text\` field, empty content.
- **\`enhance\` non-streaming** (6 tests): success with trim + filter, Bearer auth header forwarding, body shape, malformed body throws \`.enhancementFailed\`, 429 → \`.rateLimitExceeded\`, 5xx → \`.serverError\`, other status → \`.customError(\"HTTP X: ...\")\`.
- **\`verifyChatCompletionsAPIKey\`** (4 tests): 200 → true, 401 → false, transport error → false, request shape (Bearer + minimal body with model + single user message).
- **\`enhanceStreaming\` request shape** (1 test): Bearer header, \`Accept: text/event-stream\`, \`stream: true\`. Full SSE parsing not testable via \`MockNetworkService\` (URLSession.AsyncBytes has no public initializer); the static \`streamingDelta\` tests above cover the parser itself.

## Test plan

- [x] \`xcodebuild test -only-testing:VivaDictaTests/OpenAICompatibleServiceTests\` - all 24 pass
- [x] \`AnthropicServiceTests\` + \`OllamaServiceTests\` + \`CustomOpenAIServiceTests\` - all 38 pass (no regressions in sibling providers)
- [x] App build succeeds

## Out of scope for this PR

- Consolidating per-provider verify methods that use \`GET /v1/models\` instead of a chat-completions probe (Cerebras, Mistral, Grok, HuggingFace) - separate follow-up.
- Defining the \`AIProvider\` protocol that \`AnthropicService\` and \`OpenAICompatibleService\` will both conform to. Want one more cycle before locking the shape.
- Migrating the Ollama / Custom OpenAI / chat-method call sites away from the AIService shims - separate follow-ups.