### PR TITLE
Move Trim Trailing Period from per-mode to global Advanced settings

### DIFF
--- a/Modules/AppGroup/Sources/AppGroup/UserDefaultsStorage.swift
+++ b/Modules/AppGroup/Sources/AppGroup/UserDefaultsStorage.swift
@@ -91,6 +91,7 @@ public enum UserDefaultsStorage {
         public static let appendWithVoiceStyle = "appendWithVoiceStyle"
         public static let isChatEnabled = "isChatEnabled"
         public static let isLiveTranslationEnabled = "isLiveTranslationEnabled"
+        public static let isStripTrailingPeriodEnabled = "isStripTrailingPeriodEnabled"
 
         // Notes filter
         public static let savedNotesFilterSourceTags = "savedNotesFilterSourceTags"

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -336,7 +336,6 @@ class AIService {
 
             isAutoTextFormattingEnabled: mode.isAutoTextFormattingEnabled,
             isSmartInsertEnabled: mode.isSmartInsertEnabled,
-            isStripTrailingPeriodEnabled: mode.isStripTrailingPeriodEnabled,
             obsidianEnabled: mode.obsidianEnabled,
             folderExportEnabled: mode.folderExportEnabled
         )
@@ -409,7 +408,6 @@ class AIService {
 
                     isAutoTextFormattingEnabled: mode.isAutoTextFormattingEnabled,
                     isSmartInsertEnabled: mode.isSmartInsertEnabled,
-                    isStripTrailingPeriodEnabled: mode.isStripTrailingPeriodEnabled,
                     obsidianEnabled: mode.obsidianEnabled,
                     folderExportEnabled: mode.folderExportEnabled
                 )
@@ -440,7 +438,6 @@ class AIService {
 
                     isAutoTextFormattingEnabled: mode.isAutoTextFormattingEnabled,
                     isSmartInsertEnabled: mode.isSmartInsertEnabled,
-                    isStripTrailingPeriodEnabled: mode.isStripTrailingPeriodEnabled,
                     obsidianEnabled: mode.obsidianEnabled,
                     folderExportEnabled: mode.folderExportEnabled
                 )
@@ -471,7 +468,6 @@ class AIService {
 
                     isAutoTextFormattingEnabled: mode.isAutoTextFormattingEnabled,
                     isSmartInsertEnabled: mode.isSmartInsertEnabled,
-                    isStripTrailingPeriodEnabled: mode.isStripTrailingPeriodEnabled,
                     obsidianEnabled: mode.obsidianEnabled,
                     folderExportEnabled: mode.folderExportEnabled
                 )
@@ -568,7 +564,6 @@ class AIService {
                 useClipboardContext: defaultMode.useClipboardContext,
                 isAutoTextFormattingEnabled: defaultMode.isAutoTextFormattingEnabled,
                 isSmartInsertEnabled: defaultMode.isSmartInsertEnabled,
-                isStripTrailingPeriodEnabled: defaultMode.isStripTrailingPeriodEnabled,
                 obsidianEnabled: defaultMode.obsidianEnabled,
                 folderExportEnabled: defaultMode.folderExportEnabled
             )
@@ -1810,7 +1805,6 @@ class AIService {
 
                     isAutoTextFormattingEnabled: mode.isAutoTextFormattingEnabled,
                     isSmartInsertEnabled: mode.isSmartInsertEnabled,
-                    isStripTrailingPeriodEnabled: mode.isStripTrailingPeriodEnabled,
                     obsidianEnabled: mode.obsidianEnabled,
                     folderExportEnabled: mode.folderExportEnabled
                 )

--- a/VivaDicta/Services/AIEnhance/VivaMode.swift
+++ b/VivaDicta/Services/AIEnhance/VivaMode.swift
@@ -84,10 +84,6 @@ struct VivaMode: Identifiable, Hashable, Codable {
     /// Whether smart insert (auto-adjust spacing and capitalization) is applied when inserting text via keyboard.
     let isSmartInsertEnabled: Bool
 
-    /// Whether to strip a single trailing period from the final transcript so casual messages
-    /// like "Okay." don't read as cold/passive-aggressive in chat contexts.
-    let isStripTrailingPeriodEnabled: Bool
-
     /// Whether this mode opts in to saving transcriptions to Obsidian.
     /// Only effective when the global Obsidian integration is enabled in
     /// Settings → Integrations.
@@ -114,7 +110,6 @@ struct VivaMode: Identifiable, Hashable, Codable {
          useClipboardContext: Bool = false,
          isAutoTextFormattingEnabled: Bool = false,
          isSmartInsertEnabled: Bool = false,
-         isStripTrailingPeriodEnabled: Bool = false,
          obsidianEnabled: Bool = true,
          folderExportEnabled: Bool = true) {
         self.id = id
@@ -132,7 +127,6 @@ struct VivaMode: Identifiable, Hashable, Codable {
         self.useClipboardContext = useClipboardContext
         self.isAutoTextFormattingEnabled = isAutoTextFormattingEnabled
         self.isSmartInsertEnabled = isSmartInsertEnabled
-        self.isStripTrailingPeriodEnabled = isStripTrailingPeriodEnabled
         self.obsidianEnabled = obsidianEnabled
         self.folderExportEnabled = folderExportEnabled
     }
@@ -163,7 +157,6 @@ struct VivaMode: Identifiable, Hashable, Codable {
         useClipboardContext = try container.decodeIfPresent(Bool.self, forKey: .useClipboardContext) ?? false
         isAutoTextFormattingEnabled = try container.decodeIfPresent(Bool.self, forKey: .isAutoTextFormattingEnabled) ?? true
         isSmartInsertEnabled = try container.decodeIfPresent(Bool.self, forKey: .isSmartInsertEnabled) ?? true
-        isStripTrailingPeriodEnabled = try container.decodeIfPresent(Bool.self, forKey: .isStripTrailingPeriodEnabled) ?? false
         obsidianEnabled = try container.decodeIfPresent(Bool.self, forKey: .obsidianEnabled) ?? true
         folderExportEnabled = try container.decodeIfPresent(Bool.self, forKey: .folderExportEnabled) ?? true
 
@@ -221,7 +214,6 @@ struct VivaMode: Identifiable, Hashable, Codable {
         case aiProvider, aiModel, reminderExtractorProvider, reminderExtractorModel, aiEnhanceEnabled
         case useClipboardContext
         case isAutoTextFormattingEnabled, isSmartInsertEnabled
-        case isStripTrailingPeriodEnabled
         case obsidianEnabled
         case folderExportEnabled
     }
@@ -244,7 +236,6 @@ struct VivaMode: Identifiable, Hashable, Codable {
         try container.encode(useClipboardContext, forKey: .useClipboardContext)
         try container.encode(isAutoTextFormattingEnabled, forKey: .isAutoTextFormattingEnabled)
         try container.encode(isSmartInsertEnabled, forKey: .isSmartInsertEnabled)
-        try container.encode(isStripTrailingPeriodEnabled, forKey: .isStripTrailingPeriodEnabled)
         try container.encode(obsidianEnabled, forKey: .obsidianEnabled)
         try container.encode(folderExportEnabled, forKey: .folderExportEnabled)
     }

--- a/VivaDicta/Services/PresetMigrationService.swift
+++ b/VivaDicta/Services/PresetMigrationService.swift
@@ -133,7 +133,6 @@ enum PresetMigrationService {
                     useClipboardContext: mode.useClipboardContext,
                     isAutoTextFormattingEnabled: mode.isAutoTextFormattingEnabled,
                     isSmartInsertEnabled: mode.isSmartInsertEnabled,
-                    isStripTrailingPeriodEnabled: mode.isStripTrailingPeriodEnabled,
                     obsidianEnabled: mode.obsidianEnabled,
                     folderExportEnabled: mode.folderExportEnabled
                 )
@@ -158,7 +157,6 @@ enum PresetMigrationService {
                         useClipboardContext: mode.useClipboardContext,
                         isAutoTextFormattingEnabled: mode.isAutoTextFormattingEnabled,
                         isSmartInsertEnabled: mode.isSmartInsertEnabled,
-                        isStripTrailingPeriodEnabled: mode.isStripTrailingPeriodEnabled,
                         obsidianEnabled: mode.obsidianEnabled,
                         folderExportEnabled: mode.folderExportEnabled
                     )

--- a/VivaDicta/Services/Transcription/TranscriptionManager.swift
+++ b/VivaDicta/Services/Transcription/TranscriptionManager.swift
@@ -173,7 +173,7 @@ class TranscriptionManager {
             result = ReplacementsService.applyReplacements(to: result)
         }
 
-        if currentMode.isStripTrailingPeriodEnabled {
+        if UserDefaults.standard.object(forKey: UserDefaultsStorage.Keys.isStripTrailingPeriodEnabled) as? Bool ?? false {
             result = TranscriptionOutputFilter.stripTrailingPeriods(result)
         }
 

--- a/VivaDicta/Views/SettingsScreen/AdvancedSettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/AdvancedSettingsView.swift
@@ -32,6 +32,9 @@ struct AdvancedSettingsView: View {
     @AppStorage(UserDefaultsStorage.Keys.isLiveTranslationEnabled)
     private var isLiveTranslationEnabled: Bool = true
 
+    @AppStorage(UserDefaultsStorage.Keys.isStripTrailingPeriodEnabled)
+    private var isStripTrailingPeriodEnabled: Bool = false
+
     private var appendWithVoiceStyle: Binding<AppendWithVoiceStyle> {
         Binding(
             get: {
@@ -87,6 +90,20 @@ struct AdvancedSettingsView: View {
                 }
             } header: {
                 Text("Features")
+            }
+
+            Section {
+                VStack(alignment: .leading, spacing: 4) {
+                    Toggle("Trim Trailing Period", isOn: $isStripTrailingPeriodEnabled)
+                        .onChange(of: isStripTrailingPeriodEnabled) { _, _ in
+                            HapticManager.selectionChanged()
+                        }
+                    Text("Strips trailing \".\" or \"...\" from transcripts so casual messages like \"Okay.\" don't read as cold. Applies to all modes.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            } header: {
+                Text("Text Processing")
             }
         }
         .navigationTitle("Advanced")

--- a/VivaDicta/Views/SettingsScreen/ModeEditView.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditView.swift
@@ -335,19 +335,6 @@ struct ModeEditView: View {
                     .onChange(of: viewModel.isSmartInsertEnabled) { _, _ in
                         HapticManager.selectionChanged()
                     }
-
-                    Toggle(isOn: $viewModel.isStripTrailingPeriodEnabled) {
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text("Trim Trailing Period")
-                                .font(.body)
-                            Text("Strips trailing \".\" or \"...\"")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-                    .onChange(of: viewModel.isStripTrailingPeriodEnabled) { _, _ in
-                        HapticManager.selectionChanged()
-                    }
                 }
 
                 Section(header: aiProcessingSectionHeader,

--- a/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
@@ -31,7 +31,6 @@ class ModeEditViewModel {
     var useClipboardContext: Bool = false
     var isAutoTextFormattingEnabled: Bool = false
     var isSmartInsertEnabled: Bool = false
-    var isStripTrailingPeriodEnabled: Bool = false
 
     var obsidianEnabled: Bool = true
     var folderExportEnabled: Bool = true
@@ -193,7 +192,6 @@ class ModeEditViewModel {
             useClipboardContext = existingMode.useClipboardContext
             isAutoTextFormattingEnabled = existingMode.isAutoTextFormattingEnabled
             isSmartInsertEnabled = existingMode.isSmartInsertEnabled
-            isStripTrailingPeriodEnabled = existingMode.isStripTrailingPeriodEnabled
             obsidianEnabled = existingMode.obsidianEnabled
             folderExportEnabled = existingMode.folderExportEnabled
 
@@ -243,7 +241,6 @@ class ModeEditViewModel {
             useClipboardContext: aiEnhanceEnabled ? useClipboardContext : false,
             isAutoTextFormattingEnabled: isAutoTextFormattingEnabled,
             isSmartInsertEnabled: isSmartInsertEnabled,
-            isStripTrailingPeriodEnabled: isStripTrailingPeriodEnabled,
             obsidianEnabled: obsidianEnabled,
             folderExportEnabled: folderExportEnabled
         )


### PR DESCRIPTION
## Summary

"Trim Trailing Period" (strips trailing `.` / `...` from transcripts) was a per-mode toggle in the Edit Mode screen. This moves it to a single global toggle under **Settings -> Advanced -> Text Processing**, so it applies to all modes instead of being configured per mode.

### Changes
- **`AdvancedSettingsView.swift`** - new "Text Processing" section with the "Trim Trailing Period" toggle (`@AppStorage`, defaults off).
- **`UserDefaultsStorage.swift`** - new global key `isStripTrailingPeriodEnabled`.
- **`TranscriptionManager.swift`** - reads the global UserDefaults flag (same pattern as `isReplacementsEnabled`) instead of `currentMode.isStripTrailingPeriodEnabled`.
- **`VivaMode.swift`** - removed the per-mode `isStripTrailingPeriodEnabled` property (declaration, init param, Codable encode/decode, CodingKey). Old persisted modes decode fine; the now-unknown JSON key is ignored.
- **`ModeEditView.swift` / `ModeEditViewModel.swift`** - removed the toggle and its view-model property from the per-mode Text Processing section.
- **`AIService.swift` (6 sites)** and **`PresetMigrationService.swift` (2 sites)** - dropped the removed init argument from all mode-copy sites.

## Testing
- `xcodebuild` Debug build for iPhone 17 Pro Max (iOS 26.4): **BUILD SUCCEEDED**.

## Migration note
The global toggle defaults **off**. A user who had enabled it on a specific mode will need to re-enable it once globally. Since the per-mode default was already off and it's a niche setting, no one-time migration was added.