### PR TITLE
Inject CustomTranscriptionModelSource + polish test suite

### DIFF
--- a/.claude/skills/improve-codebase-architecture
+++ b/.claude/skills/improve-codebase-architecture
@@ -1,1 +1,0 @@
-../../.agents/skills/improve-codebase-architecture

--- a/VivaDicta/Services/Transcription/CustomTranscription/CustomTranscriptionModelManager.swift
+++ b/VivaDicta/Services/Transcription/CustomTranscription/CustomTranscriptionModelManager.swift
@@ -10,9 +10,18 @@ import AppGroup
 import Keychain
 import os
 
+/// Read-only seam used by `TranscriptionManager` to ask "is there a configured
+/// custom transcription model right now?" without depending on the concrete
+/// singleton, so tests can substitute a fake.
+@MainActor
+protocol CustomTranscriptionModelSource {
+    var isConfigured: Bool { get }
+    var configuredModel: CustomTranscriptionModel? { get }
+}
+
 @Observable
 @MainActor
-final class CustomTranscriptionModelManager {
+final class CustomTranscriptionModelManager: CustomTranscriptionModelSource {
     static let shared = CustomTranscriptionModelManager(keychain: DefaultKeychainService())
 
     private let logger = Logger(category: .customTranscriptionService)

--- a/VivaDicta/Services/Transcription/TranscriptionManager.swift
+++ b/VivaDicta/Services/Transcription/TranscriptionManager.swift
@@ -34,9 +34,14 @@ class TranscriptionManager {
     private let logger = Logger(category: .transcriptionManager)
 
     private let engine: any TranscriptionEngine
+    private let customTranscriptionSource: any CustomTranscriptionModelSource
 
-    init(engine: any TranscriptionEngine = DefaultTranscriptionEngine()) {
+    init(
+        engine: any TranscriptionEngine = DefaultTranscriptionEngine(),
+        customTranscriptionSource: any CustomTranscriptionModelSource = CustomTranscriptionModelManager.shared
+    ) {
         self.engine = engine
+        self.customTranscriptionSource = customTranscriptionSource
     }
 
     /// The currently active transcription mode determining which model to use.
@@ -58,7 +63,7 @@ class TranscriptionManager {
         let hasConfiguredCloudModels = TranscriptionModelProvider.allCloudModels.contains { model in
             model.apiKey != nil
         }
-        let hasCustomModel = CustomTranscriptionModelManager.shared.isConfigured
+        let hasCustomModel = customTranscriptionSource.isConfigured
         return hasParakeetModels || hasWhisperKitModels || hasConfiguredCloudModels || hasCustomModel
     }
 
@@ -113,7 +118,7 @@ class TranscriptionManager {
         let modelName = currentMode.transcriptionModel
 
         if provider == .customTranscription && modelName == "custom" {
-            return CustomTranscriptionModelManager.shared.configuredModel
+            return customTranscriptionSource.configuredModel
         }
 
         let allModels: [any TranscriptionModel] =

--- a/VivaDictaTests/AIServiceConfigurationTests.swift
+++ b/VivaDictaTests/AIServiceConfigurationTests.swift
@@ -241,34 +241,25 @@ struct AIServiceConfigurationTests {
 
     // MARK: - Apple FM Sampling Profiles
 
-    @Test func appleFMSamplingProfile_extractivePresetsUseExtractive() {
-        let extractivePresetIDs = [
-            "summary",
-            "action_points",
-            "key_points",
-            "takeaways",
-            "mind_map"
-        ]
-
-        for presetID in extractivePresetIDs {
-            #expect(AppleFoundationModelSamplingProfile.profile(for: presetID) == .extractive)
-        }
+    @Test(arguments: [
+        ("summary", AppleFoundationModelSamplingProfile.extractive),
+        ("action_points", .extractive),
+        ("key_points", .extractive),
+        ("takeaways", .extractive),
+        ("mind_map", .extractive),
+        ("regular", .balanced),
+        ("chat", .conversational),
+        ("philosophical", .creative),
+        ("custom_123", .balanced)
+    ])
+    func appleFMSamplingProfile_mapsPresetIDToProfile(
+        presetID: String,
+        expected: AppleFoundationModelSamplingProfile
+    ) {
+        #expect(AppleFoundationModelSamplingProfile.profile(for: presetID) == expected)
     }
 
-    @Test func appleFMSamplingProfile_regularUsesBalanced() {
-        #expect(AppleFoundationModelSamplingProfile.profile(for: "regular") == .balanced)
-    }
-
-    @Test func appleFMSamplingProfile_chatUsesConversational() {
-        #expect(AppleFoundationModelSamplingProfile.profile(for: "chat") == .conversational)
-    }
-
-    @Test func appleFMSamplingProfile_philosophicalUsesCreative() {
-        #expect(AppleFoundationModelSamplingProfile.profile(for: "philosophical") == .creative)
-    }
-
-    @Test func appleFMSamplingProfile_unknownPresetFallsBackToBalanced() {
-        #expect(AppleFoundationModelSamplingProfile.profile(for: "custom_123") == .balanced)
+    @Test func appleFMSamplingProfile_nilPresetFallsBackToBalanced() {
         #expect(AppleFoundationModelSamplingProfile.profile(for: nil) == .balanced)
     }
 

--- a/VivaDictaTests/AudioCleanupServiceTests.swift
+++ b/VivaDictaTests/AudioCleanupServiceTests.swift
@@ -12,6 +12,7 @@ import SwiftData
 @testable import VivaDicta
 
 @MainActor
+@Suite(.tags(.cleanup, .database), .timeLimit(.minutes(1)))
 struct AudioCleanupServiceTests {
 
     private let testSuiteName = "AudioCleanupServiceTests.\(UUID().uuidString)"

--- a/VivaDictaTests/DataControllerTests.swift
+++ b/VivaDictaTests/DataControllerTests.swift
@@ -10,6 +10,7 @@ import SwiftData
 import Testing
 @testable import VivaDicta
 
+@Suite(.tags(.database))
 struct DataControllerTests {
 
     let sut: DataController

--- a/VivaDictaTests/NoteCleanupServiceTests.swift
+++ b/VivaDictaTests/NoteCleanupServiceTests.swift
@@ -12,6 +12,7 @@ import SwiftData
 @testable import VivaDicta
 
 @MainActor
+@Suite(.tags(.cleanup, .database), .timeLimit(.minutes(1)))
 struct NoteCleanupServiceTests {
 
     private let testSuiteName = "NoteCleanupServiceTests.\(UUID().uuidString)"

--- a/VivaDictaTests/TestTags.swift
+++ b/VivaDictaTests/TestTags.swift
@@ -7,4 +7,12 @@ extension Tag {
     /// No real network calls happen - the tag exists so the suites can be
     /// selected/excluded as a group from an Xcode Test Plan.
     @Tag static var networking: Self
+
+    /// Marks suites that touch the filesystem (audio files, exports, temp
+    /// directories). Selectable so a slow CI tier can run them separately.
+    @Tag static var cleanup: Self
+
+    /// Marks suites that build a real SwiftData `ModelContainer`. Heavier than
+    /// pure-value tests, lighter than full integration runs.
+    @Tag static var database: Self
 }

--- a/VivaDictaTests/TranscriptionManagerTests.swift
+++ b/VivaDictaTests/TranscriptionManagerTests.swift
@@ -15,21 +15,26 @@ import TranscriptionKitMocks
 /// (`TranscriptionKitMocks`) to inject a `MockTranscriptionEngine` into
 /// `TranscriptionManager` through the `any TranscriptionEngine` protocol.
 ///
-/// Coverage is intentionally narrow: the manager reads several singletons
-/// directly (`UserDefaultsStorage.shared`, `AppGroupCoordinator.shared`,
-/// `CustomTranscriptionModelManager.shared`) so end-to-end pipeline tests
-/// are out of scope until those are DI'd as well. These tests prove the
-/// protocol-DI wire and exercise the control-flow branches that don't
-/// touch app-wide state.
+/// Coverage is intentionally narrow: the manager still reads a couple of
+/// singletons directly (`UserDefaultsStorage.shared`, `AppGroupCoordinator.shared`)
+/// so end-to-end pipeline tests are out of scope until those are DI'd as well.
+/// The custom-transcription source is now injected (see `FakeCustomSource`),
+/// so `hasAvailableTranscriptionModels` and the custom-model path of
+/// `getCurrentTranscriptionModel` are testable.
 @MainActor
 struct TranscriptionManagerTests {
 
     let mockEngine: MockTranscriptionEngine
+    let customSource: FakeCustomSource
     let sut: TranscriptionManager
 
     init() {
         mockEngine = MockTranscriptionEngine()
-        sut = TranscriptionManager(engine: mockEngine)
+        customSource = FakeCustomSource()
+        sut = TranscriptionManager(
+            engine: mockEngine,
+            customTranscriptionSource: customSource
+        )
     }
 
     private func makeMode(
@@ -85,4 +90,49 @@ struct TranscriptionManagerTests {
 
         #expect(sut.currentMode.id == mode.id)
     }
+
+    // MARK: - Custom transcription source injection
+
+    @Test func hasAvailableTranscriptionModels_isTrue_whenOnlyCustomSourceIsConfigured() {
+        customSource.isConfigured = true
+        customSource.configuredModel = Self.makeCustomModel()
+
+        #expect(sut.hasAvailableTranscriptionModels)
+    }
+
+    @Test func getCurrentTranscriptionModel_returnsCustomModel_whenSourceConfigured() {
+        let model = Self.makeCustomModel()
+        customSource.isConfigured = true
+        customSource.configuredModel = model
+        sut.setCurrentMode(makeMode(provider: .customTranscription, model: "custom"))
+
+        let result = sut.getCurrentTranscriptionModel()
+
+        #expect((result as? CustomTranscriptionModel)?.id == model.id)
+    }
+
+    @Test func getCurrentTranscriptionModel_returnsNil_whenCustomSourceUnconfigured() {
+        customSource.isConfigured = false
+        customSource.configuredModel = nil
+        sut.setCurrentMode(makeMode(provider: .customTranscription, model: "custom"))
+
+        #expect(sut.getCurrentTranscriptionModel() == nil)
+    }
+
+    private static func makeCustomModel() -> CustomTranscriptionModel {
+        CustomTranscriptionModel(
+            id: UUID(),
+            name: "custom",
+            displayName: "Custom",
+            apiEndpoint: "https://example.com/v1",
+            modelName: "test-model",
+            isMultilingual: true
+        )
+    }
+}
+
+@MainActor
+final class FakeCustomSource: CustomTranscriptionModelSource {
+    var isConfigured: Bool = false
+    var configuredModel: CustomTranscriptionModel? = nil
 }

--- a/VivaDictaTests/VivaModeModelNormalizationTests.swift
+++ b/VivaDictaTests/VivaModeModelNormalizationTests.swift
@@ -13,41 +13,29 @@ struct VivaModeModelNormalizationTests {
 
     // MARK: - AI model normalization
 
-    @Test func aiModel_geminiRetiredProPreview_isRewritten() {
-        let normalized = VivaMode.normalizedModelID("gemini-3-pro-preview", provider: .gemini)
-        #expect(normalized == "gemini-3.1-pro-preview")
-    }
-
-    @Test func aiModel_currentGeminiModel_isPassedThrough() {
-        let normalized = VivaMode.normalizedModelID("gemini-3.5-flash", provider: .gemini)
-        #expect(normalized == "gemini-3.5-flash")
-    }
-
-    @Test func aiModel_nonGeminiProvider_isNotRewritten() {
-        let normalized = VivaMode.normalizedModelID("gemini-3-pro-preview", provider: .openAI)
-        #expect(normalized == "gemini-3-pro-preview")
-    }
-
-    @Test func aiModel_nilProvider_isNotRewritten() {
-        let normalized = VivaMode.normalizedModelID("gemini-3-pro-preview", provider: nil)
-        #expect(normalized == "gemini-3-pro-preview")
+    @Test(arguments: [
+        (input: "gemini-3-pro-preview", provider: AIProvider?.some(.gemini), expected: "gemini-3.1-pro-preview"),
+        (input: "gemini-3.5-flash", provider: .some(.gemini), expected: "gemini-3.5-flash"),
+        (input: "gemini-3-pro-preview", provider: .some(.openAI), expected: "gemini-3-pro-preview"),
+        (input: "gemini-3-pro-preview", provider: nil, expected: "gemini-3-pro-preview")
+    ])
+    func aiModel_normalization(input: String, provider: AIProvider?, expected: String) {
+        #expect(VivaMode.normalizedModelID(input, provider: provider) == expected)
     }
 
     // MARK: - Transcription model normalization
 
-    @Test func transcriptionModel_geminiRetiredProPreview_isRewritten() {
-        let normalized = VivaMode.normalizedTranscriptionModelID("gemini-3-pro-preview", provider: .gemini)
-        #expect(normalized == "gemini-3.1-pro-preview")
-    }
-
-    @Test func transcriptionModel_currentGeminiModel_isPassedThrough() {
-        let normalized = VivaMode.normalizedTranscriptionModelID("gemini-3.5-flash", provider: .gemini)
-        #expect(normalized == "gemini-3.5-flash")
-    }
-
-    @Test func transcriptionModel_nonGeminiProvider_isNotRewritten() {
-        let normalized = VivaMode.normalizedTranscriptionModelID("gemini-3-pro-preview", provider: .openAI)
-        #expect(normalized == "gemini-3-pro-preview")
+    @Test(arguments: [
+        (input: "gemini-3-pro-preview", provider: TranscriptionModelProvider.gemini, expected: "gemini-3.1-pro-preview"),
+        (input: "gemini-3.5-flash", provider: .gemini, expected: "gemini-3.5-flash"),
+        (input: "gemini-3-pro-preview", provider: .openAI, expected: "gemini-3-pro-preview")
+    ])
+    func transcriptionModel_normalization(
+        input: String,
+        provider: TranscriptionModelProvider,
+        expected: String
+    ) {
+        #expect(VivaMode.normalizedTranscriptionModelID(input, provider: provider) == expected)
     }
 
     // MARK: - Decoder integration


### PR DESCRIPTION
## Summary

Two related test-quality changes, one commit each:

**Inject CustomTranscriptionModelSource into TranscriptionManager**
- New read-only `CustomTranscriptionModelSource` protocol (`isConfigured` + `configuredModel`) seams over the previous `CustomTranscriptionModelManager.shared` calls inside `TranscriptionManager.hasAvailableTranscriptionModels` and `getCurrentTranscriptionModel`. Existing manager class conforms via a one-line `: CustomTranscriptionModelSource`; production call site unchanged because the init parameter defaults to `.shared`.
- Three new tests exercise the seam end-to-end: `hasAvailableTranscriptionModels` true when only the custom source is configured, and both branches of `getCurrentTranscriptionModel` for the custom provider.

**Parameterize duplicated tests, add tags + timeLimit to cleanup suites**
- 5 Apple FM sampling-profile tests → 1 parameterized + 1 nil-fallback.
- 7 Gemini model-normalization tests → 2 parameterized.
- `TestTags` expands with `.cleanup` and `.database`.
- `AudioCleanupServiceTests` / `NoteCleanupServiceTests` now carry `.tags(.cleanup, .database)` plus `.timeLimit(.minutes(1))` so a hung file-I/O assertion can't stall CI.
- `DataControllerTests` tagged `.database`.

Skipped `.serialized` on the cleanup suites: each test already uses a UUID-suffixed temp dir, so the trait would just slow them down.

## Test plan

- [x] `xcodebuild build` for iPhone 17 Pro Max / iOS 26.4 - 0 errors
- [x] `xcodebuild test` - all green (540 unique tests; parameterized cases each count as one but cover more assertions overall)