### PR TITLE
Add Advanced toggles to hide Chats and Live Translation

### DIFF
--- a/Modules/AppGroup/Sources/AppGroup/UserDefaultsStorage.swift
+++ b/Modules/AppGroup/Sources/AppGroup/UserDefaultsStorage.swift
@@ -89,6 +89,8 @@ public enum UserDefaultsStorage {
 
         // Advanced settings
         public static let appendWithVoiceStyle = "appendWithVoiceStyle"
+        public static let isChatEnabled = "isChatEnabled"
+        public static let isLiveTranslationEnabled = "isLiveTranslationEnabled"
 
         // Notes filter
         public static let savedNotesFilterSourceTags = "savedNotesFilterSourceTags"

--- a/VivaDicta/Views/MainFloatingActionButtonsView.swift
+++ b/VivaDicta/Views/MainFloatingActionButtonsView.swift
@@ -7,11 +7,15 @@
 
 import SwiftUI
 import DesignSystem
+import AppGroup
 import TipKit
 
 struct MainFloatingActionButtonsView: View {
     @Environment(\.isSearching) private var isSearching
     @Environment(\.colorScheme) private var colorScheme
+
+    @AppStorage(UserDefaultsStorage.Keys.isChatEnabled)
+    private var isChatEnabled: Bool = true
 
     let sheetTransitions: Namespace.ID
     let onShowChats: () -> Void
@@ -21,9 +25,11 @@ struct MainFloatingActionButtonsView: View {
         ZStack {
             recordButton
 
-            HStack {
-                Spacer()
-                chatsButton
+            if isChatEnabled {
+                HStack {
+                    Spacer()
+                    chatsButton
+                }
             }
         }
         .padding(.horizontal)

--- a/VivaDicta/Views/MainView.swift
+++ b/VivaDicta/Views/MainView.swift
@@ -52,6 +52,12 @@ struct MainView: View {
     @State private var zipShareFile: ExportedShareFile?
     @State private var isPreparingZipShare = false
 
+    @AppStorage(UserDefaultsStorage.Keys.isChatEnabled)
+    private var isChatEnabled: Bool = true
+
+    @AppStorage(UserDefaultsStorage.Keys.isLiveTranslationEnabled)
+    private var isLiveTranslationEnabled: Bool = true
+
     private let logger = Logger(category: .mainView)
 
     @Namespace private var sheetTransitions
@@ -469,21 +475,23 @@ struct MainView: View {
                 .matchedTransitionSource(id: "NotesFilterSheetTransition", in: sheetTransitions)
             }
 
-            if #available(iOS 26.0, *) {
-                ToolbarSpacer(.fixed, placement: .topBarTrailing)
-            }
-
-            ToolbarItem(placement: .topBarTrailing) {
-                Button {
-                    HapticManager.lightImpact()
-                    showingLiveTranslation = true
-                    Task { await LiveTranslationDiscoveryTip.liveTranslationOpenedEvent.donate() }
-                } label: {
-                    Image(systemName: "globe.americas.fill")
+            if isLiveTranslationEnabled {
+                if #available(iOS 26.0, *) {
+                    ToolbarSpacer(.fixed, placement: .topBarTrailing)
                 }
-                .accessibilityLabel("Live Translation")
-                .matchedTransitionSource(id: "LiveTranslationSheetTransition", in: sheetTransitions)
-                .popoverTip(LiveTranslationDiscoveryTip())
+
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        HapticManager.lightImpact()
+                        showingLiveTranslation = true
+                        Task { await LiveTranslationDiscoveryTip.liveTranslationOpenedEvent.donate() }
+                    } label: {
+                        Image(systemName: "globe.americas.fill")
+                    }
+                    .accessibilityLabel("Live Translation")
+                    .matchedTransitionSource(id: "LiveTranslationSheetTransition", in: sheetTransitions)
+                    .popoverTip(LiveTranslationDiscoveryTip())
+                }
             }
 
             if #available(iOS 26.0, *) {
@@ -583,17 +591,19 @@ struct MainView: View {
                 .disabled(selectedTranscriptionIDs.isEmpty)
             }
             
-            if #available(iOS 26.0, *) {
-                ToolbarSpacer(.fixed, placement: .bottomBar)
-            }
-            
-            ToolbarItem(placement: .bottomBar) {
-                Button {
-                    startMultiNoteChatWithSelected()
-                } label: {
-                    Label("Create Chat", systemImage: "plus.bubble")
+            if isChatEnabled {
+                if #available(iOS 26.0, *) {
+                    ToolbarSpacer(.fixed, placement: .bottomBar)
                 }
-                .disabled(selectedTranscriptionIDs.isEmpty)
+
+                ToolbarItem(placement: .bottomBar) {
+                    Button {
+                        startMultiNoteChatWithSelected()
+                    } label: {
+                        Label("Create Chat", systemImage: "plus.bubble")
+                    }
+                    .disabled(selectedTranscriptionIDs.isEmpty)
+                }
             }
 
             if #available(iOS 26.0, *) {

--- a/VivaDicta/Views/SettingsScreen/AdvancedSettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/AdvancedSettingsView.swift
@@ -26,6 +26,12 @@ struct AdvancedSettingsView: View {
     @AppStorage(UserDefaultsStorage.Keys.appendWithVoiceStyle)
     private var appendWithVoiceStyleRaw: String = AppendWithVoiceStyle.toolbar.rawValue
 
+    @AppStorage(UserDefaultsStorage.Keys.isChatEnabled)
+    private var isChatEnabled: Bool = true
+
+    @AppStorage(UserDefaultsStorage.Keys.isLiveTranslationEnabled)
+    private var isLiveTranslationEnabled: Bool = true
+
     private var appendWithVoiceStyle: Binding<AppendWithVoiceStyle> {
         Binding(
             get: {
@@ -57,6 +63,30 @@ struct AdvancedSettingsView: View {
                 }
             } header: {
                 Text("Note Detail")
+            }
+
+            Section {
+                VStack(alignment: .leading, spacing: 4) {
+                    Toggle("Chats", isOn: $isChatEnabled)
+                        .onChange(of: isChatEnabled) { _, _ in
+                            HapticManager.selectionChanged()
+                        }
+                    Text("Show chat buttons on the main screen and in note detail. Disable to hide chat entry points across the app.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Toggle("Live Translation", isOn: $isLiveTranslationEnabled)
+                        .onChange(of: isLiveTranslationEnabled) { _, _ in
+                            HapticManager.selectionChanged()
+                        }
+                    Text("Show the Live Translation button in the main screen toolbar. Disable to hide it if you don't use live translation.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            } header: {
+                Text("Features")
             }
         }
         .navigationTitle("Advanced")

--- a/VivaDicta/Views/SettingsScreen/AdvancedSettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/AdvancedSettingsView.swift
@@ -71,7 +71,7 @@ struct AdvancedSettingsView: View {
                         .onChange(of: isChatEnabled) { _, _ in
                             HapticManager.selectionChanged()
                         }
-                    Text("Show chat buttons on the main screen and in note detail. Disable to hide chat entry points across the app.")
+                    Text("Show chat buttons on the main screen and in note detail. Disable to hide chat buttons across the app. Siri Shortcuts and deep links can still open chats.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }

--- a/VivaDicta/Views/TranscriptionDetailView.swift
+++ b/VivaDicta/Views/TranscriptionDetailView.swift
@@ -51,6 +51,9 @@ struct TranscriptionDetailView: View {
     @AppStorage(UserDefaultsStorage.Keys.appendWithVoiceStyle)
     private var appendWithVoiceStyleRaw: String = AppendWithVoiceStyle.toolbar.rawValue
 
+    @AppStorage(UserDefaultsStorage.Keys.isChatEnabled)
+    private var isChatEnabled: Bool = true
+
     @AppStorage(UserDefaultsStorage.Keys.isObsidianSendButtonEnabled)
     private var isObsidianSendButtonEnabled: Bool = false
 
@@ -890,32 +893,34 @@ struct TranscriptionDetailView: View {
                 .popoverTip(AIVariationsDiscoveryTip())
 
                 Spacer()
-                
+
                 // Button 3: Chat with Note
-                Button {
-                    HapticManager.lightImpact()
-                    if isAIConfigured {
-                        if chatViewModel == nil {
-                            let conversation = findOrCreateConversation(for: transcription)
-                            chatViewModel = ChatViewModel(
-                                conversation: conversation,
-                                transcription: transcription,
-                                aiService: appState.aiService,
-                                modelContext: modelContext
-                            )
+                if isChatEnabled {
+                    Button {
+                        HapticManager.lightImpact()
+                        if isAIConfigured {
+                            if chatViewModel == nil {
+                                let conversation = findOrCreateConversation(for: transcription)
+                                chatViewModel = ChatViewModel(
+                                    conversation: conversation,
+                                    transcription: transcription,
+                                    aiService: appState.aiService,
+                                    modelContext: modelContext
+                                )
+                            }
+                            showChat = true
+                            Task { await SingleNoteChatDiscoveryTip.singleNoteChatOpenedEvent.donate() }
+                        } else {
+                            showConfigureChat = true
                         }
-                        showChat = true
-                        Task { await SingleNoteChatDiscoveryTip.singleNoteChatOpenedEvent.donate() }
-                    } else {
-                        showConfigureChat = true
+                    } label: {
+                        chatButtonLabel
                     }
-                } label: {
-                    chatButtonLabel
+                    .buttonStyle(.plain)
+                    .popoverTip(SingleNoteChatDiscoveryTip())
+
+                    Spacer()
                 }
-                .buttonStyle(.plain)
-                .popoverTip(SingleNoteChatDiscoveryTip())
-                
-                Spacer()
 
                 // Button 4: Edit / Append
                 Menu {


### PR DESCRIPTION
## Summary

Adds two new toggles under **Settings > Advanced > Features** so users can hide features they don't use. Both default to **on**, so existing users see no change.

- **Chats** - when off, hides:
  - the floating chats bubble on the main screen (`MainFloatingActionButtonsView`)
  - the "Create Chat" action in the selection-mode bottom toolbar (`MainView`)
  - the chat button (Button 3) in the note detail bottom action bar (`TranscriptionDetailView`)
- **Live Translation** - when off, hides the globe button (`globe.americas.fill`) in the main screen trailing toolbar (`MainView`).

Persistence follows the existing `@AppStorage` pattern used by `appendWithVoiceStyle`. Two new keys added to `UserDefaultsStorage.Keys`:
- `isChatEnabled` (Bool, default true)
- `isLiveTranslationEnabled` (Bool, default true)

## Test plan

- [ ] Settings > Advanced shows new "Features" section with Chats and Live Translation toggles, both on by default
- [ ] Toggle Chats off: floating chats bubble disappears on main; "Create Chat" disappears in selection mode; chat button (and surrounding Spacer) disappears in note detail
- [ ] Toggle Chats on: all chat entry points return
- [ ] Toggle Live Translation off: globe icon disappears from main toolbar; toolbar layout collapses cleanly (its `ToolbarSpacer` is also hidden)
- [ ] Toggle Live Translation on: globe returns
- [ ] Toggles persist across app relaunch