### PR TITLE
Inject AIService/TranscriptionManager via init instead of fallback singletons

### DIFF
--- a/VivaDicta/AppState.swift
+++ b/VivaDicta/AppState.swift
@@ -120,20 +120,25 @@ class AppState {
     /// Audio file URL received via "Open With" from Files app.
     var openedAudioFileURL: URL?
 
-    init(modelContainer: ModelContainer) {
-        transcriptionManager = TranscriptionManager()
-        aiService = AIService()
-        presetManager = PresetManager(userDefaults: UserDefaultsStorage.shared)
-        aiService.presetManager = presetManager
-        PresetMigrationService.migrateIfNeeded(presetManager: presetManager, aiService: aiService)
+    init(
+        modelContainer: ModelContainer,
+        transcriptionManager: TranscriptionManager = TranscriptionManager(),
+        aiService: AIService = AIService(),
+        presetManager: PresetManager? = nil
+    ) {
+        self.transcriptionManager = transcriptionManager
+        self.aiService = aiService
+        self.presetManager = presetManager ?? PresetManager(userDefaults: UserDefaultsStorage.shared)
+        aiService.presetManager = self.presetManager
+        PresetMigrationService.migrateIfNeeded(presetManager: self.presetManager, aiService: aiService)
 
         // Set up preset sync service for CloudKit sync
         presetSyncService = PresetSyncService()
         presetSyncService.configure(modelContext: modelContainer.mainContext)
         presetSyncService.migrateOldCustomRewritePresets()
-        presetSyncService.migrateExistingCustomPresets(presetManager: presetManager)
-        presetSyncService.syncFromCloudKit(presetManager: presetManager)
-        presetManager.syncService = presetSyncService
+        presetSyncService.migrateExistingCustomPresets(presetManager: self.presetManager)
+        presetSyncService.syncFromCloudKit(presetManager: self.presetManager)
+        self.presetManager.syncService = presetSyncService
 
         recordViewModel = RecordViewModel(appState: self, modelContainer: modelContainer)
         downloadManager = ModelDownloadManager()

--- a/VivaDicta/Views/ModelsScreen/CloudModelConfigurationView.swift
+++ b/VivaDicta/Views/ModelsScreen/CloudModelConfigurationView.swift
@@ -10,12 +10,12 @@ import SwiftUI
 struct CloudModelConfigurationView: View {
     @Environment(\.dismiss) var dismiss
     var model: CloudModel
+    let aiService: AIService
     var onSave: (CloudModel) -> Void
 
     @State var apiKey: String = ""
     @State private var isVerifying: Bool = false
     @State private var verificationError: String? = nil
-    @State private var aiService = AIService()
     @State private var showDeleteConfirmation: Bool = false
     @State private var clearButtonVisible = false
 
@@ -262,6 +262,7 @@ struct CloudModelConfigurationView: View {
 #Preview {
     CloudModelConfigurationView(
         model: TranscriptionModelProvider.allCloudModels[0],
+        aiService: AIService(),
         onSave: { _ in }
     )
 }

--- a/VivaDicta/Views/RecordViewModel.swift
+++ b/VivaDicta/Views/RecordViewModel.swift
@@ -89,30 +89,30 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
 
     weak var appState: AppState?
     var modelContext: ModelContext
-    
-    public var transcriptionManager: TranscriptionManager {
-        appState?.transcriptionManager ?? TranscriptionManager()
-    }
-    public var aiService: AIService {
-        appState?.aiService ?? AIService()
-    }
+
+    public let transcriptionManager: TranscriptionManager
+    public let aiService: AIService
 
     var selectedModeName: String {
-        get { appState?.aiService.selectedModeName ?? "" }
-        set { appState?.aiService.selectedModeName = newValue }
+        get { aiService.selectedModeName }
+        set { aiService.selectedModeName = newValue }
     }
 
     var availableModes: [VivaMode] {
-        appState?.aiService.modes ?? []
+        aiService.modes
     }
 
     init(
         appState: AppState,
         modelContainer: ModelContainer,
+        transcriptionManager: TranscriptionManager? = nil,
+        aiService: AIService? = nil,
         audioRecordingService: AudioRecordingService = DefaultAudioRecordingService(),
         audioFileService: AudioFileService = DefaultAudioFileService()
     ) {
         self.appState = appState
+        self.transcriptionManager = transcriptionManager ?? appState.transcriptionManager
+        self.aiService = aiService ?? appState.aiService
         self.modelContext = ModelContext(modelContainer)
         self.audioRecordingService = audioRecordingService
         self.audioFileService = audioFileService

--- a/VivaDicta/Views/SettingsScreen/ModelsView.swift
+++ b/VivaDicta/Views/SettingsScreen/ModelsView.swift
@@ -86,6 +86,7 @@ struct ModelsView: View {
         .navigationDestination(item: $cloudModelToConfigure, destination: { model in
             CloudModelConfigurationView(
                 model: model,
+                aiService: appState.aiService,
                 onSave: { cloudModel in
                     cloudModelConfigured(cloudModel)
                 })


### PR DESCRIPTION
## Summary

- `CloudModelConfigurationView` now receives `aiService` from `ModelsView` instead of `@State private var aiService = AIService()`. The old form constructed a fresh real keychain/network/OAuth stack on every view init, defeating the protocol-based test setup the rest of the codebase relies on.
- `RecordViewModel` captures `transcriptionManager` and `aiService` as stored properties at init time, removing the `?? TranscriptionManager()` / `?? AIService()` fallbacks on the computed accessors. Those fallbacks silently spun up real services whenever the weak `appState` was nil - including in tests. The new init takes optional overrides so tests can pass mocks directly.
- `AppState.init` now accepts `transcriptionManager`, `aiService`, and `presetManager` as defaulted parameters, so tests can substitute mocks without changing the production call site in `VivaDictaApp`.

These three changes unblock testing `RecordViewModel` and `AppState` against mock services - previously documented as blocked in `RecordViewModelTests.swift`.

## Test plan

- [x] `xcodebuild build` for iPhone 17 Pro Max / iOS 26.4 - succeeds (0 errors)
- [x] `xcodebuild test` - all 545 tests across all suites pass
- [ ] Smoke test in simulator: open Models screen, add an API key for a cloud model, verify save flow
- [ ] Smoke test: trigger a recording from the main view and from the keyboard extension