### PR TITLE
Hoist SUT, parameterize repetitive tests, modernize throws assertions

### DIFF
--- a/Modules/CloudTranscription/Tests/CloudTranscriptionTests/GroqTranscriptionServiceTests.swift
+++ b/Modules/CloudTranscription/Tests/CloudTranscriptionTests/GroqTranscriptionServiceTests.swift
@@ -217,15 +217,15 @@ struct GroqTranscriptionServiceTests {
         let audio = try makeAudioFile()
         let sut = makeService(networkService: networkService)
 
-        do {
+        let error = try await #require(throws: CloudTranscriptionError.self) {
             _ = try await sut.transcribe(audioURL: audio)
-            Issue.record("expected apiRequestFailed to throw")
-        } catch let CloudTranscriptionError.apiRequestFailed(statusCode, message) {
-            #expect(statusCode == 401)
-            #expect(message.contains("invalid key"))
-        } catch {
-            Issue.record("expected CloudTranscriptionError.apiRequestFailed, got \(error)")
         }
+        guard case let .apiRequestFailed(statusCode, message) = error else {
+            Issue.record("expected CloudTranscriptionError.apiRequestFailed, got \(error)")
+            return
+        }
+        #expect(statusCode == 401)
+        #expect(message.contains("invalid key"))
     }
 
     @Test func undecodableJSONOn200ThrowsNoTranscriptionReturned() async throws {
@@ -234,13 +234,12 @@ struct GroqTranscriptionServiceTests {
         let audio = try makeAudioFile()
         let sut = makeService(networkService: networkService)
 
-        do {
+        let error = try await #require(throws: CloudTranscriptionError.self) {
             _ = try await sut.transcribe(audioURL: audio)
-            Issue.record("expected noTranscriptionReturned to throw")
-        } catch CloudTranscriptionError.noTranscriptionReturned {
-            // expected
-        } catch {
+        }
+        guard case .noTranscriptionReturned = error else {
             Issue.record("expected noTranscriptionReturned, got \(error)")
+            return
         }
     }
 }

--- a/Modules/CloudTranscription/Tests/CloudTranscriptionTests/OpenAITranscriptionServiceTests.swift
+++ b/Modules/CloudTranscription/Tests/CloudTranscriptionTests/OpenAITranscriptionServiceTests.swift
@@ -190,15 +190,15 @@ struct OpenAITranscriptionServiceTests {
         let audio = try makeAudioFile()
         let sut = makeService(networkService: networkService)
 
-        do {
+        let error = try await #require(throws: CloudTranscriptionError.self) {
             _ = try await sut.transcribe(audioURL: audio)
-            Issue.record("expected apiRequestFailed to throw")
-        } catch let CloudTranscriptionError.apiRequestFailed(statusCode, message) {
-            #expect(statusCode == 401)
-            #expect(message.contains("invalid key"))
-        } catch {
-            Issue.record("expected CloudTranscriptionError.apiRequestFailed, got \(error)")
         }
+        guard case let .apiRequestFailed(statusCode, message) = error else {
+            Issue.record("expected CloudTranscriptionError.apiRequestFailed, got \(error)")
+            return
+        }
+        #expect(statusCode == 401)
+        #expect(message.contains("invalid key"))
     }
 
     @Test func undecodableJSONOn200ThrowsNoTranscriptionReturned() async throws {
@@ -207,13 +207,12 @@ struct OpenAITranscriptionServiceTests {
         let audio = try makeAudioFile()
         let sut = makeService(networkService: networkService)
 
-        do {
+        let error = try await #require(throws: CloudTranscriptionError.self) {
             _ = try await sut.transcribe(audioURL: audio)
-            Issue.record("expected noTranscriptionReturned to throw")
-        } catch CloudTranscriptionError.noTranscriptionReturned {
-            // expected
-        } catch {
+        }
+        guard case .noTranscriptionReturned = error else {
             Issue.record("expected noTranscriptionReturned, got \(error)")
+            return
         }
     }
 }

