### PR TITLE
Hoist sut in mock tests + UI-TESTING launch arg setup

### DIFF
--- a/Modules/AudioRecording/Tests/AudioRecordingTests/AudioRecordingTests.swift
+++ b/Modules/AudioRecording/Tests/AudioRecordingTests/AudioRecordingTests.swift
@@ -8,8 +8,9 @@ import AudioRecordingMocks
 
 struct DefaultAudioFileServiceTests {
 
+    let sut = DefaultAudioFileService()
+
     @Test func move_transfersFileToDestination() throws {
-        let sut = DefaultAudioFileService()
         let source = try makeTempFile(contents: Data([1, 2, 3]))
         let destination = uniqueTempURL()
 
@@ -21,8 +22,7 @@ struct DefaultAudioFileServiceTests {
     }
 
     @Test func move_throwsWhenSourceMissing() {
-        let sut = DefaultAudioFileService()
-        let missingSource = uniqueTempURL()
+let missingSource = uniqueTempURL()
         let destination = uniqueTempURL()
 
         #expect(throws: (any Error).self) {
@@ -31,8 +31,7 @@ struct DefaultAudioFileServiceTests {
     }
 
     @Test func remove_deletesFile() throws {
-        let sut = DefaultAudioFileService()
-        let url = try makeTempFile(contents: Data([0xff]))
+let url = try makeTempFile(contents: Data([0xff]))
 
         try sut.remove(at: url)
 
@@ -40,8 +39,7 @@ struct DefaultAudioFileServiceTests {
     }
 
     @Test func remove_throwsWhenFileMissing() {
-        let sut = DefaultAudioFileService()
-        let missing = uniqueTempURL()
+let missing = uniqueTempURL()
 
         #expect(throws: (any Error).self) {
             try sut.remove(at: missing)
@@ -49,8 +47,7 @@ struct DefaultAudioFileServiceTests {
     }
 
     @Test func fileSize_returnsBytesOnDisk() throws {
-        let sut = DefaultAudioFileService()
-        let payload = Data(repeating: 0xab, count: 512)
+let payload = Data(repeating: 0xab, count: 512)
         let url = try makeTempFile(contents: payload)
         defer { try? FileManager.default.removeItem(at: url) }
 
@@ -60,8 +57,7 @@ struct DefaultAudioFileServiceTests {
     }
 
     @Test func duration_returnsSecondsOfGeneratedWav() async throws {
-        let sut = DefaultAudioFileService()
-        let source = try makeSineWaveFile(sampleRate: 44_100, durationSeconds: 0.5)
+let source = try makeSineWaveFile(sampleRate: 44_100, durationSeconds: 0.5)
         defer { try? FileManager.default.removeItem(at: source) }
 
         let duration = try await sut.duration(of: source)
@@ -71,8 +67,7 @@ struct DefaultAudioFileServiceTests {
     }
 
     @Test func downsampleTo16kHzMono_producesValidShorterRateFile() async throws {
-        let sut = DefaultAudioFileService()
-        let source = try makeSineWaveFile(sampleRate: 44_100, durationSeconds: 0.5)
+let source = try makeSineWaveFile(sampleRate: 44_100, durationSeconds: 0.5)
         defer { try? FileManager.default.removeItem(at: source) }
         let destination = source.deletingPathExtension().appendingPathExtension("16k.wav")
         defer { try? FileManager.default.removeItem(at: destination) }

--- a/Modules/AudioRecording/Tests/AudioRecordingTests/AudioRecordingTests.swift
+++ b/Modules/AudioRecording/Tests/AudioRecordingTests/AudioRecordingTests.swift
@@ -22,7 +22,7 @@ struct DefaultAudioFileServiceTests {
     }
 
     @Test func move_throwsWhenSourceMissing() {
-let missingSource = uniqueTempURL()
+        let missingSource = uniqueTempURL()
         let destination = uniqueTempURL()
 
         #expect(throws: (any Error).self) {
@@ -31,7 +31,7 @@ let missingSource = uniqueTempURL()
     }
 
     @Test func remove_deletesFile() throws {
-let url = try makeTempFile(contents: Data([0xff]))
+        let url = try makeTempFile(contents: Data([0xff]))
 
         try sut.remove(at: url)
 
@@ -39,7 +39,7 @@ let url = try makeTempFile(contents: Data([0xff]))
     }
 
     @Test func remove_throwsWhenFileMissing() {
-let missing = uniqueTempURL()
+        let missing = uniqueTempURL()
 
         #expect(throws: (any Error).self) {
             try sut.remove(at: missing)
@@ -47,7 +47,7 @@ let missing = uniqueTempURL()
     }
 
     @Test func fileSize_returnsBytesOnDisk() throws {
-let payload = Data(repeating: 0xab, count: 512)
+        let payload = Data(repeating: 0xab, count: 512)
         let url = try makeTempFile(contents: payload)
         defer { try? FileManager.default.removeItem(at: url) }
 
@@ -57,7 +57,7 @@ let payload = Data(repeating: 0xab, count: 512)
     }
 
     @Test func duration_returnsSecondsOfGeneratedWav() async throws {
-let source = try makeSineWaveFile(sampleRate: 44_100, durationSeconds: 0.5)
+        let source = try makeSineWaveFile(sampleRate: 44_100, durationSeconds: 0.5)
         defer { try? FileManager.default.removeItem(at: source) }
 
         let duration = try await sut.duration(of: source)
@@ -67,7 +67,7 @@ let source = try makeSineWaveFile(sampleRate: 44_100, durationSeconds: 0.5)
     }
 
     @Test func downsampleTo16kHzMono_producesValidShorterRateFile() async throws {
-let source = try makeSineWaveFile(sampleRate: 44_100, durationSeconds: 0.5)
+        let source = try makeSineWaveFile(sampleRate: 44_100, durationSeconds: 0.5)
         defer { try? FileManager.default.removeItem(at: source) }
         let destination = source.deletingPathExtension().appendingPathExtension("16k.wav")
         defer { try? FileManager.default.removeItem(at: destination) }

--- a/Modules/Keychain/Tests/KeychainTests/MockKeychainServiceTests.swift
+++ b/Modules/Keychain/Tests/KeychainTests/MockKeychainServiceTests.swift
@@ -13,35 +13,36 @@ import KeychainMocks
 @Suite("MockKeychainService contract")
 struct MockKeychainServiceTests {
 
+    var sut: MockKeychainService
+
+    init() {
+        self.sut = MockKeychainService()
+    }
+
     @Test func inMemoryRoundtripForStrings() {
-        let sut = MockKeychainService()
         #expect(sut.save("hello", forKey: "k", syncable: true))
         #expect(sut.getString(forKey: "k", syncable: true) == "hello")
     }
 
     @Test func inMemoryRoundtripForData() {
-        let sut = MockKeychainService()
         let bytes = Data([0x01, 0x02, 0x03])
         #expect(sut.save(data: bytes, forKey: "k", syncable: true))
         #expect(sut.getData(forKey: "k", syncable: true) == bytes)
     }
 
     @Test func stubOverrideForcesSaveFailure() {
-        let sut = MockKeychainService()
         sut.stubSaveStringResult = false
         #expect(!sut.save("hello", forKey: "k", syncable: true))
         #expect(sut.getString(forKey: "k", syncable: true) == nil)
     }
 
     @Test func deleteRemovesFromBackingStore() {
-        let sut = MockKeychainService()
         sut.save("temp", forKey: "k", syncable: true)
         #expect(sut.delete(forKey: "k", syncable: true))
         #expect(sut.getString(forKey: "k", syncable: true) == nil)
     }
 
     @Test func callCountsIncrement() {
-        let sut = MockKeychainService()
         sut.save("a", forKey: "x", syncable: true)
         sut.save("b", forKey: "y", syncable: true)
         _ = sut.getString(forKey: "x", syncable: true)
@@ -52,7 +53,6 @@ struct MockKeychainServiceTests {
     }
 
     @Test func didSaveStringFiresAfterMutation() {
-        let sut = MockKeychainService()
         var observed: String?
         sut.didSaveString = {
             observed = sut.getString(forKey: "k", syncable: true)

--- a/Modules/Networking/Tests/NetworkingTests/MockNetworkServiceTests.swift
+++ b/Modules/Networking/Tests/NetworkingTests/MockNetworkServiceTests.swift
@@ -9,6 +9,12 @@ import TestUtilities
 @Suite("MockNetworkService contract")
 struct MockNetworkServiceTests {
 
+    var sut: MockNetworkService
+
+    init() {
+        self.sut = MockNetworkService()
+    }
+
     private let endpoint = URL(string: "https://example.com/api")!
 
     private func makeResponse(_ code: Int) -> HTTPURLResponse {
@@ -21,7 +27,6 @@ struct MockNetworkServiceTests {
     }
 
     @Test func sendReturnsStubbedResponse() async throws {
-        let sut = MockNetworkService()
         let body = Data("ok".utf8)
         sut.stubSendResponse = .success((body, makeResponse(200)))
 
@@ -33,7 +38,6 @@ struct MockNetworkServiceTests {
     }
 
     @Test func sendCapturesRequestAndStatusCodeOverride() async throws {
-        let sut = MockNetworkService()
         sut.stubSendResponse = .success((Data(), makeResponse(200)))
 
         var request = URLRequest(url: endpoint)
@@ -49,7 +53,6 @@ struct MockNetworkServiceTests {
 
     @Test func sendPropagatesStubbedError() async {
         struct Boom: Error {}
-        let sut = MockNetworkService()
         sut.stubSendResponse = .failure(Boom())
 
         await #expect(throws: Boom.self) {
@@ -62,7 +65,6 @@ struct MockNetworkServiceTests {
     }
 
     @Test func sendJSONReturnsTypedStub() async throws {
-        let sut = MockNetworkService()
         sut.stubSendJSONResponse = .success(Echo(value: "hi"))
 
         let result: Echo = try await sut.sendJSON(URLRequest(url: endpoint))
@@ -72,7 +74,6 @@ struct MockNetworkServiceTests {
     }
 
     @Test func sendJSONWithMismatchedStubThrowsStubNotSetError() async {
-        let sut = MockNetworkService()
         sut.stubSendJSONResponse = .success("string instead of Echo")
 
         await #expect(throws: StubNotSetError.self) {
@@ -81,7 +82,6 @@ struct MockNetworkServiceTests {
     }
 
     @Test func uploadCapturesBody() async throws {
-        let sut = MockNetworkService()
         sut.stubUploadResponse = .success((Data(), makeResponse(200)))
 
         let body = Data("payload".utf8)
@@ -93,7 +93,6 @@ struct MockNetworkServiceTests {
 
     @Test func unsetSendStubRecordsIssue() async {
         await withKnownIssue {
-            let sut = MockNetworkService()
             await #expect(throws: StubNotSetError.self) {
                 _ = try await sut.send(URLRequest(url: endpoint))
             }
@@ -101,8 +100,6 @@ struct MockNetworkServiceTests {
     }
 
     @Test func bytesAlwaysThrowsStubNotSetError() async {
-        let sut = MockNetworkService()
-
         await #expect(throws: StubNotSetError.self) {
             _ = try await sut.bytes(for: URLRequest(url: endpoint))
         }

--- a/Modules/Networking/Tests/NetworkingTests/MockURLSessionTests.swift
+++ b/Modules/Networking/Tests/NetworkingTests/MockURLSessionTests.swift
@@ -9,6 +9,12 @@ import TestUtilities
 @Suite("MockURLSession contract")
 struct MockURLSessionTests {
 
+    var sut: MockURLSession
+
+    init() {
+        self.sut = MockURLSession()
+    }
+
     private func makeResponse(_ code: Int) -> HTTPURLResponse {
         HTTPURLResponse(
             url: URL(string: "https://example.com")!,
@@ -19,7 +25,6 @@ struct MockURLSessionTests {
     }
 
     @Test func returnsStubbedSuccessResponse() async throws {
-        let sut = MockURLSession()
         sut.stubUploadResponse = .success((Data("ok".utf8), makeResponse(200)))
 
         let request = URLRequest(url: URL(string: "https://example.com/x")!)
@@ -31,7 +36,6 @@ struct MockURLSessionTests {
 
     @Test func propagatesStubbedError() async {
         struct Boom: Error {}
-        let sut = MockURLSession()
         sut.stubUploadResponse = .failure(Boom())
 
         await #expect(throws: Boom.self) {
@@ -43,7 +47,6 @@ struct MockURLSessionTests {
     }
 
     @Test func capturesRequestAndBody() async throws {
-        let sut = MockURLSession()
         sut.stubUploadResponse = .success((Data(), makeResponse(200)))
 
         var request = URLRequest(url: URL(string: "https://example.com/api")!)
@@ -62,7 +65,6 @@ struct MockURLSessionTests {
 
     @Test func unsetStubRecordsIssue() async {
         await withKnownIssue {
-            let sut = MockURLSession()
             await #expect(throws: StubNotSetError.self) {
                 _ = try await sut.upload(
                     for: URLRequest(url: URL(string: "https://example.com")!),
@@ -73,7 +75,6 @@ struct MockURLSessionTests {
     }
 
     @Test func didUploadCallbackFiresAfterCall() async throws {
-        let sut = MockURLSession()
         sut.stubUploadResponse = .success((Data(), makeResponse(200)))
 
         var fired = false

--- a/Modules/OAuth/Tests/OAuthTests/OAuthTests.swift
+++ b/Modules/OAuth/Tests/OAuthTests/OAuthTests.swift
@@ -10,9 +10,17 @@ import TestUtilities
 @MainActor
 struct OAuthManagerTests {
 
+    var keychain: MockKeychainService
+    var provider: MockOAuthProvider
+    var sut: DefaultOAuthManager
+
+    init() {
+        self.keychain = MockKeychainService()
+        self.provider = MockOAuthProvider(keychainKey: "test.oauth.credential")
+        self.sut = DefaultOAuthManager(keychain: keychain)
+    }
+
     @Test func signOutDeletesCredentialFromKeychain() throws {
-        let keychain = MockKeychainService()
-        let provider = MockOAuthProvider(keychainKey: "test.oauth.credential")
         let credential = OAuthCredential(
             accessToken: "access",
             refreshToken: "refresh",
@@ -24,7 +32,6 @@ struct OAuthManagerTests {
         let encoded = try JSONEncoder().encode(credential)
         keychain.save(data: encoded, forKey: provider.keychainKey, syncable: false)
 
-        let sut = DefaultOAuthManager(keychain: keychain)
         #expect(sut.isSignedIn(provider: provider))
 
         sut.signOut(provider: provider)
@@ -35,16 +42,10 @@ struct OAuthManagerTests {
     }
 
     @Test func isSignedInReturnsFalseWhenKeychainEmpty() {
-        let keychain = MockKeychainService()
-        let provider = MockOAuthProvider(keychainKey: "test.oauth.credential")
-        let sut = DefaultOAuthManager(keychain: keychain)
-
         #expect(!sut.isSignedIn(provider: provider))
     }
 
     @Test func accountEmailReturnsStoredEmail() throws {
-        let keychain = MockKeychainService()
-        let provider = MockOAuthProvider(keychainKey: "test.oauth.credential")
         let credential = OAuthCredential(
             accessToken: "access",
             refreshToken: "refresh",
@@ -56,13 +57,15 @@ struct OAuthManagerTests {
         let encoded = try JSONEncoder().encode(credential)
         keychain.save(data: encoded, forKey: provider.keychainKey, syncable: false)
 
-        let sut = DefaultOAuthManager(keychain: keychain)
         #expect(sut.accountEmail(for: provider) == "user@example.com")
     }
 }
 
 @MainActor
 struct CopilotOAuthManagerTests {
+
+    // SUT config varies per test (one passes a real bgTask, one passes nil),
+    // so each test constructs its own DefaultCopilotOAuthManager.
 
     @Test func signOutDeletesCredential() throws {
         let keychain = MockKeychainService()
@@ -96,12 +99,17 @@ struct CopilotOAuthManagerTests {
 
 struct MockOAuthProviderTests {
 
+    var sut: MockOAuthProvider
+
+    init() {
+        self.sut = MockOAuthProvider()
+    }
+
     @Test func postAuthSetupThrowsWhenStubMissing() async {
         // evaluate() records a Swift Testing Issue when the stub is nil -
         // that's the contract that surfaces forgotten stubs in real tests.
         // Acknowledge it via withKnownIssue while still asserting the throw.
         await withKnownIssue {
-            let sut = MockOAuthProvider()
             await #expect(throws: StubNotSetError.self) {
                 _ = try await sut.postAuthSetup(accessToken: "token")
             }
@@ -109,7 +117,6 @@ struct MockOAuthProviderTests {
     }
 
     @Test func postAuthSetupReturnsStubbedValue() async throws {
-        let sut = MockOAuthProvider()
         sut.stubPostAuthSetupResponse = .success("project-id-42")
         let result = try await sut.postAuthSetup(accessToken: "token")
         #expect(result == "project-id-42")
@@ -119,7 +126,6 @@ struct MockOAuthProviderTests {
 
     @Test func postAuthSetupPropagatesStubbedError() async {
         struct Boom: Error {}
-        let sut = MockOAuthProvider()
         sut.stubPostAuthSetupResponse = .failure(Boom())
         await #expect(throws: Boom.self) {
             _ = try await sut.postAuthSetup(accessToken: "x")
@@ -130,8 +136,13 @@ struct MockOAuthProviderTests {
 @MainActor
 struct MockBackgroundTaskServiceTests {
 
+    var sut: MockBackgroundTaskService
+
+    init() {
+        self.sut = MockBackgroundTaskService()
+    }
+
     @Test func beginReturnsIncrementingIdentifiers() {
-        let sut = MockBackgroundTaskService()
         let id1 = sut.beginBackgroundTask(name: "first", onExpiration: {})
         let id2 = sut.beginBackgroundTask(name: "second", onExpiration: {})
         #expect(id1 == 1)
@@ -141,14 +152,12 @@ struct MockBackgroundTaskServiceTests {
     }
 
     @Test func stubBeginResultOverridesIdentifier() {
-        let sut = MockBackgroundTaskService()
         sut.stubBeginResult = .some(nil)
         let id = sut.beginBackgroundTask(name: "name", onExpiration: {})
         #expect(id == nil)
     }
 
     @Test func endRecordsIdentifier() {
-        let sut = MockBackgroundTaskService()
         _ = sut.beginBackgroundTask(name: "name", onExpiration: {})
         sut.endBackgroundTask(1)
         #expect(sut.endCallCount == 1)

--- a/VivaDicta/VivaDictaApp.swift
+++ b/VivaDicta/VivaDictaApp.swift
@@ -33,6 +33,15 @@ struct VivaDictaApp: App {
     private let logger = Logger(category: .app)
 
     init() {
+        #if DEBUG || QA
+        if ProcessInfo.processInfo.arguments.contains("UI-TESTING") {
+            UIView.setAnimationsEnabled(false)
+            UserDefaults.standard.removePersistentDomain(forName: Bundle.main.bundleIdentifier!)
+            UserDefaults(suiteName: AppGroupCoordinator.shared.appGroupId)?
+                .removePersistentDomain(forName: AppGroupCoordinator.shared.appGroupId)
+        }
+        #endif
+        
         // Track app launch count for analytics and feature gating
         AppLaunchTracker.recordLaunch()
 

--- a/VivaDicta/VivaDictaApp.swift
+++ b/VivaDicta/VivaDictaApp.swift
@@ -36,9 +36,16 @@ struct VivaDictaApp: App {
         #if DEBUG || QA
         if ProcessInfo.processInfo.arguments.contains("UI-TESTING") {
             UIView.setAnimationsEnabled(false)
-            UserDefaults.standard.removePersistentDomain(forName: Bundle.main.bundleIdentifier!)
-            UserDefaults(suiteName: AppGroupCoordinator.shared.appGroupId)?
-                .removePersistentDomain(forName: AppGroupCoordinator.shared.appGroupId)
+            if let bundleId = Bundle.main.bundleIdentifier {
+                UserDefaults.standard.removePersistentDomain(forName: bundleId)
+            }
+            // Inline the App Group ID so this wipe runs before any
+            // AppGroupCoordinator.shared access, which would trigger the
+            // singleton's init (registering observers, etc.) before state
+            // is cleared.
+            let appGroupId = "group.com.antonnovoselov.VivaDicta"
+            UserDefaults(suiteName: appGroupId)?
+                .removePersistentDomain(forName: appGroupId)
         }
         #endif
         

--- a/VivaDictaUITests/VivaDictaUITests.swift
+++ b/VivaDictaUITests/VivaDictaUITests.swift
@@ -22,7 +22,7 @@ final class VivaDictaUITests: XCTestCase {
     @MainActor
     func testLaunchPerformance() throws {
         measure(metrics: [XCTApplicationLaunchMetric()]) {
-            XCUIApplication().launch()
+            app.launch()
         }
     }
 }

--- a/VivaDictaUITests/VivaDictaUITests.swift
+++ b/VivaDictaUITests/VivaDictaUITests.swift
@@ -8,36 +8,35 @@
 import XCTest
 
 final class VivaDictaUITests: XCTestCase {
+    
+    var app: XCUIApplication!
 
     override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-
-        // In UI tests it is usually best to stop immediately when a failure occurs.
         continueAfterFailure = false
 
-        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
-    }
-
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
-    @MainActor
-    func testExample() throws {
-        // UI tests must launch the application that they test.
-        let app = XCUIApplication()
+        app = XCUIApplication()
+        app.launchArguments = ["UI-TESTING"]
         app.launch()
-
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // XCUIAutomation Documentation
-        // https://developer.apple.com/documentation/xcuiautomation
     }
-
+    
     @MainActor
     func testLaunchPerformance() throws {
-        // This measures how long it takes to launch your application.
         measure(metrics: [XCTApplicationLaunchMetric()]) {
             XCUIApplication().launch()
         }
+    }
+}
+
+
+
+extension XCUIElement {
+    func clear() {
+        guard let stringValue = self.value as? String else {
+            XCTFail("Failed to clear text in XCUIElement")
+            return
+        }
+
+        let deleteString = String(repeating: XCUIKeyboardKey.delete.rawValue, count: stringValue.count)
+        typeText(deleteString)
     }
 }


### PR DESCRIPTION
## Summary

Two related test-infrastructure changes:

### 1. Hoist `sut` to property + init in mock contract tests

Apply the per-test-instance property pattern to mock contract test files where every test constructs the same SUT with no varying config:

- `MockKeychainServiceTests` (6 tests)
- `MockNetworkServiceTests` (8 tests)
- `MockURLSessionTests` (5 tests)
- `DefaultAudioFileServiceTests` (7 tests)
- `OAuthManagerTests` + `MockOAuthProviderTests` + `MockBackgroundTaskServiceTests` (9 tests across 3 structs)

Swift Testing creates a fresh struct per `@Test`, so the `init()` runs per test - no shared state.

**Skipped** files where the SUT varies per test (`CopilotOAuthManagerTests`) or where multiple SUT types share a struct (`MockOAuthManagerLifecycleTests`, `DefaultAudioRecordingServiceTests`). Pure-function tests (no SUT) were also skipped.

### 2. UI-TESTING launch argument setup

Adds an early-init block in `VivaDictaApp` gated by `#if DEBUG || QA` and the `UI-TESTING` launch argument. When set by `XCUIApplication.launchArguments`, the block:

- Disables UIView animations via `setAnimationsEnabled(false)` for faster, more deterministic UI tests
- Wipes `UserDefaults.standard` (main app domain) so each UI test run starts from a clean state
- Wipes the App Group UserDefaults (`group.com.antonnovoselov.VivaDicta`) too, so any keyboard-side state from a prior run can't leak

Updates the UITests scaffold to pass `UI-TESTING` via `launchArguments` and refactors `setUp` to use a stored `app` property.

## Notes

- The hoist sweep was deliberately scoped to mock contract tests (single SUT type, no varying config) and not extended to the main app's `VivaDictaTests` suite. CLAUDE.md cautions against sweeping refactors, and the per-file evaluation showed many `VivaDictaTests` files have varying-per-test config that would be harmed by forcing the hoist pattern.
- `setAnimationsEnabled(false)` only disables UIKit animations, not SwiftUI `.animation(...)` modifiers. If SwiftUI animations cause UI-test flakes later, those would need separate handling.

## Test plan

- [x] `swift test` in each touched module - all pass
- [x] `xcodebuild build` for VivaDicta - SUCCEEDED
- [ ] Verify a real UI test launches with the wiped UserDefaults state