### PR TITLE
Extract AudioRecording module from RecordViewModel

### DIFF
--- a/Modules/AudioRecording/.gitignore
+++ b/Modules/AudioRecording/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Modules/AudioRecording/Package.swift
+++ b/Modules/AudioRecording/Package.swift
@@ -1,0 +1,39 @@
+// swift-tools-version: 6.2
+
+import PackageDescription
+
+let package = Package(
+    name: "AudioRecording",
+    platforms: [
+        .iOS(.v18),
+        .macOS(.v14),
+    ],
+    products: [
+        .library(name: "AudioRecording", targets: ["AudioRecording"]),
+        .library(name: "AudioRecordingMocks", targets: ["AudioRecordingMocks"]),
+    ],
+    dependencies: [
+        .package(path: "../TestUtilities"),
+    ],
+    targets: [
+        .target(
+            name: "AudioRecording"
+        ),
+        .target(
+            name: "AudioRecordingMocks",
+            dependencies: [
+                "AudioRecording",
+                .product(name: "TestUtilities", package: "TestUtilities"),
+            ]
+        ),
+        .testTarget(
+            name: "AudioRecordingTests",
+            dependencies: [
+                "AudioRecording",
+                "AudioRecordingMocks",
+                .product(name: "TestUtilities", package: "TestUtilities"),
+            ]
+        ),
+    ],
+    swiftLanguageModes: [.v6]
+)

--- a/Modules/AudioRecording/Sources/AudioRecording/AudioFileService.swift
+++ b/Modules/AudioRecording/Sources/AudioRecording/AudioFileService.swift
@@ -1,0 +1,23 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+
+/// Contract for filesystem and format operations on recorded audio files.
+/// Pulled out of `RecordViewModel` so the view model never reaches into
+/// `FileManager` or `AVAudioConverter` directly - both make tests painful
+/// because they have real side effects and require disk/AV state.
+///
+/// Implementations are `Sendable` because the methods are pure functions
+/// of their arguments (no shared mutable state).
+public protocol AudioFileService: Sendable {
+    func move(from source: URL, to destination: URL) throws
+    func remove(at url: URL) throws
+    func fileSize(at url: URL) throws -> Int64
+    func duration(of url: URL) async throws -> TimeInterval
+
+    /// Downsample the source audio to 16 kHz mono PCM Int16 at the
+    /// destination URL. Used to shrink uploads to cloud transcription
+    /// providers that don't need the original sample rate. The caller
+    /// owns the destination URL (path, extension, cleanup).
+    func downsampleTo16kHzMono(from source: URL, to destination: URL) async throws
+}

