### PR TITLE
Open note editor directly from pencil when voice FAB is enabled

### DIFF
--- a/VivaDicta/Views/TranscriptionDetailView.swift
+++ b/VivaDicta/Views/TranscriptionDetailView.swift
@@ -923,22 +923,32 @@ struct TranscriptionDetailView: View {
                 }
 
                 // Button 4: Edit / Append
-                Menu {
-                    Button("Edit Text", systemImage: "pencil") {
+                if appendWithVoiceStyle == .floatingButton {
+                    // Voice append lives in the FAB, so the pencil opens the editor directly.
+                    Button {
                         HapticManager.lightImpact()
                         showTextEditor = true
+                    } label: {
+                        Image(systemName: "pencil")
+                            .font(.system(size: 20))
+                            .frame(width: 44, height: 44)
                     }
+                } else {
+                    Menu {
+                        Button("Edit Text", systemImage: "pencil") {
+                            HapticManager.lightImpact()
+                            showTextEditor = true
+                        }
 
-                    if appendWithVoiceStyle == .toolbar {
                         Button("Append with Voice", systemImage: "mic") {
                             startVoiceAppend()
                         }
                         .disabled(appState.recordViewModel.recordingState != .idle)
+                    } label: {
+                        Image(systemName: "pencil")
+                            .font(.system(size: 20))
+                            .frame(width: 44, height: 44)
                     }
-                } label: {
-                    Image(systemName: "pencil")
-                        .font(.system(size: 20))
-                        .frame(width: 44, height: 44)
                 }
 
                 Spacer()

--- a/VivaDicta/Views/TranscriptionDetailView.swift
+++ b/VivaDicta/Views/TranscriptionDetailView.swift
@@ -933,6 +933,7 @@ struct TranscriptionDetailView: View {
                             .font(.system(size: 20))
                             .frame(width: 44, height: 44)
                     }
+                    .accessibilityLabel("Edit Text")
                 } else {
                     Menu {
                         Button("Edit Text", systemImage: "pencil") {


### PR DESCRIPTION
## Summary

In the note detail bottom action bar, the pencil button's behavior now adapts to the **Append with Voice** setting (Advanced settings):

- **Floating Button mode** (voice FAB active): the pencil button opens the text editor immediately. Previously it showed a menu containing only "Edit Text", since "Append with Voice" already lives in the floating mic button - so the extra tap into a one-item menu was redundant.
- **Toolbar mode**: unchanged - the pencil still opens a menu with both "Edit Text" and "Append with Voice".

## Testing

- `xcodebuild` Debug build for iPhone 17 Pro Max (iOS 26.4): **BUILD SUCCEEDED**.

## Notes

No breaking changes. Pure UI behavior refinement gated on the existing `appendWithVoiceStyle` preference.