### PR TITLE
Add TranscriptionCoreMocks library with MockTranscriptionService

### DIFF
--- a/Modules/TranscriptionCore/Package.swift
+++ b/Modules/TranscriptionCore/Package.swift
@@ -10,12 +10,17 @@ let package = Package(
     ],
     products: [
         .library(name: "TranscriptionCore", targets: ["TranscriptionCore"]),
+        .library(name: "TranscriptionCoreMocks", targets: ["TranscriptionCoreMocks"]),
     ],
     targets: [
         .target(name: "TranscriptionCore"),
+        .target(
+            name: "TranscriptionCoreMocks",
+            dependencies: ["TranscriptionCore"]
+        ),
         .testTarget(
             name: "TranscriptionCoreTests",
-            dependencies: ["TranscriptionCore"]
+            dependencies: ["TranscriptionCore", "TranscriptionCoreMocks"]
         ),
     ],
     swiftLanguageModes: [.v6]

--- a/Modules/TranscriptionCore/Sources/TranscriptionCoreMocks/MockTranscriptionService.swift
+++ b/Modules/TranscriptionCore/Sources/TranscriptionCoreMocks/MockTranscriptionService.swift
@@ -1,0 +1,42 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import TranscriptionCore
+
+/// Backend-agnostic mock for `TranscriptionService`. Stub a fixed result
+/// (success or error) and inspect what URL was transcribed.
+///
+/// Use this when the code under test only cares about the
+/// `TranscriptionService` protocol (e.g. orchestration code in
+/// `TranscriptionKit`), not which concrete backend is plugged in. When
+/// the test needs backend-specific behavior, use the concrete mocks in
+/// `CloudTranscriptionMocks` / `LocalTranscriptionMocks` instead.
+public final class MockTranscriptionService: TranscriptionService, @unchecked Sendable {
+    /// What `transcribe(audioURL:)` returns. When `nil` the mock falls
+    /// back to a stub `TranscriptionServiceResult.plain("")`.
+    public var stubTranscribeResult: Result<TranscriptionServiceResult, Error>?
+
+    /// Every `audioURL` argument that has been passed to `transcribe`, in
+    /// call order.
+    public private(set) var transcribeCalls: [URL] = []
+
+    /// Count of `transcribe` invocations. Equivalent to `transcribeCalls.count`
+    /// but cheaper to assert against.
+    public var transcribeCallCount: Int { transcribeCalls.count }
+
+    public init() {}
+
+    public func transcribe(audioURL: URL) async throws -> TranscriptionServiceResult {
+        transcribeCalls.append(audioURL)
+
+        guard let stub = stubTranscribeResult else {
+            return .plain("")
+        }
+        switch stub {
+        case let .success(result):
+            return result
+        case let .failure(error):
+            throw error
+        }
+    }
+}