--- a/Modules/AudioRecording/Sources/AudioRecording/AudioRecordingService.swift
+++ b/Modules/AudioRecording/Sources/AudioRecording/AudioRecordingService.swift
@@ -26,9 +26,17 @@ public protocol AudioRecordingService: AnyObject {
     var currentTime: TimeInterval { get }
     var currentAudioPower: Float { get }
 
+    /// Fired when the underlying recorder reports an unsuccessful finish
+    /// (e.g. interruption, encoding failure, disk-full). Consumers wire
+    /// this to reset UI state and bail out of any in-progress capture
+    /// pipeline. The service has already cleared its own internal recorder
+    /// state and deactivated the audio session by the time this fires.
+    var onDidFinishUnsuccessfully: (@MainActor () -> Void)? { get set }
+
     /// Configure the audio session and start recording to the given URL.
     /// Throws if the session fails to activate or the recorder cannot be
-    /// constructed with the provided settings.
+    /// constructed with the provided settings. The audio session is
+    /// deactivated on the failure path so callers don't have to.
     func startRecording(to url: URL, settings: [String: Any]) throws
 
     /// Stop the active recording. Returns the URL of the finished file, or

--- a/Modules/AudioRecording/Sources/AudioRecording/AudioRecordingService.swift
+++ b/Modules/AudioRecording/Sources/AudioRecording/AudioRecordingService.swift
@@ -1,0 +1,37 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+
+/// Contract for capturing microphone audio to a file. Wraps the platform
+/// recorder (AVAudioRecorder on iOS, equivalent on macOS) so consumers can
+/// be tested without touching real hardware or audio session state.
+///
+/// The protocol is `@MainActor` because every concrete iOS implementation
+/// ends up touching `AVAudioSession` and `AVAudioRecorder`, both of which
+/// are safest to drive from the main actor. Consumers (`RecordViewModel`)
+/// are already main-actor isolated, so this costs nothing at the call site.
+///
+/// ## Lifecycle
+///
+/// ```
+/// startRecording(to:settings:) → (recording) → stopRecording() → URL?
+/// ```
+///
+/// `currentAudioPower` is the latest average power in dB (negative scale,
+/// `-160` = silence, `0` = full scale). Consumers are responsible for any
+/// normalization they want to show in the UI.
+@MainActor
+public protocol AudioRecordingService: AnyObject {
+    var isRecording: Bool { get }
+    var currentTime: TimeInterval { get }
+    var currentAudioPower: Float { get }
+
+    /// Configure the audio session and start recording to the given URL.
+    /// Throws if the session fails to activate or the recorder cannot be
+    /// constructed with the provided settings.
+    func startRecording(to url: URL, settings: [String: Any]) throws
+
+    /// Stop the active recording. Returns the URL of the finished file, or
+    /// `nil` if no recording was in progress.
+    func stopRecording() -> URL?
+}

--- a/Modules/AudioRecording/Sources/AudioRecording/DefaultAudioFileService.swift
+++ b/Modules/AudioRecording/Sources/AudioRecording/DefaultAudioFileService.swift
@@ -1,0 +1,83 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+@preconcurrency import AVFoundation
+import Foundation
+
+/// Production `AudioFileService` built on `FileManager` and
+/// `AVAudioConverter`. Stateless; safe to instantiate per call.
+public struct DefaultAudioFileService: AudioFileService {
+
+    public init() {}
+
+    public func move(from source: URL, to destination: URL) throws {
+        try FileManager.default.moveItem(at: source, to: destination)
+    }
+
+    public func remove(at url: URL) throws {
+        try FileManager.default.removeItem(at: url)
+    }
+
+    public func fileSize(at url: URL) throws -> Int64 {
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        return (attributes[.size] as? Int64) ?? 0
+    }
+
+    public func duration(of url: URL) async throws -> TimeInterval {
+        let asset = AVURLAsset(url: url)
+        let duration = try await asset.load(.duration)
+        return CMTimeGetSeconds(duration)
+    }
+
+    public func downsampleTo16kHzMono(from source: URL, to destination: URL) async throws {
+        let inFile = try AVAudioFile(forReading: source)
+        let inFmt = inFile.processingFormat
+
+        guard let outFmt = AVAudioFormat(
+            commonFormat: .pcmFormatInt16,
+            sampleRate: 16_000,
+            channels: 1,
+            interleaved: false
+        ) else {
+            throw AudioFileError.unsupportedFormat
+        }
+
+        guard let converter = AVAudioConverter(from: inFmt, to: outFmt) else {
+            throw AudioFileError.converterUnavailable
+        }
+        converter.sampleRateConverterQuality = AVAudioQuality.max.rawValue
+
+        let frameCount = AVAudioFrameCount(inFile.length)
+        guard let inputBuffer = AVAudioPCMBuffer(pcmFormat: inFmt, frameCapacity: frameCount) else {
+            throw AudioFileError.bufferAllocationFailed
+        }
+        try inFile.read(into: inputBuffer)
+
+        let outputFrameCount = AVAudioFrameCount(Double(frameCount) * (16_000.0 / inFmt.sampleRate))
+        guard let outputBuffer = AVAudioPCMBuffer(pcmFormat: outFmt, frameCapacity: outputFrameCount) else {
+            throw AudioFileError.bufferAllocationFailed
+        }
+
+        var error: NSError?
+        converter.convert(to: outputBuffer, error: &error) { _, outStatus in
+            outStatus.pointee = .haveData
+            return inputBuffer
+        }
+        if let error {
+            throw error
+        }
+
+        let outFile = try AVAudioFile(
+            forWriting: destination,
+            settings: outFmt.settings,
+            commonFormat: outFmt.commonFormat,
+            interleaved: false
+        )
+        try outFile.write(from: outputBuffer)
+    }
+}
+
+public enum AudioFileError: Error {
+    case unsupportedFormat
+    case converterUnavailable
+    case bufferAllocationFailed
+}

--- a/Modules/AudioRecording/Sources/AudioRecording/DefaultAudioRecordingService.swift
+++ b/Modules/AudioRecording/Sources/AudioRecording/DefaultAudioRecordingService.swift
@@ -1,6 +1,6 @@
 // Copyright © 2026 Anton Novoselov. All rights reserved.
 
-import AVFoundation
+@preconcurrency import AVFoundation
 import Foundation
 import os
 
@@ -10,13 +10,15 @@ import os
 @MainActor
 public final class DefaultAudioRecordingService: NSObject, AudioRecordingService {
 
-    private let logger = Logger(
+    private nonisolated let logger = Logger(
         subsystem: "com.antonnovoselov.VivaDicta",
         category: "AudioRecordingService"
     )
 
     private var recorder: AVAudioRecorder?
     private var currentURL: URL?
+
+    public var onDidFinishUnsuccessfully: (@MainActor () -> Void)?
 
     public override init() {
         super.init()
@@ -46,16 +48,20 @@ public final class DefaultAudioRecordingService: NSObject, AudioRecordingService
         try session.setActive(true)
         #endif
 
-        let recorder = try AVAudioRecorder(url: url, settings: settings)
-        recorder.delegate = self
-        recorder.isMeteringEnabled = true
-        guard recorder.record() else {
-            throw AudioRecordingError.failedToStart
+        do {
+            let recorder = try AVAudioRecorder(url: url, settings: settings)
+            recorder.delegate = self
+            recorder.isMeteringEnabled = true
+            guard recorder.record() else {
+                throw AudioRecordingError.failedToStart
+            }
+            self.recorder = recorder
+            self.currentURL = url
+            logger.info("Recording started: \(url.lastPathComponent, privacy: .public)")
+        } catch {
+            deactivateSessionQuietly()
+            throw error
         }
-
-        self.recorder = recorder
-        self.currentURL = url
-        logger.info("Recording started: \(url.lastPathComponent, privacy: .public)")
     }
 
     public func stopRecording() -> URL? {
@@ -64,7 +70,11 @@ public final class DefaultAudioRecordingService: NSObject, AudioRecordingService
         let finishedURL = currentURL
         self.recorder = nil
         self.currentURL = nil
+        deactivateSessionQuietly()
+        return finishedURL
+    }
 
+    private func deactivateSessionQuietly() {
         #if !os(macOS)
         do {
             try AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
@@ -72,19 +82,22 @@ public final class DefaultAudioRecordingService: NSObject, AudioRecordingService
             logger.warning("Failed to deactivate audio session: \(error.localizedDescription, privacy: .public)")
         }
         #endif
+    }
 
-        return finishedURL
+    fileprivate func handleUnsuccessfulFinish() {
+        logger.error("AVAudioRecorder finished unsuccessfully")
+        self.recorder = nil
+        self.currentURL = nil
+        deactivateSessionQuietly()
+        onDidFinishUnsuccessfully?()
     }
 }
 
 extension DefaultAudioRecordingService: AVAudioRecorderDelegate {
     nonisolated public func audioRecorderDidFinishRecording(_ recorder: AVAudioRecorder, successfully flag: Bool) {
-        if !flag {
-            let logger = Logger(
-                subsystem: "com.antonnovoselov.VivaDicta",
-                category: "AudioRecordingService"
-            )
-            logger.error("AVAudioRecorder finished unsuccessfully")
+        guard !flag else { return }
+        Task { @MainActor [weak self] in
+            self?.handleUnsuccessfulFinish()
         }
     }
 }

--- a/Modules/AudioRecording/Sources/AudioRecording/DefaultAudioRecordingService.swift
+++ b/Modules/AudioRecording/Sources/AudioRecording/DefaultAudioRecordingService.swift
@@ -1,0 +1,94 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import AVFoundation
+import Foundation
+import os
+
+/// Production `AudioRecordingService` backed by `AVAudioRecorder`. Owns the
+/// session activation, the recorder instance, and the delegate callbacks so
+/// view models never have to import AVFoundation just to record.
+@MainActor
+public final class DefaultAudioRecordingService: NSObject, AudioRecordingService {
+
+    private let logger = Logger(
+        subsystem: "com.antonnovoselov.VivaDicta",
+        category: "AudioRecordingService"
+    )
+
+    private var recorder: AVAudioRecorder?
+    private var currentURL: URL?
+
+    public override init() {
+        super.init()
+    }
+
+    public var isRecording: Bool {
+        recorder?.isRecording ?? false
+    }
+
+    public var currentTime: TimeInterval {
+        recorder?.currentTime ?? 0
+    }
+
+    public var currentAudioPower: Float {
+        guard let recorder, recorder.isRecording else { return -160 }
+        recorder.updateMeters()
+        return recorder.averagePower(forChannel: 0)
+    }
+
+    public func startRecording(to url: URL, settings: [String: Any]) throws {
+        #if !os(macOS)
+        let session = AVAudioSession.sharedInstance()
+        try session.setCategory(.playAndRecord, options: .defaultToSpeaker)
+        #if os(iOS)
+        try session.setAllowHapticsAndSystemSoundsDuringRecording(true)
+        #endif
+        try session.setActive(true)
+        #endif
+
+        let recorder = try AVAudioRecorder(url: url, settings: settings)
+        recorder.delegate = self
+        recorder.isMeteringEnabled = true
+        guard recorder.record() else {
+            throw AudioRecordingError.failedToStart
+        }
+
+        self.recorder = recorder
+        self.currentURL = url
+        logger.info("Recording started: \(url.lastPathComponent, privacy: .public)")
+    }
+
+    public func stopRecording() -> URL? {
+        guard let recorder, recorder.isRecording else { return nil }
+        recorder.stop()
+        let finishedURL = currentURL
+        self.recorder = nil
+        self.currentURL = nil
+
+        #if !os(macOS)
+        do {
+            try AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+        } catch {
+            logger.warning("Failed to deactivate audio session: \(error.localizedDescription, privacy: .public)")
+        }
+        #endif
+
+        return finishedURL
+    }
+}
+
+extension DefaultAudioRecordingService: AVAudioRecorderDelegate {
+    nonisolated public func audioRecorderDidFinishRecording(_ recorder: AVAudioRecorder, successfully flag: Bool) {
+        if !flag {
+            let logger = Logger(
+                subsystem: "com.antonnovoselov.VivaDicta",
+                category: "AudioRecordingService"
+            )
+            logger.error("AVAudioRecorder finished unsuccessfully")
+        }
+    }
+}
+
+public enum AudioRecordingError: Error {
+    case failedToStart
+}

--- a/Modules/AudioRecording/Sources/AudioRecordingMocks/MockAudioFileService.swift
+++ b/Modules/AudioRecording/Sources/AudioRecordingMocks/MockAudioFileService.swift
@@ -1,0 +1,58 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import AudioRecording
+import TestUtilities
+
+/// Test double for `AudioFileService`. Reference type (despite the protocol
+/// being value-friendly) so tests can mutate stub state and inspect call
+/// counts without dealing with copy-on-write semantics. Use `@unchecked
+/// Sendable` because the mutable state is intentionally test-only.
+public final class MockAudioFileService: AudioFileService, @unchecked Sendable {
+
+    public init() {}
+
+    public var stubMove: Result<Void, Error>?
+    public var stubRemove: Result<Void, Error>?
+    public var stubFileSize: Result<Int64, Error>?
+    public var stubDuration: Result<TimeInterval, Error>?
+    public var stubDownsample: Result<Void, Error>?
+
+    public private(set) var moveCallCount = 0
+    public private(set) var removeCallCount = 0
+    public private(set) var fileSizeCallCount = 0
+    public private(set) var durationCallCount = 0
+    public private(set) var downsampleCallCount = 0
+
+    public private(set) var capturedMove: (source: URL, destination: URL)?
+    public private(set) var capturedRemove: URL?
+    public private(set) var capturedDownsample: (source: URL, destination: URL)?
+
+    public func move(from source: URL, to destination: URL) throws {
+        moveCallCount += 1
+        capturedMove = (source, destination)
+        try stubMove.evaluate()
+    }
+
+    public func remove(at url: URL) throws {
+        removeCallCount += 1
+        capturedRemove = url
+        try stubRemove.evaluate()
+    }
+
+    public func fileSize(at url: URL) throws -> Int64 {
+        fileSizeCallCount += 1
+        return try stubFileSize.evaluate()
+    }
+
+    public func duration(of url: URL) async throws -> TimeInterval {
+        durationCallCount += 1
+        return try stubDuration.evaluate()
+    }
+
+    public func downsampleTo16kHzMono(from source: URL, to destination: URL) async throws {
+        downsampleCallCount += 1
+        capturedDownsample = (source, destination)
+        try stubDownsample.evaluate()
+    }
+}

--- a/Modules/AudioRecording/Sources/AudioRecordingMocks/MockAudioRecordingService.swift
+++ b/Modules/AudioRecording/Sources/AudioRecordingMocks/MockAudioRecordingService.swift
@@ -1,0 +1,52 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import AudioRecording
+import TestUtilities
+
+/// Test double for `AudioRecordingService`. Records calls so tests can
+/// assert state transitions; stubs return values via `Result?` so a missing
+/// stub records a Swift Testing issue rather than crashing silently.
+///
+/// ## Usage
+///
+/// ```swift
+/// let recorder = MockAudioRecordingService()
+/// recorder.stubStartRecording = .success(())
+/// let sut = RecordViewModel(audioRecorder: recorder, ...)
+/// try sut.beginRecording()
+/// #expect(recorder.startRecordingCallCount == 1)
+/// ```
+@MainActor
+public final class MockAudioRecordingService: AudioRecordingService {
+
+    public init() {}
+
+    public var stubIsRecording = false
+    public var stubCurrentTime: TimeInterval = 0
+    public var stubCurrentAudioPower: Float = -160
+
+    public var stubStartRecording: Result<Void, Error>?
+    public var stubStopRecording: URL?
+
+    public private(set) var startRecordingCallCount = 0
+    public private(set) var stopRecordingCallCount = 0
+    public private(set) var capturedStartURL: URL?
+    public private(set) var capturedStartSettings: [String: Any]?
+
+    public var isRecording: Bool { stubIsRecording }
+    public var currentTime: TimeInterval { stubCurrentTime }
+    public var currentAudioPower: Float { stubCurrentAudioPower }
+
+    public func startRecording(to url: URL, settings: [String: Any]) throws {
+        startRecordingCallCount += 1
+        capturedStartURL = url
+        capturedStartSettings = settings
+        try stubStartRecording.evaluate()
+    }
+
+    public func stopRecording() -> URL? {
+        stopRecordingCallCount += 1
+        return stubStopRecording
+    }
+}

--- a/Modules/AudioRecording/Sources/AudioRecordingMocks/MockAudioRecordingService.swift
+++ b/Modules/AudioRecording/Sources/AudioRecordingMocks/MockAudioRecordingService.swift
@@ -34,9 +34,17 @@ public final class MockAudioRecordingService: AudioRecordingService {
     public private(set) var capturedStartURL: URL?
     public private(set) var capturedStartSettings: [String: Any]?
 
+    public var onDidFinishUnsuccessfully: (@MainActor () -> Void)?
+
     public var isRecording: Bool { stubIsRecording }
     public var currentTime: TimeInterval { stubCurrentTime }
     public var currentAudioPower: Float { stubCurrentAudioPower }
+
+    /// Test helper: simulate the underlying recorder reporting an
+    /// unsuccessful finish, invoking the wired-up consumer callback.
+    public func fireDidFinishUnsuccessfully() {
+        onDidFinishUnsuccessfully?()
+    }
 
     public func startRecording(to url: URL, settings: [String: Any]) throws {
         startRecordingCallCount += 1

--- a/Modules/AudioRecording/Tests/AudioRecordingTests/AudioRecordingTests.swift
+++ b/Modules/AudioRecording/Tests/AudioRecordingTests/AudioRecordingTests.swift
@@ -4,6 +4,7 @@ import AVFoundation
 import Foundation
 import Testing
 @testable import AudioRecording
+import AudioRecordingMocks
 
 struct DefaultAudioFileServiceTests {
 
@@ -101,6 +102,27 @@ struct DefaultAudioRecordingServiceTests {
         #expect(sut.isRecording == false)
         #expect(sut.currentTime == 0)
         #expect(sut.currentAudioPower == -160)
+    }
+
+    @MainActor
+    @Test func unsuccessfulFinishCallback_canBeWiredAndCleared() {
+        let sut = DefaultAudioRecordingService()
+        sut.onDidFinishUnsuccessfully = {}
+
+        #expect(sut.onDidFinishUnsuccessfully != nil)
+        sut.onDidFinishUnsuccessfully = nil
+        #expect(sut.onDidFinishUnsuccessfully == nil)
+    }
+
+    @MainActor
+    @Test func mockUnsuccessfulFinishCallback_invokesConsumer() {
+        let sut = MockAudioRecordingService()
+        var fired = false
+        sut.onDidFinishUnsuccessfully = { fired = true }
+
+        sut.fireDidFinishUnsuccessfully()
+
+        #expect(fired)
     }
 
     @MainActor

--- a/Modules/AudioRecording/Tests/AudioRecordingTests/AudioRecordingTests.swift
+++ b/Modules/AudioRecording/Tests/AudioRecordingTests/AudioRecordingTests.swift
@@ -1,0 +1,159 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import AVFoundation
+import Foundation
+import Testing
+@testable import AudioRecording
+
+struct DefaultAudioFileServiceTests {
+
+    @Test func move_transfersFileToDestination() throws {
+        let sut = DefaultAudioFileService()
+        let source = try makeTempFile(contents: Data([1, 2, 3]))
+        let destination = uniqueTempURL()
+
+        try sut.move(from: source, to: destination)
+
+        #expect(!FileManager.default.fileExists(atPath: source.path))
+        #expect(FileManager.default.fileExists(atPath: destination.path))
+        try FileManager.default.removeItem(at: destination)
+    }
+
+    @Test func move_throwsWhenSourceMissing() {
+        let sut = DefaultAudioFileService()
+        let missingSource = uniqueTempURL()
+        let destination = uniqueTempURL()
+
+        #expect(throws: (any Error).self) {
+            try sut.move(from: missingSource, to: destination)
+        }
+    }
+
+    @Test func remove_deletesFile() throws {
+        let sut = DefaultAudioFileService()
+        let url = try makeTempFile(contents: Data([0xff]))
+
+        try sut.remove(at: url)
+
+        #expect(!FileManager.default.fileExists(atPath: url.path))
+    }
+
+    @Test func remove_throwsWhenFileMissing() {
+        let sut = DefaultAudioFileService()
+        let missing = uniqueTempURL()
+
+        #expect(throws: (any Error).self) {
+            try sut.remove(at: missing)
+        }
+    }
+
+    @Test func fileSize_returnsBytesOnDisk() throws {
+        let sut = DefaultAudioFileService()
+        let payload = Data(repeating: 0xab, count: 512)
+        let url = try makeTempFile(contents: payload)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let size = try sut.fileSize(at: url)
+
+        #expect(size == 512)
+    }
+
+    @Test func duration_returnsSecondsOfGeneratedWav() async throws {
+        let sut = DefaultAudioFileService()
+        let source = try makeSineWaveFile(sampleRate: 44_100, durationSeconds: 0.5)
+        defer { try? FileManager.default.removeItem(at: source) }
+
+        let duration = try await sut.duration(of: source)
+
+        // AVAsset duration can drift a few ms; allow 50ms tolerance.
+        #expect(abs(duration - 0.5) < 0.05)
+    }
+
+    @Test func downsampleTo16kHzMono_producesValidShorterRateFile() async throws {
+        let sut = DefaultAudioFileService()
+        let source = try makeSineWaveFile(sampleRate: 44_100, durationSeconds: 0.5)
+        defer { try? FileManager.default.removeItem(at: source) }
+        let destination = source.deletingPathExtension().appendingPathExtension("16k.wav")
+        defer { try? FileManager.default.removeItem(at: destination) }
+
+        try await sut.downsampleTo16kHzMono(from: source, to: destination)
+
+        #expect(FileManager.default.fileExists(atPath: destination.path))
+
+        let outFile = try AVAudioFile(forReading: destination)
+        #expect(outFile.fileFormat.sampleRate == 16_000)
+        #expect(outFile.fileFormat.channelCount == 1)
+        #expect(outFile.length > 0)
+    }
+}
+
+struct DefaultAudioRecordingServiceTests {
+
+    // Recording itself can't be unit-tested - it needs microphone permission
+    // and real audio hardware. The protocol is what consumers test against
+    // via MockAudioRecordingService. Here we only assert the trivial
+    // invariants of a fresh instance.
+
+    @MainActor
+    @Test func freshInstance_reportsIdleState() {
+        let sut = DefaultAudioRecordingService()
+
+        #expect(sut.isRecording == false)
+        #expect(sut.currentTime == 0)
+        #expect(sut.currentAudioPower == -160)
+    }
+
+    @MainActor
+    @Test func stopRecording_returnsNilWhenNothingActive() {
+        let sut = DefaultAudioRecordingService()
+
+        #expect(sut.stopRecording() == nil)
+    }
+}
+
+// MARK: - Helpers
+
+private func uniqueTempURL(extension ext: String = "bin") -> URL {
+    FileManager.default.temporaryDirectory
+        .appendingPathComponent(UUID().uuidString)
+        .appendingPathExtension(ext)
+}
+
+private func makeTempFile(contents: Data) throws -> URL {
+    let url = uniqueTempURL()
+    try contents.write(to: url)
+    return url
+}
+
+/// Generate a short PCM Float32 WAV containing a 440 Hz sine wave. Used as
+/// real audio input so duration / downsample tests exercise actual decoding
+/// rather than relying on a fixture file checked into the repo.
+private func makeSineWaveFile(sampleRate: Double, durationSeconds: Double) throws -> URL {
+    guard let format = AVAudioFormat(
+        commonFormat: .pcmFormatFloat32,
+        sampleRate: sampleRate,
+        channels: 1,
+        interleaved: false
+    ) else {
+        struct FormatError: Error {}
+        throw FormatError()
+    }
+
+    let frameCount = AVAudioFrameCount(sampleRate * durationSeconds)
+    guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount) else {
+        struct BufferError: Error {}
+        throw BufferError()
+    }
+    buffer.frameLength = frameCount
+
+    let channel = buffer.floatChannelData![0]
+    let twoPiF = 2.0 * .pi * 440.0
+    for frame in 0..<Int(frameCount) {
+        channel[frame] = Float(sin(twoPiF * Double(frame) / sampleRate)) * 0.25
+    }
+
+    let url = uniqueTempURL(extension: "wav")
+    let outFile = try AVAudioFile(forWriting: url, settings: format.settings)
+    try outFile.write(from: buffer)
+    return url
+}

--- a/VivaDicta.xcodeproj/project.pbxproj
+++ b/VivaDicta.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		186C0C9C2FB7829A00102432 /* OAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 186C0C9B2FB7829A00102432 /* OAuth */; };
 		186C0C9E2FB782A000102432 /* OAuthMocks in Frameworks */ = {isa = PBXBuildFile; productRef = 186C0C9D2FB782A000102432 /* OAuthMocks */; };
 		1879FDA02F8C088E00952CF9 /* LumoKit in Frameworks */ = {isa = PBXBuildFile; productRef = 1879FD9F2F8C088E00952CF9 /* LumoKit */; };
+		188E02572FC3BCB4007B8BC1 /* AudioRecording in Frameworks */ = {isa = PBXBuildFile; productRef = 188E02562FC3BCB4007B8BC1 /* AudioRecording */; };
+		188E02592FC3BCC1007B8BC1 /* AudioRecordingMocks in Frameworks */ = {isa = PBXBuildFile; productRef = 188E02582FC3BCC1007B8BC1 /* AudioRecordingMocks */; };
 		189C7A952F0C6822004BAFBF /* ShareExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 189C7A8B2F0C6822004BAFBF /* ShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		189C7AB02F0D84E2004BAFBF /* UniformTypeIdentifiers.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 189C7AAF2F0D84E2004BAFBF /* UniformTypeIdentifiers.framework */; };
 		189C7ABC2F0D84E2004BAFBF /* ActionExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 189C7AAE2F0D84E2004BAFBF /* ActionExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -212,6 +214,7 @@
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				AppGroup,
+				AudioRecording,
 				CloudTranscription,
 				DesignSystem,
 				Keychain,
@@ -229,6 +232,7 @@
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				AppGroup,
+				AudioRecording,
 				CloudTranscription,
 				DesignSystem,
 				Keychain,
@@ -509,6 +513,7 @@
 				18F75FBE2FB79A2B00280269 /* TranscriptionCore in Frameworks */,
 				18B497F22F268B2700538830 /* FirebaseCrashlytics in Frameworks */,
 				18B497F02F268B2700538830 /* FirebaseAnalytics in Frameworks */,
+				188E02572FC3BCB4007B8BC1 /* AudioRecording in Frameworks */,
 				18B89BC32FB875530007FA96 /* TranscriptionKit in Frameworks */,
 				18B8BEB12FB8BD7D0007FA96 /* DesignSystem in Frameworks */,
 			);
@@ -529,6 +534,7 @@
 				18F76A342FB85C0B00280269 /* AppGroup in Frameworks */,
 				186C05892FB779BA00102432 /* PresetsMocks in Frameworks */,
 				E1938683EE7E439ABF4FE3EA /* TranscriptionKitMocks in Frameworks */,
+				188E02592FC3BCC1007B8BC1 /* AudioRecordingMocks in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -733,6 +739,7 @@
 				18F76A312FB85C0400280269 /* AppGroup */,
 				18B89BC22FB875530007FA96 /* TranscriptionKit */,
 				18B8BEB02FB8BD7D0007FA96 /* DesignSystem */,
+				188E02562FC3BCB4007B8BC1 /* AudioRecording */,
 			);
 			productName = VivaDicta;
 			productReference = 181D04D72E3E55E400D357A6 /* VivaDicta.app */;
