### PR TITLE
Introduce MaintenanceCoordinator for cleanup orchestration

### DIFF
--- a/VivaDicta/AppState.swift
+++ b/VivaDicta/AppState.swift
@@ -79,6 +79,9 @@ class AppState {
     /// Service for managing background task protection.
     var backgroundTaskService: BackgroundTaskManager!
 
+    /// Orchestrates periodic cleanup services (notes, audio, chats).
+    var maintenanceCoordinator: MaintenanceCoordinator!
+
 
     // MARK: - Navigation State
 
@@ -124,11 +127,17 @@ class AppState {
         modelContainer: ModelContainer,
         transcriptionManager: TranscriptionManager = TranscriptionManager(),
         aiService: AIService = AIService(),
-        presetManager: PresetManager? = nil
+        presetManager: PresetManager? = nil,
+        maintenanceCoordinator: MaintenanceCoordinator? = nil
     ) {
         self.transcriptionManager = transcriptionManager
         self.aiService = aiService
         self.presetManager = presetManager ?? PresetManager(userDefaults: UserDefaultsStorage.shared)
+        self.maintenanceCoordinator = maintenanceCoordinator ?? MaintenanceCoordinator(services: [
+            NoteCleanupService.shared,
+            AudioCleanupService.shared,
+            ChatCleanupService.shared
+        ])
         aiService.presetManager = self.presetManager
         PresetMigrationService.migrateIfNeeded(presetManager: self.presetManager, aiService: aiService)
 

--- a/VivaDicta/Services/AudioCleanupService.swift
+++ b/VivaDicta/Services/AudioCleanupService.swift
@@ -12,7 +12,7 @@ import os
 
 /// Service responsible for cleaning up old audio files based on user settings
 @MainActor
-final class AudioCleanupService {
+final class AudioCleanupService: MaintenanceService {
     static let shared = AudioCleanupService()
 
     private static let lastCleanupKey = "lastAudioCleanupDate"

--- a/VivaDicta/Services/ChatCleanupService.swift
+++ b/VivaDicta/Services/ChatCleanupService.swift
@@ -15,7 +15,7 @@ import os
 /// Deleting a `ChatConversation` cascade-deletes its `ChatMessage` records.
 /// Detached single-note chats are also cleaned up conservatively to prevent hidden orphan buildup.
 @MainActor
-final class ChatCleanupService {
+final class ChatCleanupService: MaintenanceService {
     static let shared = ChatCleanupService()
 
     private static let lastCleanupKey = "lastChatCleanupDate"

--- a/VivaDicta/Services/MaintenanceCoordinator.swift
+++ b/VivaDicta/Services/MaintenanceCoordinator.swift
@@ -8,10 +8,12 @@
 import Foundation
 import SwiftData
 
-/// One side of the maintenance contract: a service that does some cleanup
-/// work iff its own user-settings gate is on. Implementations stay
-/// independent (`NoteCleanupService`, `AudioCleanupService`, `ChatCleanupService`);
-/// `MaintenanceCoordinator` just runs them in order.
+/// One side of the maintenance contract: a service that the coordinator can
+/// ask to do some cleanup work. The service itself decides whether to
+/// actually do anything on a given call (typical adopters gate on a user
+/// preference, but that is not part of the protocol). The current adopters
+/// - `NoteCleanupService`, `AudioCleanupService`, `ChatCleanupService` -
+/// stay independent; `MaintenanceCoordinator` just runs them in sequence.
 @MainActor
 protocol MaintenanceService {
     func performCleanupIfNeeded(modelContext: ModelContext) async
@@ -30,7 +32,11 @@ final class MaintenanceCoordinator {
 
     /// Runs every registered cleanup service, in registration order, on the
     /// given model context. Each service independently decides whether to
-    /// actually do work based on its own user-settings gate.
+    /// actually do work.
+    ///
+    /// Order is stable but not load-bearing: services are independent and
+    /// must not depend on each other's side effects. The sequential await is
+    /// chosen for predictable resource use, not because of ordering needs.
     func performAllCleanupIfNeeded(modelContext: ModelContext) async {
         for service in services {
             await service.performCleanupIfNeeded(modelContext: modelContext)

--- a/VivaDicta/Services/MaintenanceCoordinator.swift
+++ b/VivaDicta/Services/MaintenanceCoordinator.swift
@@ -1,0 +1,39 @@
+//
+//  MaintenanceCoordinator.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.05.26
+//
+
+import Foundation
+import SwiftData
+
+/// One side of the maintenance contract: a service that does some cleanup
+/// work iff its own user-settings gate is on. Implementations stay
+/// independent (`NoteCleanupService`, `AudioCleanupService`, `ChatCleanupService`);
+/// `MaintenanceCoordinator` just runs them in order.
+@MainActor
+protocol MaintenanceService {
+    func performCleanupIfNeeded(modelContext: ModelContext) async
+}
+
+/// Orchestrates the app's periodic cleanup services as a single unit so that
+/// callers (MainView's `.task`, app launch flows) don't need to know which
+/// cleanup services exist or in what order to run them.
+@MainActor
+final class MaintenanceCoordinator {
+    private let services: [any MaintenanceService]
+
+    init(services: [any MaintenanceService]) {
+        self.services = services
+    }
+
+    /// Runs every registered cleanup service, in registration order, on the
+    /// given model context. Each service independently decides whether to
+    /// actually do work based on its own user-settings gate.
+    func performAllCleanupIfNeeded(modelContext: ModelContext) async {
+        for service in services {
+            await service.performCleanupIfNeeded(modelContext: modelContext)
+        }
+    }
+}

--- a/VivaDicta/Services/NoteCleanupService.swift
+++ b/VivaDicta/Services/NoteCleanupService.swift
@@ -14,7 +14,7 @@ import os
 
 /// Service responsible for auto-deleting old transcription notes based on user settings
 @MainActor
-final class NoteCleanupService {
+final class NoteCleanupService: MaintenanceService {
     static let shared = NoteCleanupService()
 
     private static let lastCleanupKey = "lastNoteCleanupDate"

--- a/VivaDicta/Views/MainView.swift
+++ b/VivaDicta/Views/MainView.swift
@@ -729,9 +729,7 @@ struct MainView: View {
     }
 
     private func performMaintenanceTasks() async {
-        await NoteCleanupService.shared.performCleanupIfNeeded(modelContext: modelContext)
-        await AudioCleanupService.shared.performCleanupIfNeeded(modelContext: modelContext)
-        await ChatCleanupService.shared.performCleanupIfNeeded(modelContext: modelContext)
+        await appState.maintenanceCoordinator.performAllCleanupIfNeeded(modelContext: modelContext)
     }
 
     private func exportSelectedTranscriptions() {

--- a/VivaDictaTests/MaintenanceCoordinatorTests.swift
+++ b/VivaDictaTests/MaintenanceCoordinatorTests.swift
@@ -1,0 +1,92 @@
+//
+//  MaintenanceCoordinatorTests.swift
+//  VivaDictaTests
+//
+//  Created by Anton Novoselov on 2026.05.26
+//
+
+import Foundation
+import SwiftData
+import Testing
+@testable import VivaDicta
+
+@MainActor
+@Suite(.tags(.database))
+struct MaintenanceCoordinatorTests {
+
+    private func makeContext() throws -> ModelContext {
+        let container = try ModelContainer(
+            for: Transcription.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        return container.mainContext
+    }
+
+    @Test func performAllCleanupIfNeeded_runsEachServiceOnce() async throws {
+        let s1 = FakeMaintenanceService(label: "a")
+        let s2 = FakeMaintenanceService(label: "b")
+        let s3 = FakeMaintenanceService(label: "c")
+        let sut = MaintenanceCoordinator(services: [s1, s2, s3])
+        let context = try makeContext()
+
+        await sut.performAllCleanupIfNeeded(modelContext: context)
+
+        #expect(s1.callCount == 1)
+        #expect(s2.callCount == 1)
+        #expect(s3.callCount == 1)
+    }
+
+    @Test func performAllCleanupIfNeeded_runsServicesInRegistrationOrder() async throws {
+        let order = OrderRecorder()
+        let s1 = FakeMaintenanceService(label: "first", recorder: order)
+        let s2 = FakeMaintenanceService(label: "second", recorder: order)
+        let s3 = FakeMaintenanceService(label: "third", recorder: order)
+        let sut = MaintenanceCoordinator(services: [s1, s2, s3])
+        let context = try makeContext()
+
+        await sut.performAllCleanupIfNeeded(modelContext: context)
+
+        #expect(order.calls == ["first", "second", "third"])
+    }
+
+    @Test func performAllCleanupIfNeeded_passesModelContextToEachService() async throws {
+        let s1 = FakeMaintenanceService(label: "a")
+        let sut = MaintenanceCoordinator(services: [s1])
+        let context = try makeContext()
+
+        await sut.performAllCleanupIfNeeded(modelContext: context)
+
+        #expect(s1.receivedContext === context)
+    }
+
+    @Test func performAllCleanupIfNeeded_withEmptyServiceList_isNoOp() async throws {
+        let sut = MaintenanceCoordinator(services: [])
+        let context = try makeContext()
+
+        await sut.performAllCleanupIfNeeded(modelContext: context)
+    }
+}
+
+@MainActor
+final class FakeMaintenanceService: MaintenanceService {
+    let label: String
+    private(set) var callCount = 0
+    private(set) var receivedContext: ModelContext?
+    private weak var recorder: OrderRecorder?
+
+    init(label: String, recorder: OrderRecorder? = nil) {
+        self.label = label
+        self.recorder = recorder
+    }
+
+    func performCleanupIfNeeded(modelContext: ModelContext) async {
+        callCount += 1
+        receivedContext = modelContext
+        recorder?.calls.append(label)
+    }
+}
+
+@MainActor
+final class OrderRecorder {
+    var calls: [String] = []
+}


### PR DESCRIPTION
## Summary

MainView used to call three cleanup singletons in sequence:

\`\`\`swift
await NoteCleanupService.shared.performCleanupIfNeeded(modelContext: modelContext)
await AudioCleanupService.shared.performCleanupIfNeeded(modelContext: modelContext)
await ChatCleanupService.shared.performCleanupIfNeeded(modelContext: modelContext)
\`\`\`

That coupled the view to the exact set of cleanup services and left the orchestration itself untestable.

This PR:
- Adds a tiny \`MaintenanceService\` protocol (only requirement: \`performCleanupIfNeeded(modelContext:) async\` - matches the existing signature on all three services).
- Adds a \`MaintenanceCoordinator\` that runs registered services in order.
- The three existing cleanup services adopt the protocol with a one-line conformance declaration. No behavior changes inside them.
- \`AppState\` owns the coordinator and defaults to \`[NoteCleanupService.shared, AudioCleanupService.shared, ChatCleanupService.shared]\`. Accepts an injected override so tests can swap in fakes.
- \`MainView.performMaintenanceTasks\` collapses to \`await appState.maintenanceCoordinator.performAllCleanupIfNeeded(modelContext: modelContext)\`.
- New \`MaintenanceCoordinatorTests\` covers four cases: each service called once, registration order, model-context propagation, empty-list no-op.

## Test plan

- [x] \`xcodebuild build\` for iPhone 17 Pro Max / iOS 26.4 - 0 errors
- [x] \`xcodebuild test\` - all green (544 tests, +4 from this PR)