### PR TITLE
Add Save options bottom sheet to Live Translation

### DIFF
--- a/VivaDicta/Views/LiveTranslation/LiveTranslationView.swift
+++ b/VivaDicta/Views/LiveTranslation/LiveTranslationView.swift
@@ -75,11 +75,14 @@ struct LiveTranslationView: View {
                 )
             }
             .sheet(isPresented: $showingSaveOptions) {
-                SaveOptionsSheet(snapshot: service.transcriptSnapshot()) { content in
+                // Capture the snapshot once here so the option-visibility
+                // decision and the actual save use the exact same data,
+                // even if a late finalization mutates `service` in between.
+                SaveOptionsSheet(snapshot: service.transcriptSnapshot()) { content, snapshot in
                     showingSaveOptions = false
-                    saveAsNote(content: content)
+                    saveAsNote(content: content, snapshot: snapshot)
                 }
-                .presentationDetents([.height(350)])
+                .presentationDetents([.medium])
                 .presentationDragIndicator(.hidden)
             }
         }
@@ -397,8 +400,10 @@ struct LiveTranslationView: View {
         )
     }
 
-    private func saveAsNote(content: SaveContent) {
-        let snapshot = service.transcriptSnapshot()
+    private func saveAsNote(
+        content: SaveContent,
+        snapshot: (sourceLanguage: LiveTranslationLanguage, original: String, targetLanguage: LiveTranslationLanguage, translation: String)
+    ) {
         let combined = combineSnapshot(snapshot, content: content)
         guard !combined.isEmpty else { return }
 
@@ -468,20 +473,22 @@ struct LiveTranslationView: View {
     }
 }
 
-fileprivate enum SaveContent {
+private enum SaveContent {
     case originalOnly
     case translatedOnly
     case both
 }
 
 private struct SaveOptionsSheet: View {
-    let snapshot: (
+    typealias Snapshot = (
         sourceLanguage: LiveTranslationLanguage,
         original: String,
         targetLanguage: LiveTranslationLanguage,
         translation: String
     )
-    let onSelect: (SaveContent) -> Void
+
+    let snapshot: Snapshot
+    let onSelect: (SaveContent, Snapshot) -> Void
 
     @Environment(\.dismiss) private var dismiss
 
@@ -503,7 +510,7 @@ private struct SaveOptionsSheet: View {
                         title: "Both languages",
                         systemImage: "doc.on.doc"
                     ) {
-                        onSelect(.both)
+                        onSelect(.both, snapshot)
                     }
                 }
                 if !snapshot.original.isEmpty {
@@ -511,7 +518,7 @@ private struct SaveOptionsSheet: View {
                         title: "\(snapshot.sourceLanguage.displayName) only",
                         systemImage: "text.bubble"
                     ) {
-                        onSelect(.originalOnly)
+                        onSelect(.originalOnly, snapshot)
                     }
                 }
                 if !snapshot.translation.isEmpty {
@@ -519,7 +526,7 @@ private struct SaveOptionsSheet: View {
                         title: "\(snapshot.targetLanguage.displayName) only",
                         systemImage: "character.bubble"
                     ) {
-                        onSelect(.translatedOnly)
+                        onSelect(.translatedOnly, snapshot)
                     }
                 }
             }

--- a/VivaDicta/Views/LiveTranslation/LiveTranslationView.swift
+++ b/VivaDicta/Views/LiveTranslation/LiveTranslationView.swift
@@ -19,6 +19,7 @@ struct LiveTranslationView: View {
     @State private var saveError: SaveErrorAlert?
     @State private var headphonesConnected = LiveTranslationAudio.isHeadphonesRouteActive
     @State private var hasSonioxKey: Bool = false
+    @State private var showingSaveOptions = false
 
     private static let sonioxConsoleURL = URL(string: "https://console.soniox.com/", encodingInvalidCharacters: false)
         ?? URL(string: "https://soniox.com")!
@@ -72,6 +73,14 @@ struct LiveTranslationView: View {
                     message: Text(error.message),
                     dismissButton: .default(Text("OK"))
                 )
+            }
+            .sheet(isPresented: $showingSaveOptions) {
+                SaveOptionsSheet(snapshot: service.transcriptSnapshot()) { content in
+                    showingSaveOptions = false
+                    saveAsNote(content: content)
+                }
+                .presentationDetents([.height(350)])
+                .presentationDragIndicator(.hidden)
             }
         }
     }
