### PR TITLE
Tag networking suites, rename locals to sut, swap force-unwrap for require

### DIFF
--- a/Modules/CloudTranscription/Tests/CloudTranscriptionTests/GroqTranscriptionServiceTests.swift
+++ b/Modules/CloudTranscription/Tests/CloudTranscriptionTests/GroqTranscriptionServiceTests.swift
@@ -15,6 +15,7 @@ import TranscriptionCore
 /// Mirrors the structure of `OpenAITranscriptionServiceTests`. Retry-path
 /// tests are intentionally skipped here - retry semantics belong on
 /// `NetworkRetry`'s own tests.
+@Suite(.tags(.networking))
 struct GroqTranscriptionServiceTests {
 
     // MARK: - Test Helpers

--- a/Modules/CloudTranscription/Tests/CloudTranscriptionTests/NetworkErrorBridgeTests.swift
+++ b/Modules/CloudTranscription/Tests/CloudTranscriptionTests/NetworkErrorBridgeTests.swift
@@ -5,7 +5,7 @@ import Foundation
 import Networking
 import Testing
 
-@Suite("NetworkError → transcription error bridge")
+@Suite("NetworkError → transcription error bridge", .tags(.networking))
 struct NetworkErrorBridgeTests {
 
     @Test func unacceptableStatusMapsToApiRequestFailed() {

--- a/Modules/CloudTranscription/Tests/CloudTranscriptionTests/OpenAITranscriptionServiceTests.swift
+++ b/Modules/CloudTranscription/Tests/CloudTranscriptionTests/OpenAITranscriptionServiceTests.swift
@@ -17,6 +17,7 @@ import TranscriptionCore
 ///
 /// Each test creates a fresh `MockNetworkService`, so there's no shared mutable
 /// state and the suite is safe to run in parallel with other suites.
+@Suite(.tags(.networking))
 struct OpenAITranscriptionServiceTests {
 
     // MARK: - Test Helpers

--- a/Modules/CloudTranscription/Tests/CloudTranscriptionTests/TestTags.swift
+++ b/Modules/CloudTranscription/Tests/CloudTranscriptionTests/TestTags.swift
@@ -5,6 +5,7 @@ import Testing
 extension Tag {
     /// Marks suites that exercise networking through a mocked transport.
     /// No real network calls happen - the tag exists so the suites can be
-    /// filtered as a group (e.g. `swift test --filter-tag networking`).
+    /// selected/excluded as a group (e.g. via an Xcode Test Plan, or
+    /// `swift test --filter-tag networking` when running this package alone).
     @Tag static var networking: Self
 }

--- a/Modules/CloudTranscription/Tests/CloudTranscriptionTests/TestTags.swift
+++ b/Modules/CloudTranscription/Tests/CloudTranscriptionTests/TestTags.swift
@@ -1,0 +1,10 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Testing
+
+extension Tag {
+    /// Marks suites that exercise networking through a mocked transport.
+    /// No real network calls happen - the tag exists so the suites can be
+    /// filtered as a group (e.g. `swift test --filter-tag networking`).
+    @Tag static var networking: Self
+}

--- a/Modules/CloudTranscription/Tests/CloudTranscriptionTests/XaiTranscriptionServiceTests.swift
+++ b/Modules/CloudTranscription/Tests/CloudTranscriptionTests/XaiTranscriptionServiceTests.swift
@@ -11,6 +11,7 @@ import TranscriptionCore
 /// `MockNetworkService`. Verifies request shape (URL, method, headers,
 /// multipart body) and response handling (success, non-2xx, undecodable
 /// JSON), plus the xAI-specific `format`/`file-last` body ordering.
+@Suite(.tags(.networking))
 struct XaiTranscriptionServiceTests {
 
     // MARK: - Test Helpers

--- a/VivaDictaTests/AIServiceConfigurationTests.swift
+++ b/VivaDictaTests/AIServiceConfigurationTests.swift
@@ -55,44 +55,44 @@ struct AIServiceConfigurationTests {
 
     @Test func isProperlyConfigured_aiDisabled_returnsFalse() {
         let mode = makeMode(aiEnhanceEnabled: false)
-        let service = makeService(withModes: [mode])
-        service.selectedModeName = mode.name
-        service.presetManager = makePresetManager()
+        let sut = makeService(withModes: [mode])
+        sut.selectedModeName = mode.name
+        sut.presetManager = makePresetManager()
 
-        #expect(service.isProperlyConfigured() == false)
+        #expect(sut.isProperlyConfigured() == false)
     }
 
     @Test func isProperlyConfigured_noProvider_returnsFalse() {
         let mode = makeMode(aiProvider: nil)
-        let service = makeService(withModes: [mode])
-        service.selectedModeName = mode.name
-        service.presetManager = makePresetManager()
+        let sut = makeService(withModes: [mode])
+        sut.selectedModeName = mode.name
+        sut.presetManager = makePresetManager()
 
-        #expect(service.isProperlyConfigured() == false)
+        #expect(sut.isProperlyConfigured() == false)
     }
 
     @Test func isProperlyConfigured_emptyModel_returnsFalse() {
         let mode = makeMode(aiModel: "")
-        let service = makeService(withModes: [mode])
-        service.selectedModeName = mode.name
-        service.presetManager = makePresetManager()
+        let sut = makeService(withModes: [mode])
+        sut.selectedModeName = mode.name
+        sut.presetManager = makePresetManager()
 
-        #expect(service.isProperlyConfigured() == false)
+        #expect(sut.isProperlyConfigured() == false)
     }
 
     @Test func isProperlyConfigured_noPreset_returnsFalse() {
         let mode = makeMode(presetId: nil)
-        let service = makeService(withModes: [mode])
-        service.selectedModeName = mode.name
-        service.presetManager = makePresetManager()
+        let sut = makeService(withModes: [mode])
+        sut.selectedModeName = mode.name
+        sut.presetManager = makePresetManager()
 
-        #expect(service.isProperlyConfigured() == false)
+        #expect(sut.isProperlyConfigured() == false)
     }
 
     @Test func isProperlyConfigured_emptyPresetInstructions_returnsFalse() {
         let mode = makeMode(presetId: "empty_preset")
-        let service = makeService(withModes: [mode])
-        service.selectedModeName = mode.name
+        let sut = makeService(withModes: [mode])
+        sut.selectedModeName = mode.name
 
         let pm = makePresetManager()
         let emptyPreset = Preset(
@@ -106,84 +106,84 @@ struct AIServiceConfigurationTests {
             isBuiltIn: false
         )
         pm.addPreset(emptyPreset)
-        service.presetManager = pm
+        sut.presetManager = pm
 
-        #expect(service.isProperlyConfigured() == false)
+        #expect(sut.isProperlyConfigured() == false)
     }
 
     @Test func isProperlyConfigured_ollamaProvider_validConfig_returnsTrue() {
         // Ollama doesn't need API key — just needs model + preset
         let mode = makeMode(aiProvider: .ollama, aiModel: "llama3.2", presetId: "regular")
-        let service = makeService(withModes: [mode])
-        service.selectedModeName = mode.name
-        service.presetManager = makePresetManager()
+        let sut = makeService(withModes: [mode])
+        sut.selectedModeName = mode.name
+        sut.presetManager = makePresetManager()
 
-        #expect(service.isProperlyConfigured() == true)
+        #expect(sut.isProperlyConfigured() == true)
     }
 
     @Test func isProperlyConfigured_customOpenAI_noEndpoint_returnsFalse() {
         let mode = makeMode(aiProvider: .customOpenAI, aiModel: "gpt-4")
-        let service = makeService(withModes: [mode])
-        service.selectedModeName = mode.name
-        service.presetManager = makePresetManager()
+        let sut = makeService(withModes: [mode])
+        sut.selectedModeName = mode.name
+        sut.presetManager = makePresetManager()
         // customOpenAIEndpointURL is "" by default
 
-        #expect(service.isProperlyConfigured() == false)
+        #expect(sut.isProperlyConfigured() == false)
     }
 
     @Test func isProperlyConfigured_cloudProvider_noAPIKey_returnsFalse() {
         // Anthropic requires API key — no key in keychain → false
         let mode = makeMode(aiProvider: .anthropic, aiModel: "claude-sonnet-4-6")
-        let service = makeService(withModes: [mode])
-        service.selectedModeName = mode.name
-        service.presetManager = makePresetManager()
+        let sut = makeService(withModes: [mode])
+        sut.selectedModeName = mode.name
+        sut.presetManager = makePresetManager()
 
-        #expect(service.isProperlyConfigured() == false)
+        #expect(sut.isProperlyConfigured() == false)
     }
 
     // MARK: - Streaming Capability Tests
 
     @Test func currentModeSupportsResponseStreaming_appleMode_returnsTrue() {
         let mode = makeMode(aiProvider: .apple, aiModel: "foundation-model")
-        let service = makeService(withModes: [mode])
-        service.selectedModeName = mode.name
+        let sut = makeService(withModes: [mode])
+        sut.selectedModeName = mode.name
 
-        #expect(service.currentModeSupportsResponseStreaming == true)
+        #expect(sut.currentModeSupportsResponseStreaming == true)
     }
 
     @Test func currentModeSupportsResponseStreaming_openAIAPIKeyMode_returnsTrue() {
         let mode = makeMode(aiProvider: .openAI, aiModel: "gpt-5-mini")
-        let service = makeService(withModes: [mode])
-        service.selectedModeName = mode.name
+        let sut = makeService(withModes: [mode])
+        sut.selectedModeName = mode.name
 
-        #expect(service.currentModeSupportsResponseStreaming == true)
+        #expect(sut.currentModeSupportsResponseStreaming == true)
     }
 
     @Test func currentModeSupportsResponseStreaming_openAIOAuth_returnsTrue() {
         let mode = makeMode(aiProvider: .openAI, aiModel: "gpt-5.4-mini")
-        let service = makeService(withModes: [mode])
-        service.selectedModeName = mode.name
-        service.isOpenAISignedIn = true
+        let sut = makeService(withModes: [mode])
+        sut.selectedModeName = mode.name
+        sut.isOpenAISignedIn = true
 
-        #expect(service.currentModeSupportsResponseStreaming == true)
+        #expect(sut.currentModeSupportsResponseStreaming == true)
     }
 
     @Test func currentModeSupportsResponseStreaming_geminiOAuth_returnsTrue() {
         let mode = makeMode(aiProvider: .gemini, aiModel: "gemini-3-flash-preview")
-        let service = makeService(withModes: [mode])
-        service.selectedModeName = mode.name
-        service.isGeminiSignedIn = true
+        let sut = makeService(withModes: [mode])
+        sut.selectedModeName = mode.name
+        sut.isGeminiSignedIn = true
 
-        #expect(service.currentModeSupportsResponseStreaming == true)
+        #expect(sut.currentModeSupportsResponseStreaming == true)
     }
 
     @Test func currentModeSupportsResponseStreaming_copilotOAuth_returnsTrue() {
         let mode = makeMode(aiProvider: .copilot, aiModel: "gpt-4o")
-        let service = makeService(withModes: [mode])
-        service.selectedModeName = mode.name
-        service.isCopilotSignedIn = true
+        let sut = makeService(withModes: [mode])
+        sut.selectedModeName = mode.name
+        sut.isCopilotSignedIn = true
 
-        #expect(service.currentModeSupportsResponseStreaming == true)
+        #expect(sut.currentModeSupportsResponseStreaming == true)
     }
 
     @Test func openAICompatibleStreamingDelta_extractsContentDelta() {
@@ -233,10 +233,10 @@ struct AIServiceConfigurationTests {
 
     @Test func currentModeSupportsResponseStreaming_anthropicReturnsTrue() {
         let mode = makeMode(aiProvider: .anthropic, aiModel: "claude-sonnet-4-6")
-        let service = makeService(withModes: [mode])
-        service.selectedModeName = mode.name
+        let sut = makeService(withModes: [mode])
+        sut.selectedModeName = mode.name
 
-        #expect(service.currentModeSupportsResponseStreaming == true)
+        #expect(sut.currentModeSupportsResponseStreaming == true)
     }
 
     // MARK: - Apple FM Sampling Profiles
@@ -277,12 +277,12 @@ struct AIServiceConfigurationTests {
     @Test func disableAIForModesUsingProvider_onlyAffectsMatchingModes() {
         let groqMode = makeMode(name: "Groq Mode", aiProvider: .groq, aiModel: "llama-3.3-70b-versatile")
         let ollamaMode = makeMode(name: "Ollama Mode", aiProvider: .ollama, aiModel: "llama3.2")
-        let service = makeService(withModes: [groqMode, ollamaMode])
+        let sut = makeService(withModes: [groqMode, ollamaMode])
 
-        service.disableAIEnhancementForModesUsingProvider(.groq)
+        sut.disableAIEnhancementForModesUsingProvider(.groq)
 
-        let updatedGroq = service.modes.first { $0.name == "Groq Mode" }!
-        let updatedOllama = service.modes.first { $0.name == "Ollama Mode" }!
+        let updatedGroq = sut.modes.first { $0.name == "Groq Mode" }!
+        let updatedOllama = sut.modes.first { $0.name == "Ollama Mode" }!
 
         #expect(updatedGroq.aiEnhanceEnabled == false)
         #expect(updatedOllama.aiEnhanceEnabled == true)
@@ -290,12 +290,12 @@ struct AIServiceConfigurationTests {
 
     @Test func disableAIForModesUsingProvider_updatesSelectedMode() {
         let mode = makeMode(name: "Active", aiProvider: .groq)
-        let service = makeService(withModes: [mode])
-        service.selectedModeName = mode.name
+        let sut = makeService(withModes: [mode])
+        sut.selectedModeName = mode.name
 
-        service.disableAIEnhancementForModesUsingProvider(.groq)
+        sut.disableAIEnhancementForModesUsingProvider(.groq)
 
-        #expect(service.selectedMode.aiEnhanceEnabled == false)
+        #expect(sut.selectedMode.aiEnhanceEnabled == false)
     }
 
     // MARK: - Disable Modes by Preset Tests
@@ -303,12 +303,12 @@ struct AIServiceConfigurationTests {
     @Test func disableAIForModesUsingPreset_onlyAffectsMatchingModes() {
         let summaryMode = makeMode(name: "Summary", presetId: "summary")
         let regularMode = makeMode(name: "Regular", presetId: "regular")
-        let service = makeService(withModes: [summaryMode, regularMode])
+        let sut = makeService(withModes: [summaryMode, regularMode])
 
-        service.disableAIEnhancementForModesUsingPreset(presetId: "summary")
+        sut.disableAIEnhancementForModesUsingPreset(presetId: "summary")
 
-        let updatedSummary = service.modes.first { $0.name == "Summary" }!
-        let updatedRegular = service.modes.first { $0.name == "Regular" }!
+        let updatedSummary = sut.modes.first { $0.name == "Summary" }!
+        let updatedRegular = sut.modes.first { $0.name == "Regular" }!
 
         #expect(updatedSummary.aiEnhanceEnabled == false)
         #expect(updatedSummary.presetId == nil)
@@ -319,37 +319,37 @@ struct AIServiceConfigurationTests {
     // MARK: - Get Available Models Tests
 
     @Test func getAvailableModels_staticProvider_returnsProviderModels() {
-        let service = makeService()
+        let sut = makeService()
 
-        let anthropicModels = service.getAvailableModels(for: .anthropic)
+        let anthropicModels = sut.getAvailableModels(for: .anthropic)
 
         #expect(anthropicModels.isEmpty == false)
         #expect(anthropicModels.contains("claude-sonnet-4-6"))
     }
 
     @Test func getAvailableModels_dynamicProvider_returnsStoredModels() {
-        let service = makeService()
-        service.openRouterModels = ["model-a", "model-b"]
+        let sut = makeService()
+        sut.openRouterModels = ["model-a", "model-b"]
 
-        let models = service.getAvailableModels(for: .openRouter)
+        let models = sut.getAvailableModels(for: .openRouter)
 
         #expect(models == ["model-a", "model-b"])
     }
 
     @Test func getAvailableModels_customOpenAI_returnsConfiguredModel() {
-        let service = makeService()
-        service.customOpenAIModelName = "my-custom-model"
+        let sut = makeService()
+        sut.customOpenAIModelName = "my-custom-model"
 
-        let models = service.getAvailableModels(for: .customOpenAI)
+        let models = sut.getAvailableModels(for: .customOpenAI)
 
         #expect(models == ["my-custom-model"])
     }
 
     @Test func getAvailableModels_customOpenAI_emptyName_returnsEmpty() {
-        let service = makeService()
-        service.customOpenAIModelName = ""
+        let sut = makeService()
+        sut.customOpenAIModelName = ""
 
-        let models = service.getAvailableModels(for: .customOpenAI)
+        let models = sut.getAvailableModels(for: .customOpenAI)
 
         #expect(models.isEmpty)
     }

--- a/VivaDictaTests/AIServiceNetworkingTests.swift
+++ b/VivaDictaTests/AIServiceNetworkingTests.swift
@@ -10,6 +10,7 @@ import Testing
 /// through to the underlying HTTP calls. Full per-provider coverage lives in
 /// each provider's own test suite; this file just locks in the wiring so a
 /// future refactor that drops the injection is caught immediately.
+@Suite(.tags(.networking))
 @MainActor
 struct AIServiceNetworkingTests {
 

--- a/VivaDictaTests/AnthropicServiceTests.swift
+++ b/VivaDictaTests/AnthropicServiceTests.swift
@@ -18,7 +18,7 @@ import Testing
 /// `URLSession.AsyncBytes`. The streaming tests here verify the
 /// outgoing request shape and rely on integration / manual testing
 /// for end-to-end SSE parsing.
-@Suite("AnthropicService")
+@Suite("AnthropicService", .tags(.networking))
 struct AnthropicServiceTests {
 
     private let endpointURL = AIProvider.anthropic.baseURL

--- a/VivaDictaTests/AudioCleanupServiceTests.swift
+++ b/VivaDictaTests/AudioCleanupServiceTests.swift
@@ -85,12 +85,12 @@ struct AudioCleanupServiceTests {
         try context.save()
 
         // Run cleanup
-        let service = AudioCleanupService(
+        let sut = AudioCleanupService(
             userDefaults: defaults,
             audioDirectory: audioDir,
             minimumCleanupInterval: 0
         )
-        await service.performCleanupIfNeeded(modelContext: context)
+        await sut.performCleanupIfNeeded(modelContext: context)
 
         // Verify: audio file still exists, transcription unchanged
         #expect(FileManager.default.fileExists(atPath: audioDir.appendingPathComponent(fileName).path))
@@ -133,12 +133,12 @@ struct AudioCleanupServiceTests {
         try context.save()
 
         // Run cleanup
-        let service = AudioCleanupService(
+        let sut = AudioCleanupService(
             userDefaults: defaults,
             audioDirectory: audioDir,
             minimumCleanupInterval: 0
         )
-        await service.performCleanupIfNeeded(modelContext: context)
+        await sut.performCleanupIfNeeded(modelContext: context)
 
         // Verify: old file deleted, recent file kept
         #expect(FileManager.default.fileExists(atPath: audioDir.appendingPathComponent(oldFileName).path) == false)
@@ -171,12 +171,12 @@ struct AudioCleanupServiceTests {
         try context.save()
 
         // Run cleanup
-        let service = AudioCleanupService(
+        let sut = AudioCleanupService(
             userDefaults: defaults,
             audioDirectory: audioDir,
             minimumCleanupInterval: 0
         )
-        await service.performCleanupIfNeeded(modelContext: context)
+        await sut.performCleanupIfNeeded(modelContext: context)
 
         // Verify: file deleted
         #expect(FileManager.default.fileExists(atPath: audioDir.appendingPathComponent(fileName).path) == false)
@@ -207,12 +207,12 @@ struct AudioCleanupServiceTests {
         try context.save()
 
         // Run cleanup
-        let service = AudioCleanupService(
+        let sut = AudioCleanupService(
             userDefaults: defaults,
             audioDirectory: audioDir,
             minimumCleanupInterval: 0
         )
-        await service.performCleanupIfNeeded(modelContext: context)
+        await sut.performCleanupIfNeeded(modelContext: context)
 
         // Verify: file still exists (5 days < 7 day default retention)
         #expect(FileManager.default.fileExists(atPath: audioDir.appendingPathComponent(fileName).path))
@@ -246,12 +246,12 @@ struct AudioCleanupServiceTests {
         #expect(transcription.audioFileName == fileName)
 
         // Run cleanup
-        let service = AudioCleanupService(
+        let sut = AudioCleanupService(
             userDefaults: defaults,
             audioDirectory: audioDir,
             minimumCleanupInterval: 0
         )
-        await service.performCleanupIfNeeded(modelContext: context)
+        await sut.performCleanupIfNeeded(modelContext: context)
 
         // Verify: audioFileName is cleared
         #expect(transcription.audioFileName == nil)
@@ -287,12 +287,12 @@ struct AudioCleanupServiceTests {
         try context.save()
 
         // Run cleanup
-        let service = AudioCleanupService(
+        let sut = AudioCleanupService(
             userDefaults: defaults,
             audioDirectory: audioDir,
             minimumCleanupInterval: 0
         )
-        await service.performCleanupIfNeeded(modelContext: context)
+        await sut.performCleanupIfNeeded(modelContext: context)
 
         // Verify: text preserved, audio cleared
         #expect(transcription.text == originalText)
@@ -326,12 +326,12 @@ struct AudioCleanupServiceTests {
         try context.save()
 
         // Run cleanup
-        let service = AudioCleanupService(
+        let sut = AudioCleanupService(
             userDefaults: defaults,
             audioDirectory: audioDir,
             minimumCleanupInterval: 0
         )
-        await service.performCleanupIfNeeded(modelContext: context)
+        await sut.performCleanupIfNeeded(modelContext: context)
 
         // Verify: nothing changed
         #expect(FileManager.default.fileExists(atPath: audioDir.appendingPathComponent(fileName).path))
@@ -361,12 +361,12 @@ struct AudioCleanupServiceTests {
         try context.save()
 
         // Run cleanup - should complete without errors
-        let service = AudioCleanupService(
+        let sut = AudioCleanupService(
             userDefaults: defaults,
             audioDirectory: audioDir,
             minimumCleanupInterval: 0
         )
-        await service.performCleanupIfNeeded(modelContext: context)
+        await sut.performCleanupIfNeeded(modelContext: context)
 
         // Verify: transcription unchanged
         #expect(transcription.text == "Old transcription without audio")
@@ -403,12 +403,12 @@ struct AudioCleanupServiceTests {
         try context.save()
 
         // Run cleanup
-        let service = AudioCleanupService(
+        let sut = AudioCleanupService(
             userDefaults: defaults,
             audioDirectory: audioDir,
             minimumCleanupInterval: 0
         )
-        await service.performCleanupIfNeeded(modelContext: context)
+        await sut.performCleanupIfNeeded(modelContext: context)
 
         // Verify file deleted from disk
         #expect(FileManager.default.fileExists(atPath: filePath.path) == false)
@@ -436,12 +436,12 @@ struct AudioCleanupServiceTests {
         try context.save()
 
         // Run cleanup - should complete without errors
-        let service = AudioCleanupService(
+        let sut = AudioCleanupService(
             userDefaults: defaults,
             audioDirectory: audioDir,
             minimumCleanupInterval: 0
         )
-        await service.performCleanupIfNeeded(modelContext: context)
+        await sut.performCleanupIfNeeded(modelContext: context)
 
         // Verify: audioFileName still cleared even if file didn't exist
         #expect(transcription.audioFileName == nil)
@@ -478,12 +478,12 @@ struct AudioCleanupServiceTests {
         try context.save()
 
         // Run cleanup
-        let service = AudioCleanupService(
+        let sut = AudioCleanupService(
             userDefaults: defaults,
             audioDirectory: audioDir,
             minimumCleanupInterval: 0
         )
-        await service.performCleanupIfNeeded(modelContext: context)
+        await sut.performCleanupIfNeeded(modelContext: context)
 
         // Verify: all files deleted, all audioFileNames cleared
         for (i, transcription) in transcriptions.enumerated() {
@@ -523,12 +523,12 @@ struct AudioCleanupServiceTests {
         try context.save()
 
         // Run cleanup with 24 hour interval (default)
-        let service = AudioCleanupService(
+        let sut = AudioCleanupService(
             userDefaults: defaults,
             audioDirectory: audioDir,
             minimumCleanupInterval: 24 * 60 * 60
         )
-        await service.performCleanupIfNeeded(modelContext: context)
+        await sut.performCleanupIfNeeded(modelContext: context)
 
         // Verify: file NOT deleted because cleanup ran recently
         #expect(FileManager.default.fileExists(atPath: audioDir.appendingPathComponent(fileName).path))
@@ -562,12 +562,12 @@ struct AudioCleanupServiceTests {
         try context.save()
 
         // Run cleanup with 24 hour interval
-        let service = AudioCleanupService(
+        let sut = AudioCleanupService(
             userDefaults: defaults,
             audioDirectory: audioDir,
             minimumCleanupInterval: 24 * 60 * 60
         )
-        await service.performCleanupIfNeeded(modelContext: context)
+        await sut.performCleanupIfNeeded(modelContext: context)
 
         // Verify: file deleted because enough time passed
         #expect(FileManager.default.fileExists(atPath: audioDir.appendingPathComponent(fileName).path) == false)
@@ -597,12 +597,12 @@ struct AudioCleanupServiceTests {
         try context.save()
 
         // Run cleanup with 24 hour interval
-        let service = AudioCleanupService(
+        let sut = AudioCleanupService(
             userDefaults: defaults,
             audioDirectory: audioDir,
             minimumCleanupInterval: 24 * 60 * 60
         )
-        await service.performCleanupIfNeeded(modelContext: context)
+        await sut.performCleanupIfNeeded(modelContext: context)
 
         // Verify: file deleted on first launch
         #expect(FileManager.default.fileExists(atPath: audioDir.appendingPathComponent(fileName).path) == false)
@@ -637,12 +637,12 @@ struct AudioCleanupServiceTests {
         let beforeCleanup = Date()
 
         // Run cleanup
-        let service = AudioCleanupService(
+        let sut = AudioCleanupService(
             userDefaults: defaults,
             audioDirectory: audioDir,
             minimumCleanupInterval: 0
         )
-        await service.performCleanupIfNeeded(modelContext: context)
+        await sut.performCleanupIfNeeded(modelContext: context)
 
         // Verify timestamp was set
         let lastCleanup = defaults.object(forKey: "lastAudioCleanupDate") as? Date

--- a/VivaDictaTests/CustomOpenAIServiceTests.swift
+++ b/VivaDictaTests/CustomOpenAIServiceTests.swift
@@ -10,7 +10,7 @@ import Testing
 /// Tests cover `CustomOpenAIService` in isolation: the status-code mapping,
 /// API-key forwarding, body shape, and URLError handling - both raw and
 /// wrapped in `NetworkError.transport`.
-@Suite("CustomOpenAIService")
+@Suite("CustomOpenAIService", .tags(.networking))
 struct CustomOpenAIServiceTests {
 
     private let endpointURL = "https://api.example.com/v1/chat/completions"

--- a/VivaDictaTests/DataControllerTests.swift
+++ b/VivaDictaTests/DataControllerTests.swift
@@ -147,7 +147,7 @@ struct DataControllerTests {
         let entities = try sut.transcriptionEntities()
 
         #expect(entities.count == 1)
-        let entity = entities.first!
+        let entity = try #require(entities.first)
         #expect(entity.id == transcription.id)
         #expect(entity.text == "Entity test")
         #expect(entity.enhancedText == "Enhanced entity")

--- a/VivaDictaTests/ModeEditViewModelTests.swift
+++ b/VivaDictaTests/ModeEditViewModelTests.swift
@@ -42,167 +42,167 @@ struct ModeEditViewModelTests {
     // MARK: - isValid Tests
 
     @Test func testIsValid_emptyName_returnsFalse() {
-        let viewModel = makeViewModel()
-        viewModel.modeName = ""
+        let sut = makeViewModel()
+        sut.modeName = ""
 
-        #expect(viewModel.isValid == false)
+        #expect(sut.isValid == false)
     }
 
     @Test func testIsValid_whitespaceOnlyName_returnsFalse() {
-        let viewModel = makeViewModel()
-        viewModel.modeName = "   "
+        let sut = makeViewModel()
+        sut.modeName = "   "
 
-        #expect(viewModel.isValid == false)
+        #expect(sut.isValid == false)
     }
 
     @Test func testIsValid_noTranscriptionModel_returnsFalse() {
-        let viewModel = makeViewModel()
-        viewModel.modeName = "Test Mode"
-        viewModel.transcriptionModel = ""
+        let sut = makeViewModel()
+        sut.modeName = "Test Mode"
+        sut.transcriptionModel = ""
 
-        #expect(viewModel.isValid == false)
+        #expect(sut.isValid == false)
     }
 
     @Test func testIsValid_aiProcessingDisabled_noAIConfigNeeded() {
-        let viewModel = makeViewModel()
-        viewModel.modeName = "Test Mode"
-        viewModel.transcriptionProvider = .parakeet
-        viewModel.transcriptionModel = "test-model"
-        viewModel.aiEnhanceEnabled = false
+        let sut = makeViewModel()
+        sut.modeName = "Test Mode"
+        sut.transcriptionProvider = .parakeet
+        sut.transcriptionModel = "test-model"
+        sut.aiEnhanceEnabled = false
 
         // When AI processing is disabled, we don't need AI config
         // But we still need transcription to be configured
         // Note: isTranscriptionProviderConfigured depends on downloaded models
         // For this test, we're checking the logic flow
-        #expect(viewModel.aiEnhanceEnabled == false)
+        #expect(sut.aiEnhanceEnabled == false)
     }
 
     @Test func testIsValid_aiProcessingEnabled_noProvider_returnsFalse() {
-        let viewModel = makeViewModel()
-        viewModel.modeName = "Test Mode"
-        viewModel.transcriptionModel = "test-model"
-        viewModel.aiEnhanceEnabled = true
-        viewModel.aiProvider = nil
+        let sut = makeViewModel()
+        sut.modeName = "Test Mode"
+        sut.transcriptionModel = "test-model"
+        sut.aiEnhanceEnabled = true
+        sut.aiProvider = nil
 
         // Should be invalid because AI processing is enabled but no provider
-        #expect(viewModel.aiEnhancementValidationMessage == "Select an AI provider, or disable AI Processing")
+        #expect(sut.aiEnhancementValidationMessage == "Select an AI provider, or disable AI Processing")
     }
 
     @Test func testIsValid_aiProcessingEnabled_noModel_returnsFalse() {
-        let viewModel = makeViewModel()
-        viewModel.modeName = "Test Mode"
-        viewModel.transcriptionModel = "test-model"
-        viewModel.aiEnhanceEnabled = true
-        viewModel.aiProvider = .openAI
-        viewModel.aiModel = nil
+        let sut = makeViewModel()
+        sut.modeName = "Test Mode"
+        sut.transcriptionModel = "test-model"
+        sut.aiEnhanceEnabled = true
+        sut.aiProvider = .openAI
+        sut.aiModel = nil
 
-        #expect(viewModel.aiEnhancementValidationMessage == "Add API key to continue, or disable AI Processing")
+        #expect(sut.aiEnhancementValidationMessage == "Add API key to continue, or disable AI Processing")
     }
 
     @Test func testIsValid_aiProcessingEnabled_emptyModel_returnsFalse() {
-        let viewModel = makeViewModel()
-        viewModel.modeName = "Test Mode"
-        viewModel.transcriptionModel = "test-model"
-        viewModel.aiEnhanceEnabled = true
-        viewModel.aiProvider = .openAI
-        viewModel.aiModel = ""
+        let sut = makeViewModel()
+        sut.modeName = "Test Mode"
+        sut.transcriptionModel = "test-model"
+        sut.aiEnhanceEnabled = true
+        sut.aiProvider = .openAI
+        sut.aiModel = ""
 
-        #expect(viewModel.aiEnhancementValidationMessage != nil)
+        #expect(sut.aiEnhancementValidationMessage != nil)
     }
 
     @Test func testIsValid_aiProcessingEnabled_noPreset_returnsFalse() {
-        let viewModel = makeViewModel()
-        viewModel.modeName = "Test Mode"
-        viewModel.transcriptionModel = "test-model"
-        viewModel.aiEnhanceEnabled = true
-        viewModel.aiProvider = .openAI
-        viewModel.aiModel = "gpt-4"
-        viewModel.selectedPresetId = nil
+        let sut = makeViewModel()
+        sut.modeName = "Test Mode"
+        sut.transcriptionModel = "test-model"
+        sut.aiEnhanceEnabled = true
+        sut.aiProvider = .openAI
+        sut.aiModel = "gpt-4"
+        sut.selectedPresetId = nil
 
         // Should show preset validation message (after API key check)
-        #expect(viewModel.aiEnhancementValidationMessage != nil)
+        #expect(sut.aiEnhancementValidationMessage != nil)
     }
 
     // MARK: - transcriptionValidationMessage Tests
 
     @Test func testTranscriptionValidationMessage_localProviderNotConfigured() {
-        let viewModel = makeViewModel()
-        viewModel.transcriptionProvider = .whisperKit
+        let sut = makeViewModel()
+        sut.transcriptionProvider = .whisperKit
         // No models downloaded, so should show download message
 
-        let message = viewModel.transcriptionValidationMessage
+        let message = sut.transcriptionValidationMessage
         #expect(message == "Download a model to continue" || message == "Select a transcription model")
     }
 
     @Test func testTranscriptionValidationMessage_cloudProviderNotConfigured() {
-        let viewModel = makeViewModel()
-        viewModel.transcriptionProvider = .groq
-        viewModel.transcriptionModel = "whisper-large-v3"
+        let sut = makeViewModel()
+        sut.transcriptionProvider = .groq
+        sut.transcriptionModel = "whisper-large-v3"
 
         // Check that validation message is present when provider not configured
         // The exact message depends on whether API key exists
-        let isConfigured = viewModel.isTranscriptionProviderConfigured(viewModel.transcriptionProvider)
+        let isConfigured = sut.isTranscriptionProviderConfigured(sut.transcriptionProvider)
         if !isConfigured {
-            #expect(viewModel.transcriptionValidationMessage == "Add API key to continue")
+            #expect(sut.transcriptionValidationMessage == "Add API key to continue")
         } else {
             // If configured (API key exists), no validation message needed
-            #expect(viewModel.transcriptionValidationMessage == nil)
+            #expect(sut.transcriptionValidationMessage == nil)
         }
     }
 
     @Test func testTranscriptionValidationMessage_emptyModel() {
-        let viewModel = makeViewModel()
-        viewModel.transcriptionProvider = .groq
-        viewModel.transcriptionModel = ""
+        let sut = makeViewModel()
+        sut.transcriptionProvider = .groq
+        sut.transcriptionModel = ""
 
         // Should have a validation message
-        #expect(viewModel.transcriptionValidationMessage != nil)
+        #expect(sut.transcriptionValidationMessage != nil)
     }
 
     // MARK: - AI Processing Validation Message Tests
 
     @Test func testAIProcessingValidationMessage_disabled_returnsNil() {
-        let viewModel = makeViewModel()
-        viewModel.aiEnhanceEnabled = false
+        let sut = makeViewModel()
+        sut.aiEnhanceEnabled = false
 
-        #expect(viewModel.aiEnhancementValidationMessage == nil)
+        #expect(sut.aiEnhancementValidationMessage == nil)
     }
 
     @Test func testAIProcessingValidationMessage_noProvider() {
-        let viewModel = makeViewModel()
-        viewModel.aiEnhanceEnabled = true
-        viewModel.aiProvider = nil
+        let sut = makeViewModel()
+        sut.aiEnhanceEnabled = true
+        sut.aiProvider = nil
 
-        #expect(viewModel.aiEnhancementValidationMessage == "Select an AI provider, or disable AI Processing")
+        #expect(sut.aiEnhancementValidationMessage == "Select an AI provider, or disable AI Processing")
     }
 
     @Test func testAIProcessingValidationMessage_noAPIKey() {
-        let viewModel = makeViewModel()
-        viewModel.aiEnhanceEnabled = true
-        viewModel.aiProvider = .openAI
+        let sut = makeViewModel()
+        sut.aiEnhanceEnabled = true
+        sut.aiProvider = .openAI
         // No API key configured
 
-        #expect(viewModel.aiEnhancementValidationMessage == "Add API key to continue, or disable AI Processing")
+        #expect(sut.aiEnhancementValidationMessage == "Add API key to continue, or disable AI Processing")
     }
 
     @Test func testAIProcessingValidationMessage_noPreset() {
-        let viewModel = makeViewModel()
-        viewModel.aiEnhanceEnabled = true
-        viewModel.aiProvider = .openAI
-        viewModel.aiModel = "gpt-4"
-        viewModel.selectedPresetId = nil
+        let sut = makeViewModel()
+        sut.aiEnhanceEnabled = true
+        sut.aiProvider = .openAI
+        sut.aiModel = "gpt-4"
+        sut.selectedPresetId = nil
         // Would need API key to get past that check, so this tests the order
 
         // The validation checks in order: provider -> API key -> model -> preset
-        #expect(viewModel.aiEnhancementValidationMessage != nil)
+        #expect(sut.aiEnhancementValidationMessage != nil)
     }
 
     // MARK: - isEditing Tests
 
     @Test func testIsEditing_newMode_returnsFalse() {
-        let viewModel = makeViewModel()
+        let sut = makeViewModel()
 
-        #expect(viewModel.isEditing == false)
+        #expect(sut.isEditing == false)
     }
 
     @Test func testIsEditing_existingMode_returnsTrue() {
@@ -219,48 +219,48 @@ struct ModeEditViewModelTests {
             aiEnhanceEnabled: false
         )
 
-        let viewModel = ModeEditViewModel(
+        let sut = ModeEditViewModel(
             mode: existingMode,
             aiService: aiService,
             presetManager: presetManager,
             transcriptionManager: transcriptionManager
         )
 
-        #expect(viewModel.isEditing == true)
+        #expect(sut.isEditing == true)
     }
 
     @Test func testSelectFirstPresetIfNeeded_skipsHiddenPresets() {
-        let viewModel = makeViewModel()
+        let sut = makeViewModel()
 
-        viewModel.presetManager.setPresetHidden(presetId: "regular", isHidden: true)
-        viewModel.selectedPresetId = nil
-        viewModel.selectFirstPresetIfNeeded()
+        sut.presetManager.setPresetHidden(presetId: "regular", isHidden: true)
+        sut.selectedPresetId = nil
+        sut.selectFirstPresetIfNeeded()
 
-        #expect(viewModel.selectedPresetId == viewModel.presetManager.visiblePresets.first?.id)
+        #expect(sut.selectedPresetId == sut.presetManager.visiblePresets.first?.id)
     }
 
     @Test func testSelectFirstPresetIfNeeded_allHidden_leavesSelectionNil() {
-        let viewModel = makeViewModel()
-        for preset in viewModel.presetManager.visiblePresets {
-            viewModel.presetManager.setPresetHidden(presetId: preset.id, isHidden: true)
+        let sut = makeViewModel()
+        for preset in sut.presetManager.visiblePresets {
+            sut.presetManager.setPresetHidden(presetId: preset.id, isHidden: true)
         }
 
-        viewModel.selectedPresetId = nil
-        viewModel.selectFirstPresetIfNeeded()
+        sut.selectedPresetId = nil
+        sut.selectFirstPresetIfNeeded()
 
-        #expect(viewModel.selectedPresetId == nil)
+        #expect(sut.selectedPresetId == nil)
     }
 
     // MARK: - Mode Name Validation Tests
 
     @Test func testModeName_trimmedForValidation() {
-        let viewModel = makeViewModel()
-        viewModel.modeName = "  Test Mode  "
-        viewModel.transcriptionModel = "test"
+        let sut = makeViewModel()
+        sut.modeName = "  Test Mode  "
+        sut.transcriptionModel = "test"
 
         // The name with whitespace should still be considered valid
         // (validation trims the name)
-        let trimmedName = viewModel.modeName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedName = sut.modeName.trimmingCharacters(in: .whitespacesAndNewlines)
         #expect(trimmedName.isEmpty == false)
     }
 }

--- a/VivaDictaTests/OllamaServiceTests.swift
+++ b/VivaDictaTests/OllamaServiceTests.swift
@@ -10,7 +10,7 @@ import Testing
 /// Tests cover `OllamaService` in isolation: the HTTP shape of model
 /// fetching (OpenAI-compatible + native fallback) and connection checks.
 /// `MockNetworkService` stands in for the real network.
-@Suite("OllamaService")
+@Suite("OllamaService", .tags(.networking))
 struct OllamaServiceTests {
 
     private let serverURL = "http://localhost:11434"

--- a/VivaDictaTests/OpenAICompatibleServiceTests.swift
+++ b/VivaDictaTests/OpenAICompatibleServiceTests.swift
@@ -14,7 +14,7 @@ import Testing
 /// `verifyChatCompletionsAPIKey` probe, and the streaming request
 /// shape (full SSE parsing is not testable via MockNetworkService;
 /// see the comment near the streaming tests).
-@Suite("OpenAICompatibleService")
+@Suite("OpenAICompatibleService", .tags(.networking))
 struct OpenAICompatibleServiceTests {
 
     private let endpointURL = "https://api.example.com/v1/chat/completions"

--- a/VivaDictaTests/TestTags.swift
+++ b/VivaDictaTests/TestTags.swift
@@ -5,6 +5,6 @@ import Testing
 extension Tag {
     /// Marks suites that exercise networking through a mocked transport.
     /// No real network calls happen - the tag exists so the suites can be
-    /// filtered as a group (e.g. `swift test --filter-tag networking`).
+    /// selected/excluded as a group from an Xcode Test Plan.
     @Tag static var networking: Self
 }

--- a/VivaDictaTests/TestTags.swift
+++ b/VivaDictaTests/TestTags.swift
@@ -1,0 +1,10 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Testing
+
+extension Tag {
+    /// Marks suites that exercise networking through a mocked transport.
+    /// No real network calls happen - the tag exists so the suites can be
+    /// filtered as a group (e.g. `swift test --filter-tag networking`).
+    @Tag static var networking: Self
+}

--- a/VivaDictaWatch Watch AppTests/WatchConnectivityServiceTests.swift
+++ b/VivaDictaWatch Watch AppTests/WatchConnectivityServiceTests.swift
@@ -14,17 +14,17 @@ struct WatchConnectivityServiceTests {
 
     // MARK: - Test Helpers
 
-    private func makeService() -> (WatchConnectivityService, UserDefaults) {
+    private func makeSUT() -> (WatchConnectivityService, UserDefaults) {
         let suiteName = "WatchConnectivityServiceTests-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
-        let service = WatchConnectivityService(defaults: defaults)
-        return (service, defaults)
+        let sut = WatchConnectivityService(defaults: defaults)
+        return (sut, defaults)
     }
 
     // MARK: - Mode Parsing
 
     @Test func parseModes_fromValidApplicationContext() {
-        let (service, _) = makeService()
+        let (sut, _) = makeSUT()
         let context: [String: Any] = [
             "modes": [
                 ["id": "regular", "name": "Regular"],
@@ -33,37 +33,37 @@ struct WatchConnectivityServiceTests {
             ]
         ]
 
-        service.parseModes(from: context)
+        sut.parseModes(from: context)
 
-        #expect(service.availableModes.count == 3)
-        #expect(service.availableModes[0].id == "regular")
-        #expect(service.availableModes[1].name == "Summary")
-        #expect(service.availableModes[2].id == "email")
+        #expect(sut.availableModes.count == 3)
+        #expect(sut.availableModes[0].id == "regular")
+        #expect(sut.availableModes[1].name == "Summary")
+        #expect(sut.availableModes[2].id == "email")
     }
 
     @Test func parseModes_emptyModesArray_setsEmptyList() {
-        let (service, _) = makeService()
+        let (sut, _) = makeSUT()
         let context: [String: Any] = ["modes": [[String: String]]()]
 
-        service.parseModes(from: context)
+        sut.parseModes(from: context)
 
-        #expect(service.availableModes.isEmpty)
+        #expect(sut.availableModes.isEmpty)
     }
 
     @Test func parseModes_missingModesKey_keepsExistingModes() {
-        let (service, _) = makeService()
+        let (sut, _) = makeSUT()
         // First set some modes
-        service.parseModes(from: ["modes": [["id": "regular", "name": "Regular"]]])
-        #expect(service.availableModes.count == 1)
+        sut.parseModes(from: ["modes": [["id": "regular", "name": "Regular"]]])
+        #expect(sut.availableModes.count == 1)
 
         // Context without modes key should not clear existing modes
-        service.parseModes(from: ["someOtherKey": "value"])
+        sut.parseModes(from: ["someOtherKey": "value"])
 
-        #expect(service.availableModes.count == 1)
+        #expect(sut.availableModes.count == 1)
     }
 
     @Test func parseModes_malformedEntries_skipsInvalid() {
-        let (service, _) = makeService()
+        let (sut, _) = makeSUT()
         let context: [String: Any] = [
             "modes": [
                 ["id": "regular", "name": "Regular"],
@@ -73,17 +73,17 @@ struct WatchConnectivityServiceTests {
             ]
         ]
 
-        service.parseModes(from: context)
+        sut.parseModes(from: context)
 
-        #expect(service.availableModes.count == 2)
-        #expect(service.availableModes[0].id == "regular")
-        #expect(service.availableModes[1].id == "valid")
+        #expect(sut.availableModes.count == 2)
+        #expect(sut.availableModes[0].id == "regular")
+        #expect(sut.availableModes[1].id == "valid")
     }
 
     // MARK: - Mode Caching
 
     @Test func availableModes_cachesToUserDefaults() {
-        let (service, defaults) = makeService()
+        let (sut, defaults) = makeSUT()
         let context: [String: Any] = [
             "modes": [
                 ["id": "regular", "name": "Regular"],
@@ -91,7 +91,7 @@ struct WatchConnectivityServiceTests {
             ]
         ]
 
-        service.parseModes(from: context)
+        sut.parseModes(from: context)
 
         let cached = defaults.array(forKey: "cachedWatchModes") as? [[String: String]]
         #expect(cached?.count == 2)


### PR DESCRIPTION
Three low-priority test-only cleanups from the Swift Testing audit. All independent, bundled for review.

## Summary

### 1. `.networking` tag

Added a `TestTags.swift` file to both test targets (`VivaDictaTests` and `CloudTranscriptionTests`) declaring `@Tag static var networking: Self`. Each test target needs its own `extension Tag` since they don't share modules.

Applied `.tags(.networking)` to 10 network-mocked service suites:

- **VivaDictaTests**: AnthropicService, OpenAICompatibleService, OllamaService, CustomOpenAIService, AIServiceNetworkingTests
- **CloudTranscriptionTests**: Xai/Groq/OpenAI transcription tests, NetworkErrorBridgeTests

The tag lets the group be selected/filtered as a unit (e.g. `swift test --filter-tag networking`). No real network calls happen anywhere - everything goes through `MockNetworkService`/`MockURLSession`.

`LiveTranslationServiceTests` was intentionally skipped despite the name - it only tests keychain reads.

### 2. SUT rename (opportunistic)

Renamed test-local SUT variables to the project's `sut` convention while these files were already being touched:

- `AudioCleanupServiceTests` - 16 sites (`service` → `sut`)
- `AIServiceConfigurationTests` - 22 sites (`service` → `sut`)
- `ModeEditViewModelTests` - 19 sites (`viewModel` → `sut`)
- `WatchConnectivityServiceTests` - 1 site, plus `makeService()` helper renamed to `makeSUT()`

`TranscriptionManagerConfigTests` and `DataControllerTests` were already done in PR #295.

### 3. Force-unwrap fix

- `DataControllerTests.swift` - `entities.first!` → `try #require(entities.first)`. The test was already `throws`, so the require slots in cleanly. On failure it now reports a real test issue with line/column instead of crashing the test runner.

Other `try!` / force-unwrap sites in non-throwing test helpers (`AIServiceConfigurationTests`, `AIServiceModeTests` `JSONEncoder().encode(modes)`, `DataControllerTests` `Calendar.current.date(...)!`) were intentionally left as-is - making the helpers throwing cascades through every caller for a realistically zero-risk encode/date construction.

## Test plan
- [x] `xcodebuild build-for-testing` (iOS) - 0 errors
- [x] `xcodebuild test -only-testing:VivaDictaTests` - 333 tests passed
- [x] `xcodebuild test -only-testing:CloudTranscriptionTests` - 50 tests passed (1 pre-existing known issue, unrelated)
- [x] `xcodebuild build-for-testing` (watchOS, Series 11) - clean. Watch tests couldn't be run due to an unrelated simulator launch issue (`Application com.antonnovoselov.VivaDicta-beta.watchkitapp is unknown to FrontBoard`); the test target itself builds.
- [ ] Full CI run