--- a/Modules/CloudTranscription/Tests/CloudTranscriptionTests/XaiTranscriptionServiceTests.swift
+++ b/Modules/CloudTranscription/Tests/CloudTranscriptionTests/XaiTranscriptionServiceTests.swift
@@ -214,15 +214,15 @@ struct XaiTranscriptionServiceTests {
         let audio = try makeAudioFile()
         let sut = makeService(networkService: networkService)
 
-        do {
+        let error = try await #require(throws: CloudTranscriptionError.self) {
             _ = try await sut.transcribe(audioURL: audio)
-            Issue.record("expected apiRequestFailed to throw")
-        } catch let CloudTranscriptionError.apiRequestFailed(statusCode, message) {
-            #expect(statusCode == 401)
-            #expect(message.contains("invalid key"))
-        } catch {
-            Issue.record("expected CloudTranscriptionError.apiRequestFailed, got \(error)")
         }
+        guard case let .apiRequestFailed(statusCode, message) = error else {
+            Issue.record("expected CloudTranscriptionError.apiRequestFailed, got \(error)")
+            return
+        }
+        #expect(statusCode == 401)
+        #expect(message.contains("invalid key"))
     }
 
     @Test func undecodableJSONOn200ThrowsNoTranscriptionReturned() async throws {
@@ -231,13 +231,12 @@ struct XaiTranscriptionServiceTests {
         let audio = try makeAudioFile()
         let sut = makeService(networkService: networkService)
 
-        do {
+        let error = try await #require(throws: CloudTranscriptionError.self) {
             _ = try await sut.transcribe(audioURL: audio)
-            Issue.record("expected noTranscriptionReturned to throw")
-        } catch CloudTranscriptionError.noTranscriptionReturned {
-            // expected
-        } catch {
+        }
+        guard case .noTranscriptionReturned = error else {
             Issue.record("expected noTranscriptionReturned, got \(error)")
+            return
         }
     }
 }

--- a/VivaDictaTests/AnthropicServiceTests.swift
+++ b/VivaDictaTests/AnthropicServiceTests.swift
@@ -120,18 +120,17 @@ struct AnthropicServiceTests {
         networkService.stubSendResponse = .success((Data(), makeHTTPResponse(429)))
         let sut = makeSUT(networkService: networkService)
 
-        do {
+        let error = try await #require(throws: EnhancementError.self) {
             _ = try await sut.enhance(
                 systemMessage: "s",
                 userMessage: "u",
                 apiKey: "k",
                 model: "m"
             )
-            Issue.record("Expected rateLimitExceeded")
-        } catch let error as EnhancementError {
-            if case .rateLimitExceeded = error {} else {
-                Issue.record("Expected .rateLimitExceeded, got \(error)")
-            }
+        }
+        guard case .rateLimitExceeded = error else {
+            Issue.record("Expected .rateLimitExceeded, got \(error)")
+            return
         }
     }
 
@@ -140,18 +139,17 @@ struct AnthropicServiceTests {
         networkService.stubSendResponse = .success((Data(), makeHTTPResponse(503)))
         let sut = makeSUT(networkService: networkService)
 
-        do {
+        let error = try await #require(throws: EnhancementError.self) {
             _ = try await sut.enhance(
                 systemMessage: "s",
                 userMessage: "u",
                 apiKey: "k",
                 model: "m"
             )
-            Issue.record("Expected serverError")
-        } catch let error as EnhancementError {
-            if case .serverError = error {} else {
-                Issue.record("Expected .serverError, got \(error)")
-            }
+        }
+        guard case .serverError = error else {
+            Issue.record("Expected .serverError, got \(error)")
+            return
         }
     }
 
@@ -161,21 +159,19 @@ struct AnthropicServiceTests {
         networkService.stubSendResponse = .success((body, makeHTTPResponse(400)))
         let sut = makeSUT(networkService: networkService)
 
-        do {
+        let error = try await #require(throws: EnhancementError.self) {
             _ = try await sut.enhance(
                 systemMessage: "s",
                 userMessage: "u",
                 apiKey: "k",
                 model: "m"
             )
-            Issue.record("Expected customError")
-        } catch let error as EnhancementError {
-            if case let .customError(message) = error {
-                #expect(message.hasPrefix("HTTP 400"))
-            } else {
-                Issue.record("Expected .customError, got \(error)")
-            }
         }
+        guard case let .customError(message) = error else {
+            Issue.record("Expected .customError, got \(error)")
+            return
+        }
+        #expect(message.hasPrefix("HTTP 400"))
     }
 
     // MARK: - verifyAPIKey