@@ -273,7 +282,7 @@ struct LiveTranslationView: View {
 
             if shouldShowSaveButton {
                 Button {
-                    saveAsNote()
+                    showingSaveOptions = true
                 } label: {
                     Label("Save as note", systemImage: "square.and.arrow.down")
                         .frame(maxWidth: .infinity)
@@ -388,16 +397,15 @@ struct LiveTranslationView: View {
         )
     }
 
-    private func saveAsNote() {
+    private func saveAsNote(content: SaveContent) {
         let snapshot = service.transcriptSnapshot()
-        guard !snapshot.original.isEmpty || !snapshot.translation.isEmpty else { return }
+        let combined = combineSnapshot(snapshot, content: content)
+        guard !combined.isEmpty else { return }
 
         // Combine source + translation into the `text` field with section
         // headings; leave `enhancedText` nil so Spotlight, list previews,
         // search, and the dual-write Variation pipeline aren't confused
         // (`enhancedText` is the AI-output cache and must not hold raw MT).
-        let combined = combineSnapshot(snapshot)
-
         let transcription = Transcription(
             text: combined,
             audioDuration: 0,
@@ -423,18 +431,26 @@ struct LiveTranslationView: View {
     }
 
     private func combineSnapshot(
-        _ snapshot: (sourceLanguage: LiveTranslationLanguage, original: String, targetLanguage: LiveTranslationLanguage, translation: String)
+        _ snapshot: (sourceLanguage: LiveTranslationLanguage, original: String, targetLanguage: LiveTranslationLanguage, translation: String),
+        content: SaveContent
     ) -> String {
         // Use the snapshot's session-time languages, not service.config.* —
         // the user can change pickers between Stop and Save.
-        var sections: [String] = []
-        if !snapshot.original.isEmpty {
-            sections.append("\(snapshot.sourceLanguage.displayName):\n\(snapshot.original)")
+        switch content {
+        case .originalOnly:
+            return snapshot.original
+        case .translatedOnly:
+            return snapshot.translation
+        case .both:
+            var sections: [String] = []
+            if !snapshot.original.isEmpty {
+                sections.append("\(snapshot.sourceLanguage.displayName):\n\(snapshot.original)")
+            }
+            if !snapshot.translation.isEmpty {
+                sections.append("\(snapshot.targetLanguage.displayName):\n\(snapshot.translation)")
+            }
+            return sections.joined(separator: "\n\n")
         }
-        if !snapshot.translation.isEmpty {
-            sections.append("\(snapshot.targetLanguage.displayName):\n\(snapshot.translation)")
-        }
-        return sections.joined(separator: "\n\n")
     }
 
     private struct FailureAlert: Identifiable {
@@ -449,6 +465,88 @@ struct LiveTranslationView: View {
     private struct SaveErrorAlert: Identifiable {
         let id = UUID()
         let message: String
+    }
+}
+
+fileprivate enum SaveContent {
+    case originalOnly
+    case translatedOnly
+    case both
+}
+
+private struct SaveOptionsSheet: View {
+    let snapshot: (
+        sourceLanguage: LiveTranslationLanguage,
+        original: String,
+        targetLanguage: LiveTranslationLanguage,
+        translation: String
+    )
+    let onSelect: (SaveContent) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(spacing: 20) {
+            VStack(spacing: 4) {
+                Text("Save as note")
+                    .font(.title3.bold())
+                Text("Choose what to include in the note")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.top, 8)
+            .frame(maxWidth: .infinity)
+
+            VStack(spacing: 10) {
+                if !snapshot.original.isEmpty && !snapshot.translation.isEmpty {
+                    optionButton(
+                        title: "Both languages",
+                        systemImage: "doc.on.doc"
+                    ) {
+                        onSelect(.both)
+                    }
+                }
+                if !snapshot.original.isEmpty {
+                    optionButton(
+                        title: "\(snapshot.sourceLanguage.displayName) only",
+                        systemImage: "text.bubble"
+                    ) {
+                        onSelect(.originalOnly)
+                    }
+                }
+                if !snapshot.translation.isEmpty {
+                    optionButton(
+                        title: "\(snapshot.targetLanguage.displayName) only",
+                        systemImage: "character.bubble"
+                    ) {
+                        onSelect(.translatedOnly)
+                    }
+                }
+            }
+
+            Spacer(minLength: 0)
+
+            Button("Cancel", role: .cancel) { dismiss() }
+                .buttonStyle(.bordered)
+                .controlSize(.large)
+                .frame(maxWidth: .infinity)
+        }
+        .padding(.horizontal)
+        .padding(.bottom)
+    }
+
+    private func optionButton(
+        title: String,
+        systemImage: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Label(title, systemImage: systemImage)
+                .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.borderedProminent)
+        .tint(.indigo)
+        .controlSize(.large)
     }
 }
 


### PR DESCRIPTION
## Summary
- Tapping **Save as note** in Live Translation now opens a bottom sheet (`.medium` detent) instead of always saving the combined source + translation
- User picks one of three options: **Both languages**, **{Source} only**, or **{Target} only**
- Options with no content are hidden, so the user can't save an empty section
- "Original only" / "Translated only" save the raw text without language headings; "Both" keeps the previous heading layout

## Test plan
- [ ] Open Live Translation, run a session in two languages, tap Stop
- [ ] Tap **Save as note** - verify a bottom sheet appears with all three options
- [ ] Pick **Both languages** - verify the note contains both sections with language headings
- [ ] Repeat with **{Source} only** - verify the note contains only the source text, no headings
- [ ] Repeat with **{Target} only** - verify the note contains only the translation, no headings
- [ ] Run a session where translation is empty (e.g. stop immediately) - verify the translated-only and "Both" options are hidden
- [ ] Tap Cancel - verify nothing is saved