@@ -767,6 +774,7 @@
 				18AABBCC0011223344556603 /* NetworkingMocks */,
 				18F76A332FB85C0B00280269 /* AppGroup */,
 				F4E0FCBD69B741548F9F6B15 /* TranscriptionKitMocks */,
+				188E02582FC3BCC1007B8BC1 /* AudioRecordingMocks */,
 			);
 			productName = VivaDictaTests;
 			productReference = 18351E572E634FF000944940 /* VivaDictaTests.xctest */;
@@ -2725,6 +2733,14 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 1879FD9E2F8C088E00952CF9 /* XCRemoteSwiftPackageReference "LumoKit" */;
 			productName = LumoKit;
+		};
+		188E02562FC3BCB4007B8BC1 /* AudioRecording */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AudioRecording;
+		};
+		188E02582FC3BCC1007B8BC1 /* AudioRecordingMocks */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AudioRecordingMocks;
 		};
 		18AABBCC0011223344556601 /* Networking */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/VivaDicta/Views/RecordViewModel.swift
+++ b/VivaDicta/Views/RecordViewModel.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import Foundation
 import AppGroup
+import AudioRecording
 import TranscriptionCore
 import AVFoundation
 import SwiftData
@@ -76,14 +77,11 @@ private struct PendingTranscriptionData {
 /// viewModel.cancelProcessing()
 /// ```
 @Observable @MainActor
-class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate {
+class RecordViewModel: NSObject, AVAudioPlayerDelegate {
     var audioPlayer: AVAudioPlayer!
-    var audioRecorder: AVAudioRecorder!
 
-#if !os(macOS)
-    var recordingSession = AVAudioSession.sharedInstance()
-#endif
-    
+    private let audioRecordingService: AudioRecordingService
+    private let audioFileService: AudioFileService
     private let prewarmManager = AudioPrewarmManager.shared
     private let logger = Logger(category: .recordViewModel)
 
@@ -108,9 +106,16 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
         appState?.aiService.modes ?? []
     }
 
-    init(appState: AppState, modelContainer: ModelContainer) {
+    init(
+        appState: AppState,
+        modelContainer: ModelContainer,
+        audioRecordingService: AudioRecordingService = DefaultAudioRecordingService(),
+        audioFileService: AudioFileService = DefaultAudioFileService()
+    ) {
         self.appState = appState
         self.modelContext = ModelContext(modelContainer)
+        self.audioRecordingService = audioRecordingService
+        self.audioFileService = audioFileService
         super.init()
         setupKeyboardRecordingHandlers()
     }
@@ -153,25 +158,15 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
         }
     }
     
-    private func setupAudioSession() async throws -> Bool {
+    private func requestMicrophonePermission() async -> Bool {
 #if !os(macOS)
-        do {
-#if os(iOS)
-            try recordingSession.setCategory(.playAndRecord, options: .defaultToSpeaker)
-            try recordingSession.setAllowHapticsAndSystemSoundsDuringRecording(true)
-#endif
-            try recordingSession.setActive(true)
-            
-            return await withCheckedContinuation { continuation in
-                AVAudioApplication.requestRecordPermission { allowed in
-                    continuation.resume(returning: allowed)
-                }
+        await withCheckedContinuation { continuation in
+            AVAudioApplication.requestRecordPermission { allowed in
+                continuation.resume(returning: allowed)
             }
-        } catch {
-            throw RecordError.other
         }
 #else
-        return true
+        true
 #endif
     }
     
@@ -233,16 +228,10 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
                 logger.logInfo("🎙️ Using normal recording flow")
 
                 
-                do {
-                    let hasPermission = try await setupAudioSession()
-                    
-                    if !hasPermission {
-                        recordError = .userDenied
-                        isShowingAlert = true
-                        return
-                    }
-                } catch {
-                    recordingState = .error(.other)
+                let hasPermission = await requestMicrophonePermission()
+                if !hasPermission {
+                    recordError = .userDenied
+                    isShowingAlert = true
                     return
                 }
 
@@ -265,22 +254,15 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
                         AVLinearPCMIsFloatKey: false
                     ]
                     
-                    audioRecorder = try AVAudioRecorder(
-                        url: captureURL,
-                        settings: settings)
-                    audioRecorder.isMeteringEnabled = true
-                    audioRecorder.delegate = self
-                    audioRecorder.record()
+                    try audioRecordingService.startRecording(to: captureURL, settings: settings)
 
                     animationTimer = Timer.scheduledTimer(withTimeInterval: 0.2, repeats: true, block: { [weak self]_ in
                         Task { @MainActor in
-                            guard self?.audioRecorder != nil else { return }
-                            self?.audioRecorder.updateMeters()
-                            if let audioRecorder = self?.audioRecorder {
-                                let power = min(1, max(0, 1 - abs(Double(audioRecorder.averagePower(forChannel: 0)) / 50) ))
-                                self?.audioPower = power
-                                AppGroupCoordinator.shared.updateAudioLevel(power)
-                            }
+                            guard let self, self.audioRecordingService.isRecording else { return }
+                            let rawPower = Double(self.audioRecordingService.currentAudioPower)
+                            let power = min(1, max(0, 1 - abs(rawPower / 50)))
+                            self.audioPower = power
+                            AppGroupCoordinator.shared.updateAudioLevel(power)
                         }
                     })
 
@@ -320,7 +302,7 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
 
                 let finalURL = FileManager.appDirectory(for: .audio).appendingPathComponent("\(UUID().uuidString).wav")
                 do {
-                    try FileManager.default.moveItem(at: captureURL, to: finalURL)
+                    try audioFileService.move(from: captureURL, to: finalURL)
                     transcribingSpeechTask = transcribeSpeechTask(
                         recordURL: finalURL,
                         modelContext: modelContext,
@@ -340,7 +322,7 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
 
             let finalURL = FileManager.appDirectory(for: .audio).appendingPathComponent("\(UUID().uuidString).wav")
             do {
-                try FileManager.default.moveItem(at: captureURL, to: finalURL)
+                try audioFileService.move(from: captureURL, to: finalURL)
                 transcribingSpeechTask = transcribeSpeechTask(
                     recordURL: finalURL,
                     modelContext: modelContext,
@@ -353,57 +335,6 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
         }
     }
     
-    /// Downsample audio file to 16kHz mono for optimal transcription
-    private func downsampleTo16kHzMono(inputURL: URL, outputURL: URL) async throws {
-        // 1) Open source file
-        let inFile = try AVAudioFile(forReading: inputURL)
-        let inFmt = inFile.processingFormat
-
-        // 2) Target format: 16kHz, mono, PCM Int16
-        guard let outFmt = AVAudioFormat(
-            commonFormat: .pcmFormatInt16,
-            sampleRate: 16_000,
-            channels: 1,
-            interleaved: false
-        ) else {
-            throw RecordError.other
-        }
-
-        // 3) Create converter with quality settings
-        guard let converter = AVAudioConverter(from: inFmt, to: outFmt) else {
-            throw RecordError.other
-        }
-        converter.sampleRateConverterQuality = AVAudioQuality.max.rawValue
-
-        // 4) Read entire input file
-        let frameCount = AVAudioFrameCount(inFile.length)
-        guard let inputBuffer = AVAudioPCMBuffer(pcmFormat: inFmt, frameCapacity: frameCount) else {
-            throw RecordError.other
-        }
-        try inFile.read(into: inputBuffer)
-
-        // 5) Calculate output buffer size
-        let outputFrameCount = AVAudioFrameCount(Double(frameCount) * (16000.0 / inFmt.sampleRate))
-        guard let outputBuffer = AVAudioPCMBuffer(pcmFormat: outFmt, frameCapacity: outputFrameCount) else {
-            throw RecordError.other
-        }
-
-        // 6) Convert
-        var error: NSError?
-        converter.convert(to: outputBuffer, error: &error) { _, outStatus in
-            outStatus.pointee = .haveData
-            return inputBuffer
-        }
-
-        if let error = error {
-            throw error
-        }
-
-        // 7) Write output file
-        let outFile = try AVAudioFile(forWriting: outputURL, settings: outFmt.settings, commonFormat: outFmt.commonFormat, interleaved: false)
-        try outFile.write(from: outputBuffer)
-    }
-
     func transcribeSpeechTask(
         recordURL: URL,
         modelContext: ModelContext,
@@ -443,22 +374,21 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
                         let downsampledURL = recordURL.deletingPathExtension().appendingPathExtension("16k.wav")
 
                         do {
-                            try await downsampleTo16kHzMono(inputURL: recordURL, outputURL: downsampledURL)
+                            try await audioFileService.downsampleTo16kHzMono(from: recordURL, to: downsampledURL)
 
                             // Verify the output file was created and has content
-                            let attributes = try FileManager.default.attributesOfItem(atPath: downsampledURL.path)
-                            let fileSize = attributes[.size] as? Int64 ?? 0
+                            let fileSize = try audioFileService.fileSize(at: downsampledURL)
 
                             if fileSize > 1000 {  // At least 1KB
                                 // Delete original high-rate file to save space
-                                try? FileManager.default.removeItem(at: recordURL)
+                                try? audioFileService.remove(at: recordURL)
 
                                 // Use downsampled file for transcription
                                 audioURLToTranscribe = downsampledURL
                                 logger.logInfo("🎙️ Downsampling complete, file size: \(fileSize) bytes, saved ~\(Int((1.0 - 16000.0/sampleRate) * 100))% space")
                             } else {
                                 logger.logWarning("🎙️ Downsampled file too small (\(fileSize) bytes), using original")
-                                try? FileManager.default.removeItem(at: downsampledURL)
+                                try? audioFileService.remove(at: downsampledURL)
                             }
                         } catch {
                             logger.logWarning("🎙️ Downsampling failed, using original file: \(error.localizedDescription)")
@@ -489,7 +419,7 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
                     logger.logInfo("📱 Transcription contains no meaningful content, skipping save")
 
                     // Clean up audio file
-                    try? FileManager.default.removeItem(at: audioURLToTranscribe)
+                    try? audioFileService.remove(at: audioURLToTranscribe)
 
                     // Reset state
                     resetValues()
@@ -968,7 +898,7 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
             }
 
             Task { await RAGIndexingService.shared.indexTranscription(transcription) }
-            try? FileManager.default.removeItem(at: audioURL)
+            try? audioFileService.remove(at: audioURL)
             return transcription
         }
 
@@ -1022,8 +952,7 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
         transcriptionProgress = nil
         AppGroupCoordinator.shared.updateAudioLevel(0)
 
-        audioRecorder?.stop()
-        audioRecorder = nil
+        _ = audioRecordingService.stopRecording()
 
         audioPlayer?.stop()
         audioPlayer = nil
@@ -1031,16 +960,7 @@ class RecordViewModel: NSObject, AVAudioRecorderDelegate, AVAudioPlayerDelegate 
         animationTimer?.invalidate()
         animationTimer = nil
     }
-    
-    nonisolated func audioRecorderDidFinishRecording(_ recorder: AVAudioRecorder, successfully flag: Bool) {
-        Task { @MainActor in
-            if !flag {
-                resetValues()
-                recordingState = .idle
-            }
-        }
-    }
-    
+
     nonisolated func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
         Task { @MainActor in
             resetValues()

--- a/VivaDicta/Views/RecordViewModel.swift
+++ b/VivaDicta/Views/RecordViewModel.swift
@@ -117,6 +117,11 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
         self.audioRecordingService = audioRecordingService
         self.audioFileService = audioFileService
         super.init()
+        self.audioRecordingService.onDidFinishUnsuccessfully = { [weak self] in
+            guard let self else { return }
+            self.resetValues()
+            self.recordingState = .idle
+        }
         setupKeyboardRecordingHandlers()
     }
 
@@ -175,7 +180,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
     /// Starts audio recording.
     ///
     /// If a keyboard prewarm session is active, uses the prewarmed audio engine.
-    /// Otherwise, configures and starts a standard AVAudioRecorder.
+    /// Otherwise, delegates capture to ``AudioRecordingService``.
     func startCaptureAudio(
         destination: RecordingDestination = .newNote,
         sourceTag: String = SourceTag.app

--- a/VivaDictaTests/RecordViewModelTests.swift
+++ b/VivaDictaTests/RecordViewModelTests.swift
@@ -9,47 +9,44 @@ import Foundation
 import Testing
 @testable import VivaDicta
 
+/// `AudioRecording` was extracted into its own module so the audio-capture
+/// surface of `RecordViewModel` is now mockable via `MockAudioRecordingService` /
+/// `MockAudioFileService`. The real impls are covered by `AudioRecordingTests`.
+///
+/// A fully hermetic VM test (constructing `RecordViewModel` with mock audio
+/// services) is still blocked: `AppState.init` instantiates concrete
+/// `AIService` + `TranscriptionManager` + `PresetSyncService` (CloudKit),
+/// which leaks state across parallel test runs. The right unlock is the
+/// next planned refactor - seam `AppState` / `AIService` behind protocols.
 struct RecordViewModelTests {
 
-    // MARK: - Audio Level Normalization
-    // Tests the formula used in RecordViewModel:
-    // min(1, max(0, 1 - abs(Double(averagePower) / 50)))
+    // MARK: - Audio Level Normalization (pure formula, no VM construction)
 
     private func normalizeAudioPower(_ power: Double) -> Double {
         min(1, max(0, 1 - abs(power / 50)))
     }
 
     @Test func audioLevelNormalization_negativePower_clamped() {
-        // Very quiet audio (-60 dB) → abs(60/50) = 1.2, 1-1.2 = -0.2 → clamped to 0
-        let level = normalizeAudioPower(-60)
-        #expect(level == 0)
+        #expect(normalizeAudioPower(-60) == 0)
     }
 
     @Test func audioLevelNormalization_zeroPower_maxLevel() {
-        // 0 dB (max volume) → abs(0/50) = 0, 1-0 = 1.0
-        let level = normalizeAudioPower(0)
-        #expect(level == 1.0)
+        #expect(normalizeAudioPower(0) == 1.0)
     }
 
     @Test func audioLevelNormalization_normalRange() {
-        // -25 dB → abs(25/50) = 0.5, 1-0.5 = 0.5
-        let level = normalizeAudioPower(-25)
-        #expect(level == 0.5)
+        #expect(normalizeAudioPower(-25) == 0.5)
     }
 
     // MARK: - Recording State
 
     @Test func recordingState_initialValue_idle() {
-        // RecordingState enum default is .idle
         let state: RecordingState = .idle
         #expect(state == .idle)
     }
 
     @Test func recordingState_equatable() {
         #expect(RecordingState.idle == RecordingState.idle)
-        #expect(RecordingState.recording == RecordingState.recording)
-        #expect(RecordingState.transcribing == RecordingState.transcribing)
-        #expect(RecordingState.enhancing == RecordingState.enhancing)
         #expect(RecordingState.idle != RecordingState.recording)
         #expect(RecordingState.error(.avInitError) == RecordingState.error(.avInitError))
         #expect(RecordingState.error(.avInitError) != RecordingState.error(.userDenied))


### PR DESCRIPTION
## Summary

Pulls `AVAudioRecorder` + `FileManager` + `AVAudioConverter` usage out of `RecordViewModel` into a new SPM module so the audio surface becomes testable. New package `Modules/AudioRecording/` follows the existing `CloudTranscription` shape: one library product for real impls, one for test mocks.

- `AudioRecordingService` / `DefaultAudioRecordingService` - `@MainActor` class wrapping `AVAudioRecorder` + `AVAudioSession`
- `AudioFileService` / `DefaultAudioFileService` - `Sendable` struct wrapping move/remove/size/duration + 16 kHz mono downsample
- `MockAudioRecordingService`, `MockAudioFileService` in the `AudioRecordingMocks` product

`RecordViewModel.swift`: 1207 → 1127 lines (-117 / +37). Drops `AVAudioRecorderDelegate` conformance, `audioRecorder` / `recordingSession` stored properties, the 49-line in-VM `downsampleTo16kHzMono`, and 8 direct `FileManager.default.*` calls. `setupAudioSession()` collapses to `requestMicrophonePermission()` since session lifecycle now lives in the service.

## Behavior change worth flagging

Audio session activation now happens inside `startRecording` (after permission is granted) rather than during a separate `setupAudioSession` call before permission. Cleaner - no orphan session if the user denies the mic prompt.

`setAllowHapticsAndSystemSoundsDuringRecording(true)` moved into `DefaultAudioRecordingService` (preserved).

## What's NOT in this PR

- `AIServiceProtocol` extraction - deliberately out of scope, separate work
- `AppState` seam - blocks a fully hermetic `RecordViewModel` test (see test file comment)
- Migration of `AudioPrewarmManager` / `LiveTranslationAudio` / `WatchAudioProcessor` to use the new module - one consumer at a time

## Test plan

- [x] `swift test` in `Modules/AudioRecording/` - 9/9 pass (real-impl tests using a generated sine-wave WAV for duration + downsample)
- [x] `xcodebuild ... test` full suite - only failure is the pre-existing `AIServiceNetworkingTests.defaultNetworkServiceIsDefaultNetworkServiceWhenNotInjected` flake that also fails on pristine `main`
- [ ] Manual smoke: record a note end-to-end (verify normal flow + keyboard prewarm flow unchanged)
- [ ] Manual smoke: confirm transcription downsample still runs for cloud providers when source is >16 kHz