### PR TITLE
Clean up Swift Testing macro usage and fix UserDefaults suite race

### DIFF
--- a/Modules/AudioRecording/Tests/AudioRecordingTests/AudioRecordingTests.swift
+++ b/Modules/AudioRecording/Tests/AudioRecordingTests/AudioRecordingTests.swift
@@ -16,7 +16,7 @@ struct DefaultAudioFileServiceTests {
 
         try sut.move(from: source, to: destination)
 
-        #expect(!FileManager.default.fileExists(atPath: source.path))
+        #expect(FileManager.default.fileExists(atPath: source.path) == false)
         #expect(FileManager.default.fileExists(atPath: destination.path))
         try FileManager.default.removeItem(at: destination)
     }
@@ -35,7 +35,7 @@ struct DefaultAudioFileServiceTests {
 
         try sut.remove(at: url)
 
-        #expect(!FileManager.default.fileExists(atPath: url.path))
+        #expect(FileManager.default.fileExists(atPath: url.path) == false)
     }
 
     @Test func remove_throwsWhenFileMissing() {

--- a/Modules/CloudTranscription/Tests/CloudTranscriptionTests/GroqTranscriptionServiceTests.swift
+++ b/Modules/CloudTranscription/Tests/CloudTranscriptionTests/GroqTranscriptionServiceTests.swift
@@ -150,7 +150,7 @@ struct GroqTranscriptionServiceTests {
 
         let body = try #require(networkService.capturedBody)
         let bodyString = try #require(String(data: body, encoding: .utf8))
-        #expect(!bodyString.contains("name=\"language\""))
+        #expect(bodyString.contains("name=\"language\"") == false)
     }
 
     // MARK: - Vocabulary / prompt (Groq-specific)
@@ -165,7 +165,7 @@ struct GroqTranscriptionServiceTests {
 
         let body = try #require(networkService.capturedBody)
         let bodyString = try #require(String(data: body, encoding: .utf8))
-        #expect(!bodyString.contains("name=\"prompt\""))
+        #expect(bodyString.contains("name=\"prompt\"") == false)
     }
 
     @Test func bodyIncludesPromptFieldWhenVocabularyProvided() async throws {

--- a/Modules/CloudTranscription/Tests/CloudTranscriptionTests/OpenAITranscriptionServiceTests.swift
+++ b/Modules/CloudTranscription/Tests/CloudTranscriptionTests/OpenAITranscriptionServiceTests.swift
@@ -152,7 +152,7 @@ struct OpenAITranscriptionServiceTests {
 
         let body = try #require(networkService.capturedBody)
         let bodyString = try #require(String(data: body, encoding: .utf8))
-        #expect(!bodyString.contains("name=\"language\""))
+        #expect(bodyString.contains("name=\"language\"") == false)
     }
 
     // MARK: - Validation / short-circuit

--- a/Modules/Keychain/Tests/KeychainTests/MockKeychainServiceTests.swift
+++ b/Modules/Keychain/Tests/KeychainTests/MockKeychainServiceTests.swift
@@ -32,7 +32,7 @@ struct MockKeychainServiceTests {
 
     @Test func stubOverrideForcesSaveFailure() {
         sut.stubSaveStringResult = false
-        #expect(!sut.save("hello", forKey: "k", syncable: true))
+        #expect(sut.save("hello", forKey: "k", syncable: true) == false)
         #expect(sut.getString(forKey: "k", syncable: true) == nil)
     }
 

--- a/Modules/OAuth/Tests/OAuthTests/MockOAuthManagerTests.swift
+++ b/Modules/OAuth/Tests/OAuthTests/MockOAuthManagerTests.swift
@@ -42,7 +42,7 @@ struct MockOAuthManagerLifecycleTests {
 
         sut.signOut(provider: provider)
 
-        #expect(!sut.isSignedIn(provider: provider))
+        #expect(sut.isSignedIn(provider: provider) == false)
         #expect(sut.accountEmail(for: provider) == nil)
     }
 
@@ -69,7 +69,7 @@ struct MockOAuthManagerLifecycleTests {
 
         sut.signOut()
 
-        #expect(!sut.isSignedIn)
+        #expect(sut.isSignedIn == false)
         #expect(sut.accountInfo == nil)
     }
 }

--- a/Modules/OAuth/Tests/OAuthTests/OAuthTests.swift
+++ b/Modules/OAuth/Tests/OAuthTests/OAuthTests.swift
@@ -36,13 +36,13 @@ struct OAuthManagerTests {
 
         sut.signOut(provider: provider)
 
-        #expect(!sut.isSignedIn(provider: provider))
+        #expect(sut.isSignedIn(provider: provider) == false)
         #expect(keychain.deleteCallCount >= 1)
         #expect(keychain.getData(forKey: provider.keychainKey, syncable: false) == nil)
     }
 
     @Test func isSignedInReturnsFalseWhenKeychainEmpty() {
-        #expect(!sut.isSignedIn(provider: provider))
+        #expect(sut.isSignedIn(provider: provider) == false)
     }
 
     @Test func accountEmailReturnsStoredEmail() throws {
@@ -85,7 +85,7 @@ struct CopilotOAuthManagerTests {
 
         sut.signOut()
 
-        #expect(!sut.isSignedIn)
+        #expect(sut.isSignedIn == false)
         #expect(keychain.deleteCallCount >= 1)
     }
 
@@ -93,7 +93,7 @@ struct CopilotOAuthManagerTests {
         let keychain = MockKeychainService()
         // Construction succeeds without a background task sut.
         let sut = DefaultCopilotOAuthManager(keychain: keychain, backgroundTaskService: nil)
-        #expect(!sut.isSignedIn)
+        #expect(sut.isSignedIn == false)
     }
 }
 

--- a/Modules/Presets/Tests/PresetsTests/PresetCatalogTests.swift
+++ b/Modules/Presets/Tests/PresetsTests/PresetCatalogTests.swift
@@ -22,19 +22,19 @@ struct PresetCatalogTests {
 
     @Test func allBuiltIn_haveNonEmptyNames() {
         for preset in PresetCatalog.allBuiltIn {
-            #expect(!preset.name.isEmpty, "Preset \(preset.id) has empty name")
+            #expect(preset.name.isEmpty == false, "Preset \(preset.id) has empty name")
         }
     }
 
     @Test func allBuiltIn_haveNonEmptyPromptInstructions() {
         for preset in PresetCatalog.allBuiltIn {
-            #expect(!preset.promptInstructions.isEmpty, "Preset \(preset.id) has empty instructions")
+            #expect(preset.promptInstructions.isEmpty == false, "Preset \(preset.id) has empty instructions")
         }
     }
 
     @Test func allBuiltIn_haveNonEmptyIcons() {
         for preset in PresetCatalog.allBuiltIn {
-            #expect(!preset.icon.isEmpty, "Preset \(preset.id) has empty icon")
+            #expect(preset.icon.isEmpty == false, "Preset \(preset.id) has empty icon")
         }
     }
 

--- a/Modules/Presets/Tests/PresetsTests/PresetManagerTests.swift
+++ b/Modules/Presets/Tests/PresetsTests/PresetManagerTests.swift
@@ -46,7 +46,7 @@ struct PresetManagerTests {
     // MARK: - Initialization Tests
 
     @Test func init_populatesBuiltInPresets() {
-        #expect(!sut.presets.isEmpty)
+        #expect(sut.presets.isEmpty == false)
         #expect(sut.presets.contains { $0.id == "regular" })
         #expect(sut.presets.contains { $0.id == "summary" })
         #expect(sut.presets.contains { $0.id == "assistant" })
@@ -74,14 +74,14 @@ struct PresetManagerTests {
     @Test func presetsInCategory_returnsFilteredPresets() {
         let rewritePresets = sut.presets(in: "Rewrite")
 
-        #expect(!rewritePresets.isEmpty)
+        #expect(rewritePresets.isEmpty == false)
         #expect(rewritePresets.allSatisfy { $0.category == "Rewrite" })
     }
 
     @Test func categories_returnsOrderedCategories() {
         let categories = sut.categories
 
-        #expect(!categories.isEmpty)
+        #expect(categories.isEmpty == false)
         // Rewrite should come before Translate based on categoryOrder
         if let rewriteIdx = categories.firstIndex(of: "Rewrite"),
            let translateIdx = categories.firstIndex(of: "Translate") {
@@ -186,7 +186,7 @@ struct PresetManagerTests {
 
         sut.setPresetHidden(presetId: "regular", isHidden: true)
 
-        #expect(!sut.visiblePresets.contains { $0.id == "regular" })
+        #expect(sut.visiblePresets.contains { $0.id == "regular" } == false)
         #expect(sut.isPresetHidden(presetId: "regular") == true)
     }
 
@@ -268,7 +268,7 @@ struct PresetManagerTests {
         )
 
         #expect(manager2.isPresetHidden(presetId: "regular") == true)
-        #expect(!manager2.visiblePresets.contains { $0.id == "regular" })
+        #expect(manager2.visiblePresets.contains { $0.id == "regular" } == false)
 
         defaults.removePersistentDomain(forName: suiteName)
     }

--- a/VivaDictaTests/AIServiceConfigurationTests.swift
+++ b/VivaDictaTests/AIServiceConfigurationTests.swift
@@ -323,7 +323,7 @@ struct AIServiceConfigurationTests {
 
         let anthropicModels = service.getAvailableModels(for: .anthropic)
 
-        #expect(!anthropicModels.isEmpty)
+        #expect(anthropicModels.isEmpty == false)
         #expect(anthropicModels.contains("claude-sonnet-4-6"))
     }
 

--- a/VivaDictaTests/AnthropicServiceTests.swift
+++ b/VivaDictaTests/AnthropicServiceTests.swift
@@ -197,7 +197,7 @@ struct AnthropicServiceTests {
 
         let valid = await sut.verifyAPIKey("sk-ant-bad")
 
-        #expect(!valid)
+        #expect(valid == false)
     }
 
     @Test func verifyAPIKeyReturnsFalseOnTransportError() async {
@@ -207,7 +207,7 @@ struct AnthropicServiceTests {
 
         let valid = await sut.verifyAPIKey("sk-ant-test")
 
-        #expect(!valid)
+        #expect(valid == false)
     }
 
     @Test func verifyAPIKeySendsCorrectHeadersAndBody() async throws {

--- a/VivaDictaTests/AudioCleanupServiceTests.swift
+++ b/VivaDictaTests/AudioCleanupServiceTests.swift
@@ -14,7 +14,7 @@ import SwiftData
 @MainActor
 struct AudioCleanupServiceTests {
 
-    private let testSuiteName = "AudioCleanupServiceTests"
+    private let testSuiteName = "AudioCleanupServiceTests.\(UUID().uuidString)"
 
     private func makeTestDefaults() -> UserDefaults {
         let defaults = UserDefaults(suiteName: testSuiteName)!
@@ -141,7 +141,7 @@ struct AudioCleanupServiceTests {
         await service.performCleanupIfNeeded(modelContext: context)
 
         // Verify: old file deleted, recent file kept
-        #expect(!FileManager.default.fileExists(atPath: audioDir.appendingPathComponent(oldFileName).path))
+        #expect(FileManager.default.fileExists(atPath: audioDir.appendingPathComponent(oldFileName).path) == false)
         #expect(FileManager.default.fileExists(atPath: audioDir.appendingPathComponent(recentFileName).path))
         #expect(oldTranscription.audioFileName == nil)
         #expect(recentTranscription.audioFileName == recentFileName)
@@ -179,7 +179,7 @@ struct AudioCleanupServiceTests {
         await service.performCleanupIfNeeded(modelContext: context)
 
         // Verify: file deleted
-        #expect(!FileManager.default.fileExists(atPath: audioDir.appendingPathComponent(fileName).path))
+        #expect(FileManager.default.fileExists(atPath: audioDir.appendingPathComponent(fileName).path) == false)
         #expect(transcription.audioFileName == nil)
 
         // Cleanup
@@ -411,7 +411,7 @@ struct AudioCleanupServiceTests {
         await service.performCleanupIfNeeded(modelContext: context)
 
         // Verify file deleted from disk
-        #expect(!FileManager.default.fileExists(atPath: filePath.path))
+        #expect(FileManager.default.fileExists(atPath: filePath.path) == false)
 
         // Cleanup
         try? FileManager.default.removeItem(at: audioDir)
@@ -488,7 +488,7 @@ struct AudioCleanupServiceTests {
         // Verify: all files deleted, all audioFileNames cleared
         for (i, transcription) in transcriptions.enumerated() {
             let fileName = "audio-\(i + 1).m4a"
-            #expect(!FileManager.default.fileExists(atPath: audioDir.appendingPathComponent(fileName).path))
+            #expect(FileManager.default.fileExists(atPath: audioDir.appendingPathComponent(fileName).path) == false)
             #expect(transcription.audioFileName == nil)
             #expect(transcription.text == "Transcription \(i + 1)")
         }
@@ -570,7 +570,7 @@ struct AudioCleanupServiceTests {
         await service.performCleanupIfNeeded(modelContext: context)
 
         // Verify: file deleted because enough time passed
-        #expect(!FileManager.default.fileExists(atPath: audioDir.appendingPathComponent(fileName).path))
+        #expect(FileManager.default.fileExists(atPath: audioDir.appendingPathComponent(fileName).path) == false)
         #expect(transcription.audioFileName == nil)
 
         // Cleanup
@@ -605,7 +605,7 @@ struct AudioCleanupServiceTests {
         await service.performCleanupIfNeeded(modelContext: context)
 
         // Verify: file deleted on first launch
-        #expect(!FileManager.default.fileExists(atPath: audioDir.appendingPathComponent(fileName).path))
+        #expect(FileManager.default.fileExists(atPath: audioDir.appendingPathComponent(fileName).path) == false)
         #expect(transcription.audioFileName == nil)
 
         // Cleanup

--- a/VivaDictaTests/ModeEditViewModelTests.swift
+++ b/VivaDictaTests/ModeEditViewModelTests.swift
@@ -261,6 +261,6 @@ struct ModeEditViewModelTests {
         // The name with whitespace should still be considered valid
         // (validation trims the name)
         let trimmedName = viewModel.modeName.trimmingCharacters(in: .whitespacesAndNewlines)
-        #expect(!trimmedName.isEmpty)
+        #expect(trimmedName.isEmpty == false)
     }
 }

--- a/VivaDictaTests/NoteCleanupServiceTests.swift
+++ b/VivaDictaTests/NoteCleanupServiceTests.swift
@@ -14,7 +14,7 @@ import SwiftData
 @MainActor
 struct NoteCleanupServiceTests {
 
-    private let testSuiteName = "NoteCleanupServiceTests"
+    private let testSuiteName = "NoteCleanupServiceTests.\(UUID().uuidString)"
 
     private func makeTestDefaults() -> UserDefaults {
         let defaults = UserDefaults(suiteName: testSuiteName)!
@@ -135,7 +135,7 @@ struct NoteCleanupServiceTests {
         await service.performCleanupIfNeeded(modelContext: context)
 
         // Old note fully deleted, recent note kept
-        #expect(!FileManager.default.fileExists(atPath: audioDir.appendingPathComponent(oldFileName).path))
+        #expect(FileManager.default.fileExists(atPath: audioDir.appendingPathComponent(oldFileName).path) == false)
         #expect(FileManager.default.fileExists(atPath: audioDir.appendingPathComponent(recentFileName).path))
 
         let fetchDescriptor = FetchDescriptor<Transcription>()
@@ -171,7 +171,7 @@ struct NoteCleanupServiceTests {
         )
         await service.performCleanupIfNeeded(modelContext: context)
 
-        #expect(!FileManager.default.fileExists(atPath: audioDir.appendingPathComponent(fileName).path))
+        #expect(FileManager.default.fileExists(atPath: audioDir.appendingPathComponent(fileName).path) == false)
         let fetchDescriptor = FetchDescriptor<Transcription>()
         let remaining = try context.fetch(fetchDescriptor)
         #expect(remaining.isEmpty)
@@ -209,7 +209,7 @@ struct NoteCleanupServiceTests {
         await service.performCleanupIfNeeded(modelContext: context)
 
         // Both audio file and transcription record should be gone
-        #expect(!FileManager.default.fileExists(atPath: audioDir.appendingPathComponent(fileName).path))
+        #expect(FileManager.default.fileExists(atPath: audioDir.appendingPathComponent(fileName).path) == false)
         let fetchDescriptor = FetchDescriptor<Transcription>()
         let remaining = try context.fetch(fetchDescriptor)
         #expect(remaining.isEmpty)
@@ -329,7 +329,7 @@ struct NoteCleanupServiceTests {
         #expect(remaining.first?.text == "Recent note")
 
         for i in 1...5 {
-            #expect(!FileManager.default.fileExists(atPath: audioDir.appendingPathComponent("audio-\(i).m4a").path))
+            #expect(FileManager.default.fileExists(atPath: audioDir.appendingPathComponent("audio-\(i).m4a").path) == false)
         }
         #expect(FileManager.default.fileExists(atPath: audioDir.appendingPathComponent(recentFileName).path))
 

--- a/VivaDictaTests/NotesFilterResetPolicyTests.swift
+++ b/VivaDictaTests/NotesFilterResetPolicyTests.swift
@@ -32,7 +32,7 @@ struct NotesFilterResetPolicyTests {
             remainingFilteredCount: 1
         )
 
-        #expect(!shouldReset)
+        #expect(shouldReset == false)
     }
 
     @Test func keepsFilterWhenSearchIsActive() {
@@ -45,7 +45,7 @@ struct NotesFilterResetPolicyTests {
             remainingFilteredCount: 0
         )
 
-        #expect(!shouldReset)
+        #expect(shouldReset == false)
     }
 
     @Test func keepsFilterWhenEverythingWasDeleted() {
@@ -58,7 +58,7 @@ struct NotesFilterResetPolicyTests {
             remainingFilteredCount: 0
         )
 
-        #expect(!shouldReset)
+        #expect(shouldReset == false)
     }
 
     @Test func keepsFilterWhenDeletionDoesNotRemoveAnyVisibleMatches() {
@@ -71,6 +71,6 @@ struct NotesFilterResetPolicyTests {
             remainingFilteredCount: 0
         )
 
-        #expect(!shouldReset)
+        #expect(shouldReset == false)
     }
 }

--- a/VivaDictaTests/OllamaServiceTests.swift
+++ b/VivaDictaTests/OllamaServiceTests.swift
@@ -160,7 +160,7 @@ struct OllamaServiceTests {
 
         let reachable = await sut.checkConnection(serverURL: serverURL)
 
-        #expect(!reachable)
+        #expect(reachable == false)
     }
 
     @Test func checkConnectionReturnsFalseOnTransportError() async {
@@ -170,7 +170,7 @@ struct OllamaServiceTests {
 
         let reachable = await sut.checkConnection(serverURL: serverURL)
 
-        #expect(!reachable)
+        #expect(reachable == false)
     }
 
 }

--- a/VivaDictaTests/OpenAICompatibleServiceTests.swift
+++ b/VivaDictaTests/OpenAICompatibleServiceTests.swift
@@ -342,7 +342,7 @@ struct OpenAICompatibleServiceTests {
             providerName: "openai"
         )
 
-        #expect(!valid)
+        #expect(valid == false)
     }
 
     @Test func verifyChatCompletionsAPIKeyReturnsFalseOnTransportError() async {
@@ -357,7 +357,7 @@ struct OpenAICompatibleServiceTests {
             providerName: "openai"
         )
 
-        #expect(!valid)
+        #expect(valid == false)
     }
 
     @Test func verifyChatCompletionsAPIKeySendsBearerAndMinimalBody() async throws {
@@ -430,7 +430,7 @@ struct OpenAICompatibleServiceTests {
             providerName: "mistral"
         )
 
-        #expect(!valid)
+        #expect(valid == false)
     }
 
     @Test func verifyGETEndpointReturnsFalseOnTransportError() async {
@@ -444,7 +444,7 @@ struct OpenAICompatibleServiceTests {
             providerName: "vercelAIGateway"
         )
 
-        #expect(!valid)
+        #expect(valid == false)
     }
 
     @Test func verifyGETEndpointSendsBearerAuthAndGETMethod() async throws {

--- a/VivaDictaTests/PromptsTemplatesTests.swift
+++ b/VivaDictaTests/PromptsTemplatesTests.swift
@@ -78,20 +78,20 @@ struct PromptsTemplatesTests {
             if template == .custom {
                 #expect(template.prompt.isEmpty)
             } else {
-                #expect(!template.prompt.isEmpty, "\(template.rawValue) has empty prompt")
+                #expect(template.prompt.isEmpty == false, "\(template.rawValue) has empty prompt")
             }
         }
     }
 
     @Test func allCases_haveNonEmptyDisplayNames() {
         for template in PromptsTemplates.allCases {
-            #expect(!template.displayName.isEmpty, "\(template.rawValue) has empty displayName")
+            #expect(template.displayName.isEmpty == false, "\(template.rawValue) has empty displayName")
         }
     }
 
     @Test func allCases_haveNonEmptyDescriptions() {
         for template in PromptsTemplates.allCases {
-            #expect(!template.description.isEmpty, "\(template.rawValue) has empty description")
+            #expect(template.description.isEmpty == false, "\(template.rawValue) has empty description")
         }
     }
 
@@ -101,7 +101,7 @@ struct PromptsTemplatesTests {
 
     @Test func nonCustom_haveNonEmptyDefaultTitles() {
         for template in PromptsTemplates.allCases where template != .custom {
-            #expect(!template.defaultTitle.isEmpty, "\(template.rawValue) has empty defaultTitle")
+            #expect(template.defaultTitle.isEmpty == false, "\(template.rawValue) has empty defaultTitle")
         }
     }
 

--- a/VivaDictaTests/TextFormatterTests.swift
+++ b/VivaDictaTests/TextFormatterTests.swift
@@ -28,8 +28,8 @@ struct TextFormatterTests {
     @Test func format_trimsWhitespace() {
         let result = TextFormatter.format("  Hello world.  ")
 
-        #expect(!result.hasPrefix(" "))
-        #expect(!result.hasSuffix(" "))
+        #expect(result.hasPrefix(" ") == false)
+        #expect(result.hasSuffix(" ") == false)
     }
 
     // MARK: - Single Paragraph (Short Text)
@@ -37,7 +37,7 @@ struct TextFormatterTests {
     @Test func format_singleShortSentence_singleParagraph() {
         let result = TextFormatter.format("This is a short sentence.")
 
-        #expect(!result.contains("\n\n"))
+        #expect(result.contains("\n\n") == false)
         #expect(result.contains("This is a short sentence."))
     }
 
@@ -45,7 +45,7 @@ struct TextFormatterTests {
         // Short sentences (< 4 words each) don't count as "significant"
         let result = TextFormatter.format("Yes. OK. I see. Thanks.")
 
-        #expect(!result.contains("\n\n"))
+        #expect(result.contains("\n\n") == false)
     }
 
     // MARK: - Paragraph Splitting
@@ -77,7 +77,7 @@ struct TextFormatterTests {
         #expect(paragraphs.count >= 2)
         // First paragraph should contain 4 significant sentences
         #expect(paragraphs[0].contains("fourth"))
-        #expect(!paragraphs[0].contains("fifth"))
+        #expect(paragraphs[0].contains("fifth") == false)
     }
 
     @Test func format_mixedShortLongSentences_balanced() {
@@ -100,7 +100,7 @@ struct TextFormatterTests {
         let result = TextFormatter.format(shortNumberText)
 
         // Short enough text → no split
-        #expect(!result.contains("\n\n"))
+        #expect(result.contains("\n\n") == false)
     }
 
     @Test func format_russianText_handledCorrectly() {

--- a/VivaDictaTests/TextInsertionFormatterTests.swift
+++ b/VivaDictaTests/TextInsertionFormatterTests.swift
@@ -48,7 +48,7 @@ struct TextInsertionFormatterTests {
         let context = makeContext(textBefore: "word ")
         let result = TextInsertionFormatter.formatTextForInsertion("test", context: context)
 
-        #expect(!result.hasPrefix(" "))
+        #expect(result.hasPrefix(" ") == false)
     }
 
     @Test func shouldAddSpaceBefore_afterPeriod_true() {
@@ -64,7 +64,7 @@ struct TextInsertionFormatterTests {
         let result = TextInsertionFormatter.formatTextForInsertion("test", context: context)
 
         // At start of document — no space before, but space after
-        #expect(!result.hasPrefix(" "))
+        #expect(result.hasPrefix(" ") == false)
     }
 
     // MARK: - Smart Spacing: After
@@ -73,14 +73,14 @@ struct TextInsertionFormatterTests {
         let context = makeContext(textBefore: "word ", textAfter: ".")
         let result = TextInsertionFormatter.formatTextForInsertion("test", context: context)
 
-        #expect(!result.hasSuffix(" "))
+        #expect(result.hasSuffix(" ") == false)
     }
 
     @Test func spacing_beforeWhitespace_noSpaceAfter() {
         let context = makeContext(textBefore: "word ", textAfter: " more")
         let result = TextInsertionFormatter.formatTextForInsertion("test", context: context)
 
-        #expect(!result.hasSuffix(" "))
+        #expect(result.hasSuffix(" ") == false)
     }
 
     @Test func spacing_endOfText_addsSpaceAfter() {

--- a/VivaDictaTests/TextProcessingFilterTests.swift
+++ b/VivaDictaTests/TextProcessingFilterTests.swift
@@ -39,7 +39,7 @@ struct TranscriptionOutputFilterTests {
         let input = "Hello [background noise] world"
         let result = TranscriptionOutputFilter.filter(input)
 
-        #expect(!result.contains("[background noise]"))
+        #expect(result.contains("[background noise]") == false)
         #expect(result.contains("Hello"))
         #expect(result.contains("world"))
     }
@@ -48,14 +48,14 @@ struct TranscriptionOutputFilterTests {
         let input = "Hello (inaudible) world"
         let result = TranscriptionOutputFilter.filter(input)
 
-        #expect(!result.contains("(inaudible)"))
+        #expect(result.contains("(inaudible)") == false)
     }
 
     @Test func filter_removesBracedContent() {
         let input = "Hello {music} world"
         let result = TranscriptionOutputFilter.filter(input)
 
-        #expect(!result.contains("{music}"))
+        #expect(result.contains("{music}") == false)
     }
 
     // MARK: - filter Tests — Filler Words
@@ -64,9 +64,9 @@ struct TranscriptionOutputFilterTests {
         let input = "So uh I think um we should eh go"
         let result = TranscriptionOutputFilter.filter(input)
 
-        #expect(!result.contains(" uh "))
-        #expect(!result.contains(" um "))
-        #expect(!result.contains(" eh "))
+        #expect(result.contains(" uh ") == false)
+        #expect(result.contains(" um ") == false)
+        #expect(result.contains(" eh ") == false)
         #expect(result.contains("I think"))
         #expect(result.contains("we should"))
     }
@@ -75,7 +75,7 @@ struct TranscriptionOutputFilterTests {
         let input = "Well, uh, I think so"
         let result = TranscriptionOutputFilter.filter(input)
 
-        #expect(!result.contains("uh,"))
+        #expect(result.contains("uh,") == false)
     }
 
     // MARK: - filter Tests — Tag Removal
@@ -84,8 +84,8 @@ struct TranscriptionOutputFilterTests {
         let input = "Hello <note>this is a note</note> world"
         let result = TranscriptionOutputFilter.filter(input)
 
-        #expect(!result.contains("<note>"))
-        #expect(!result.contains("this is a note"))
+        #expect(result.contains("<note>") == false)
+        #expect(result.contains("this is a note") == false)
         #expect(result.contains("Hello"))
         #expect(result.contains("world"))
     }
@@ -129,16 +129,16 @@ struct TranscriptionOutputFilterTests {
         let inputRu = "Это um важное hmm сообщение для теста."
         let result = TranscriptionOutputFilter.filter(inputRu, language: "ru")
 
-        #expect(!result.contains("um"))
-        #expect(!result.contains("hmm"))
+        #expect(result.contains("um") == false)
+        #expect(result.contains("hmm") == false)
     }
 
     @Test func filter_russianFillers_removedWhenLanguageIsRussian() {
         let input = "Я думаю ээ что нам ыыы нужно идти."
         let result = TranscriptionOutputFilter.filter(input, language: "ru")
 
-        #expect(!result.contains("ээ"))
-        #expect(!result.contains("ыыы"))
+        #expect(result.contains("ээ") == false)
+        #expect(result.contains("ыыы") == false)
         #expect(result.contains("Я думаю"))
         #expect(result.contains("нужно идти"))
     }
@@ -147,7 +147,7 @@ struct TranscriptionOutputFilterTests {
         let input = "Я э-э думаю что э-э-э нам нужно идти."
         let result = TranscriptionOutputFilter.filter(input, language: "ru")
 
-        #expect(!result.contains("э-э"))
+        #expect(result.contains("э-э") == false)
         #expect(result.contains("Я"))
         #expect(result.contains("думаю"))
         #expect(result.contains("нужно идти"))
@@ -157,8 +157,8 @@ struct TranscriptionOutputFilterTests {
         let input = "Ich denke äh dass wir ähm gehen sollten."
         let result = TranscriptionOutputFilter.filter(input, language: "de")
 
-        #expect(!result.contains("äh"))
-        #expect(!result.contains("ähm"))
+        #expect(result.contains("äh") == false)
+        #expect(result.contains("ähm") == false)
         #expect(result.contains("Ich denke"))
         #expect(result.contains("gehen sollten"))
     }
@@ -167,8 +167,8 @@ struct TranscriptionOutputFilterTests {
         let input = "Je pense euh qu'on devrait heu y aller."
         let result = TranscriptionOutputFilter.filter(input, language: "fr")
 
-        #expect(!result.contains("euh"))
-        #expect(!result.contains("heu"))
+        #expect(result.contains("euh") == false)
+        #expect(result.contains("heu") == false)
         #expect(result.contains("Je pense"))
         #expect(result.contains("y aller"))
     }
@@ -177,8 +177,8 @@ struct TranscriptionOutputFilterTests {
         let input = "Yo creo ehm que deberíamos eee ir."
         let result = TranscriptionOutputFilter.filter(input, language: "es")
 
-        #expect(!result.contains("ehm"))
-        #expect(!result.contains("eee"))
+        #expect(result.contains("ehm") == false)
+        #expect(result.contains("eee") == false)
         #expect(result.contains("Yo creo"))
         #expect(result.contains("deberíamos"))
     }
@@ -198,7 +198,7 @@ struct TranscriptionOutputFilterTests {
         let input = "Well, eh, ok."
         let result = TranscriptionOutputFilter.filter(input, language: "auto")
 
-        #expect(!result.contains("eh"))
+        #expect(result.contains("eh") == false)
     }
 
     @Test func filter_explicitLanguageWithRegionSuffix_resolvesToBase() {
@@ -206,7 +206,7 @@ struct TranscriptionOutputFilterTests {
         let input = "I think eh we should go."
         let result = TranscriptionOutputFilter.filter(input, language: "en-US")
 
-        #expect(!result.contains(" eh "))
+        #expect(result.contains(" eh ") == false)
     }
 
     // MARK: - stripTrailingPeriod Tests


### PR DESCRIPTION
## Summary
- Replaced 80 `#expect(!X)` calls with `#expect(X == false)` across 20 test files. The leading `!` defeats Swift Testing's macro expansion - on failure the macro only sees the final negated boolean and reports an opaque \"expression was false\" instead of surfacing the actual operand. Rewriting as `X == false` lets the macro introspect both sides and print the real value when a test fails.
- Fixed a parallel-execution race in `AudioCleanupServiceTests` and `NoteCleanupServiceTests`: both used a fixed UserDefaults suite name (`\"AudioCleanupServiceTests\"`, `\"NoteCleanupServiceTests\"`) and called `removePersistentDomain` at the top of each test. Under Swift Testing's default parallel execution, one test could wipe another test's defaults mid-run. Suffixed the suite name with `UUID().uuidString` so each test gets its own private suite.

No behavior changes - the assertions still pass/fail on the same conditions. This is purely a diagnostic-quality and test-isolation improvement.

## Test plan
- [x] `xcodebuild ... build` - 0 errors
- [x] `xcodebuild ... build-for-testing` - 0 errors
- [ ] Full test run on CI