### PR TITLE
Backfill tests for APIKeyMigrationService and ReminderExtractionService

### DIFF
--- a/VivaDicta/Services/APIKeyMigrationService.swift
+++ b/VivaDicta/Services/APIKeyMigrationService.swift
@@ -12,20 +12,32 @@ import os
 
 /// One-time migration of API keys from UserDefaults (App Group) to Keychain (iCloud sync).
 final class APIKeyMigrationService: Sendable {
-    static let shared = APIKeyMigrationService(keychain: DefaultKeychainService())
+    static let shared = APIKeyMigrationService(
+        keychain: DefaultKeychainService(),
+        sourceDefaults: UserDefaultsStorage.shared,
+        flagDefaults: UserDefaults.standard
+    )
 
     private let keychain: any KeychainService
+    private let sourceDefaults: UserDefaults
+    private let flagDefaults: UserDefaults
     private let logger = Logger(category: .keychainService)
     private let migrationCompletedKey = "HasMigratedAPIKeysToKeychain"
 
-    init(keychain: any KeychainService) {
+    init(
+        keychain: any KeychainService,
+        sourceDefaults: UserDefaults = UserDefaultsStorage.shared,
+        flagDefaults: UserDefaults = UserDefaults.standard
+    ) {
         self.keychain = keychain
+        self.sourceDefaults = sourceDefaults
+        self.flagDefaults = flagDefaults
     }
 
     /// Migrates existing API keys from UserDefaults to Keychain.
     /// Safe to call multiple times — only runs once.
     func migrateIfNeeded() {
-        guard !UserDefaults.standard.bool(forKey: migrationCompletedKey) else { return }
+        guard !flagDefaults.bool(forKey: migrationCompletedKey) else { return }
 
         logger.logInfo("Starting API key migration from UserDefaults to Keychain")
         var migrated = 0
@@ -40,7 +52,7 @@ final class APIKeyMigrationService: Sendable {
 
         for provider in providersToMigrate {
             let oldKey = "apiKeyTemplate" + provider.rawValue
-            if let value = UserDefaultsStorage.shared.string(forKey: oldKey),
+            if let value = sourceDefaults.string(forKey: oldKey),
                !value.isEmpty {
                 keychain.save(value, forKey: provider.keychainKey)
                 migrated += 1
@@ -50,14 +62,14 @@ final class APIKeyMigrationService: Sendable {
 
         // Migrate custom transcription API key
         let oldCustomTranscriptionKey = "apiKey.customTranscription"
-        if let value = UserDefaultsStorage.shared.string(forKey: oldCustomTranscriptionKey),
+        if let value = sourceDefaults.string(forKey: oldCustomTranscriptionKey),
            !value.isEmpty {
             keychain.save(value, forKey: "customTranscriptionAPIKey")
             migrated += 1
             logger.logInfo("Migrated custom transcription API key")
         }
 
-        UserDefaults.standard.set(true, forKey: migrationCompletedKey)
+        flagDefaults.set(true, forKey: migrationCompletedKey)
         logger.logInfo("API key migration completed: \(migrated) keys migrated")
     }
 }

--- a/VivaDictaTests/APIKeyMigrationServiceTests.swift
+++ b/VivaDictaTests/APIKeyMigrationServiceTests.swift
@@ -1,0 +1,144 @@
+//
+//  APIKeyMigrationServiceTests.swift
+//  VivaDictaTests
+//
+//  Created by Anton Novoselov on 2026.05.27
+//
+
+import Foundation
+import Keychain
+import KeychainMocks
+import Testing
+@testable import VivaDicta
+
+struct APIKeyMigrationServiceTests {
+
+    private let suiteName = "APIKeyMigrationTests.\(UUID().uuidString)"
+    private let flagSuiteName = "APIKeyMigrationTests.flag.\(UUID().uuidString)"
+
+    private func makeDefaults() -> (source: UserDefaults, flag: UserDefaults) {
+        let source = UserDefaults(suiteName: suiteName)!
+        source.removePersistentDomain(forName: suiteName)
+        let flag = UserDefaults(suiteName: flagSuiteName)!
+        flag.removePersistentDomain(forName: flagSuiteName)
+        return (source, flag)
+    }
+
+    private func makeSUT(
+        keychain: MockKeychainService,
+        sourceDefaults: UserDefaults,
+        flagDefaults: UserDefaults
+    ) -> APIKeyMigrationService {
+        APIKeyMigrationService(
+            keychain: keychain,
+            sourceDefaults: sourceDefaults,
+            flagDefaults: flagDefaults
+        )
+    }
+
+    // MARK: - Flag short-circuit
+
+    @Test func migrateIfNeeded_isNoOp_whenAlreadyMigrated() {
+        let (source, flag) = makeDefaults()
+        let keychain = MockKeychainService()
+        source.set("sk-test", forKey: "apiKeyTemplate" + AIProvider.openAI.rawValue)
+        flag.set(true, forKey: "HasMigratedAPIKeysToKeychain")
+
+        let sut = makeSUT(keychain: keychain, sourceDefaults: source, flagDefaults: flag)
+        sut.migrateIfNeeded()
+
+        #expect(keychain.saveStringCallCount == 0)
+    }
+
+    // MARK: - Provider key migration
+
+    @Test func migrateIfNeeded_movesProviderKey_fromSourceDefaultsToKeychain() {
+        let (source, flag) = makeDefaults()
+        let keychain = MockKeychainService()
+        source.set("sk-openai-xyz", forKey: "apiKeyTemplate" + AIProvider.openAI.rawValue)
+
+        let sut = makeSUT(keychain: keychain, sourceDefaults: source, flagDefaults: flag)
+        sut.migrateIfNeeded()
+
+        #expect(keychain.getString(forKey: AIProvider.openAI.keychainKey) == "sk-openai-xyz")
+    }
+
+    @Test func migrateIfNeeded_migratesMultipleProviders_inOnePass() {
+        let (source, flag) = makeDefaults()
+        let keychain = MockKeychainService()
+        source.set("k-openai", forKey: "apiKeyTemplate" + AIProvider.openAI.rawValue)
+        source.set("k-anthropic", forKey: "apiKeyTemplate" + AIProvider.anthropic.rawValue)
+        source.set("k-groq", forKey: "apiKeyTemplate" + AIProvider.groq.rawValue)
+
+        let sut = makeSUT(keychain: keychain, sourceDefaults: source, flagDefaults: flag)
+        sut.migrateIfNeeded()
+
+        #expect(keychain.getString(forKey: AIProvider.openAI.keychainKey) == "k-openai")
+        #expect(keychain.getString(forKey: AIProvider.anthropic.keychainKey) == "k-anthropic")
+        #expect(keychain.getString(forKey: AIProvider.groq.keychainKey) == "k-groq")
+    }
+
+    @Test func migrateIfNeeded_skipsEmptyAndMissingKeys() {
+        let (source, flag) = makeDefaults()
+        let keychain = MockKeychainService()
+        source.set("", forKey: "apiKeyTemplate" + AIProvider.openAI.rawValue)
+        // anthropic key not set at all
+
+        let sut = makeSUT(keychain: keychain, sourceDefaults: source, flagDefaults: flag)
+        sut.migrateIfNeeded()
+
+        #expect(keychain.saveStringCallCount == 0)
+    }
+
+    // MARK: - Custom transcription key migration
+
+    @Test func migrateIfNeeded_migratesCustomTranscriptionKey() {
+        let (source, flag) = makeDefaults()
+        let keychain = MockKeychainService()
+        source.set("custom-transcribe-key", forKey: "apiKey.customTranscription")
+
+        let sut = makeSUT(keychain: keychain, sourceDefaults: source, flagDefaults: flag)
+        sut.migrateIfNeeded()
+
+        #expect(keychain.getString(forKey: "customTranscriptionAPIKey") == "custom-transcribe-key")
+    }
+
+    // MARK: - Completion flag
+
+    @Test func migrateIfNeeded_setsCompletionFlag_afterRun() {
+        let (source, flag) = makeDefaults()
+        let keychain = MockKeychainService()
+
+        let sut = makeSUT(keychain: keychain, sourceDefaults: source, flagDefaults: flag)
+        sut.migrateIfNeeded()
+
+        #expect(flag.bool(forKey: "HasMigratedAPIKeysToKeychain"))
+    }
+
+    @Test func migrateIfNeeded_setsFlag_evenWhenNoKeysToMigrate() {
+        let (source, flag) = makeDefaults()
+        let keychain = MockKeychainService()
+
+        let sut = makeSUT(keychain: keychain, sourceDefaults: source, flagDefaults: flag)
+        sut.migrateIfNeeded()
+
+        #expect(flag.bool(forKey: "HasMigratedAPIKeysToKeychain"))
+        #expect(keychain.saveStringCallCount == 0)
+    }
+
+    // MARK: - Idempotency
+
+    @Test func migrateIfNeeded_secondCall_isNoOp() {
+        let (source, flag) = makeDefaults()
+        let keychain = MockKeychainService()
+        source.set("k-openai", forKey: "apiKeyTemplate" + AIProvider.openAI.rawValue)
+
+        let sut = makeSUT(keychain: keychain, sourceDefaults: source, flagDefaults: flag)
+        sut.migrateIfNeeded()
+        let countAfterFirst = keychain.saveStringCallCount
+
+        sut.migrateIfNeeded()
+
+        #expect(keychain.saveStringCallCount == countAfterFirst)
+    }
+}

--- a/VivaDictaTests/ReminderExtractionServiceTests.swift
+++ b/VivaDictaTests/ReminderExtractionServiceTests.swift
@@ -1,0 +1,98 @@
+//
+//  ReminderExtractionServiceTests.swift
+//  VivaDictaTests
+//
+//  Created by Anton Novoselov on 2026.05.27
+//
+
+import Foundation
+import Testing
+@testable import VivaDicta
+
+/// `ReminderExtractionService.extractAndPersist` makes real cloud/Apple FM
+/// calls and is out of scope for unit tests. `canExtractReminders` is the
+/// public surface that gatekeeps the auto-extraction flow, and that's what
+/// these tests pin down. Apple Foundation Model availability depends on
+/// `SystemLanguageModel.default.availability` on the simulator, so tests
+/// that would otherwise fall through to the Apple branch are excluded.
+@MainActor
+struct ReminderExtractionServiceTests {
+
+    private let suiteName = "ReminderExtractionServiceTests.\(UUID().uuidString)"
+
+    private func makeAIService() -> AIService {
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return AIService(userDefaults: defaults)
+    }
+
+    private func makeMode(
+        reminderExtractorProvider: AIProvider? = nil,
+        reminderExtractorModel: String? = nil,
+        aiProvider: AIProvider? = nil,
+        aiModel: String = ""
+    ) -> VivaMode {
+        VivaMode(
+            id: UUID(),
+            name: "Test",
+            transcriptionProvider: .whisperKit,
+            transcriptionModel: "test-whisper",
+            presetId: "regular",
+            aiProvider: aiProvider,
+            aiModel: aiModel,
+            reminderExtractorProvider: reminderExtractorProvider,
+            reminderExtractorModel: reminderExtractorModel,
+            aiEnhanceEnabled: true
+        )
+    }
+
+    // MARK: - Explicit reminder extractor provider
+
+    @Test func canExtractReminders_returnsFalse_whenReminderExtractorRequiresKey_butNoneConnected() {
+        let aiService = makeAIService()
+        let sut = ReminderExtractionService(aiService: aiService)
+        let mode = makeMode(reminderExtractorProvider: .openAI, reminderExtractorModel: "gpt-5")
+
+        #expect(sut.canExtractReminders(using: mode) == false)
+    }
+
+    @Test func canExtractReminders_returnsTrue_whenReminderExtractorIsOllamaWithModel() {
+        let aiService = makeAIService()
+        let sut = ReminderExtractionService(aiService: aiService)
+        let mode = makeMode(reminderExtractorProvider: .ollama, reminderExtractorModel: "llama3.2")
+
+        #expect(sut.canExtractReminders(using: mode))
+    }
+
+    @Test func canExtractReminders_returnsFalse_whenReminderExtractorHasNoModel() {
+        let aiService = makeAIService()
+        let sut = ReminderExtractionService(aiService: aiService)
+        let mode = makeMode(reminderExtractorProvider: .openAI, reminderExtractorModel: nil)
+
+        #expect(sut.canExtractReminders(using: mode) == false)
+    }
+
+    @Test func canExtractReminders_returnsFalse_whenReminderExtractorIsCopilot() {
+        // Copilot is hardcoded as unsupported for reminder extraction.
+        let aiService = makeAIService()
+        let sut = ReminderExtractionService(aiService: aiService)
+        let mode = makeMode(reminderExtractorProvider: .copilot, reminderExtractorModel: "gpt-4o")
+
+        #expect(sut.canExtractReminders(using: mode) == false)
+    }
+
+    // MARK: - Fallback to mode.aiProvider when no explicit reminder extractor
+
+    @Test func canExtractReminders_fallsBackToModeAIProvider_whenNoExplicitReminderExtractor() {
+        let aiService = makeAIService()
+        let sut = ReminderExtractionService(aiService: aiService)
+        let mode = makeMode(
+            reminderExtractorProvider: nil,
+            reminderExtractorModel: nil,
+            aiProvider: .ollama,
+            aiModel: "llama3.2"
+        )
+
+        #expect(sut.canExtractReminders(using: mode))
+    }
+}


### PR DESCRIPTION
## Summary

Wave A of the test coverage backfill. Both services were flagged in the audit as untested but already accepting their primary dependency via init - so they were nominally testable. In practice one needed a small DI tweak first.

**APIKeyMigrationService**
- Added \`sourceDefaults\` and \`flagDefaults\` init params (defaulting to \`UserDefaultsStorage.shared\` and \`UserDefaults.standard\`). The service used to read and write through both singletons directly, so any test would have polluted process-global state. Production behavior is unchanged - the \`.shared\` factory passes the real defaults.
- 8 new tests cover: flag short-circuit, single + multi-provider key migration, skip-empty-and-missing source values, custom transcription key migration, flag set after run (with and without keys to move), idempotency.

**ReminderExtractionService**
- 5 new tests pin \`canExtractReminders(using:)\` for the explicit reminder-extractor path:
  - false when a cloud provider requires a key that isn't connected
  - true for Ollama + model (no key needed)
  - false when extractor has no model
  - false for Copilot (hardcoded unsupported)
  - falls back to \`mode.aiProvider\` when no explicit extractor is set
- \`extractAndPersist\` makes real network/Apple FM calls and is out of scope here. \`AppleFoundationModelAvailability.isAvailable\` is environment-dependent on the simulator, so any test that would fall through to the Apple FM branch is intentionally skipped.

## Test plan

- [x] \`xcodebuild build\` for iPhone 17 Pro Max / iOS 26.4 - 0 errors
- [x] \`xcodebuild test\` - all green (557 tests; +13 from this PR)