--- a/VivaDictaTests/DataControllerTests.swift
+++ b/VivaDictaTests/DataControllerTests.swift
@@ -12,13 +12,15 @@ import Testing
 
 struct DataControllerTests {
 
-    // MARK: - Helper Methods
+    let sut: DataController
 
-    private func makeDataController() -> DataController {
+    init() throws {
         let config = ModelConfiguration(isStoredInMemoryOnly: true)
-        let container = try! ModelContainer(for: Transcription.self, configurations: config)
-        return DataController(modelContainer: container)
+        let container = try ModelContainer(for: Transcription.self, configurations: config)
+        sut = DataController(modelContainer: container)
     }
+
+    // MARK: - Helper Methods
 
     private func createTranscription(
         text: String = "Test transcription",
@@ -40,39 +42,33 @@ struct DataControllerTests {
     // MARK: - Transcriptions Fetching Tests
 
     @Test func fetchTranscriptions_emptyDatabase_returnsEmptyArray() throws {
-        let controller = makeDataController()
-
-        let result = try controller.transcriptions()
+        let result = try sut.transcriptions()
 
         #expect(result.isEmpty)
     }
 
     @Test func fetchTranscriptions_withData_returnsAllTranscriptions() throws {
-        let controller = makeDataController()
-
         // Insert test data
         let t1 = createTranscription(text: "First note")
         let t2 = createTranscription(text: "Second note")
-        controller.modelContext.insert(t1)
-        controller.modelContext.insert(t2)
-        try controller.modelContext.save()
+        sut.modelContext.insert(t1)
+        sut.modelContext.insert(t2)
+        try sut.modelContext.save()
 
-        let result = try controller.transcriptions()
+        let result = try sut.transcriptions()
 
         #expect(result.count == 2)
     }
 
     @Test func fetchTranscriptions_sortedByTimestampDescending() throws {
-        let controller = makeDataController()
-
         // Insert with different timestamps
         let older = createTranscription(text: "Older", daysAgo: 2)
         let newer = createTranscription(text: "Newer", daysAgo: 0)
-        controller.modelContext.insert(older)
-        controller.modelContext.insert(newer)
-        try controller.modelContext.save()
+        sut.modelContext.insert(older)
+        sut.modelContext.insert(newer)
+        try sut.modelContext.save()
 
-        let result = try controller.transcriptions()
+        let result = try sut.transcriptions()
 
         #expect(result.count == 2)
         #expect(result.first?.text == "Newer")
@@ -80,30 +76,26 @@ struct DataControllerTests {
     }
 
     @Test func fetchTranscriptions_withLimit_respectsLimit() throws {
-        let controller = makeDataController()
-
         // Insert multiple transcriptions
         for i in 1...5 {
             let t = createTranscription(text: "Note \(i)")
-            controller.modelContext.insert(t)
+            sut.modelContext.insert(t)
         }
-        try controller.modelContext.save()
+        try sut.modelContext.save()
 
-        let result = try controller.transcriptions(limit: 3)
+        let result = try sut.transcriptions(limit: 3)
 
         #expect(result.count == 3)
     }
 
     @Test func fetchTranscriptions_withPredicate_filtersCorrectly() throws {
-        let controller = makeDataController()
-
         let withEnhanced = createTranscription(text: "Original", enhancedText: "Enhanced version")
         let withoutEnhanced = createTranscription(text: "Plain text")
-        controller.modelContext.insert(withEnhanced)
-        controller.modelContext.insert(withoutEnhanced)
-        try controller.modelContext.save()
+        sut.modelContext.insert(withEnhanced)
+        sut.modelContext.insert(withoutEnhanced)
+        try sut.modelContext.save()
 
-        let result = try controller.transcriptions(matching: #Predicate {
+        let result = try sut.transcriptions(matching: #Predicate {
             $0.enhancedText != nil
         })
 
@@ -114,35 +106,29 @@ struct DataControllerTests {
     // MARK: - Transcription by ID Tests
 
     @Test func transcriptionById_existingId_returnsTranscription() throws {
-        let controller = makeDataController()
-
         let transcription = createTranscription(text: "Find me")
-        controller.modelContext.insert(transcription)
-        try controller.modelContext.save()
+        sut.modelContext.insert(transcription)
+        try sut.modelContext.save()
 
-        let result = try controller.transcription(byId: transcription.id)
+        let result = try sut.transcription(byId: transcription.id)
 
         #expect(result != nil)
         #expect(result?.text == "Find me")
     }
 
     @Test func transcriptionById_nonExistingId_returnsNil() throws {
-        let controller = makeDataController()
-
         let transcription = createTranscription(text: "Exists")
-        controller.modelContext.insert(transcription)
-        try controller.modelContext.save()
+        sut.modelContext.insert(transcription)
+        try sut.modelContext.save()
 
         let nonExistentId = UUID()
-        let result = try controller.transcription(byId: nonExistentId)
+        let result = try sut.transcription(byId: nonExistentId)
 
         #expect(result == nil)
     }
 
     @Test func transcriptionById_emptyDatabase_returnsNil() throws {
-        let controller = makeDataController()
-
-        let result = try controller.transcription(byId: UUID())
+        let result = try sut.transcription(byId: UUID())
 
         #expect(result == nil)
     }
@@ -150,17 +136,15 @@ struct DataControllerTests {
     // MARK: - Transcription Entities Tests
 
     @Test func transcriptionEntities_convertsToEntities() throws {
-        let controller = makeDataController()
-
         let transcription = createTranscription(
             text: "Entity test",
             enhancedText: "Enhanced entity",
             audioDuration: 30.0
         )
-        controller.modelContext.insert(transcription)
-        try controller.modelContext.save()
+        sut.modelContext.insert(transcription)
+        try sut.modelContext.save()
 
-        let entities = try controller.transcriptionEntities()
+        let entities = try sut.transcriptionEntities()
 
         #expect(entities.count == 1)
         let entity = entities.first!
@@ -171,28 +155,24 @@ struct DataControllerTests {
     }
 
     @Test func transcriptionEntities_withLimit_respectsLimit() throws {
-        let controller = makeDataController()
-
         for i in 1...5 {
-            controller.modelContext.insert(createTranscription(text: "Note \(i)"))
+            sut.modelContext.insert(createTranscription(text: "Note \(i)"))
         }
-        try controller.modelContext.save()
+        try sut.modelContext.save()
 
-        let entities = try controller.transcriptionEntities(limit: 2)
+        let entities = try sut.transcriptionEntities(limit: 2)
 
         #expect(entities.count == 2)
     }
 
     @Test func transcriptionEntities_withPredicate_filtersCorrectly() throws {
-        let controller = makeDataController()
-
         let longAudio = createTranscription(text: "Long", audioDuration: 120.0)
         let shortAudio = createTranscription(text: "Short", audioDuration: 10.0)
-        controller.modelContext.insert(longAudio)
-        controller.modelContext.insert(shortAudio)
-        try controller.modelContext.save()
+        sut.modelContext.insert(longAudio)
+        sut.modelContext.insert(shortAudio)
+        try sut.modelContext.save()
 
-        let entities = try controller.transcriptionEntities(matching: #Predicate {
+        let entities = try sut.transcriptionEntities(matching: #Predicate {
             $0.audioDuration > 60
         })
 
@@ -203,38 +183,32 @@ struct DataControllerTests {
     // MARK: - Transcription Count Tests
 
     @Test func transcriptionCount_emptyDatabase_returnsZero() throws {
-        let controller = makeDataController()
-
-        let count = try controller.transcriptionCount()
+        let count = try sut.transcriptionCount()
 
         #expect(count == 0)
     }
 
     @Test func transcriptionCount_withData_returnsCorrectCount() throws {
-        let controller = makeDataController()
+        sut.modelContext.insert(createTranscription(text: "One"))
+        sut.modelContext.insert(createTranscription(text: "Two"))
+        sut.modelContext.insert(createTranscription(text: "Three"))
+        try sut.modelContext.save()
 
-        controller.modelContext.insert(createTranscription(text: "One"))
-        controller.modelContext.insert(createTranscription(text: "Two"))
-        controller.modelContext.insert(createTranscription(text: "Three"))
-        try controller.modelContext.save()
-
-        let count = try controller.transcriptionCount()
+        let count = try sut.transcriptionCount()
 
         #expect(count == 3)
     }
 
     @Test func transcriptionCount_withPredicate_countsFilteredResults() throws {
-        let controller = makeDataController()
-
         // Create transcriptions with different dates
         let recent = createTranscription(text: "Recent", daysAgo: 5)
         let old = createTranscription(text: "Old", daysAgo: 45)
-        controller.modelContext.insert(recent)
-        controller.modelContext.insert(old)
-        try controller.modelContext.save()
+        sut.modelContext.insert(recent)
+        sut.modelContext.insert(old)
+        try sut.modelContext.save()
 
         let cutoff = Calendar.current.date(byAdding: .day, value: -30, to: Date())!
-        let count = try controller.transcriptionCount(matching: #Predicate {
+        let count = try sut.transcriptionCount(matching: #Predicate {
             $0.timestamp > cutoff
         })
 
@@ -244,24 +218,20 @@ struct DataControllerTests {
     // MARK: - Edge Cases
 
     @Test func fetchTranscriptions_limitZero_meansNoLimit() throws {
-        let controller = makeDataController()
-
-        controller.modelContext.insert(createTranscription(text: "Test"))
-        try controller.modelContext.save()
+        sut.modelContext.insert(createTranscription(text: "Test"))
+        try sut.modelContext.save()
 
         // In SwiftData, fetchLimit = 0 means no limit (returns all results)
-        let result = try controller.transcriptions(limit: 0)
+        let result = try sut.transcriptions(limit: 0)
 
         #expect(result.count == 1)
     }
 
     @Test func fetchTranscriptions_limitLargerThanData_returnsAllData() throws {
-        let controller = makeDataController()
+        sut.modelContext.insert(createTranscription(text: "Only one"))
+        try sut.modelContext.save()
 
-        controller.modelContext.insert(createTranscription(text: "Only one"))
-        try controller.modelContext.save()
-
-        let result = try controller.transcriptions(limit: 100)
+        let result = try sut.transcriptions(limit: 100)
 
         #expect(result.count == 1)
     }

--- a/VivaDictaTests/OpenAICompatibleServiceTests.swift
+++ b/VivaDictaTests/OpenAICompatibleServiceTests.swift
@@ -216,12 +216,12 @@ struct OpenAICompatibleServiceTests {
         }
     }
 
-    @Test func enhanceMaps429ToRateLimitExceeded() async {
+    @Test func enhanceMaps429ToRateLimitExceeded() async throws {
         let networkService = MockNetworkService()
         networkService.stubSendResponse = .success((Data(), makeHTTPResponse(429)))
         let sut = makeSUT(networkService: networkService)
 
-        do {
+        let error = try await #require(throws: EnhancementError.self) {
             _ = try await sut.enhance(
                 url: URL(string: endpointURL)!,
                 modelName: "m",
@@ -230,22 +230,19 @@ struct OpenAICompatibleServiceTests {
                 headers: [:],
                 timeout: 30
             )
-            Issue.record("Expected rateLimitExceeded")
-        } catch let error as EnhancementError {
-            if case .rateLimitExceeded = error {} else {
-                Issue.record("Expected .rateLimitExceeded, got \(error)")
-            }
-        } catch {
-            Issue.record("Expected EnhancementError, got \(error)")
+        }
+        guard case .rateLimitExceeded = error else {
+            Issue.record("Expected .rateLimitExceeded, got \(error)")
+            return
         }
     }
 
-    @Test func enhanceMaps5xxToServerError() async {
+    @Test func enhanceMaps5xxToServerError() async throws {
         let networkService = MockNetworkService()
         networkService.stubSendResponse = .success((Data(), makeHTTPResponse(502)))
         let sut = makeSUT(networkService: networkService)
 
-        do {
+        let error = try await #require(throws: EnhancementError.self) {
             _ = try await sut.enhance(
                 url: URL(string: endpointURL)!,
                 modelName: "m",
@@ -254,22 +251,19 @@ struct OpenAICompatibleServiceTests {
                 headers: [:],
                 timeout: 30
             )
-            Issue.record("Expected serverError")
-        } catch let error as EnhancementError {
-            if case .serverError = error {} else {
-                Issue.record("Expected .serverError, got \(error)")
-            }
-        } catch {
-            Issue.record("Expected EnhancementError, got \(error)")
+        }
+        guard case .serverError = error else {
+            Issue.record("Expected .serverError, got \(error)")
+            return
         }
     }
 
-    @Test func enhanceRethrowsURLErrorTransport() async {
+    @Test func enhanceRethrowsURLErrorTransport() async throws {
         let networkService = MockNetworkService()
         networkService.stubSendResponse = .failure(URLError(.timedOut))
         let sut = makeSUT(networkService: networkService)
 
-        do {
+        let error = try await #require(throws: URLError.self) {
             _ = try await sut.enhance(
                 url: URL(string: endpointURL)!,
                 modelName: "m",
@@ -278,21 +272,17 @@ struct OpenAICompatibleServiceTests {
                 headers: [:],
                 timeout: 30
             )
-            Issue.record("Expected URLError")
-        } catch let error as URLError {
-            #expect(error.code == .timedOut)
-        } catch {
-            Issue.record("Expected URLError, got \(error)")
         }
+        #expect(error.code == .timedOut)
     }
 
-    @Test func enhanceMapsOtherStatusToCustomError() async {
+    @Test func enhanceMapsOtherStatusToCustomError() async throws {
         let networkService = MockNetworkService()
         let body = Data(#"{"error":"unauthorized"}"#.utf8)
         networkService.stubSendResponse = .success((body, makeHTTPResponse(401)))
         let sut = makeSUT(networkService: networkService)
 
-        do {
+        let error = try await #require(throws: EnhancementError.self) {
             _ = try await sut.enhance(
                 url: URL(string: endpointURL)!,
                 modelName: "m",
@@ -301,16 +291,12 @@ struct OpenAICompatibleServiceTests {
                 headers: [:],
                 timeout: 30
             )
-            Issue.record("Expected customError")
-        } catch let error as EnhancementError {
-            if case let .customError(message) = error {
-                #expect(message.hasPrefix("HTTP 401"))
-            } else {
-                Issue.record("Expected .customError, got \(error)")
-            }
-        } catch {
-            Issue.record("Expected EnhancementError, got \(error)")
         }
+        guard case let .customError(message) = error else {
+            Issue.record("Expected .customError, got \(error)")
+            return
+        }
+        #expect(message.hasPrefix("HTTP 401"))
     }
 
     // MARK: - verifyChatCompletionsAPIKey

--- a/VivaDictaTests/TextProcessingFilterTests.swift
+++ b/VivaDictaTests/TextProcessingFilterTests.swift
@@ -133,54 +133,52 @@ struct TranscriptionOutputFilterTests {
         #expect(result.contains("hmm") == false)
     }
 
-    @Test func filter_russianFillers_removedWhenLanguageIsRussian() {
-        let input = "Я думаю ээ что нам ыыы нужно идти."
-        let result = TranscriptionOutputFilter.filter(input, language: "ru")
+    @Test(arguments: [
+        (
+            lang: "ru",
+            input: "Я думаю ээ что нам ыыы нужно идти.",
+            removed: ["ээ", "ыыы"],
+            kept: ["Я думаю", "нужно идти"]
+        ),
+        (
+            lang: "ru",
+            input: "Я э-э думаю что э-э-э нам нужно идти.",
+            removed: ["э-э"],
+            kept: ["Я", "думаю", "нужно идти"]
+        ),
+        (
+            lang: "de",
+            input: "Ich denke äh dass wir ähm gehen sollten.",
+            removed: ["äh", "ähm"],
+            kept: ["Ich denke", "gehen sollten"]
+        ),
+        (
+            lang: "fr",
+            input: "Je pense euh qu'on devrait heu y aller.",
+            removed: ["euh", "heu"],
+            kept: ["Je pense", "y aller"]
+        ),
+        (
+            lang: "es",
+            input: "Yo creo ehm que deberíamos eee ir.",
+            removed: ["ehm", "eee"],
+            kept: ["Yo creo", "deberíamos"]
+        ),
+    ])
+    func filter_languageFillers_removedWhenLanguageMatches(
+        lang: String,
+        input: String,
+        removed: [String],
+        kept: [String]
+    ) {
+        let result = TranscriptionOutputFilter.filter(input, language: lang)
 
-        #expect(result.contains("ээ") == false)
-        #expect(result.contains("ыыы") == false)
-        #expect(result.contains("Я думаю"))
-        #expect(result.contains("нужно идти"))
-    }
-
-    @Test func filter_russianHyphenatedFillers_removedWhenLanguageIsRussian() {
-        let input = "Я э-э думаю что э-э-э нам нужно идти."
-        let result = TranscriptionOutputFilter.filter(input, language: "ru")
-
-        #expect(result.contains("э-э") == false)
-        #expect(result.contains("Я"))
-        #expect(result.contains("думаю"))
-        #expect(result.contains("нужно идти"))
-    }
-
-    @Test func filter_germanFillers_removedWhenLanguageIsGerman() {
-        let input = "Ich denke äh dass wir ähm gehen sollten."
-        let result = TranscriptionOutputFilter.filter(input, language: "de")
-
-        #expect(result.contains("äh") == false)
-        #expect(result.contains("ähm") == false)
-        #expect(result.contains("Ich denke"))
-        #expect(result.contains("gehen sollten"))
-    }
-
-    @Test func filter_frenchFillers_removedWhenLanguageIsFrench() {
-        let input = "Je pense euh qu'on devrait heu y aller."
-        let result = TranscriptionOutputFilter.filter(input, language: "fr")
-
-        #expect(result.contains("euh") == false)
-        #expect(result.contains("heu") == false)
-        #expect(result.contains("Je pense"))
-        #expect(result.contains("y aller"))
-    }
-
-    @Test func filter_spanishFillers_removedWhenLanguageIsSpanish() {
-        let input = "Yo creo ehm que deberíamos eee ir."
-        let result = TranscriptionOutputFilter.filter(input, language: "es")
-
-        #expect(result.contains("ehm") == false)
-        #expect(result.contains("eee") == false)
-        #expect(result.contains("Yo creo"))
-        #expect(result.contains("deberíamos"))
+        for token in removed {
+            #expect(result.contains(token) == false, "[\(lang)] expected \"\(token)\" to be removed; got: \(result)")
+        }
+        for token in kept {
+            #expect(result.contains(token), "[\(lang)] expected \"\(token)\" to be kept; got: \(result)")
+        }
     }
 
     @Test func filter_germanFillers_notRemovedWhenLanguageIsRussian() {

--- a/VivaDictaTests/TranscriptionManagerConfigTests.swift
+++ b/VivaDictaTests/TranscriptionManagerConfigTests.swift
@@ -12,6 +12,12 @@ import CloudTranscription
 
 struct TranscriptionManagerConfigTests {
 
+    let sut: TranscriptionManager
+
+    init() {
+        sut = TranscriptionManager()
+    }
+
     // MARK: - Test Helpers
 
     private func makeMode(
@@ -34,49 +40,43 @@ struct TranscriptionManagerConfigTests {
     // MARK: - Set Current Mode
 
     @Test func setCurrentMode_updatesMode() {
-        let manager = TranscriptionManager()
         let mode = makeMode(name: "Custom Mode")
 
-        manager.setCurrentMode(mode)
+        sut.setCurrentMode(mode)
 
-        #expect(manager.currentMode.name == "Custom Mode")
+        #expect(sut.currentMode.name == "Custom Mode")
     }
 
     @Test func setCurrentMode_appliesLanguage() {
-        let manager = TranscriptionManager()
         let mode = makeMode(language: "es")
 
-        manager.setCurrentMode(mode)
+        sut.setCurrentMode(mode)
 
-        #expect(manager.selectedLanguage == "es")
+        #expect(sut.selectedLanguage == "es")
     }
 
     @Test func setCurrentMode_nilLanguage_defaultsToAuto() {
-        let manager = TranscriptionManager()
         let mode = makeMode(language: nil)
 
-        manager.setCurrentMode(mode)
+        sut.setCurrentMode(mode)
 
-        #expect(manager.selectedLanguage == "auto")
+        #expect(sut.selectedLanguage == "auto")
     }
 
     // MARK: - Get Current Model
 
     @Test func getCurrentModel_defaultMode_returnsNil() {
         // Default mode has empty transcriptionModel → no match
-        let manager = TranscriptionManager()
-
-        let model = manager.getCurrentTranscriptionModel()
+        let model = sut.getCurrentTranscriptionModel()
 
         #expect(model == nil)
     }
 
     @Test func getCurrentModel_invalidModel_returnsNil() {
-        let manager = TranscriptionManager()
         let mode = makeMode(model: "nonexistent-model-xyz")
-        manager.setCurrentMode(mode)
+        sut.setCurrentMode(mode)
 
-        let model = manager.getCurrentTranscriptionModel()
+        let model = sut.getCurrentTranscriptionModel()
 
         #expect(model == nil)
     }
@@ -84,23 +84,21 @@ struct TranscriptionManagerConfigTests {
     // MARK: - Update Cloud Models
 
     @Test func updateCloudModels_firesCallback() {
-        let manager = TranscriptionManager()
         var callbackFired = false
-        manager.onCloudModelsUpdate = { callbackFired = true }
+        sut.onCloudModelsUpdate = { callbackFired = true }
 
-        manager.updateCloudModels()
+        sut.updateCloudModels()
 
         #expect(callbackFired == true)
     }
 
     @Test func updateCloudModels_rebuildsModelList() {
-        let manager = TranscriptionManager()
-        let countBefore = manager.allAvailableModels.count
+        let countBefore = sut.allAvailableModels.count
 
-        manager.updateCloudModels()
+        sut.updateCloudModels()
 
         // Should repopulate (count may be same but list was rebuilt)
-        #expect(manager.allAvailableModels.count == countBefore)
+        #expect(sut.allAvailableModels.count == countBefore)
     }
 }
 

--- a/VivaDictaTests/TranscriptionManagerTests.swift
+++ b/VivaDictaTests/TranscriptionManagerTests.swift
@@ -24,6 +24,14 @@ import TranscriptionKitMocks
 @MainActor
 struct TranscriptionManagerTests {
 
+    let mockEngine: MockTranscriptionEngine
+    let sut: TranscriptionManager
+
+    init() {
+        mockEngine = MockTranscriptionEngine()
+        sut = TranscriptionManager(engine: mockEngine)
+    }
+
     private func makeMode(
         provider: TranscriptionModelProvider,
         model: String
@@ -41,8 +49,6 @@ struct TranscriptionManagerTests {
     // MARK: - preloadWhisperKitModelIfNeeded
 
     @Test func preloadWhisperKitModelIfNeeded_doesNothing_whenCurrentModeIsParakeet() async {
-        let mockEngine = MockTranscriptionEngine()
-        let sut = TranscriptionManager(engine: mockEngine)
         sut.setCurrentMode(makeMode(provider: .parakeet, model: "parakeet-tdt-0.6b-v3"))
 
         await sut.preloadWhisperKitModelIfNeeded()
@@ -51,8 +57,6 @@ struct TranscriptionManagerTests {
     }
 
     @Test func preloadWhisperKitModelIfNeeded_doesNothing_whenCurrentModeIsCloudProvider() async {
-        let mockEngine = MockTranscriptionEngine()
-        let sut = TranscriptionManager(engine: mockEngine)
         sut.setCurrentMode(makeMode(provider: .openAI, model: "whisper-1"))
 
         await sut.preloadWhisperKitModelIfNeeded()
@@ -63,8 +67,6 @@ struct TranscriptionManagerTests {
     // MARK: - transcribe error path
 
     @Test func transcribe_throws_andDoesNotInvokeEngine_whenCurrentModelIsUnknown() async {
-        let mockEngine = MockTranscriptionEngine()
-        let sut = TranscriptionManager(engine: mockEngine)
         sut.setCurrentMode(makeMode(provider: .whisperKit, model: "nonexistent-model-xyz"))
 
         let url = URL(fileURLWithPath: "/tmp/x.wav")
@@ -77,8 +79,6 @@ struct TranscriptionManagerTests {
     // MARK: - setCurrentMode
 
     @Test func setCurrentMode_updatesCurrentMode() {
-        let mockEngine = MockTranscriptionEngine()
-        let sut = TranscriptionManager(engine: mockEngine)
         let mode = makeMode(provider: .parakeet, model: "parakeet-tdt-0.6b-v3")
 
         sut.setCurrentMode(mode)


### PR DESCRIPTION
Three independent test-only refactors bundled together since they all came out of the same Swift Testing audit.

## Summary

### 1. Hoist SUT to property + init()

Where every test in the file built the same SUT, moved it to a struct property initialized in `init()`. Renamed the local to `sut` per the project convention. With Swift Testing's per-test struct instantiation each test still gets a fresh SUT — this just removes the duplication.

- `TranscriptionManagerTests` — `mockEngine` + `sut` hoisted (4 tests)
- `TranscriptionManagerConfigTests` — `sut: TranscriptionManager` hoisted, `manager` → `sut` (7 tests)
- `DataControllerTests` — `sut: DataController` hoisted with throwing `init()` (drops a `try!`), `controller` → `sut`, `makeDataController()` helper removed (16 tests)

### 2. Parameterize language-filler tests

`TextProcessingFilterTests` had 5 near-identical `filter_<lang>Fillers_removedWhenLanguageIs<Lang>` tests differing only by `(language, input, removedTokens, keptTokens)`. Collapsed into a single `@Test(arguments: [...])` over a tuple. Test count is preserved (each tuple is a separate case in test reports), and a failure now gets a useful `[lang] expected \"token\" to be removed; got: ...` message that names which row failed.

### 3. Modernize throws assertions

Replaced `do/catch + Issue.record` with `#require(throws:) + guard case` in the AI-provider service tests. The Swift 6.1+ `#require(throws:)` returns the captured error, so we can use a single `guard case` for the case match instead of a nested `if case` inside the `catch`. Also removes the bottom-of-block `catch { Issue.record(...) }` since `#require(throws:)` already fails the test when nothing or the wrong type is thrown.

- `AnthropicServiceTests` — 3 blocks
- `OpenAICompatibleServiceTests` — 4 blocks (the `enhanceRethrowsURLErrorTransport` test got the biggest cleanup)
- `XaiTranscriptionServiceTests` — 2 blocks
- `GroqTranscriptionServiceTests` — 2 blocks
- `OpenAITranscriptionServiceTests` — 2 blocks

`NetworkErrorBridgeTests` was checked but already uses the clean `guard case` pattern (no throwing call to wrap), so no changes there.

## Test plan
- [x] `xcodebuild build-for-testing` — 0 errors
- [x] `xcodebuild test -only-testing:VivaDictaTests` — 333 tests passed, 0 failed
- [x] Affected suites in `CloudTranscriptionTests` — all green
- [ ] Full CI test run