### PR TITLE
Hoist sut + mocks in remaining suites with constant SUT shape

### DIFF
--- a/Modules/AppGroup/Tests/AppGroupTests/AppGroupCoordinatorSessionTests.swift
+++ b/Modules/AppGroup/Tests/AppGroupTests/AppGroupCoordinatorSessionTests.swift
@@ -11,28 +11,25 @@ import Testing
 
 struct AppGroupCoordinatorSessionTests {
 
-    // MARK: - Test Helpers
-
     private let suiteName = "AppGroupCoordinatorSessionTests.\(UUID().uuidString)"
+    let defaults: UserDefaults
+    let sut: AppGroupCoordinator
 
-    private func makeCoordinator() -> AppGroupCoordinator {
-        let defaults = UserDefaults(suiteName: suiteName)!
+    init() {
+        defaults = UserDefaults(suiteName: suiteName)!
         defaults.removePersistentDomain(forName: suiteName)
-        return AppGroupCoordinator(userDefaults: defaults)
+        sut = AppGroupCoordinator(userDefaults: defaults)
     }
 
     // MARK: - Activate / Deactivate Session
 
     @Test func activateKeyboardSession_setsActiveAndExpiry() {
-        let sut = makeCoordinator()
-
         sut.activateKeyboardSession(timeoutSeconds: 60)
 
         #expect(sut.isKeyboardSessionActive == true)
     }
 
     @Test func deactivateKeyboardSession_clearsState() {
-        let sut = makeCoordinator()
         sut.activateKeyboardSession(timeoutSeconds: 60)
 
         sut.deactivateKeyboardSession()
@@ -41,14 +38,10 @@ struct AppGroupCoordinatorSessionTests {
     }
 
     @Test func isKeyboardSessionActive_notActivated_false() {
-        let sut = makeCoordinator()
-
         #expect(sut.isKeyboardSessionActive == false)
     }
 
     @Test func isKeyboardSessionActive_activated_true() {
-        let sut = makeCoordinator()
-
         sut.activateKeyboardSession(timeoutSeconds: 300)
 
         #expect(sut.isKeyboardSessionActive == true)
@@ -57,10 +50,6 @@ struct AppGroupCoordinatorSessionTests {
     // MARK: - Refresh Session Expiry
 
     @Test func refreshSessionExpiry_extendsTimeout() {
-        let defaults = UserDefaults(suiteName: suiteName)!
-        defaults.removePersistentDomain(forName: suiteName)
-        let sut = AppGroupCoordinator(userDefaults: defaults)
-
         sut.activateKeyboardSession(timeoutSeconds: 10)
         let oldExpiry = defaults.double(forKey: "keyboardSessionExpiryTime")
 
@@ -72,10 +61,6 @@ struct AppGroupCoordinatorSessionTests {
     }
 
     @Test func refreshSessionExpiry_inactiveSession_noOp() {
-        let defaults = UserDefaults(suiteName: suiteName)!
-        defaults.removePersistentDomain(forName: suiteName)
-        let sut = AppGroupCoordinator(userDefaults: defaults)
-
         sut.refreshKeyboardSessionExpiry(timeoutSeconds: 60)
 
         let expiry = defaults.double(forKey: "keyboardSessionExpiryTime")
@@ -85,8 +70,6 @@ struct AppGroupCoordinatorSessionTests {
     // MARK: - Settings Flags
 
     @Test func settingsFlags_defaultValues() {
-        let sut = makeCoordinator()
-
         #expect(sut.isSmartFormattingOnPasteEnabled == true)
         #expect(sut.isKeepTranscriptInClipboardEnabled == false)
         #expect(sut.isSpeakerDiarizationEnabled == false)
@@ -95,8 +78,6 @@ struct AppGroupCoordinatorSessionTests {
     }
 
     @Test func settingsFlags_setAndGet() {
-        let sut = makeCoordinator()
-
         sut.isSmartFormattingOnPasteEnabled = false
         #expect(sut.isSmartFormattingOnPasteEnabled == false)
 

--- a/Modules/AppGroup/Tests/AppGroupTests/AppGroupCoordinatorStateTests.swift
+++ b/Modules/AppGroup/Tests/AppGroupTests/AppGroupCoordinatorStateTests.swift
@@ -11,52 +11,43 @@ import Testing
 
 struct AppGroupCoordinatorStateTests {
 
-    // MARK: - Test Helpers
-
     private let suiteName = "AppGroupCoordinatorStateTests.\(UUID().uuidString)"
+    let defaults: UserDefaults
+    let sut: AppGroupCoordinator
 
-    private func makeCoordinator() -> AppGroupCoordinator {
-        let defaults = UserDefaults(suiteName: suiteName)!
+    init() {
+        defaults = UserDefaults(suiteName: suiteName)!
         defaults.removePersistentDomain(forName: suiteName)
-        return AppGroupCoordinator(userDefaults: defaults)
+        sut = AppGroupCoordinator(userDefaults: defaults)
     }
 
     // MARK: - Audio Level Tests
 
     @Test func audioLevel_clampsNegativeToZero() {
-        let sut = makeCoordinator()
-
         sut.updateAudioLevel(-0.5)
 
         #expect(sut.currentAudioLevel == 0.0)
     }
 
     @Test func audioLevel_clampsAboveOneToOne() {
-        let sut = makeCoordinator()
-
         sut.updateAudioLevel(1.5)
 
         #expect(sut.currentAudioLevel == 1.0)
     }
 
     @Test func audioLevel_normalValueStored() {
-        let sut = makeCoordinator()
-
         sut.updateAudioLevel(0.7)
 
         #expect(abs(sut.currentAudioLevel - 0.7) < 0.001)
     }
 
     @Test func audioLevel_defaultIsZero() {
-        let sut = makeCoordinator()
-
         #expect(sut.currentAudioLevel == 0.0)
     }
 
     // MARK: - Transcription Status Tests
 
     @Test func transcriptionStatus_roundTrips() {
-        let sut = makeCoordinator()
         let statuses: [AppGroupCoordinator.TranscriptionStatus] = [
             .idle, .recording, .transcribing, .enhancing, .completed, .error
         ]
@@ -68,14 +59,13 @@ struct AppGroupCoordinatorStateTests {
     }
 
     @Test func transcriptionStatus_defaultIsIdle() {
-        let sut = makeCoordinator()
-
         #expect(sut.transcriptionStatus == .idle)
     }
 
     @Test func transcriptionStatus_invalidString_returnsIdle() {
-        let defaults = UserDefaults(suiteName: suiteName)!
-        defaults.removePersistentDomain(forName: suiteName)
+        // Pre-seed a garbage value, then build a fresh coordinator that has
+        // to read it at construction time. Shadows the hoisted `sut`
+        // intentionally so initial-read behaviour is exercised.
         defaults.set("garbage_status", forKey: "transcriptionStatus")
         let sut = AppGroupCoordinator(userDefaults: defaults)
 
@@ -85,8 +75,6 @@ struct AppGroupCoordinatorStateTests {
     // MARK: - Recording State Tests
 
     @Test func recordingState_setAndGet() {
-        let sut = makeCoordinator()
-
         sut.updateRecordingState(true)
         #expect(sut.isRecording == true)
 
@@ -97,15 +85,12 @@ struct AppGroupCoordinatorStateTests {
     // MARK: - Transcribed Text Sharing Tests
 
     @Test func shareTranscribedText_storesAndSetsCompleted() {
-        let sut = makeCoordinator()
-
         sut.shareTranscribedText("Hello world")
 
         #expect(sut.transcriptionStatus == .completed)
     }
 
     @Test func getAndConsumeTranscribedText_retrievesAndClears() {
-        let sut = makeCoordinator()
         sut.shareTranscribedText("Test text")
 
         let text = sut.getAndConsumeTranscribedText()
@@ -116,7 +101,6 @@ struct AppGroupCoordinatorStateTests {
     }
 
     @Test func getAndConsumeTranscribedText_setsStatusIdle() {
-        let sut = makeCoordinator()
         sut.shareTranscribedText("Test text")
 
         _ = sut.getAndConsumeTranscribedText()
@@ -127,7 +111,6 @@ struct AppGroupCoordinatorStateTests {
     // MARK: - Clipboard Context Tests
 
     @Test func getAndConsumeClipboardContext_retrievesAndClears() {
-        let sut = makeCoordinator()
         sut.setKeyboardClipboardContext("clipboard content")
 
         let text = sut.getAndConsumeKeyboardClipboardContext()
@@ -138,7 +121,6 @@ struct AppGroupCoordinatorStateTests {
     }
 
     @Test func setKeyboardClipboardContext_nil_clears() {
-        let sut = makeCoordinator()
         sut.setKeyboardClipboardContext("something")
         sut.setKeyboardClipboardContext(nil)
 

--- a/Modules/CloudTranscription/Tests/CloudTranscriptionTests/CloudTranscriptionTests.swift
+++ b/Modules/CloudTranscription/Tests/CloudTranscriptionTests/CloudTranscriptionTests.swift
@@ -54,8 +54,13 @@ struct OpenAIConfigTests {
 
 struct MockTranscriptionServiceTests {
 
+    let sut: MockTranscriptionService
+
+    init() {
+        sut = MockTranscriptionService()
+    }
+
     @Test func transcribeReturnsStubbedValue() async throws {
-        let sut = MockTranscriptionService()
         sut.stubTranscribeResponse = .success(.plain("hello world"))
         let url = URL(fileURLWithPath: "/tmp/audio.wav")
         let result = try await sut.transcribe(audioURL: url)
@@ -66,7 +71,6 @@ struct MockTranscriptionServiceTests {
 
     @Test func transcribePropagatesStubbedError() async {
         struct Boom: Error {}
-        let sut = MockTranscriptionService()
         sut.stubTranscribeResponse = .failure(Boom())
         let url = URL(fileURLWithPath: "/tmp/audio.wav")
         await #expect(throws: Boom.self) {
@@ -76,7 +80,6 @@ struct MockTranscriptionServiceTests {
 
     @Test func transcribeWithoutStubThrowsStubNotSet() async {
         await withKnownIssue {
-            let sut = MockTranscriptionService()
             let url = URL(fileURLWithPath: "/tmp/audio.wav")
             await #expect(throws: StubNotSetError.self) {
                 _ = try await sut.transcribe(audioURL: url)

--- a/Modules/Networking/Tests/NetworkingTests/DefaultNetworkServiceTests.swift
+++ b/Modules/Networking/Tests/NetworkingTests/DefaultNetworkServiceTests.swift
@@ -9,6 +9,13 @@ import Testing
 struct DefaultNetworkServiceTests {
 
     private let endpoint = URL(string: "https://example.com/api")!
+    let session: MockURLSession
+    let sut: DefaultNetworkService
+
+    init() {
+        session = MockURLSession()
+        sut = DefaultNetworkService(session: session)
+    }
 
     private func makeResponse(_ code: Int) -> HTTPURLResponse {
         HTTPURLResponse(
@@ -22,10 +29,8 @@ struct DefaultNetworkServiceTests {
     // MARK: send
 
     @Test func sendReturnsBodyAndHTTPResponseOnSuccess() async throws {
-        let session = MockURLSession()
         let payload = Data(#"{"ok":true}"#.utf8)
         session.stubDataResponse = .success((payload, makeResponse(200)))
-        let sut = DefaultNetworkService(session: session)
 
         let (data, response) = try await sut.send(URLRequest(url: endpoint))
 
@@ -35,10 +40,8 @@ struct DefaultNetworkServiceTests {
     }
 
     @Test func sendThrowsUnacceptableStatusFor4xx() async throws {
-        let session = MockURLSession()
         let body = Data(#"{"error":"nope"}"#.utf8)
         session.stubDataResponse = .success((body, makeResponse(404)))
-        let sut = DefaultNetworkService(session: session)
 
         await #expect {
             try await sut.send(URLRequest(url: endpoint))
@@ -53,9 +56,7 @@ struct DefaultNetworkServiceTests {
 
     @Test func sendWrapsTransportError() async throws {
         struct Boom: Error {}
-        let session = MockURLSession()
         session.stubDataResponse = .failure(Boom())
-        let sut = DefaultNetworkService(session: session)
 
         await #expect {
             try await sut.send(URLRequest(url: endpoint))
@@ -67,9 +68,7 @@ struct DefaultNetworkServiceTests {
     }
 
     @Test func customAcceptableStatusCodesOverrideDefault() async throws {
-        let session = MockURLSession()
         session.stubDataResponse = .success((Data(), makeResponse(302)))
-        let sut = DefaultNetworkService(session: session)
 
         let (_, response) = try await sut.send(
             URLRequest(url: endpoint),
@@ -85,9 +84,7 @@ struct DefaultNetworkServiceTests {
     }
 
     @Test func sendJSONDecodesResponse() async throws {
-        let session = MockURLSession()
         session.stubDataResponse = .success((Data(#"{"value":"hi"}"#.utf8), makeResponse(200)))
-        let sut = DefaultNetworkService(session: session)
 
         let result: Echo = try await sut.sendJSON(URLRequest(url: endpoint))
 
@@ -95,9 +92,7 @@ struct DefaultNetworkServiceTests {
     }
 
     @Test func sendJSONWrapsDecodingErrors() async throws {
-        let session = MockURLSession()
         session.stubDataResponse = .success((Data(#"{"wrong":"shape"}"#.utf8), makeResponse(200)))
-        let sut = DefaultNetworkService(session: session)
 
         await #expect {
             let _: Echo = try await sut.sendJSON(URLRequest(url: endpoint))
@@ -111,9 +106,7 @@ struct DefaultNetworkServiceTests {
     // MARK: upload
 
     @Test func uploadPassesBodyToSession() async throws {
-        let session = MockURLSession()
         session.stubUploadResponse = .success((Data(), makeResponse(200)))
-        let sut = DefaultNetworkService(session: session)
 
         let body = Data("payload".utf8)
         _ = try await sut.upload(URLRequest(url: endpoint), from: body)
@@ -123,9 +116,7 @@ struct DefaultNetworkServiceTests {
     }
 
     @Test func uploadThrowsForServerErrors() async throws {
-        let session = MockURLSession()
         session.stubUploadResponse = .success((Data("internal".utf8), makeResponse(500)))
-        let sut = DefaultNetworkService(session: session)
 
         await #expect {
             _ = try await sut.upload(URLRequest(url: endpoint), from: Data())

--- a/VivaDictaTests/AnthropicServiceTests.swift
+++ b/VivaDictaTests/AnthropicServiceTests.swift
@@ -22,26 +22,27 @@ import Testing
 struct AnthropicServiceTests {
 
     private let endpointURL = AIProvider.anthropic.baseURL
+    let networkService: MockNetworkService
+    let sut: AnthropicService
 
-    private func makeHTTPResponse(_ code: Int) -> HTTPURLResponse {
-        HTTPURLResponse(url: URL(string: endpointURL)!, statusCode: code, httpVersion: nil, headerFields: nil)!
-    }
-
-    private func makeSUT(networkService: MockNetworkService) -> AnthropicService {
-        AnthropicService(
+    init() {
+        networkService = MockNetworkService()
+        sut = AnthropicService(
             networkService: networkService,
             logger: Logger(subsystem: "test", category: "AnthropicServiceTests"),
             baseTimeout: 30
         )
     }
 
+    private func makeHTTPResponse(_ code: Int) -> HTTPURLResponse {
+        HTTPURLResponse(url: URL(string: endpointURL)!, statusCode: code, httpVersion: nil, headerFields: nil)!
+    }
+
     // MARK: - Request shape (non-streaming)
 
     @Test func enhanceSendsXAPIKeyHeaderNotBearer() async throws {
-        let networkService = MockNetworkService()
         let body = Data(#"{"content":[{"text":"ok"}]}"#.utf8)
         networkService.stubSendResponse = .success((body, makeHTTPResponse(200)))
-        let sut = makeSUT(networkService: networkService)
 
         _ = try await sut.enhance(
             systemMessage: "system",
@@ -58,10 +59,8 @@ struct AnthropicServiceTests {
     }
 
     @Test func enhanceSendsAnthropicMessagesBodyShape() async throws {
-        let networkService = MockNetworkService()
         let body = Data(#"{"content":[{"text":"ok"}]}"#.utf8)
         networkService.stubSendResponse = .success((body, makeHTTPResponse(200)))
-        let sut = makeSUT(networkService: networkService)
 
         _ = try await sut.enhance(
             systemMessage: "you are a helper",
@@ -83,10 +82,8 @@ struct AnthropicServiceTests {
     // MARK: - Non-streaming success/error mapping
 
     @Test func enhanceReturnsTextFromAnthropicContentArray() async throws {
-        let networkService = MockNetworkService()
         let body = Data(#"{"content":[{"type":"text","text":"  enhanced output  "}]}"#.utf8)
         networkService.stubSendResponse = .success((body, makeHTTPResponse(200)))
-        let sut = makeSUT(networkService: networkService)
 
         let result = try await sut.enhance(
             systemMessage: "system",
@@ -100,10 +97,8 @@ struct AnthropicServiceTests {
     }
 
     @Test func enhanceThrowsEnhancementFailedOnMalformedBody() async throws {
-        let networkService = MockNetworkService()
         let body = Data(#"{"unexpected":"shape"}"#.utf8)
         networkService.stubSendResponse = .success((body, makeHTTPResponse(200)))
-        let sut = makeSUT(networkService: networkService)
 
         await #expect(throws: EnhancementError.self) {
             _ = try await sut.enhance(
@@ -116,9 +111,7 @@ struct AnthropicServiceTests {
     }
 
     @Test func enhanceMaps429ToRateLimitExceeded() async throws {
-        let networkService = MockNetworkService()
         networkService.stubSendResponse = .success((Data(), makeHTTPResponse(429)))
-        let sut = makeSUT(networkService: networkService)
 
         let error = try await #require(throws: EnhancementError.self) {
             _ = try await sut.enhance(
@@ -135,9 +128,7 @@ struct AnthropicServiceTests {
     }
 
     @Test func enhanceMaps5xxToServerError() async throws {
-        let networkService = MockNetworkService()
         networkService.stubSendResponse = .success((Data(), makeHTTPResponse(503)))
-        let sut = makeSUT(networkService: networkService)
 
         let error = try await #require(throws: EnhancementError.self) {
             _ = try await sut.enhance(
@@ -154,10 +145,8 @@ struct AnthropicServiceTests {
     }
 
     @Test func enhanceMapsOtherStatusToCustomError() async throws {
-        let networkService = MockNetworkService()
         let body = Data(#"{"error":{"message":"bad model"}}"#.utf8)
         networkService.stubSendResponse = .success((body, makeHTTPResponse(400)))
-        let sut = makeSUT(networkService: networkService)
 
         let error = try await #require(throws: EnhancementError.self) {
             _ = try await sut.enhance(
@@ -177,9 +166,7 @@ struct AnthropicServiceTests {
     // MARK: - verifyAPIKey
 
     @Test func verifyAPIKeyReturnsTrueOn200() async {
-        let networkService = MockNetworkService()
         networkService.stubSendResponse = .success((Data(), makeHTTPResponse(200)))
-        let sut = makeSUT(networkService: networkService)
 
         let valid = await sut.verifyAPIKey("sk-ant-test")
 
@@ -187,9 +174,7 @@ struct AnthropicServiceTests {
     }
 
     @Test func verifyAPIKeyReturnsFalseOn401() async {
-        let networkService = MockNetworkService()
         networkService.stubSendResponse = .success((Data(), makeHTTPResponse(401)))
-        let sut = makeSUT(networkService: networkService)
 
         let valid = await sut.verifyAPIKey("sk-ant-bad")
 
@@ -197,9 +182,7 @@ struct AnthropicServiceTests {
     }
 
     @Test func verifyAPIKeyReturnsFalseOnTransportError() async {
-        let networkService = MockNetworkService()
         networkService.stubSendResponse = .failure(URLError(.notConnectedToInternet))
-        let sut = makeSUT(networkService: networkService)
 
         let valid = await sut.verifyAPIKey("sk-ant-test")
 
@@ -207,9 +190,7 @@ struct AnthropicServiceTests {
     }
 
     @Test func verifyAPIKeySendsCorrectHeadersAndBody() async throws {
-        let networkService = MockNetworkService()
         networkService.stubSendResponse = .success((Data(), makeHTTPResponse(200)))
-        let sut = makeSUT(networkService: networkService)
 
         _ = await sut.verifyAPIKey("sk-ant-test")
 
@@ -232,9 +213,6 @@ struct AnthropicServiceTests {
     // integration / manual testing.
 
     @Test func enhanceStreamingSendsCorrectHeadersAndStreamingBody() async throws {
-        let networkService = MockNetworkService()
-        let sut = makeSUT(networkService: networkService)
-
         _ = try? await sut.enhanceStreaming(
             systemMessage: "you are a helper",
             userMessage: "stream this",

--- a/VivaDictaTests/CustomOpenAIServiceTests.swift
+++ b/VivaDictaTests/CustomOpenAIServiceTests.swift
@@ -19,8 +19,12 @@ struct CustomOpenAIServiceTests {
         HTTPURLResponse(url: URL(string: endpointURL)!, statusCode: code, httpVersion: nil, headerFields: nil)!
     }
 
-    private func makeSUT(networkService: MockNetworkService) -> CustomOpenAIService {
-        CustomOpenAIService(
+    let networkService: MockNetworkService
+    let sut: CustomOpenAIService
+
+    init() {
+        networkService = MockNetworkService()
+        sut = CustomOpenAIService(
             networkService: networkService,
             logger: Logger(subsystem: "test", category: "CustomOpenAIServiceTests")
         )
@@ -29,9 +33,7 @@ struct CustomOpenAIServiceTests {
     // MARK: - Success path
 
     @Test func testEndpointReturnsSuccessOn200() async {
-        let networkService = MockNetworkService()
         networkService.stubSendResponse = .success((Data(), makeHTTPResponse(200)))
-        let sut = makeSUT(networkService: networkService)
 
         let result = await sut.testEndpoint(endpointURL: endpointURL, modelName: "gpt-4", apiKey: "sk-test")
 
@@ -42,9 +44,7 @@ struct CustomOpenAIServiceTests {
     // MARK: - Request shape
 
     @Test func testEndpointSendsBearerAuthorizationWhenAPIKeyProvided() async {
-        let networkService = MockNetworkService()
         networkService.stubSendResponse = .success((Data(), makeHTTPResponse(200)))
-        let sut = makeSUT(networkService: networkService)
 
         _ = await sut.testEndpoint(endpointURL: endpointURL, modelName: "gpt-4", apiKey: "sk-abc")
 
@@ -52,9 +52,7 @@ struct CustomOpenAIServiceTests {
     }
 
     @Test func testEndpointOmitsAuthorizationWhenAPIKeyIsNil() async {
-        let networkService = MockNetworkService()
         networkService.stubSendResponse = .success((Data(), makeHTTPResponse(200)))
-        let sut = makeSUT(networkService: networkService)
 
         _ = await sut.testEndpoint(endpointURL: endpointURL, modelName: "gpt-4", apiKey: nil)
 
@@ -62,9 +60,7 @@ struct CustomOpenAIServiceTests {
     }
 
     @Test func testEndpointOmitsAuthorizationWhenAPIKeyIsEmpty() async {
-        let networkService = MockNetworkService()
         networkService.stubSendResponse = .success((Data(), makeHTTPResponse(200)))
-        let sut = makeSUT(networkService: networkService)
 
         _ = await sut.testEndpoint(endpointURL: endpointURL, modelName: "gpt-4", apiKey: "")
 
@@ -72,9 +68,7 @@ struct CustomOpenAIServiceTests {
     }
 
     @Test func testEndpointSendsMinimalChatCompletionBody() async throws {
-        let networkService = MockNetworkService()
         networkService.stubSendResponse = .success((Data(), makeHTTPResponse(200)))
-        let sut = makeSUT(networkService: networkService)
 
         _ = await sut.testEndpoint(endpointURL: endpointURL, modelName: "gpt-4-test", apiKey: nil)
 
@@ -88,9 +82,7 @@ struct CustomOpenAIServiceTests {
     // MARK: - Status code mapping
 
     @Test func testEndpointMapsUnauthorizedTo401Message() async {
-        let networkService = MockNetworkService()
         networkService.stubSendResponse = .success((Data(), makeHTTPResponse(401)))
-        let sut = makeSUT(networkService: networkService)
 
         let result = await sut.testEndpoint(endpointURL: endpointURL, modelName: "gpt-4", apiKey: "sk-test")
 
@@ -98,9 +90,7 @@ struct CustomOpenAIServiceTests {
     }
 
     @Test func testEndpointMapsNotFoundTo404Message() async {
-        let networkService = MockNetworkService()
         networkService.stubSendResponse = .success((Data(), makeHTTPResponse(404)))
-        let sut = makeSUT(networkService: networkService)
 
         let result = await sut.testEndpoint(endpointURL: endpointURL, modelName: "gpt-4", apiKey: nil)
 
@@ -108,10 +98,8 @@ struct CustomOpenAIServiceTests {
     }
 
     @Test func testEndpointExtractsErrorMessageFromBadRequestBody() async {
-        let networkService = MockNetworkService()
         let body = Data(#"{"error": {"message": "model 'foo' not found"}}"#.utf8)
         networkService.stubSendResponse = .success((body, makeHTTPResponse(400)))
-        let sut = makeSUT(networkService: networkService)
 
         let result = await sut.testEndpoint(endpointURL: endpointURL, modelName: "foo", apiKey: nil)
 
@@ -119,10 +107,8 @@ struct CustomOpenAIServiceTests {
     }
 
     @Test func testEndpointFallsBackToGenericMessageOnMalformedBadRequestBody() async {
-        let networkService = MockNetworkService()
         let body = Data("plain text error".utf8)
         networkService.stubSendResponse = .success((body, makeHTTPResponse(400)))
-        let sut = makeSUT(networkService: networkService)
 
         let result = await sut.testEndpoint(endpointURL: endpointURL, modelName: "gpt-4", apiKey: nil)
 
@@ -134,9 +120,7 @@ struct CustomOpenAIServiceTests {
     }
 
     @Test func testEndpointMapsServerErrorTo5xxMessage() async {
-        let networkService = MockNetworkService()
         networkService.stubSendResponse = .success((Data(), makeHTTPResponse(503)))
-        let sut = makeSUT(networkService: networkService)
 
         let result = await sut.testEndpoint(endpointURL: endpointURL, modelName: "gpt-4", apiKey: nil)
 
@@ -146,9 +130,7 @@ struct CustomOpenAIServiceTests {
     // MARK: - Transport errors
 
     @Test func testEndpointMapsCannotConnectToFriendlyMessage() async {
-        let networkService = MockNetworkService()
         networkService.stubSendResponse = .failure(NetworkError.transport(URLError(.cannotConnectToHost)))
-        let sut = makeSUT(networkService: networkService)
 
         let result = await sut.testEndpoint(endpointURL: endpointURL, modelName: "gpt-4", apiKey: nil)
 
@@ -156,9 +138,7 @@ struct CustomOpenAIServiceTests {
     }
 
     @Test func testEndpointMapsTimeoutToFriendlyMessage() async {
-        let networkService = MockNetworkService()
         networkService.stubSendResponse = .failure(NetworkError.transport(URLError(.timedOut)))
-        let sut = makeSUT(networkService: networkService)
 
         let result = await sut.testEndpoint(endpointURL: endpointURL, modelName: "gpt-4", apiKey: nil)
 
@@ -166,9 +146,7 @@ struct CustomOpenAIServiceTests {
     }
 
     @Test func testEndpointMapsNoInternetToFriendlyMessage() async {
-        let networkService = MockNetworkService()
         networkService.stubSendResponse = .failure(NetworkError.transport(URLError(.notConnectedToInternet)))
-        let sut = makeSUT(networkService: networkService)
 
         let result = await sut.testEndpoint(endpointURL: endpointURL, modelName: "gpt-4", apiKey: nil)
 
@@ -183,9 +161,7 @@ struct CustomOpenAIServiceTests {
     /// "Two paths, two contexts" doc on `unwrapURLError`. This test pins
     /// the production code path so it doesn't silently break.
     @Test func testEndpointMapsRawURLErrorTransportToFriendlyMessage() async {
-        let networkService = MockNetworkService()
         networkService.stubSendResponse = .failure(URLError(.timedOut))
-        let sut = makeSUT(networkService: networkService)
 
         let result = await sut.testEndpoint(endpointURL: endpointURL, modelName: "gpt-4", apiKey: nil)
 
@@ -193,14 +169,12 @@ struct CustomOpenAIServiceTests {
     }
 
     @Test func testEndpointMapsBridgedNSURLErrorDomainToFriendlyMessage() async {
-        let networkService = MockNetworkService()
         // NSError(domain: NSURLErrorDomain, code: ...) bridges to URLError,
         // so the typed `error as? URLError` cast in `unwrapURLError` succeeds
         // for it - same as the production case where `DefaultNetworkService`
         // would have surfaced a `NetworkError.transport(URLError)`.
         let nsError = NSError(domain: NSURLErrorDomain, code: URLError.cannotConnectToHost.rawValue)
         networkService.stubSendResponse = .failure(nsError)
-        let sut = makeSUT(networkService: networkService)
 
         let result = await sut.testEndpoint(endpointURL: endpointURL, modelName: "gpt-4", apiKey: nil)
 
@@ -208,8 +182,6 @@ struct CustomOpenAIServiceTests {
     }
 
     @Test func testEndpointReturnsInvalidURLFailureForUnparseableEndpoint() async {
-        let networkService = MockNetworkService()
-        let sut = makeSUT(networkService: networkService)
 
         // Empty string is the one URL(string:) actually rejects.
         let result = await sut.testEndpoint(endpointURL: "", modelName: "gpt-4", apiKey: nil)

--- a/VivaDictaTests/LiveTranslationServiceTests.swift
+++ b/VivaDictaTests/LiveTranslationServiceTests.swift
@@ -16,27 +16,26 @@ import Testing
 @MainActor
 struct LiveTranslationServiceTests {
 
-    @Test func hasAPIKey_returnsFalse_whenKeychainIsEmpty() {
-        let mockKeychain = MockKeychainService()
-        let sut = LiveTranslationService(keychain: mockKeychain)
+    let mockKeychain: MockKeychainService
+    let sut: LiveTranslationService
 
+    init() {
+        mockKeychain = MockKeychainService()
+        sut = LiveTranslationService(keychain: mockKeychain)
+    }
+
+    @Test func hasAPIKey_returnsFalse_whenKeychainIsEmpty() {
         #expect(sut.hasAPIKey == false)
     }
 
     @Test func hasAPIKey_returnsTrue_whenSonioxAPIKeyIsStored() {
-        let mockKeychain = MockKeychainService()
         mockKeychain.save("test-api-key", forKey: "sonioxAPIKey", syncable: true)
-
-        let sut = LiveTranslationService(keychain: mockKeychain)
 
         #expect(sut.hasAPIKey == true)
     }
 
     @Test func hasAPIKey_returnsFalse_whenStoredValueIsWhitespaceOnly() {
-        let mockKeychain = MockKeychainService()
         mockKeychain.save("   ", forKey: "sonioxAPIKey", syncable: true)
-
-        let sut = LiveTranslationService(keychain: mockKeychain)
 
         #expect(sut.hasAPIKey == false)
     }

--- a/VivaDictaTests/OpenAICompatibleServiceTests.swift
+++ b/VivaDictaTests/OpenAICompatibleServiceTests.swift
@@ -18,16 +18,19 @@ import Testing
 struct OpenAICompatibleServiceTests {
 
     private let endpointURL = "https://api.example.com/v1/chat/completions"
+    let networkService: MockNetworkService
+    let sut: OpenAICompatibleService
 
-    private func makeHTTPResponse(_ code: Int) -> HTTPURLResponse {
-        HTTPURLResponse(url: URL(string: endpointURL)!, statusCode: code, httpVersion: nil, headerFields: nil)!
-    }
-
-    private func makeSUT(networkService: MockNetworkService) -> OpenAICompatibleService {
-        OpenAICompatibleService(
+    init() {
+        networkService = MockNetworkService()
+        sut = OpenAICompatibleService(
             networkService: networkService,
             logger: Logger(subsystem: "test", category: "OpenAICompatibleServiceTests")
         )
+    }
+
+    private func makeHTTPResponse(_ code: Int) -> HTTPURLResponse {
+        HTTPURLResponse(url: URL(string: endpointURL)!, statusCode: code, httpVersion: nil, headerFields: nil)!
     }
 
     // MARK: - Static buildRequestBody
@@ -132,10 +135,8 @@ struct OpenAICompatibleServiceTests {
     // MARK: - enhance non-streaming success
 
     @Test func enhanceReturnsTextFromChoicesArray() async throws {
-        let networkService = MockNetworkService()
         let body = Data(#"{"choices":[{"message":{"content":"  enhanced output  "}}]}"#.utf8)
         networkService.stubSendResponse = .success((body, makeHTTPResponse(200)))
-        let sut = makeSUT(networkService: networkService)
 
         let result = try await sut.enhance(
             url: URL(string: endpointURL)!,
@@ -151,10 +152,8 @@ struct OpenAICompatibleServiceTests {
     }
 
     @Test func enhanceSendsBearerAuthorizationHeader() async throws {
-        let networkService = MockNetworkService()
         let body = Data(#"{"choices":[{"message":{"content":"ok"}}]}"#.utf8)
         networkService.stubSendResponse = .success((body, makeHTTPResponse(200)))
-        let sut = makeSUT(networkService: networkService)
 
         _ = try await sut.enhance(
             url: URL(string: endpointURL)!,
@@ -171,10 +170,8 @@ struct OpenAICompatibleServiceTests {
     }
 
     @Test func enhanceSendsChatCompletionsBody() async throws {
-        let networkService = MockNetworkService()
         let body = Data(#"{"choices":[{"message":{"content":"ok"}}]}"#.utf8)
         networkService.stubSendResponse = .success((body, makeHTTPResponse(200)))
-        let sut = makeSUT(networkService: networkService)
 
         _ = try await sut.enhance(
             url: URL(string: endpointURL)!,
@@ -199,10 +196,8 @@ struct OpenAICompatibleServiceTests {
     // MARK: - enhance error mapping
 
     @Test func enhanceThrowsEnhancementFailedOnMalformedBody() async {
-        let networkService = MockNetworkService()
         let body = Data(#"{"unexpected":"shape"}"#.utf8)
         networkService.stubSendResponse = .success((body, makeHTTPResponse(200)))
-        let sut = makeSUT(networkService: networkService)
 
         await #expect(throws: EnhancementError.self) {
             _ = try await sut.enhance(
@@ -217,9 +212,7 @@ struct OpenAICompatibleServiceTests {
     }
 
     @Test func enhanceMaps429ToRateLimitExceeded() async throws {
-        let networkService = MockNetworkService()
         networkService.stubSendResponse = .success((Data(), makeHTTPResponse(429)))
-        let sut = makeSUT(networkService: networkService)
 
         let error = try await #require(throws: EnhancementError.self) {
             _ = try await sut.enhance(
@@ -238,9 +231,7 @@ struct OpenAICompatibleServiceTests {
     }
 
     @Test func enhanceMaps5xxToServerError() async throws {
-        let networkService = MockNetworkService()
         networkService.stubSendResponse = .success((Data(), makeHTTPResponse(502)))
-        let sut = makeSUT(networkService: networkService)
 
         let error = try await #require(throws: EnhancementError.self) {
             _ = try await sut.enhance(
@@ -259,9 +250,7 @@ struct OpenAICompatibleServiceTests {
     }
 
     @Test func enhanceRethrowsURLErrorTransport() async throws {
-        let networkService = MockNetworkService()
         networkService.stubSendResponse = .failure(URLError(.timedOut))
-        let sut = makeSUT(networkService: networkService)
 
         let error = try await #require(throws: URLError.self) {
             _ = try await sut.enhance(
@@ -277,10 +266,8 @@ struct OpenAICompatibleServiceTests {
     }
 
     @Test func enhanceMapsOtherStatusToCustomError() async throws {
-        let networkService = MockNetworkService()
         let body = Data(#"{"error":"unauthorized"}"#.utf8)
         networkService.stubSendResponse = .success((body, makeHTTPResponse(401)))
-        let sut = makeSUT(networkService: networkService)
 
         let error = try await #require(throws: EnhancementError.self) {
             _ = try await sut.enhance(
@@ -302,9 +289,7 @@ struct OpenAICompatibleServiceTests {
     // MARK: - verifyChatCompletionsAPIKey
 
     @Test func verifyChatCompletionsAPIKeyReturnsTrueOn200() async {
-        let networkService = MockNetworkService()
         networkService.stubSendResponse = .success((Data(), makeHTTPResponse(200)))
-        let sut = makeSUT(networkService: networkService)
 
         let valid = await sut.verifyChatCompletionsAPIKey(
             "sk-test",
@@ -317,9 +302,7 @@ struct OpenAICompatibleServiceTests {
     }
 
     @Test func verifyChatCompletionsAPIKeyReturnsFalseOn401() async {
-        let networkService = MockNetworkService()
         networkService.stubSendResponse = .success((Data(), makeHTTPResponse(401)))
-        let sut = makeSUT(networkService: networkService)
 
         let valid = await sut.verifyChatCompletionsAPIKey(
             "sk-bad",
@@ -332,9 +315,7 @@ struct OpenAICompatibleServiceTests {
     }
 
     @Test func verifyChatCompletionsAPIKeyReturnsFalseOnTransportError() async {
-        let networkService = MockNetworkService()
         networkService.stubSendResponse = .failure(URLError(.notConnectedToInternet))
-        let sut = makeSUT(networkService: networkService)
 
         let valid = await sut.verifyChatCompletionsAPIKey(
             "sk-test",
@@ -347,9 +328,7 @@ struct OpenAICompatibleServiceTests {
     }
 
     @Test func verifyChatCompletionsAPIKeySendsBearerAndMinimalBody() async throws {
-        let networkService = MockNetworkService()
         networkService.stubSendResponse = .success((Data(), makeHTTPResponse(200)))
-        let sut = makeSUT(networkService: networkService)
 
         _ = await sut.verifyChatCompletionsAPIKey(
             "sk-probe",
@@ -372,9 +351,7 @@ struct OpenAICompatibleServiceTests {
     @Test func verifyChatCompletionsAPIKeyIncludesMaxTokensWhenProvided() async throws {
         // Caps the probe response on heavy default models (HuggingFace's 120B,
         // Grok frontier) to avoid false-negative timeouts on slow networks.
-        let networkService = MockNetworkService()
         networkService.stubSendResponse = .success((Data(), makeHTTPResponse(200)))
-        let sut = makeSUT(networkService: networkService)
 
         _ = await sut.verifyChatCompletionsAPIKey(
             "sk-probe",
@@ -392,9 +369,7 @@ struct OpenAICompatibleServiceTests {
     // MARK: - verifyGETEndpoint
 
     @Test func verifyGETEndpointReturnsTrueOn200() async {
-        let networkService = MockNetworkService()
         networkService.stubSendResponse = .success((Data(), makeHTTPResponse(200)))
-        let sut = makeSUT(networkService: networkService)
 
         let valid = await sut.verifyGETEndpoint(
             "sk-test",
@@ -406,9 +381,7 @@ struct OpenAICompatibleServiceTests {
     }
 
     @Test func verifyGETEndpointReturnsFalseOn401() async {
-        let networkService = MockNetworkService()
         networkService.stubSendResponse = .success((Data(), makeHTTPResponse(401)))
-        let sut = makeSUT(networkService: networkService)
 
         let valid = await sut.verifyGETEndpoint(
             "sk-bad",
@@ -420,9 +393,7 @@ struct OpenAICompatibleServiceTests {
     }
 
     @Test func verifyGETEndpointReturnsFalseOnTransportError() async {
-        let networkService = MockNetworkService()
         networkService.stubSendResponse = .failure(URLError(.notConnectedToInternet))
-        let sut = makeSUT(networkService: networkService)
 
         let valid = await sut.verifyGETEndpoint(
             "sk-test",
@@ -434,9 +405,7 @@ struct OpenAICompatibleServiceTests {
     }
 
     @Test func verifyGETEndpointSendsBearerAuthAndGETMethod() async throws {
-        let networkService = MockNetworkService()
         networkService.stubSendResponse = .success((Data(), makeHTTPResponse(200)))
-        let sut = makeSUT(networkService: networkService)
 
         _ = await sut.verifyGETEndpoint(
             "sk-probe",
@@ -459,9 +428,6 @@ struct OpenAICompatibleServiceTests {
     // exercised by the static `streamingDelta(from:)` tests above.
 
     @Test func enhanceStreamingSendsCorrectHeadersAndBody() async throws {
-        let networkService = MockNetworkService()
-        let sut = makeSUT(networkService: networkService)
-
         _ = try? await sut.enhanceStreaming(
             url: URL(string: endpointURL)!,
             modelName: "gpt-4",


### PR DESCRIPTION
Apply the hoist-SUT-to-property-with-init pattern to the remaining suites where every test builds the same SUT around a stub-then-call mock. Each test still gets a fresh struct (and fresh mock) per Swift Testing's per-test instantiation; the stubbing-then-calling pattern works because the mock is a reference type held by both the test and the SUT.

## Summary

**Files hoisted (8 suites):**

- `AnthropicServiceTests` (12 tests, hoist `networkService` + `sut`)
- `OpenAICompatibleServiceTests` (18 tests, same shape)
- `CustomOpenAIServiceTests` (16 tests, same shape)
- `DefaultNetworkServiceTests` (8 tests, hoist `session` + `sut`)
- `LiveTranslationServiceTests` (3 tests, hoist `mockKeychain` + `sut`)
- `MockTranscriptionServiceTests` inside `CloudTranscriptionTests.swift` (3 tests)
- `AppGroupCoordinatorSessionTests` (8 tests, hoist `defaults` + `sut`)
- `AppGroupCoordinatorStateTests` (13 tests, hoist `defaults` + `sut`; one special-init test intentionally shadows `sut` with an inline comment explaining why)

**Deliberately skipped:**

- `OllamaServiceTests` - 5 tests use `MockNetworkService`, 4 use a custom `SequencedMockNetworkService` for fallback-path tests. Mixed mock types would force 4 tests to shadow.
- `Xai/Groq/OpenAITranscriptionServiceTests` - each has a `makeService(networkService:, apiKey:, modelName:, language:, ...)` factory with default args, and ~5 of 11-13 tests per file pass non-default config. The factory-with-defaults pattern is the recommended choice when SUT config varies per test.

This finishes the sweep started in PR #295 and #296. Test count and behaviour are preserved; only construction site moves.

## Test plan
- [x] `xcodebuild test -only-testing:VivaDictaTests` - 333 tests, 0 failures
- [x] `xcodebuild test -only-testing:CloudTranscriptionTests` - 50 tests, 0 failures (1 pre-existing known issue, unrelated)
- [x] `xcodebuild test -only-testing:NetworkingTests` - 23 tests, 0 failures
- [x] `xcodebuild test -only-testing:AppGroupTests` - 22 tests, 0 failures
- [ ] Full CI run