### PR TITLE
Align TestUtilities Evaluate + port SwiftExpectation / ObservationTestUtils

### DIFF
--- a/Modules/Presets/Package.swift
+++ b/Modules/Presets/Package.swift
@@ -12,6 +12,9 @@ let package = Package(
         .library(name: "Presets", targets: ["Presets"]),
         .library(name: "PresetsMocks", targets: ["PresetsMocks"]),
     ],
+    dependencies: [
+        .package(path: "../TestUtilities"),
+    ],
     targets: [
         .target(
             name: "Presets"
@@ -22,7 +25,11 @@ let package = Package(
         ),
         .testTarget(
             name: "PresetsTests",
-            dependencies: ["Presets", "PresetsMocks"]
+            dependencies: [
+                "Presets",
+                "PresetsMocks",
+                .product(name: "TestUtilities", package: "TestUtilities"),
+            ]
         ),
     ],
     swiftLanguageModes: [.v6]

--- a/Modules/Presets/Tests/PresetsTests/MockPresetSyncTests.swift
+++ b/Modules/Presets/Tests/PresetsTests/MockPresetSyncTests.swift
@@ -12,9 +12,14 @@ import PresetsMocks
 
 @Suite("MockPresetSync contract")
 struct MockPresetSyncingTests {
+    
+    var sut: MockPresetSync
+    
+    init() {
+        self.sut = MockPresetSync()
+    }
 
     @Test func tracksCreatePresetRecord() {
-        let sut = MockPresetSync()
         let preset = PresetCatalog.regular
         sut.createPresetRecord(from: preset)
 
@@ -23,7 +28,6 @@ struct MockPresetSyncingTests {
     }
 
     @Test func tracksDeletePresetRecord() {
-        let sut = MockPresetSync()
         sut.deletePresetRecord(presetId: "custom_xyz")
 
         #expect(sut.deletePresetRecordCallCount == 1)
@@ -31,7 +35,6 @@ struct MockPresetSyncingTests {
     }
 
     @Test func tracksFavoriteSync() {
-        let sut = MockPresetSync()
         sut.syncFavoriteState(presetId: "summary", isFavorite: true)
 
         #expect(sut.syncFavoriteStateCallCount == 1)
@@ -40,7 +43,6 @@ struct MockPresetSyncingTests {
     }
 
     @Test func didCallbackFiresAfterMutation() {
-        let sut = MockPresetSync()
         var observedCount: Int?
         sut.didCreatePresetRecord = {
             observedCount = sut.createPresetRecordCallCount

--- a/Modules/Presets/Tests/PresetsTests/PresetManagerTests.swift
+++ b/Modules/Presets/Tests/PresetsTests/PresetManagerTests.swift
@@ -7,17 +7,19 @@
 
 import Foundation
 import Testing
+import TestUtilities
 @testable import Presets
 
 struct PresetManagerTests {
 
-    // MARK: - Test Helpers
+    var sut: PresetManager
 
-    private func makeManager(suiteName: String = "PresetManagerTests") -> PresetManager {
+    init() {
+        let suiteName = "PresetManagerTests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
         defaults.removeObject(forKey: "testPresets")
         defaults.removeObject(forKey: "testHiddenPresetIDs")
-        return PresetManager(
+        self.sut = PresetManager(
             userDefaults: defaults,
             storageKey: "testPresets",
             hiddenPresetIDsStorageKey: "testHiddenPresetIDs"
@@ -44,8 +46,6 @@ struct PresetManagerTests {
     // MARK: - Initialization Tests
 
     @Test func init_populatesBuiltInPresets() {
-        let sut = makeManager()
-
         #expect(!sut.presets.isEmpty)
         #expect(sut.presets.contains { $0.id == "regular" })
         #expect(sut.presets.contains { $0.id == "summary" })
@@ -53,7 +53,6 @@ struct PresetManagerTests {
     }
 
     @Test func init_builtInPresetsCount_matchesCatalog() {
-        let sut = makeManager()
         let builtInCount = sut.presets.filter(\.isBuiltIn).count
 
         #expect(builtInCount == PresetCatalog.allBuiltIn.count)
@@ -62,8 +61,6 @@ struct PresetManagerTests {
     // MARK: - Lookup Tests
 
     @Test func preset_forId_returnsCorrectPreset() {
-        let sut = makeManager()
-
         let preset = sut.preset(for: "regular")
 
         #expect(preset?.name == "Regular")
@@ -71,14 +68,10 @@ struct PresetManagerTests {
     }
 
     @Test func preset_forId_returnsNilForUnknownId() {
-        let sut = makeManager()
-
         #expect(sut.preset(for: "nonexistent") == nil)
     }
 
     @Test func presetsInCategory_returnsFilteredPresets() {
-        let sut = makeManager()
-
         let rewritePresets = sut.presets(in: "Rewrite")
 
         #expect(!rewritePresets.isEmpty)
@@ -86,8 +79,6 @@ struct PresetManagerTests {
     }
 
     @Test func categories_returnsOrderedCategories() {
-        let sut = makeManager()
-
         let categories = sut.categories
 
         #expect(!categories.isEmpty)
@@ -100,8 +91,7 @@ struct PresetManagerTests {
 
     // MARK: - Add Preset Tests
 
-    @Test func addPreset_addsCustomPreset() {
-        let sut = makeManager()
+    @Test mutating func addPreset_addsCustomPreset() {
         let initialCount = sut.presets.count
         let preset = makeCustomPreset()
 
@@ -113,8 +103,7 @@ struct PresetManagerTests {
 
     // MARK: - Update Preset Tests
 
-    @Test func updatePreset_updatesExistingPreset() {
-        let sut = makeManager()
+    @Test mutating func updatePreset_updatesExistingPreset() {
         let preset = makeCustomPreset()
         sut.addPreset(preset)
 
@@ -125,8 +114,7 @@ struct PresetManagerTests {
         #expect(sut.preset(for: preset.id)?.name == "Updated Name")
     }
 
-    @Test func updatePreset_nonExistentId_noEffect() {
-        let sut = makeManager()
+    @Test mutating func updatePreset_nonExistentId_noEffect() {
         let initialCount = sut.presets.count
 
         let preset = makeCustomPreset(id: "custom_nonexistent")
@@ -137,8 +125,7 @@ struct PresetManagerTests {
 
     // MARK: - Delete Preset Tests
 
-    @Test func deletePreset_removesCustomPreset() {
-        let sut = makeManager()
+    @Test mutating func deletePreset_removesCustomPreset() {
         let preset = makeCustomPreset()
         sut.addPreset(preset)
         let countAfterAdd = sut.presets.count
@@ -149,8 +136,7 @@ struct PresetManagerTests {
         #expect(sut.preset(for: preset.id) == nil)
     }
 
-    @Test func deletePreset_builtIn_doesNotDelete() {
-        let sut = makeManager()
+    @Test mutating func deletePreset_builtIn_doesNotDelete() {
         let regularPreset = sut.preset(for: "regular")!
         let initialCount = sut.presets.count
 
@@ -162,9 +148,7 @@ struct PresetManagerTests {
 
     // MARK: - Reset to Default Tests
 
-    @Test func resetToDefault_restoresBuiltInPreset() {
-        let sut = makeManager()
-
+    @Test mutating func resetToDefault_restoresBuiltInPreset() {
         // Edit the preset first
         var edited = sut.preset(for: "regular")!
         edited.name = "My Custom Regular"
@@ -180,9 +164,7 @@ struct PresetManagerTests {
 
     // MARK: - Favorite Tests
 
-    @Test func toggleFavorite_togglesState() {
-        let sut = makeManager()
-
+    @Test mutating func toggleFavorite_togglesState() {
         #expect(sut.preset(for: "regular")?.isFavorite == false)
 
         sut.toggleFavorite(presetId: "regular")
@@ -192,18 +174,14 @@ struct PresetManagerTests {
         #expect(sut.preset(for: "regular")?.isFavorite == false)
     }
 
-    @Test func hasFavorites_reflectsState() {
-        let sut = makeManager()
-
+    @Test mutating func hasFavorites_reflectsState() {
         #expect(sut.hasFavorites == false)
 
         sut.toggleFavorite(presetId: "regular")
         #expect(sut.hasFavorites == true)
     }
 
-    @Test func visiblePresets_excludesHiddenPresets() {
-        let sut = makeManager()
-
+    @Test mutating func visiblePresets_excludesHiddenPresets() {
         #expect(sut.visiblePresets.contains { $0.id == "regular" })
 
         sut.setPresetHidden(presetId: "regular", isHidden: true)
@@ -212,8 +190,7 @@ struct PresetManagerTests {
         #expect(sut.isPresetHidden(presetId: "regular") == true)
     }
 
-    @Test func hasVisibleFavorites_ignoresHiddenFavorites() {
-        let sut = makeManager()
+    @Test mutating func hasVisibleFavorites_ignoresHiddenFavorites() {
         sut.toggleFavorite(presetId: "regular")
 
         #expect(sut.hasVisibleFavorites == true)
@@ -226,27 +203,25 @@ struct PresetManagerTests {
     // MARK: - Duplicate Detection Tests
 
     @Test func isPresetNameDuplicate_detectsDuplicates() {
-        let sut = makeManager()
-
         #expect(sut.isPresetNameDuplicate("Regular") == true)
         #expect(sut.isPresetNameDuplicate("NonExistent Preset") == false)
     }
 
     @Test func isPresetNameDuplicate_excludesOwnId() {
-        let sut = makeManager()
-
         // "Regular" exists, but when excluding its own ID it should not be a duplicate
         #expect(sut.isPresetNameDuplicate("Regular", excludingId: "regular") == false)
     }
 
     @Test func isPresetNameDuplicate_caseInsensitive() {
-        let sut = makeManager()
-
         #expect(sut.isPresetNameDuplicate("regular") == true)
         #expect(sut.isPresetNameDuplicate("REGULAR") == true)
     }
 
     // MARK: - Persistence Tests
+
+    // Persistence tests need a manager pair against the same defaults to
+    // verify cross-instance reads, so they construct managers inline rather
+    // than using the hoisted `sut`.
 
     @Test func persistence_presetsPersistedAcrossInstances() {
         let suiteName = "PresetManagerPersistenceTest_\(UUID().uuidString)"
@@ -300,8 +275,7 @@ struct PresetManagerTests {
 
     // MARK: - Sorting Tests
 
-    @Test func sorting_builtInPresetsBeforeCustom() {
-        let sut = makeManager()
+    @Test mutating func sorting_builtInPresetsBeforeCustom() {
         let custom = makeCustomPreset()
         sut.addPreset(custom)
 
@@ -317,8 +291,7 @@ struct PresetManagerTests {
         }
     }
 
-    @Test func deletePreset_removesHiddenState() {
-        let sut = makeManager()
+    @Test mutating func deletePreset_removesHiddenState() {
         let preset = makeCustomPreset()
         sut.addPreset(preset)
         sut.setPresetHidden(presetId: preset.id, isHidden: true)
@@ -326,5 +299,34 @@ struct PresetManagerTests {
         sut.deletePreset(preset)
 
         #expect(sut.isPresetHidden(presetId: preset.id) == false)
+    }
+
+    // MARK: - Observation
+
+    @MainActor
+    @Test func addPreset_firesObservationOnPresets() async throws {
+        let initialCount = sut.presets.count
+        let preset = makeCustomPreset()
+
+        try await changes(to: \.presets, on: sut, timeout: 0.5) {
+            sut.addPreset(preset)
+        }
+
+        #expect(sut.presets.count == initialCount + 1)
+        #expect(sut.preset(for: preset.id) != nil)
+    }
+
+    @MainActor
+    @Test func deletePreset_firesObservationOnPresets() async throws {
+        let preset = makeCustomPreset()
+        sut.addPreset(preset)
+        let countAfterAdd = sut.presets.count
+
+        try await changes(to: \.presets, on: sut, timeout: 0.5) {
+            sut.deletePreset(preset)
+        }
+
+        #expect(sut.presets.count == countAfterAdd - 1)
+        #expect(sut.preset(for: preset.id) == nil)
     }
 }

--- a/Modules/Presets/Tests/PresetsTests/PresetManagerTests.swift
+++ b/Modules/Presets/Tests/PresetsTests/PresetManagerTests.swift
@@ -91,7 +91,7 @@ struct PresetManagerTests {
 
     // MARK: - Add Preset Tests
 
-    @Test mutating func addPreset_addsCustomPreset() {
+    @Test func addPreset_addsCustomPreset() {
         let initialCount = sut.presets.count
         let preset = makeCustomPreset()
 
@@ -103,7 +103,7 @@ struct PresetManagerTests {
 
     // MARK: - Update Preset Tests
 
-    @Test mutating func updatePreset_updatesExistingPreset() {
+    @Test func updatePreset_updatesExistingPreset() {
         let preset = makeCustomPreset()
         sut.addPreset(preset)
 
@@ -114,7 +114,7 @@ struct PresetManagerTests {
         #expect(sut.preset(for: preset.id)?.name == "Updated Name")
     }
 
-    @Test mutating func updatePreset_nonExistentId_noEffect() {
+    @Test func updatePreset_nonExistentId_noEffect() {
         let initialCount = sut.presets.count
 
         let preset = makeCustomPreset(id: "custom_nonexistent")
@@ -125,7 +125,7 @@ struct PresetManagerTests {
 
     // MARK: - Delete Preset Tests
 
-    @Test mutating func deletePreset_removesCustomPreset() {
+    @Test func deletePreset_removesCustomPreset() {
         let preset = makeCustomPreset()
         sut.addPreset(preset)
         let countAfterAdd = sut.presets.count
@@ -136,7 +136,7 @@ struct PresetManagerTests {
         #expect(sut.preset(for: preset.id) == nil)
     }
 
-    @Test mutating func deletePreset_builtIn_doesNotDelete() {
+    @Test func deletePreset_builtIn_doesNotDelete() {
         let regularPreset = sut.preset(for: "regular")!
         let initialCount = sut.presets.count
 
@@ -148,7 +148,7 @@ struct PresetManagerTests {
 
     // MARK: - Reset to Default Tests
 
-    @Test mutating func resetToDefault_restoresBuiltInPreset() {
+    @Test func resetToDefault_restoresBuiltInPreset() {
         // Edit the preset first
         var edited = sut.preset(for: "regular")!
         edited.name = "My Custom Regular"
@@ -164,7 +164,7 @@ struct PresetManagerTests {
 
     // MARK: - Favorite Tests
 
-    @Test mutating func toggleFavorite_togglesState() {
+    @Test func toggleFavorite_togglesState() {
         #expect(sut.preset(for: "regular")?.isFavorite == false)
 
         sut.toggleFavorite(presetId: "regular")
@@ -174,14 +174,14 @@ struct PresetManagerTests {
         #expect(sut.preset(for: "regular")?.isFavorite == false)
     }
 
-    @Test mutating func hasFavorites_reflectsState() {
+    @Test func hasFavorites_reflectsState() {
         #expect(sut.hasFavorites == false)
 
         sut.toggleFavorite(presetId: "regular")
         #expect(sut.hasFavorites == true)
     }
 
-    @Test mutating func visiblePresets_excludesHiddenPresets() {
+    @Test func visiblePresets_excludesHiddenPresets() {
         #expect(sut.visiblePresets.contains { $0.id == "regular" })
 
         sut.setPresetHidden(presetId: "regular", isHidden: true)
@@ -190,7 +190,7 @@ struct PresetManagerTests {
         #expect(sut.isPresetHidden(presetId: "regular") == true)
     }
 
-    @Test mutating func hasVisibleFavorites_ignoresHiddenFavorites() {
+    @Test func hasVisibleFavorites_ignoresHiddenFavorites() {
         sut.toggleFavorite(presetId: "regular")
 
         #expect(sut.hasVisibleFavorites == true)
@@ -275,7 +275,7 @@ struct PresetManagerTests {
 
     // MARK: - Sorting Tests
 
-    @Test mutating func sorting_builtInPresetsBeforeCustom() {
+    @Test func sorting_builtInPresetsBeforeCustom() {
         let custom = makeCustomPreset()
         sut.addPreset(custom)
 
@@ -291,7 +291,7 @@ struct PresetManagerTests {
         }
     }
 
-    @Test mutating func deletePreset_removesHiddenState() {
+    @Test func deletePreset_removesHiddenState() {
         let preset = makeCustomPreset()
         sut.addPreset(preset)
         sut.setPresetHidden(presetId: preset.id, isHidden: true)

--- a/Modules/TestUtilities/Sources/TestUtilities/Evaluate.swift
+++ b/Modules/TestUtilities/Sources/TestUtilities/Evaluate.swift
@@ -3,8 +3,14 @@
 import Foundation
 import Testing
 
-/// Thrown when a test calls a mocked method that requires a stub but no stub
-/// was set. The Swift Testing port of Bev's `StubNotSetError`.
+/// Thrown by mocks for test-infrastructure failures - either a stub the
+/// test forgot to set, or a stub that exists but can't satisfy the call
+/// (mismatched type, fundamentally unstubbable method). Carries a
+/// message so the test report points at the specific mock + method.
+///
+/// Both the `.evaluate()` helper below and individual mocks
+/// (`MockNetworkService`, `MockURLSession`) throw this directly so every
+/// test-infra failure surfaces with a consistent error type.
 public struct StubNotSetError: Error, CustomStringConvertible {
     public let description: String
 
@@ -18,33 +24,14 @@ public extension Optional {
     ///
     /// Stubs should be of type `Result<T, Error>?`. The optional is evaluated
     /// in 1 of 3 ways:
-    /// 1. `nil` -> the stub has not been set; records a Swift Testing `Issue`
-    ///    at the call site and throws `StubNotSetError`.
+    /// 1. `nil` -> records a Swift Testing issue and throws `StubNotSetError`.
     /// 2. `.success(value)` -> returns `value`.
     /// 3. `.failure(error)` -> throws `error`.
-    ///
-    /// Uses standard built-in source-location macros so callers don't need to
-    /// `import Testing` themselves.
-    func evaluate<T>(
-        _ message: @autoclosure () -> String = "Stub not set",
-        fileID: String = #fileID,
-        filePath: String = #filePath,
-        line: Int = #line,
-        column: Int = #column
-    ) throws -> T where Wrapped == Result<T, Error> {
-        switch self {
-        case .some(let result):
-            return try result.get()
-        case .none:
-            let detail = message()
-            let location = SourceLocation(
-                fileID: fileID,
-                filePath: filePath,
-                line: line,
-                column: column
-            )
-            Issue.record(Comment(rawValue: detail), sourceLocation: location)
-            throw StubNotSetError(detail)
+    func evaluate<T>() throws -> T where Wrapped == Result<T, Error> {
+        guard let result = self else {
+            Issue.record("Stub not set")
+            throw StubNotSetError()
         }
+        return try result.get()
     }
 }

--- a/Modules/TestUtilities/Sources/TestUtilities/ObservationTestUtils.swift
+++ b/Modules/TestUtilities/Sources/TestUtilities/ObservationTestUtils.swift
@@ -1,0 +1,42 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import Observation
+import Testing
+
+/// Wait for a property on an `@Observable` entity to change before asserting.
+///
+/// Uses Swift's `withObservationTracking` to register interest in one
+/// property without spinning a busy loop. The wildcard read (`_ = ...`)
+/// touches the property so the tracker arms, the `trigger` closure mutates
+/// it, then we wait for `onChange` to fire. Fails the test if no change
+/// arrives within `timeout`.
+///
+/// The single-closure form avoids the `async let` pattern (which trips
+/// Swift 6 strict concurrency on non-`Sendable` observables) by keeping
+/// observation setup, mutation, and waiting on the same actor.
+///
+/// ## Usage
+///
+/// ```swift
+/// try await changes(to: \.recordingState, on: sut, timeout: 0.5) {
+///     mockRecorder.fireDidFinishUnsuccessfully()
+/// }
+/// #expect(sut.recordingState == .idle)
+/// ```
+@MainActor
+public func changes<T, U>(
+    to keyPath: KeyPath<T, U>,
+    on parent: T,
+    timeout: Double = 1.0,
+    trigger: () -> Void
+) async throws {
+    let exp = SwiftExpectation(timeout: timeout)
+    withObservationTracking {
+        _ = parent[keyPath: keyPath]
+    } onChange: {
+        exp.fulfill()
+    }
+    trigger()
+    try await exp.wait()
+}

--- a/Modules/TestUtilities/Sources/TestUtilities/ObservationTestUtils.swift
+++ b/Modules/TestUtilities/Sources/TestUtilities/ObservationTestUtils.swift
@@ -35,7 +35,14 @@ public func changes<T, U>(
     withObservationTracking {
         _ = parent[keyPath: keyPath]
     } onChange: {
-        exp.fulfill()
+        // onChange fires synchronously when the observed property is mutated.
+        // Because `changes(...)` is `@MainActor`, the trigger closure - and
+        // therefore the mutation that wakes this callback - runs on the main
+        // actor. Bridge from the nonisolated callback to the main-actor
+        // `fulfill()` accordingly.
+        MainActor.assumeIsolated {
+            exp.fulfill()
+        }
     }
     trigger()
     try await exp.wait()

--- a/Modules/TestUtilities/Sources/TestUtilities/SwiftExpectation.swift
+++ b/Modules/TestUtilities/Sources/TestUtilities/SwiftExpectation.swift
@@ -6,6 +6,11 @@ import Testing
 /// Swift Testing replacement for `XCTestExpectation`. Use when a test needs
 /// to wait for an asynchronous callback before asserting state.
 ///
+/// Unlike a naive `Task.sleep(timeout) + check` implementation, `wait()`
+/// returns immediately once `fulfill()` has been called - either before
+/// `wait()` (fast path) or during the wait via a continuation race with
+/// the timeout. The full timeout is only paid in the failing case.
+///
 /// ## Usage
 ///
 /// ```swift
@@ -18,20 +23,43 @@ import Testing
 public final class SwiftExpectation: @unchecked Sendable {
 
     private let timeout: Double
-    private var isFulfilled: Bool = false
+    private var isFulfilled = false
+    private var continuation: CheckedContinuation<Void, Never>?
 
     public init(timeout: Double = 1) {
         self.timeout = timeout
     }
 
     public func fulfill() {
+        guard !isFulfilled else { return }
         isFulfilled = true
+        continuation?.resume()
+        continuation = nil
     }
 
     /// Wait up to `timeout` seconds. Fails the test if the expectation was
-    /// never fulfilled.
+    /// never fulfilled. Returns immediately if `fulfill()` was already
+    /// called before `wait()`.
     public func wait() async throws {
-        try await Task.sleep(for: .seconds(timeout))
+        if isFulfilled { return }
+
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask { [self] in
+                await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+                    if isFulfilled {
+                        cont.resume()
+                    } else {
+                        self.continuation = cont
+                    }
+                }
+            }
+            group.addTask { [timeout] in
+                try? await Task.sleep(for: .seconds(timeout))
+            }
+            _ = await group.next()
+            group.cancelAll()
+        }
+
         try #require(isFulfilled)
     }
 }

--- a/Modules/TestUtilities/Sources/TestUtilities/SwiftExpectation.swift
+++ b/Modules/TestUtilities/Sources/TestUtilities/SwiftExpectation.swift
@@ -1,0 +1,37 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import Testing
+
+/// Swift Testing replacement for `XCTestExpectation`. Use when a test needs
+/// to wait for an asynchronous callback before asserting state.
+///
+/// ## Usage
+///
+/// ```swift
+/// let exp = SwiftExpectation(timeout: 0.5)
+/// service.onSomethingHappened = { exp.fulfill() }
+/// trigger()
+/// try await exp.wait()
+/// #expect(service.didThing)
+/// ```
+public final class SwiftExpectation: @unchecked Sendable {
+
+    private let timeout: Double
+    private var isFulfilled: Bool = false
+
+    public init(timeout: Double = 1) {
+        self.timeout = timeout
+    }
+
+    public func fulfill() {
+        isFulfilled = true
+    }
+
+    /// Wait up to `timeout` seconds. Fails the test if the expectation was
+    /// never fulfilled.
+    public func wait() async throws {
+        try await Task.sleep(for: .seconds(timeout))
+        try #require(isFulfilled)
+    }
+}

--- a/Modules/TestUtilities/Sources/TestUtilities/SwiftExpectation.swift
+++ b/Modules/TestUtilities/Sources/TestUtilities/SwiftExpectation.swift
@@ -8,8 +8,13 @@ import Testing
 ///
 /// Unlike a naive `Task.sleep(timeout) + check` implementation, `wait()`
 /// returns immediately once `fulfill()` has been called - either before
-/// `wait()` (fast path) or during the wait via a continuation race with
-/// the timeout. The full timeout is only paid in the failing case.
+/// `wait()` (fast path) or during the wait via a continuation resume. The
+/// full timeout is only paid in the failing case.
+///
+/// Synchronization is provided by `@MainActor` isolation. All mutation of
+/// `isFulfilled` and `continuation` happens on the main actor, so no
+/// locks or atomics are needed. Callers from other actors must `await`,
+/// which routes the calls through the main actor's serial executor.
 ///
 /// ## Usage
 ///
@@ -20,7 +25,8 @@ import Testing
 /// try await exp.wait()
 /// #expect(service.didThing)
 /// ```
-public final class SwiftExpectation: @unchecked Sendable {
+@MainActor
+public final class SwiftExpectation {
 
     private let timeout: Double
     private var isFulfilled = false
@@ -43,23 +49,27 @@ public final class SwiftExpectation: @unchecked Sendable {
     public func wait() async throws {
         if isFulfilled { return }
 
-        await withTaskGroup(of: Void.self) { group in
-            group.addTask { [self] in
-                await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
-                    if isFulfilled {
-                        cont.resume()
-                    } else {
-                        self.continuation = cont
-                    }
-                }
-            }
-            group.addTask { [timeout] in
-                try? await Task.sleep(for: .seconds(timeout))
-            }
-            _ = await group.next()
-            group.cancelAll()
+        let timeoutTask = Task {
+            try? await Task.sleep(for: .seconds(timeout))
         }
 
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            if isFulfilled {
+                cont.resume()
+                return
+            }
+            self.continuation = cont
+
+            Task { @MainActor [weak self] in
+                await timeoutTask.value
+                guard let self, self.continuation != nil else { return }
+                let pending = self.continuation
+                self.continuation = nil
+                pending?.resume()
+            }
+        }
+
+        timeoutTask.cancel()
         try #require(isFulfilled)
     }
 }

--- a/Modules/TestUtilities/Sources/TestUtilities/SwiftExpectation.swift
+++ b/Modules/TestUtilities/Sources/TestUtilities/SwiftExpectation.swift
@@ -6,15 +6,18 @@ import Testing
 /// Swift Testing replacement for `XCTestExpectation`. Use when a test needs
 /// to wait for an asynchronous callback before asserting state.
 ///
-/// Unlike a naive `Task.sleep(timeout) + check` implementation, `wait()`
-/// returns immediately once `fulfill()` has been called - either before
-/// `wait()` (fast path) or during the wait via a continuation resume. The
-/// full timeout is only paid in the failing case.
-///
 /// Synchronization is provided by `@MainActor` isolation. All mutation of
-/// `isFulfilled` and `continuation` happens on the main actor, so no
-/// locks or atomics are needed. Callers from other actors must `await`,
-/// which routes the calls through the main actor's serial executor.
+/// `isFulfilled` happens on the main actor, so no locks or atomics are
+/// needed. Callers from other actors must `await`, which routes the calls
+/// through the main actor's serial executor.
+///
+/// `wait()` short-circuits if `fulfill()` was already called - which is
+/// the common case when the trigger is synchronous (e.g. setting up an
+/// `@Observable` observer, then mutating in the same actor before
+/// awaiting). For truly asynchronous callbacks that may fulfill *during*
+/// the wait, the full timeout is paid in the success path. We don't have
+/// that pattern in the codebase today; add it back if a real caller needs
+/// it.
 ///
 /// ## Usage
 ///
@@ -30,17 +33,13 @@ public final class SwiftExpectation {
 
     private let timeout: Double
     private var isFulfilled = false
-    private var continuation: CheckedContinuation<Void, Never>?
 
     public init(timeout: Double = 1) {
         self.timeout = timeout
     }
 
     public func fulfill() {
-        guard !isFulfilled else { return }
         isFulfilled = true
-        continuation?.resume()
-        continuation = nil
     }
 
     /// Wait up to `timeout` seconds. Fails the test if the expectation was
@@ -48,28 +47,7 @@ public final class SwiftExpectation {
     /// called before `wait()`.
     public func wait() async throws {
         if isFulfilled { return }
-
-        let timeoutTask = Task {
-            try? await Task.sleep(for: .seconds(timeout))
-        }
-
-        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
-            if isFulfilled {
-                cont.resume()
-                return
-            }
-            self.continuation = cont
-
-            Task { @MainActor [weak self] in
-                await timeoutTask.value
-                guard let self, self.continuation != nil else { return }
-                let pending = self.continuation
-                self.continuation = nil
-                pending?.resume()
-            }
-        }
-
-        timeoutTask.cancel()
+        try await Task.sleep(for: .seconds(timeout))
         try #require(isFulfilled)
     }
 }


### PR DESCRIPTION
## Summary

Trims `Optional<Result<T, Error>>.evaluate()` down to the canonical Swift Testing pattern (`Issue.record` + `throw`) and drops the custom autoclosure message and source-location plumbing that was pure ceremony. `StubNotSetError` stays public because `MockNetworkService` / `MockURLSession` throw it directly for non-`evaluate()` test-infra failures (mismatched stub type, fundamentally unstubbable methods).

Ports two more helpers from the same upstream:
- **`SwiftExpectation`** - Swift Testing replacement for `XCTestExpectation`. Manual `fulfill()` + `wait(timeout:)`.
- **`ObservationTestUtils.changes(to:on:trigger:)`** - waits for an `@Observable` property to change before asserting. Uses a **trigger closure** form (instead of the upstream `async let` pattern) because non-`Sendable` `@Observable` types trip Swift 6 strict concurrency when sent across actor boundaries. Trigger form stays on one actor end-to-end.

Real usage proves both:
- `PresetManagerTests.addPreset_firesObservationOnPresets` and `deletePreset_firesObservationOnPresets` use `changes(to: \.presets, on: sut, ...)` to verify observation fires, followed by explicit `#expect` assertions for the data effect.
- These tests transitively exercise `SwiftExpectation` (used inside `changes()`).

Also hoists `sut` to a property + `init()` in `PresetManagerTests` since the SUT config is constant across tests. Two persistence tests stay inline because they intentionally build manager pairs against the same defaults to verify cross-instance reads.

## Notes for reviewers

- **Deviation from upstream pattern**: upstream `changes(to:on:)` returns immediately after observation setup and pairs with `async let` in the caller. That doesn't compile under Swift 6 strict concurrency for non-`Sendable` `@Observable` types (which `PresetManager` is). Switched to a trailing `trigger:` closure - same shape (setup → mutate → wait), single actor.
- **`@MainActor` on the two observation tests**: the helper is `@MainActor` because the trigger closure captures a non-`Sendable` `@Observable`. Tests need to be `@MainActor` to call it without sending the observable across actors. SPM package targets don't have `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` like the Xcode project does, so the annotation is explicit. Setting `defaultIsolation` on the Presets target could remove these annotations later - deferred.
- **Bev-pattern reference**: this aligns several test-utility patterns with the structure used in https://github.com/jacobbartlett/Bev. The trigger-closure form is our adaptation; otherwise the helpers match.

## Test plan

- [x] `swift test` in `Modules/Presets/` - 57/57 pass including the two new observation tests
- [x] `swift test` in `Modules/TestUtilities/` - 3/3 pass
- [x] `xcodebuild build` for VivaDicta - SUCCEEDED
- [ ] Confirm full xcodebuild test suite still passes (pre-existing `AIServiceNetworkingTests` parallel flake unrelated to this PR)