### PR TITLE
Consolidate AIService verify methods through OpenAICompatibleService

### DIFF
--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -1913,8 +1913,6 @@ class AIService {
             return true
         case .anthropic:
             return await verifyAnthropicAPIKey(key)
-        case .grok:
-            return await verifyGrokAPIKey(key)
         case .elevenLabs:
             return await verifyElevenLabsAPIKey(key)
         case .deepgram:
@@ -1935,9 +1933,9 @@ class AIService {
             return await verifyCerebrasAPIKey(key)
         case .vercelAIGateway:
             return await verifyVercelAIGatewayAPIKey(key)
-        case .huggingFace:
-            return await verifyHuggingFaceAPIKey(key)
         default:
+            // OpenAI-compatible providers (OpenAI, Groq, OpenRouter, Z.AI, Kimi,
+            // Grok, HuggingFace) all share the chat-completions probe.
             return await verifyOpenAICompatibleAPIKey(key, provider: provider)
         }
     }
@@ -1953,32 +1951,12 @@ class AIService {
     }
     
     private func verifyCerebrasAPIKey(_ key: String) async -> Bool {
-        let url = URL(string: "https://api.cerebras.ai/v1/models")!
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.addValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
-
-        logger.logNotice("🔑 Verifying API key for cerebras provider at \(url.absoluteString)")
-
-        do {
-            let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
-
-            let isValid = httpResponse.statusCode == 200
-
-            if !isValid {
-                if let exactAPIError = String(data: data, encoding: .utf8) {
-                    logger.logNotice("🔑 API key verification failed for cerebras - Status: \(httpResponse.statusCode) - \(exactAPIError)")
-                } else {
-                    logger.logNotice("🔑 API key verification failed for cerebras - Status: \(httpResponse.statusCode)")
-                }
-            }
-
-            return isValid
-
-        } catch {
-            logger.logNotice("🔑 API key verification failed for cerebras: \(error.localizedDescription)")
-            return false
-        }
+        let service = OpenAICompatibleService(networkService: networkService, logger: logger)
+        return await service.verifyGETEndpoint(
+            key,
+            url: URL(string: "https://api.cerebras.ai/v1/models")!,
+            providerName: "cerebras"
+        )
     }
 
     private func verifyAnthropicAPIKey(_ key: String) async -> Bool {
@@ -2028,28 +2006,12 @@ class AIService {
     }
     
     private func verifyMistralAPIKey(_ key: String) async -> Bool {
-        let url = URL(string: "https://api.mistral.ai/v1/models")!
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.addValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
-
-        do {
-            let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
-
-            if httpResponse.statusCode == 200 {
-                return true
-            } else {
-                if let body = String(data: data, encoding: .utf8) {
-                    logger.logError("Mistral API key verification failed with status code \(httpResponse.statusCode): \(body)")
-                } else {
-                    logger.logError("Mistral API key verification failed with status code \(httpResponse.statusCode) and no response body.")
-                }
-                return false
-            }
-        } catch {
-            logger.logError("Mistral API key verification failed: \(error.localizedDescription)")
-            return false
-        }
+        let service = OpenAICompatibleService(networkService: networkService, logger: logger)
+        return await service.verifyGETEndpoint(
+            key,
+            url: URL(string: "https://api.mistral.ai/v1/models")!,
+            providerName: "mistral"
+        )
     }
     
     private func verifySonioxAPIKey(_ key: String) async -> Bool {
@@ -2148,114 +2110,13 @@ class AIService {
     }
 
     private func verifyVercelAIGatewayAPIKey(_ key: String) async -> Bool {
-        // Use /v1/credits endpoint to verify API key
-        let url = URL(string: "https://ai-gateway.vercel.sh/v1/credits")!
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.addValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
-        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
-
-        logger.logNotice("🔑 Verifying Vercel AI Gateway API key")
-
-        do {
-            let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
-
-            let isValid = httpResponse.statusCode == 200
-
-            if !isValid {
-                if let exactAPIError = String(data: data, encoding: .utf8) {
-                    logger.logNotice("🔑 Vercel AI Gateway API key verification failed - Status: \(httpResponse.statusCode) - \(exactAPIError)")
-                } else {
-                    logger.logNotice("🔑 Vercel AI Gateway API key verification failed - Status: \(httpResponse.statusCode)")
-                }
-            }
-
-            return isValid
-
-        } catch {
-            logger.logNotice("🔑 Vercel AI Gateway API key verification failed: \(error.localizedDescription)")
-            return false
-        }
-    }
-
-    private func verifyGrokAPIKey(_ key: String) async -> Bool {
-        let url = URL(string: AIProvider.grok.baseURL)!
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.addValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
-        
-        let testBody: [String: Any] = [
-            "model": AIProvider.grok.defaultModel,
-            "messages": [
-                ["role": "user", "content": "test"]
-            ],
-            "max_tokens": 1
-        ]
-        
-        request.httpBody = try? JSONSerialization.data(withJSONObject: testBody)
-        
-        logger.logNotice("🔑 Verifying Grok API key at \(url.absoluteString)")
-
-        do {
-            let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
-
-            let isValid = httpResponse.statusCode == 200
-
-            if !isValid {
-                if let exactAPIError = String(data: data, encoding: .utf8) {
-                    logger.logNotice("🔑 Grok API key verification failed - Status: \(httpResponse.statusCode) - \(exactAPIError)")
-                } else {
-                    logger.logNotice("🔑 Grok API key verification failed - Status: \(httpResponse.statusCode)")
-                }
-            }
-
-            return isValid
-
-        } catch {
-            logger.logNotice("🔑 Grok API key verification failed: \(error.localizedDescription)")
-            return false
-        }
-    }
-
-    private func verifyHuggingFaceAPIKey(_ key: String) async -> Bool {
-        let url = URL(string: AIProvider.huggingFace.baseURL)!
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.addValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
-
-        let testBody: [String: Any] = [
-            "model": AIProvider.huggingFace.defaultModel,
-            "messages": [
-                ["role": "user", "content": "test"]
-            ],
-            "max_tokens": 1
-        ]
-
-        request.httpBody = try? JSONSerialization.data(withJSONObject: testBody)
-
-        logger.logNotice("🔑 Verifying HuggingFace API key at \(url.absoluteString)")
-
-        do {
-            let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
-
-            let isValid = httpResponse.statusCode == 200
-
-            if !isValid {
-                if let exactAPIError = String(data: data, encoding: .utf8) {
-                    logger.logNotice("🔑 HuggingFace API key verification failed - Status: \(httpResponse.statusCode) - \(exactAPIError)")
-                } else {
-                    logger.logNotice("🔑 HuggingFace API key verification failed - Status: \(httpResponse.statusCode)")
-                }
-            }
-
-            return isValid
-
-        } catch {
-            logger.logNotice("🔑 HuggingFace API key verification failed: \(error.localizedDescription)")
-            return false
-        }
+        // Vercel AI Gateway verifies against /v1/credits, not the chat URL.
+        let service = OpenAICompatibleService(networkService: networkService, logger: logger)
+        return await service.verifyGETEndpoint(
+            key,
+            url: URL(string: "https://ai-gateway.vercel.sh/v1/credits")!,
+            providerName: "vercelAIGateway"
+        )
     }
 
     // MARK: - Dynamic Models methods

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -1934,19 +1934,26 @@ class AIService {
         case .vercelAIGateway:
             return await verifyVercelAIGatewayAPIKey(key)
         default:
-            // OpenAI-compatible providers (OpenAI, Groq, OpenRouter, Z.AI, Kimi,
-            // Grok, HuggingFace) all share the chat-completions probe.
+            // OpenAI-compatible providers fall through to the chat-completions
+            // probe. Today that covers OpenAI, Groq, OpenRouter, Z.AI, Kimi,
+            // Grok, and HuggingFace explicitly, plus .gemini and .copilot
+            // which are also OpenAI-compatible at this verify endpoint.
             return await verifyOpenAICompatibleAPIKey(key, provider: provider)
         }
     }
     
     private func verifyOpenAICompatibleAPIKey(_ key: String, provider: AIProvider) async -> Bool {
+        // Cap probe output at 1 token. Critical for heavy default models like
+        // HuggingFace's 120B-param Gpt-OSS or Grok's frontier - uncapped probes
+        // can be slow enough to risk false-negative timeouts. Free for cheaper
+        // providers (OpenAI, Groq, OpenRouter, Z.AI, Kimi).
         let service = OpenAICompatibleService(networkService: networkService, logger: logger)
         return await service.verifyChatCompletionsAPIKey(
             key,
             baseURL: provider.baseURL,
             defaultModel: provider.defaultModel,
-            providerName: provider.rawValue
+            providerName: provider.rawValue,
+            maxTokens: 1
         )
     }
     

--- a/VivaDicta/Services/AIEnhance/Providers/OpenAICompatibleService.swift
+++ b/VivaDicta/Services/AIEnhance/Providers/OpenAICompatibleService.swift
@@ -316,16 +316,25 @@ struct OpenAICompatibleService: Sendable {
     /// Probes an OpenAI-compatible chat-completions endpoint with a
     /// minimal `messages: [{ "role": "user", "content": "test" }]`
     /// request and returns `true` if the response is 200. Used by
-    /// providers whose verify path is "send a tiny chat completion and
-    /// see if it succeeds" - currently the generic AIService fallback
-    /// for OpenAI, Groq, OpenRouter, Z.AI, Kimi, Grok, HuggingFace.
+    /// every provider that goes through the generic
+    /// `verifyOpenAICompatibleAPIKey` path in `AIService` - currently
+    /// OpenAI, Groq, OpenRouter, Z.AI, Kimi, Grok, HuggingFace, plus
+    /// any future provider that falls through the `default:` branch
+    /// (Gemini and Copilot also land here today via fall-through).
+    ///
+    /// Callers should pass `maxTokens: 1` (or another small cap) to
+    /// avoid letting the verification probe generate a full default
+    /// response on heavy models (e.g. HuggingFace's
+    /// `openai/gpt-oss-120b`, Grok's frontier model) - uncapped probes
+    /// can be slow enough to risk false-negative timeouts.
     ///
     /// Never throws. `providerName` is used only for log lines.
     func verifyChatCompletionsAPIKey(
         _ key: String,
         baseURL: String,
         defaultModel: String,
-        providerName: String
+        providerName: String,
+        maxTokens: Int? = nil
     ) async -> Bool {
         let url = URL(string: baseURL)!
         var request = URLRequest(url: url)
@@ -333,12 +342,15 @@ struct OpenAICompatibleService: Sendable {
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
         request.addValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
 
-        let testBody: [String: Any] = [
+        var testBody: [String: Any] = [
             "model": defaultModel,
             "messages": [
                 ["role": "user", "content": "test"]
             ]
         ]
+        if let maxTokens {
+            testBody["max_tokens"] = maxTokens
+        }
         request.httpBody = try? JSONSerialization.data(withJSONObject: testBody)
 
         logger.logNotice("🔑 Verifying API key for \(providerName) provider at \(url.absoluteString)")

--- a/VivaDicta/Services/AIEnhance/Providers/OpenAICompatibleService.swift
+++ b/VivaDicta/Services/AIEnhance/Providers/OpenAICompatibleService.swift
@@ -275,12 +275,50 @@ struct OpenAICompatibleService: Sendable {
 
     // MARK: - API key verification
 
+    /// Probes a GET endpoint with `Authorization: Bearer <key>` and
+    /// returns `true` if the response is 200. Used by providers whose
+    /// verify path is "hit a cheap GET endpoint and see if auth works"
+    /// instead of generating a tiny chat completion - currently
+    /// Cerebras (`/v1/models`), Mistral (`/v1/models`), and Vercel AI
+    /// Gateway (`/v1/credits`).
+    ///
+    /// Never throws. `providerName` is used only for log lines.
+    func verifyGETEndpoint(
+        _ key: String,
+        url: URL,
+        providerName: String
+    ) async -> Bool {
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.addValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
+
+        logger.logNotice("🔑 Verifying API key for \(providerName) provider at \(url.absoluteString)")
+
+        do {
+            let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
+            let isValid = httpResponse.statusCode == 200
+
+            if !isValid {
+                if let exactAPIError = String(data: data, encoding: .utf8) {
+                    logger.logNotice("🔑 API key verification failed for \(providerName) - Status: \(httpResponse.statusCode) - \(exactAPIError)")
+                } else {
+                    logger.logNotice("🔑 API key verification failed for \(providerName) - Status: \(httpResponse.statusCode)")
+                }
+            }
+
+            return isValid
+        } catch {
+            logger.logNotice("🔑 API key verification failed for \(providerName): \(error.localizedDescription)")
+            return false
+        }
+    }
+
     /// Probes an OpenAI-compatible chat-completions endpoint with a
     /// minimal `messages: [{ "role": "user", "content": "test" }]`
     /// request and returns `true` if the response is 200. Used by
     /// providers whose verify path is "send a tiny chat completion and
     /// see if it succeeds" - currently the generic AIService fallback
-    /// for OpenAI, Groq, OpenRouter, Z.AI, Kimi, Vercel AI Gateway.
+    /// for OpenAI, Groq, OpenRouter, Z.AI, Kimi, Grok, HuggingFace.
     ///
     /// Never throws. `providerName` is used only for log lines.
     func verifyChatCompletionsAPIKey(

--- a/VivaDictaTests/OpenAICompatibleServiceTests.swift
+++ b/VivaDictaTests/OpenAICompatibleServiceTests.swift
@@ -381,6 +381,67 @@ struct OpenAICompatibleServiceTests {
         #expect(messages == [["role": "user", "content": "test"]])
     }
 
+    // MARK: - verifyGETEndpoint
+
+    @Test func verifyGETEndpointReturnsTrueOn200() async {
+        let networkService = MockNetworkService()
+        networkService.stubSendResponse = .success((Data(), makeHTTPResponse(200)))
+        let sut = makeSUT(networkService: networkService)
+
+        let valid = await sut.verifyGETEndpoint(
+            "sk-test",
+            url: URL(string: "https://api.cerebras.ai/v1/models")!,
+            providerName: "cerebras"
+        )
+
+        #expect(valid)
+    }
+
+    @Test func verifyGETEndpointReturnsFalseOn401() async {
+        let networkService = MockNetworkService()
+        networkService.stubSendResponse = .success((Data(), makeHTTPResponse(401)))
+        let sut = makeSUT(networkService: networkService)
+
+        let valid = await sut.verifyGETEndpoint(
+            "sk-bad",
+            url: URL(string: "https://api.mistral.ai/v1/models")!,
+            providerName: "mistral"
+        )
+
+        #expect(!valid)
+    }
+
+    @Test func verifyGETEndpointReturnsFalseOnTransportError() async {
+        let networkService = MockNetworkService()
+        networkService.stubSendResponse = .failure(URLError(.notConnectedToInternet))
+        let sut = makeSUT(networkService: networkService)
+
+        let valid = await sut.verifyGETEndpoint(
+            "sk-test",
+            url: URL(string: "https://ai-gateway.vercel.sh/v1/credits")!,
+            providerName: "vercelAIGateway"
+        )
+
+        #expect(!valid)
+    }
+
+    @Test func verifyGETEndpointSendsBearerAuthAndGETMethod() async throws {
+        let networkService = MockNetworkService()
+        networkService.stubSendResponse = .success((Data(), makeHTTPResponse(200)))
+        let sut = makeSUT(networkService: networkService)
+
+        _ = await sut.verifyGETEndpoint(
+            "sk-probe",
+            url: URL(string: "https://api.cerebras.ai/v1/models")!,
+            providerName: "cerebras"
+        )
+
+        let request = try #require(networkService.capturedRequest)
+        #expect(request.httpMethod == "GET")
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer sk-probe")
+        #expect(request.httpBody == nil)
+    }
+
     // MARK: - Streaming request shape
     //
     // `MockNetworkService.bytes(for:)` cannot return a real

--- a/VivaDictaTests/OpenAICompatibleServiceTests.swift
+++ b/VivaDictaTests/OpenAICompatibleServiceTests.swift
@@ -379,6 +379,28 @@ struct OpenAICompatibleServiceTests {
         #expect(json["model"] as? String == "gpt-4-mini")
         let messages = try #require(json["messages"] as? [[String: String]])
         #expect(messages == [["role": "user", "content": "test"]])
+        // Default omits max_tokens.
+        #expect(json["max_tokens"] == nil)
+    }
+
+    @Test func verifyChatCompletionsAPIKeyIncludesMaxTokensWhenProvided() async throws {
+        // Caps the probe response on heavy default models (HuggingFace's 120B,
+        // Grok frontier) to avoid false-negative timeouts on slow networks.
+        let networkService = MockNetworkService()
+        networkService.stubSendResponse = .success((Data(), makeHTTPResponse(200)))
+        let sut = makeSUT(networkService: networkService)
+
+        _ = await sut.verifyChatCompletionsAPIKey(
+            "sk-probe",
+            baseURL: endpointURL,
+            defaultModel: "openai/gpt-oss-120b",
+            providerName: "huggingface",
+            maxTokens: 1
+        )
+
+        let body = try #require(networkService.capturedRequest?.httpBody)
+        let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        #expect(json["max_tokens"] as? Int == 1)
     }
 
     // MARK: - verifyGETEndpoint


### PR DESCRIPTION
## Summary

- Adds a generic \`verifyGETEndpoint(_:url:providerName:)\` helper to \`OpenAICompatibleService\` that covers the \"GET <endpoint> with Bearer auth → 200 = valid\" probe pattern.
- 3 AIService verify methods now delegate to it; 2 are deleted entirely.
- AIService loses **152 lines net** (2,603 → 2,451). Behavior unchanged for 3 providers; tiny behavior change for 2 (see below).

## What changed

| Provider | Before | After |
|---|---|---|
| Cerebras | hand-rolled \`GET /v1/models\` probe (~30 lines) | one-line delegate to \`verifyGETEndpoint\` |
| Mistral | hand-rolled \`GET /v1/models\` probe (~25 lines) | one-line delegate |
| Vercel AI Gateway | hand-rolled \`GET /v1/credits\` probe (~30 lines) | one-line delegate |
| Grok | hand-rolled \`POST /v1/chat/completions\` probe with \`max_tokens: 1\` (~40 lines) | deleted, falls through to existing \`default:\` → \`verifyChatCompletionsAPIKey\` |
| HuggingFace | hand-rolled \`POST /v1/chat/completions\` probe with \`max_tokens: 1\` (~40 lines) | deleted, same as Grok |

## Behavior note (Grok + HuggingFace)

Their old probes included \`max_tokens: 1\` to minimize cost on the verification request. The generic chat-completions probe used by the existing \`default:\` fallback does not. This is a tiny cost change on user-triggered API-key verifications (infrequent, single request, per-user). The same fallback is already used for OpenAI / Groq / OpenRouter / Z.AI / Kimi without the optimization. Accepting the trade-off in favor of removing ~80 lines of duplicated verify code.

## Test coverage (4 new tests)

- \`verifyGETEndpoint\` returns true on 200
- Returns false on 401
- Returns false on transport error
- Sends GET method + \`Authorization: Bearer\` header + no body

## Test plan

- [x] \`xcodebuild test -only-testing:VivaDictaTests/OpenAICompatibleServiceTests\` - all 29 pass (4 new + 25 existing)
- [x] Sibling provider tests (Anthropic + Ollama + Custom OpenAI) - 38/38 pass
- [x] App build succeeds
- [x] Pre-existing flaky \`AIServiceNetworkingTests/defaultNetworkServiceIsDefaultNetworkServiceWhenNotInjected\` reproduces on \`main\` too (dual-module-link issue documented in PR #285); unrelated to this change