### PR TITLE
Backfill tests for DictionaryMigrationService

### DIFF
--- a/VivaDicta/Services/DictionaryMigrationService.swift
+++ b/VivaDicta/Services/DictionaryMigrationService.swift
@@ -4,17 +4,29 @@ import SwiftData
 import os
 
 class DictionaryMigrationService {
-    static let shared = DictionaryMigrationService()
+    static let shared = DictionaryMigrationService(
+        sourceDefaults: UserDefaultsStorage.appPrivate,
+        flagDefaults: UserDefaults.standard
+    )
+
     private let logger = Logger(category: .dictionaryMigration)
+    private let sourceDefaults: UserDefaults
+    private let flagDefaults: UserDefaults
 
     private let migrationCompletedKey = "HasMigratedDictionaryToSwiftData"
 
-    private init() {}
+    init(
+        sourceDefaults: UserDefaults = UserDefaultsStorage.appPrivate,
+        flagDefaults: UserDefaults = UserDefaults.standard
+    ) {
+        self.sourceDefaults = sourceDefaults
+        self.flagDefaults = flagDefaults
+    }
 
     /// Migrates dictionary data from UserDefaults to SwiftData.
     /// This is a one-time operation that preserves all existing user data.
     func migrateIfNeeded(context: ModelContext) {
-        if UserDefaults.standard.bool(forKey: migrationCompletedKey) {
+        if flagDefaults.bool(forKey: migrationCompletedKey) {
             return
         }
 
@@ -24,8 +36,7 @@ class DictionaryMigrationService {
         var replacementsMigrated = 0
 
         // Migrate vocabulary words
-        let vocabDefaults = UserDefaultsStorage.appPrivate
-        if let words = vocabDefaults.stringArray(forKey: UserDefaultsStorage.Keys.customVocabularyWords) {
+        if let words = sourceDefaults.stringArray(forKey: UserDefaultsStorage.Keys.customVocabularyWords) {
             logger.logInfo("Found \(words.count) vocabulary words to migrate")
 
             for word in words {
@@ -40,7 +51,7 @@ class DictionaryMigrationService {
         }
 
         // Migrate word replacements
-        if let data = vocabDefaults.data(forKey: UserDefaultsStorage.Keys.textReplacements),
+        if let data = sourceDefaults.data(forKey: UserDefaultsStorage.Keys.textReplacements),
            let oldReplacements = try? JSONDecoder().decode([LegacyReplacement].self, from: data) {
             logger.logInfo("Found \(oldReplacements.count) word replacements to migrate")
 
@@ -59,7 +70,7 @@ class DictionaryMigrationService {
         // Save the migrated data
         do {
             try context.save()
-            UserDefaults.standard.set(true, forKey: migrationCompletedKey)
+            flagDefaults.set(true, forKey: migrationCompletedKey)
             logger.logInfo("Dictionary migration completed successfully")
         } catch {
             logger.logError("Failed to save migrated dictionary data: \(error.localizedDescription)")

--- a/VivaDicta/Services/DictionaryMigrationService.swift
+++ b/VivaDicta/Services/DictionaryMigrationService.swift
@@ -3,7 +3,7 @@ import AppGroup
 import SwiftData
 import os
 
-class DictionaryMigrationService {
+final class DictionaryMigrationService {
     static let shared = DictionaryMigrationService(
         sourceDefaults: UserDefaultsStorage.appPrivate,
         flagDefaults: UserDefaults.standard

--- a/VivaDictaTests/DictionaryMigrationServiceTests.swift
+++ b/VivaDictaTests/DictionaryMigrationServiceTests.swift
@@ -129,6 +129,23 @@ struct DictionaryMigrationServiceTests {
         #expect(try fetchReplacements(in: context).isEmpty)
     }
 
+    @Test func migrateIfNeeded_handlesCorruptedReplacementsBlob_andStillMarksMigrationDone() throws {
+        // The SUT decodes the legacy replacements payload with `try?`, so a
+        // malformed blob silently produces zero replacements AND still flips
+        // the completion flag. Pin that contract so a future refactor to
+        // `try` (which would throw and abort the migration) can't change
+        // semantics without a test failure.
+        let (source, flag) = makeDefaults()
+        source.set(Data("not valid json".utf8), forKey: UserDefaultsStorage.Keys.textReplacements)
+        let context = try makeContext()
+
+        let sut = DictionaryMigrationService(sourceDefaults: source, flagDefaults: flag)
+        sut.migrateIfNeeded(context: context)
+
+        #expect(try fetchReplacements(in: context).isEmpty)
+        #expect(flag.bool(forKey: migrationCompletedKey))
+    }
+
     // MARK: - Idempotency
 
     @Test func migrateIfNeeded_secondCall_doesNotDuplicateRecords() throws {

--- a/VivaDictaTests/DictionaryMigrationServiceTests.swift
+++ b/VivaDictaTests/DictionaryMigrationServiceTests.swift
@@ -1,0 +1,153 @@
+//
+//  DictionaryMigrationServiceTests.swift
+//  VivaDictaTests
+//
+//  Created by Anton Novoselov on 2026.05.27
+//
+
+import Foundation
+import AppGroup
+import SwiftData
+import Testing
+@testable import VivaDicta
+
+@MainActor
+@Suite(.tags(.database))
+struct DictionaryMigrationServiceTests {
+
+    private let migrationCompletedKey = "HasMigratedDictionaryToSwiftData"
+
+    private func makeDefaults() -> (source: UserDefaults, flag: UserDefaults) {
+        let sourceName = "DictionaryMigrationTests.source.\(UUID().uuidString)"
+        let flagName = "DictionaryMigrationTests.flag.\(UUID().uuidString)"
+        let source = UserDefaults(suiteName: sourceName)!
+        source.removePersistentDomain(forName: sourceName)
+        let flag = UserDefaults(suiteName: flagName)!
+        flag.removePersistentDomain(forName: flagName)
+        return (source, flag)
+    }
+
+    private func makeContext() throws -> ModelContext {
+        let container = try ModelContainer(
+            for: VocabularyWord.self, WordReplacement.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        return container.mainContext
+    }
+
+    private func fetchVocabulary(in context: ModelContext) throws -> [VocabularyWord] {
+        try context.fetch(FetchDescriptor<VocabularyWord>())
+    }
+
+    private func fetchReplacements(in context: ModelContext) throws -> [WordReplacement] {
+        try context.fetch(FetchDescriptor<WordReplacement>())
+    }
+
+    // MARK: - Flag short-circuit
+
+    @Test func migrateIfNeeded_isNoOp_whenAlreadyMigrated() throws {
+        let (source, flag) = makeDefaults()
+        source.set(["hello", "world"], forKey: UserDefaultsStorage.Keys.customVocabularyWords)
+        flag.set(true, forKey: migrationCompletedKey)
+        let context = try makeContext()
+
+        let sut = DictionaryMigrationService(sourceDefaults: source, flagDefaults: flag)
+        sut.migrateIfNeeded(context: context)
+
+        #expect(try fetchVocabulary(in: context).isEmpty)
+    }
+
+    // MARK: - Vocabulary migration
+
+    @Test func migrateIfNeeded_migratesVocabularyWords_intoSwiftData() throws {
+        let (source, flag) = makeDefaults()
+        source.set(["swift", "swiftdata", "xcode"], forKey: UserDefaultsStorage.Keys.customVocabularyWords)
+        let context = try makeContext()
+
+        let sut = DictionaryMigrationService(sourceDefaults: source, flagDefaults: flag)
+        sut.migrateIfNeeded(context: context)
+
+        let migrated = try fetchVocabulary(in: context).map(\.word).sorted()
+        #expect(migrated == ["swift", "swiftdata", "xcode"])
+    }
+
+    @Test func migrateIfNeeded_skipsEmptyAndWhitespaceVocabularyEntries() throws {
+        let (source, flag) = makeDefaults()
+        source.set(["valid", "   ", "", "  trimmed  "], forKey: UserDefaultsStorage.Keys.customVocabularyWords)
+        let context = try makeContext()
+
+        let sut = DictionaryMigrationService(sourceDefaults: source, flagDefaults: flag)
+        sut.migrateIfNeeded(context: context)
+
+        let migrated = try fetchVocabulary(in: context).map(\.word).sorted()
+        #expect(migrated == ["trimmed", "valid"])
+    }
+
+    // MARK: - Replacements migration
+
+    @Test func migrateIfNeeded_migratesWordReplacements_intoSwiftData() throws {
+        let (source, flag) = makeDefaults()
+        let legacy = [
+            LegacyReplacementWire(id: UUID(), original: "u", replacement: "you"),
+            LegacyReplacementWire(id: UUID(), original: "btw", replacement: "by the way")
+        ]
+        source.set(try JSONEncoder().encode(legacy), forKey: UserDefaultsStorage.Keys.textReplacements)
+        let context = try makeContext()
+
+        let sut = DictionaryMigrationService(sourceDefaults: source, flagDefaults: flag)
+        sut.migrateIfNeeded(context: context)
+
+        let migrated = try fetchReplacements(in: context)
+            .map { ($0.originalText, $0.replacementText) }
+            .sorted { $0.0 < $1.0 }
+        #expect(migrated.count == 2)
+        #expect(migrated[0] == ("btw", "by the way"))
+        #expect(migrated[1] == ("u", "you"))
+    }
+
+    // MARK: - Flag set after run
+
+    @Test func migrateIfNeeded_setsCompletionFlag_afterRun() throws {
+        let (source, flag) = makeDefaults()
+        let context = try makeContext()
+
+        let sut = DictionaryMigrationService(sourceDefaults: source, flagDefaults: flag)
+        sut.migrateIfNeeded(context: context)
+
+        #expect(flag.bool(forKey: migrationCompletedKey))
+    }
+
+    @Test func migrateIfNeeded_setsCompletionFlag_evenWithNothingToMigrate() throws {
+        let (source, flag) = makeDefaults()
+        let context = try makeContext()
+
+        let sut = DictionaryMigrationService(sourceDefaults: source, flagDefaults: flag)
+        sut.migrateIfNeeded(context: context)
+
+        #expect(flag.bool(forKey: migrationCompletedKey))
+        #expect(try fetchVocabulary(in: context).isEmpty)
+        #expect(try fetchReplacements(in: context).isEmpty)
+    }
+
+    // MARK: - Idempotency
+
+    @Test func migrateIfNeeded_secondCall_doesNotDuplicateRecords() throws {
+        let (source, flag) = makeDefaults()
+        source.set(["hello"], forKey: UserDefaultsStorage.Keys.customVocabularyWords)
+        let context = try makeContext()
+
+        let sut = DictionaryMigrationService(sourceDefaults: source, flagDefaults: flag)
+        sut.migrateIfNeeded(context: context)
+        sut.migrateIfNeeded(context: context)
+
+        #expect(try fetchVocabulary(in: context).count == 1)
+    }
+}
+
+/// Local mirror of the private `LegacyReplacement` payload that the SUT decodes.
+/// Kept in tests so the wire format is documented next to the assertions.
+private struct LegacyReplacementWire: Codable {
+    let id: UUID
+    let original: String
+    let replacement: String
+}


### PR DESCRIPTION
## Summary

Same shape as #301's APIKeyMigrationService work. The service used to read source data from \`UserDefaultsStorage.appPrivate\` and the completion flag from \`UserDefaults.standard\` directly, which made the migration logic untestable without polluting process-global state.

- Adds \`sourceDefaults\` and \`flagDefaults\` init params (defaulting to the same singletons). \`.shared\` factory passes the real defaults; production behavior is unchanged.
- Init is no longer \`private\` so tests can construct the service with isolated UserDefaults.
- 7 new tests:
  - flag short-circuit when already migrated
  - vocabulary words migrate into SwiftData
  - empty/whitespace vocabulary entries are skipped
  - word replacements migrate from the legacy JSON payload
  - completion flag is set after a run
  - completion flag is set even when there's nothing to migrate
  - idempotency: second call doesn't duplicate rows

## Test plan

- [x] \`xcodebuild build\` for iPhone 17 Pro Max / iOS 26.4 - 0 errors
- [x] \`xcodebuild test\` - all green (+7 new tests)