--- a/Modules/TranscriptionCore/Tests/TranscriptionCoreTests/MockTranscriptionServiceTests.swift
+++ b/Modules/TranscriptionCore/Tests/TranscriptionCoreTests/MockTranscriptionServiceTests.swift
@@ -1,0 +1,62 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import Testing
+@testable import TranscriptionCore
+@testable import TranscriptionCoreMocks
+
+@Suite("MockTranscriptionService")
+struct MockTranscriptionServiceTests {
+
+    private let audioURL = URL(fileURLWithPath: "/tmp/test.m4a")
+
+    @Test func returnsEmptyResultWhenNoStubSet() async throws {
+        let sut = MockTranscriptionService()
+
+        let result = try await sut.transcribe(audioURL: audioURL)
+
+        #expect(result.text == "")
+        #expect(result.isSpeakerAttributed == false)
+    }
+
+    @Test func returnsStubbedSuccessResult() async throws {
+        let sut = MockTranscriptionService()
+        sut.stubTranscribeResult = .success(.plain("hello world"))
+
+        let result = try await sut.transcribe(audioURL: audioURL)
+
+        #expect(result.text == "hello world")
+    }
+
+    @Test func returnsStubbedSpeakerAttributedResult() async throws {
+        let sut = MockTranscriptionService()
+        sut.stubTranscribeResult = .success(.speakerAttributed("S1: hi\nS2: hey"))
+
+        let result = try await sut.transcribe(audioURL: audioURL)
+
+        #expect(result.text == "S1: hi\nS2: hey")
+        #expect(result.isSpeakerAttributed)
+    }
+
+    @Test func throwsStubbedError() async {
+        struct TestError: Error, Equatable {}
+        let sut = MockTranscriptionService()
+        sut.stubTranscribeResult = .failure(TestError())
+
+        await #expect(throws: TestError.self) {
+            _ = try await sut.transcribe(audioURL: self.audioURL)
+        }
+    }
+
+    @Test func recordsAllTranscribeCallsInOrder() async throws {
+        let sut = MockTranscriptionService()
+        let url1 = URL(fileURLWithPath: "/tmp/a.m4a")
+        let url2 = URL(fileURLWithPath: "/tmp/b.m4a")
+
+        _ = try await sut.transcribe(audioURL: url1)
+        _ = try await sut.transcribe(audioURL: url2)
+
+        #expect(sut.transcribeCallCount == 2)
+        #expect(sut.transcribeCalls == [url1, url2])
+    }
+}

--- a/Modules/TranscriptionKit/Package.swift
+++ b/Modules/TranscriptionKit/Package.swift
@@ -48,6 +48,7 @@ let package = Package(
             dependencies: [
                 "TranscriptionKit",
                 .product(name: "TranscriptionCore", package: "TranscriptionCore"),
+                .product(name: "TranscriptionCoreMocks", package: "TranscriptionCore"),
                 .product(name: "CloudTranscriptionMocks", package: "CloudTranscription"),
                 .product(name: "LocalTranscriptionMocks", package: "LocalTranscription"),
             ]


### PR DESCRIPTION
## Summary

Completes the module-Mocks pattern. Every other module that exports a public service protocol already has a sibling \`*Mocks\` library (KeychainMocks, NetworkingMocks, OAuthMocks, CloudTranscriptionMocks, LocalTranscriptionMocks, etc.). TranscriptionCore was the one gap: it exports a public \`TranscriptionService\` protocol consumed by three modules, with no corresponding mock.

## What changed

- New \`TranscriptionCoreMocks\` library target + product in \`TranscriptionCore/Package.swift\`.
- \`MockTranscriptionService\` (~35 LOC). Backend-agnostic: records every \`transcribe(audioURL:)\` call and returns a stubbed \`Result<TranscriptionServiceResult, Error>\` (defaults to \`.plain(\"\")\` when no stub is set).
- 5 tests covering: default no-stub behavior, stubbed success (plain + speaker-attributed), stubbed error throw, and call-order recording.
- Wired into \`TranscriptionKitTests\` (the most direct consumer of the abstract protocol). \`CloudTranscriptionTests\` and \`LocalTranscriptionTests\` aren't updated - they already exercise their own concrete \`TranscriptionService\` implementations.

## When to reach for this mock

When the code under test only cares about the \`TranscriptionService\` protocol contract - e.g. orchestration logic in TranscriptionKit that dispatches to whichever backend the user picked - without caring which concrete backend is plugged in. When backend-specific behavior matters, the concrete mocks in \`CloudTranscriptionMocks\` / \`LocalTranscriptionMocks\` are still the right call.

## What I did NOT change

Initially looked like \`TranscriptionKit\`'s production dep on \`Networking\` was dead code (no \`import Networking\` / \`URLSession\` in source). It's not - the \`Package.swift\` comment documents it as a deliberate workaround for SPM transitive linking of the \`URLSession: URLSessionProtocol\` conformance referenced by CloudTranscription service initializers. Left alone.

## Test plan

- [x] \`swift test\` in \`Modules/TranscriptionCore/\` - 15/15 pass (5 new + 10 existing)
- [x] Full app build via \`xcodebuild\` - succeeds