### PR TITLE
Add inline tag selection during recording

### DIFF
--- a/VivaDicta/Views/RecordViewModel.swift
+++ b/VivaDicta/Views/RecordViewModel.swift
@@ -156,6 +156,13 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
     var recordError: RecordError = .other
     
     var audioPower = 0.0
+
+    /// Tag IDs the user selected while recording, applied to the new `Transcription` on save.
+    ///
+    /// The transcription does not exist yet during recording, so selections are buffered here
+    /// and turned into `TranscriptionTagAssignment` records in ``saveNewTranscription(...)``.
+    /// Cleared when a new recording starts, on cancel, and after the assignments are written.
+    var pendingTagIds: Set<UUID> = []
     var siriWaveFormOpacity: CGFloat {
         switch recordingState {
         case .recording: return 1
@@ -193,6 +200,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
             }
 
             activeSourceTag = sourceTag
+            pendingTagIds.removeAll()
 
             // Check if prewarm session is active (keyboard recording)
             if prewarmManager.isSessionActive {
@@ -621,6 +629,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
         pendingTranscription = nil
         activeRecordingDestination = .newNote
         activeSourceTag = SourceTag.app
+        pendingTagIds.removeAll()
 
         // Stop real capture if still recording
         if prewarmManager.isSessionActive && prewarmManager.audioEngine?.isRunning == true {
@@ -834,6 +843,12 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
         )
 
         modelContext.insert(transcription)
+
+        // Apply tags chosen during recording.
+        for tagId in pendingTagIds {
+            modelContext.insert(TranscriptionTagAssignment(tagId: tagId, transcription: transcription))
+        }
+        pendingTagIds.removeAll()
 
         if let enhancedText {
             let variation = TranscriptionVariation(

--- a/VivaDicta/Views/RecordViewModel.swift
+++ b/VivaDicta/Views/RecordViewModel.swift
@@ -700,6 +700,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
                 )
 
                 pending.modelContext.insert(transcription)
+                applyPendingTags(to: transcription, modelContext: pending.modelContext)
                 do {
                     try pending.modelContext.save()
                     logger.logInfo("📱 Saved transcription without enhancement")
@@ -844,11 +845,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
 
         modelContext.insert(transcription)
 
-        // Apply tags chosen during recording.
-        for tagId in pendingTagIds {
-            modelContext.insert(TranscriptionTagAssignment(tagId: tagId, transcription: transcription))
-        }
-        pendingTagIds.removeAll()
+        applyPendingTags(to: transcription, modelContext: modelContext)
 
         if let enhancedText {
             let variation = TranscriptionVariation(
@@ -889,6 +886,21 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
         return transcription
     }
 
+    /// Applies the tags selected during recording to the saved transcription and clears the buffer.
+    ///
+    /// Skips tag IDs already assigned (relevant for the append-to-note path, where the
+    /// target transcription may already carry assignments). Called from every save path so
+    /// in-recording tag selections survive regardless of how the recording is finalized.
+    private func applyPendingTags(to transcription: Transcription, modelContext: ModelContext) {
+        guard !pendingTagIds.isEmpty else { return }
+
+        let alreadyAssigned = Set((transcription.tagAssignments ?? []).map(\.tagId))
+        for tagId in pendingTagIds where !alreadyAssigned.contains(tagId) {
+            modelContext.insert(TranscriptionTagAssignment(tagId: tagId, transcription: transcription))
+        }
+        pendingTagIds.removeAll()
+    }
+
     private func appendTranscribedText(
         _ transcribedText: String,
         to transcriptionID: UUID,
@@ -910,6 +922,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
             }
             transcription.variations = []
             transcription.enhancedText = nil
+            applyPendingTags(to: transcription, modelContext: modelContext)
             try modelContext.save()
 
             let transcriptionEntity = transcription.entity

--- a/VivaDicta/Views/RecordingSheetView.swift
+++ b/VivaDicta/Views/RecordingSheetView.swift
@@ -80,7 +80,7 @@ struct RecordingSheetView: View {
                 Spacer()
 
                 if isTagSelectorExpanded {
-                    RecordingTagChipsRow(selectedTagIds: $appState.recordViewModel.pendingTagIds)
+                    RecordingTagChipsRow(tags: allTags, selectedTagIds: $appState.recordViewModel.pendingTagIds)
                         .transition(.opacity.combined(with: .move(edge: .bottom)))
                 }
 
@@ -113,7 +113,7 @@ struct RecordingSheetView: View {
                     Spacer()
 
                     // Balances the leading tag button so the stop button stays centered
-                    Color.clear.frame(width: 44, height: 44)
+                    Spacer().frame(width: 44)
                 }
                 .padding(.horizontal, 16)
                 .padding(.bottom)
@@ -141,9 +141,11 @@ struct RecordingSheetView: View {
 
     private func toggleTagSelector() {
         HapticManager.lightImpact()
+        // SwiftUI animates the detent change on its own timing; only the chip-row
+        // transition needs the explicit animation, so keep the detent assignment outside it.
+        detent = !isTagSelectorExpanded ? .expandedHeight : .collapsedHeight
         withAnimation {
             isTagSelectorExpanded.toggle()
-            detent = isTagSelectorExpanded ? .expandedHeight : .collapsedHeight
         }
     }
 

--- a/VivaDicta/Views/RecordingSheetView.swift
+++ b/VivaDicta/Views/RecordingSheetView.swift
@@ -17,7 +17,11 @@ struct RecordingSheetView: View {
     @AppStorage(UserDefaultsStorage.Keys.isASCIIOrbEnabled)
     private var isASCIIOrbEnabled: Bool = true
 
+    @Query(sort: \TranscriptionTag.sortOrder) private var allTags: [TranscriptionTag]
+
     @State private var recordingStartDate = Date()
+    @State private var detent: PresentationDetent = .collapsedHeight
+    @State private var isTagSelectorExpanded = false
 
     private var vm: RecordViewModel {
         appState.recordViewModel
@@ -74,23 +78,49 @@ struct RecordingSheetView: View {
                 }
                 
                 Spacer()
-                
-                Button {
-                    stopRecordingAndDismiss()
-                } label: {
-                    Image(systemName: "stop.fill")
-                        .font(.system(size: 24, weight: .semibold))
-                        .foregroundStyle(.white)
-                        .frame(width: 56, height: 56)
-                        .recordingSheetButtonBackground(color: .red)
+
+                if isTagSelectorExpanded {
+                    RecordingTagChipsRow(selectedTagIds: $appState.recordViewModel.pendingTagIds)
+                        .transition(.opacity.combined(with: .move(edge: .bottom)))
                 }
-                .accessibilityLabel("Stop Recording")
-                .disabled(vm.recordingState != .recording)
+
+                HStack {
+                    // Tag button - opens the inline tag selector (bottom-left corner)
+                    if allTags.isEmpty {
+                        Color.clear.frame(width: 44, height: 44)
+                    } else {
+                        RecordingTagButton(
+                            selectedCount: vm.pendingTagIds.count,
+                            isExpanded: isTagSelectorExpanded,
+                            action: toggleTagSelector
+                        )
+                    }
+
+                    Spacer()
+
+                    Button {
+                        stopRecordingAndDismiss()
+                    } label: {
+                        Image(systemName: "stop.fill")
+                            .font(.system(size: 24, weight: .semibold))
+                            .foregroundStyle(.white)
+                            .frame(width: 56, height: 56)
+                            .recordingSheetButtonBackground(color: .red)
+                    }
+                    .accessibilityLabel("Stop Recording")
+                    .disabled(vm.recordingState != .recording)
+
+                    Spacer()
+
+                    // Balances the leading tag button so the stop button stays centered
+                    Color.clear.frame(width: 44, height: 44)
+                }
+                .padding(.horizontal, 16)
                 .padding(.bottom)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .presentationDetents([.height(340)])
+        .presentationDetents([.collapsedHeight, .expandedHeight], selection: $detent)
         .presentationDragIndicator(.hidden)
         .onAppear { recordingStartDate = Date() }
         .interactiveDismissDisabled(vm.recordingState == .recording)
@@ -109,11 +139,61 @@ struct RecordingSheetView: View {
         }
     }
 
+    private func toggleTagSelector() {
+        HapticManager.lightImpact()
+        withAnimation {
+            isTagSelectorExpanded.toggle()
+            detent = isTagSelectorExpanded ? .expandedHeight : .collapsedHeight
+        }
+    }
+
     private func stopRecordingAndDismiss() {
         vm.stopCaptureAudio(modelContext: modelContext)
         // Sheet will automatically dismiss when recordingState changes from .recording
         // This happens via the onChange modifier in MainView
     }
+}
+
+// MARK: - Recording Tag Button
+
+/// Bottom-left button that reveals the inline tag selector, with a badge showing
+/// how many tags are currently selected for the in-progress recording.
+private struct RecordingTagButton: View {
+    let selectedCount: Int
+    let isExpanded: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: "tag")
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(isExpanded ? Color.accentColor : .secondary)
+                .frame(width: 44, height: 44)
+                .recordingSheetButtonBackground(color: nil)
+                .contentShape(.circle)
+                .overlay(alignment: .topTrailing) {
+                    if selectedCount > 0 {
+                        Text(selectedCount, format: .number)
+                            .font(.caption2)
+                            .bold()
+                            .foregroundStyle(.white)
+                            .frame(minWidth: 18, minHeight: 18)
+                            .background(.red, in: .circle)
+                    }
+                }
+        }
+        .accessibilityLabel("Tags")
+        .accessibilityValue(selectedCount > 0 ? "\(selectedCount) selected" : "None selected")
+    }
+}
+
+// MARK: - Detent Heights
+
+extension PresentationDetent {
+    /// Recording sheet height with the tag selector collapsed.
+    fileprivate static let collapsedHeight = Self.height(340)
+    /// Recording sheet height with the tag selector expanded.
+    fileprivate static let expandedHeight = Self.height(440)
 }
 
 // MARK: - Recording Sheet Button Background

--- a/VivaDicta/Views/RecordingSheetView.swift
+++ b/VivaDicta/Views/RecordingSheetView.swift
@@ -20,7 +20,6 @@ struct RecordingSheetView: View {
     @Query(sort: \TranscriptionTag.sortOrder) private var allTags: [TranscriptionTag]
 
     @State private var recordingStartDate = Date()
-    @State private var detent: PresentationDetent = .collapsedHeight
     @State private var isTagSelectorExpanded = false
 
     private var vm: RecordViewModel {
@@ -81,6 +80,7 @@ struct RecordingSheetView: View {
 
                 if isTagSelectorExpanded {
                     RecordingTagChipsRow(tags: allTags, selectedTagIds: $appState.recordViewModel.pendingTagIds)
+                        .padding(.bottom, 20)
                         .transition(.opacity.combined(with: .move(edge: .bottom)))
                 }
 
@@ -120,7 +120,7 @@ struct RecordingSheetView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .presentationDetents([.collapsedHeight, .expandedHeight], selection: $detent)
+        .presentationDetents([.height(340)])
         .presentationDragIndicator(.hidden)
         .onAppear { recordingStartDate = Date() }
         .interactiveDismissDisabled(vm.recordingState == .recording)
@@ -141,9 +141,6 @@ struct RecordingSheetView: View {
 
     private func toggleTagSelector() {
         HapticManager.lightImpact()
-        // SwiftUI animates the detent change on its own timing; only the chip-row
-        // transition needs the explicit animation, so keep the detent assignment outside it.
-        detent = !isTagSelectorExpanded ? .expandedHeight : .collapsedHeight
         withAnimation {
             isTagSelectorExpanded.toggle()
         }
@@ -187,15 +184,6 @@ private struct RecordingTagButton: View {
         .accessibilityLabel("Tags")
         .accessibilityValue(selectedCount > 0 ? "\(selectedCount) selected" : "None selected")
     }
-}
-
-// MARK: - Detent Heights
-
-extension PresentationDetent {
-    /// Recording sheet height with the tag selector collapsed.
-    fileprivate static let collapsedHeight = Self.height(340)
-    /// Recording sheet height with the tag selector expanded.
-    fileprivate static let expandedHeight = Self.height(440)
 }
 
 // MARK: - Recording Sheet Button Background

--- a/VivaDicta/Views/RecordingTagChipsRow.swift
+++ b/VivaDicta/Views/RecordingTagChipsRow.swift
@@ -37,9 +37,13 @@ struct RecordingTagChipsRow: View {
                     .accessibilityAddTraits(isSelected ? .isSelected : [])
                 }
             }
-            .padding(.horizontal)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
         }
+        
         .scrollIndicators(.hidden)
+        .padding(.horizontal)
+        .glassRowBackground()
     }
 
     private func toggle(_ tag: TranscriptionTag) {
@@ -49,5 +53,24 @@ struct RecordingTagChipsRow: View {
             selectedTagIds.insert(tag.id)
         }
         HapticManager.selectionChanged()
+    }
+}
+
+// MARK: - Glass Row Background
+
+private struct GlassRowBackgroundModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(iOS 26, *) {
+            content.glassEffect(.regular)
+        } else {
+            content.background(.ultraThinMaterial)
+        }
+    }
+}
+
+extension View {
+    /// Liquid Glass tray behind the tag chips so they stay legible over the recording orb.
+    fileprivate func glassRowBackground() -> some View {
+        modifier(GlassRowBackgroundModifier())
     }
 }

--- a/VivaDicta/Views/RecordingTagChipsRow.swift
+++ b/VivaDicta/Views/RecordingTagChipsRow.swift
@@ -1,0 +1,53 @@
+//
+//  RecordingTagChipsRow.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.05.28
+//
+
+import SwiftUI
+import SwiftData
+
+/// Horizontal row of selectable tag chips shown inline in the recording sheet.
+///
+/// Toggles membership in `selectedTagIds` (buffered on ``RecordViewModel/pendingTagIds``)
+/// without touching SwiftData. The chosen tags are applied to the new `Transcription`
+/// when the recording is saved. Picks from existing tags only - tag creation lives in Settings.
+struct RecordingTagChipsRow: View {
+    @Binding var selectedTagIds: Set<UUID>
+    @Query(sort: \TranscriptionTag.sortOrder) private var allTags: [TranscriptionTag]
+
+    var body: some View {
+        ScrollView(.horizontal) {
+            HStack(spacing: 6) {
+                ForEach(allTags) { tag in
+                    let isSelected = selectedTagIds.contains(tag.id)
+                    let tagColor = Color(hex: tag.colorHex) ?? .blue
+                    Button {
+                        toggle(tag)
+                    } label: {
+                        Label(tag.name, systemImage: isSelected ? "checkmark" : tag.icon)
+                            .font(.caption)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 6)
+                            .background(isSelected ? tagColor : tagColor.opacity(0.15))
+                            .foregroundStyle(isSelected ? .white : tagColor)
+                            .clipShape(.capsule)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.horizontal)
+        }
+        .scrollIndicators(.hidden)
+    }
+
+    private func toggle(_ tag: TranscriptionTag) {
+        if selectedTagIds.contains(tag.id) {
+            selectedTagIds.remove(tag.id)
+        } else {
+            selectedTagIds.insert(tag.id)
+        }
+        HapticManager.selectionChanged()
+    }
+}

--- a/VivaDicta/Views/RecordingTagChipsRow.swift
+++ b/VivaDicta/Views/RecordingTagChipsRow.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import SwiftData
 
 /// Horizontal row of selectable tag chips shown inline in the recording sheet.
 ///
@@ -14,19 +13,19 @@ import SwiftData
 /// without touching SwiftData. The chosen tags are applied to the new `Transcription`
 /// when the recording is saved. Picks from existing tags only - tag creation lives in Settings.
 struct RecordingTagChipsRow: View {
+    let tags: [TranscriptionTag]
     @Binding var selectedTagIds: Set<UUID>
-    @Query(sort: \TranscriptionTag.sortOrder) private var allTags: [TranscriptionTag]
 
     var body: some View {
         ScrollView(.horizontal) {
             HStack(spacing: 6) {
-                ForEach(allTags) { tag in
+                ForEach(tags) { tag in
                     let isSelected = selectedTagIds.contains(tag.id)
                     let tagColor = Color(hex: tag.colorHex) ?? .blue
                     Button {
                         toggle(tag)
                     } label: {
-                        Label(tag.name, systemImage: isSelected ? "checkmark" : tag.icon)
+                        Label(tag.name, systemImage: tag.icon)
                             .font(.caption)
                             .padding(.horizontal, 10)
                             .padding(.vertical, 6)
@@ -35,6 +34,7 @@ struct RecordingTagChipsRow: View {
                             .clipShape(.capsule)
                     }
                     .buttonStyle(.plain)
+                    .accessibilityAddTraits(isSelected ? .isSelected : [])
                 }
             }
             .padding(.horizontal)


### PR DESCRIPTION
## Summary

Adds a tag button to the recording sheet so users can tag a note **while recording**, mirroring the tagging UI in the transcription detail screen.

The bottom-left corner of the recording sheet (previously empty) now holds a tag button. Tapping it expands the sheet and reveals a horizontal row of existing tags as toggleable chips.

## How it works

- During recording the `Transcription` does not exist yet, so tag selections are buffered in `RecordViewModel.pendingTagIds` (`Set<UUID>`) and turned into `TranscriptionTagAssignment` records inside `saveNewTranscription()` once the recording is saved.
- The buffer is cleared when a new recording starts (`startCaptureAudio`) and on `cancelTranscribe()`. It is intentionally **not** cleared in `resetValues()`, which runs mid-transcription and would otherwise wipe the selection before save.
- Tags flow through the existing `TranscriptionTag` / `TranscriptionTagAssignment` models, so CloudKit sync and the detail-screen tag UI pick them up with no extra work.

## UI details

- Tag button shows a red count badge when tags are selected; the stop button stays centered via a balancing clear spacer.
- Tapping the button expands the sheet detent (340pt → 440pt) and toggles an inline chip row; tapping again collapses it. Selections persist either way until stop or cancel.
- Picks from **existing tags only** - tag creation stays in Settings. The button is hidden entirely when no tags exist.
- New views (`RecordingTagChipsRow`, `RecordingTagButton`) are their own `struct`s per the project's SwiftUI conventions.

## Testing

- `xcodebuild` build succeeds for the iOS Simulator target.
- Manual verification of expand/collapse and save flow recommended on-device.