### PR TITLE
Add Default AI Mode setting for AI Actions in note detail

### DIFF
--- a/Modules/AppGroup/Sources/AppGroup/UserDefaultsStorage.swift
+++ b/Modules/AppGroup/Sources/AppGroup/UserDefaultsStorage.swift
@@ -93,6 +93,10 @@ public enum UserDefaultsStorage {
         public static let isLiveTranslationEnabled = "isLiveTranslationEnabled"
         public static let isStripTrailingPeriodEnabled = "isStripTrailingPeriodEnabled"
 
+        /// UUID string of the mode used for AI actions in note detail when the
+        /// currently selected mode has no AI processing configured. Empty = none.
+        public static let defaultAIModeId = "defaultAIModeId"
+
         // Notes filter
         public static let savedNotesFilterSourceTags = "savedNotesFilterSourceTags"
         public static let savedNotesFilterUserTagIds = "savedNotesFilterUserTagIds"

--- a/VivaDicta/Views/SettingsScreen/AdvancedSettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/AdvancedSettingsView.swift
@@ -53,6 +53,11 @@ struct AdvancedSettingsView: View {
 
     /// Modes that have AI processing enabled and a provider/model configured
     /// (a preset is not required - the user picks one in the AI Actions sheet).
+    ///
+    /// Must use the same `requirePreset: false` filter as the AI Actions sheet's
+    /// `availableModes` (`TranscriptionDetailView`). The sheet only honors a saved
+    /// default when that mode is still present in its `availableModes`, so if these
+    /// two filters ever diverge the default could silently never apply.
     private var aiConfiguredModes: [VivaMode] {
         appState.aiService.modes.filter {
             appState.aiService.isProperlyConfigured(for: $0, requirePreset: false)

--- a/VivaDicta/Views/SettingsScreen/AdvancedSettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/AdvancedSettingsView.swift
@@ -23,6 +23,8 @@ enum AppendWithVoiceStyle: String, CaseIterable, Identifiable {
 }
 
 struct AdvancedSettingsView: View {
+    @Environment(AppState.self) private var appState
+
     @AppStorage(UserDefaultsStorage.Keys.appendWithVoiceStyle)
     private var appendWithVoiceStyleRaw: String = AppendWithVoiceStyle.toolbar.rawValue
 
@@ -35,6 +37,9 @@ struct AdvancedSettingsView: View {
     @AppStorage(UserDefaultsStorage.Keys.isStripTrailingPeriodEnabled)
     private var isStripTrailingPeriodEnabled: Bool = false
 
+    @AppStorage(UserDefaultsStorage.Keys.defaultAIModeId)
+    private var defaultAIModeId: String = ""
+
     private var appendWithVoiceStyle: Binding<AppendWithVoiceStyle> {
         Binding(
             get: {
@@ -42,6 +47,29 @@ struct AdvancedSettingsView: View {
             },
             set: { newValue in
                 appendWithVoiceStyleRaw = newValue.rawValue
+            }
+        )
+    }
+
+    /// Modes that have AI processing enabled and a provider/model configured
+    /// (a preset is not required - the user picks one in the AI Actions sheet).
+    private var aiConfiguredModes: [VivaMode] {
+        appState.aiService.modes.filter {
+            appState.aiService.isProperlyConfigured(for: $0, requirePreset: false)
+        }
+    }
+
+    /// Falls back to "None" when the stored mode no longer exists or no longer
+    /// has AI configured, so the picker never shows a stale/blank selection.
+    private var defaultAIMode: Binding<String> {
+        Binding(
+            get: {
+                aiConfiguredModes.contains { $0.id.uuidString == defaultAIModeId }
+                    ? defaultAIModeId
+                    : ""
+            },
+            set: { newValue in
+                defaultAIModeId = newValue
             }
         )
     }
@@ -61,6 +89,23 @@ struct AdvancedSettingsView: View {
                         HapticManager.selectionChanged()
                     }
                     Text("Choose how to access the Append with Voice action on a note. Toolbar puts it inside the pencil menu in the bottom action bar; Floating Button shows a microphone shortcut in the bottom-right corner.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Picker("Default AI Mode", selection: defaultAIMode) {
+                        Text("None").tag("")
+                        ForEach(aiConfiguredModes) { mode in
+                            Text(mode.name).tag(mode.id.uuidString)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                    .tint(.primary)
+                    .onChange(of: defaultAIMode.wrappedValue) { _, _ in
+                        HapticManager.selectionChanged()
+                    }
+                    Text("Mode pre-selected for AI actions in a note when the current mode has no AI processing. You can still switch modes in the AI Actions sheet.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -116,5 +161,6 @@ struct AdvancedSettingsView: View {
     NavigationStack {
         AdvancedSettingsView()
     }
+    .environment(AppState())
 }
 #endif

--- a/VivaDicta/Views/TranscriptionDetailView.swift
+++ b/VivaDicta/Views/TranscriptionDetailView.swift
@@ -54,6 +54,9 @@ struct TranscriptionDetailView: View {
     @AppStorage(UserDefaultsStorage.Keys.isChatEnabled)
     private var isChatEnabled: Bool = true
 
+    @AppStorage(UserDefaultsStorage.Keys.defaultAIModeId)
+    private var defaultAIModeId: String = ""
+
     @AppStorage(UserDefaultsStorage.Keys.isObsidianSendButtonEnabled)
     private var isObsidianSendButtonEnabled: Bool = false
 
@@ -463,6 +466,7 @@ struct TranscriptionDetailView: View {
                     appState.aiService.isProperlyConfigured(for: mode, requirePreset: false)
                 },
                 activeModeIsAIConfigured: isAIConfigured,
+                preselectedOverrideModeId: UUID(uuidString: defaultAIModeId),
                 onOpenSettings: {
                     showPresetPicker = false
                     appState.shouldNavigateToModeSettings = true
@@ -1560,6 +1564,37 @@ private struct PresetPickerSheet: View {
     @State private var selectedCategory: String?
     @State private var searchText = ""
     @State private var overrideModeId: UUID?
+
+    init(
+        presetManager: PresetManager,
+        existingVariationIds: Set<String>,
+        activeMode: VivaMode,
+        availableModes: [VivaMode],
+        activeModeIsAIConfigured: Bool,
+        preselectedOverrideModeId: UUID?,
+        onOpenSettings: @escaping () -> Void,
+        onReviewExtractedTasks: (() -> Void)?,
+        onExtractTasks: (() -> Void)?,
+        onSelect: @escaping (Preset, VivaMode?) -> Void
+    ) {
+        self.presetManager = presetManager
+        self.existingVariationIds = existingVariationIds
+        self.activeMode = activeMode
+        self.availableModes = availableModes
+        self.activeModeIsAIConfigured = activeModeIsAIConfigured
+        self.onOpenSettings = onOpenSettings
+        self.onReviewExtractedTasks = onReviewExtractedTasks
+        self.onExtractTasks = onExtractTasks
+        self.onSelect = onSelect
+
+        // When the active mode can't do AI, pre-select the user's default AI mode
+        // so presets appear immediately instead of the "not configured" empty state.
+        // Only honored if that mode still exists and is still AI-configured.
+        let shouldPreselect = !activeModeIsAIConfigured
+            && preselectedOverrideModeId != nil
+            && availableModes.contains { $0.id == preselectedOverrideModeId }
+        _overrideModeId = State(initialValue: shouldPreselect ? preselectedOverrideModeId : nil)
+    }
 
     private var overrideMode: VivaMode? {
         guard let overrideModeId else { return nil }

--- a/VivaDicta/Views/TranscriptionDetailView.swift
+++ b/VivaDicta/Views/TranscriptionDetailView.swift
@@ -1587,11 +1587,17 @@ private struct PresetPickerSheet: View {
         self.onExtractTasks = onExtractTasks
         self.onSelect = onSelect
 
-        // When the active mode can't do AI, pre-select the user's default AI mode
-        // so presets appear immediately instead of the "not configured" empty state.
-        // Only honored if that mode still exists and is still AI-configured.
-        let shouldPreselect = !activeModeIsAIConfigured
-            && preselectedOverrideModeId != nil
+        // When the active mode can't run AI actions, pre-select the user's default
+        // AI mode so presets appear immediately instead of the "not configured"
+        // empty state. Only honored if that mode still exists and is AI-configured.
+        //
+        // "Can run AI actions" means presence in `availableModes` (the
+        // `requirePreset: false` set), NOT `activeModeIsAIConfigured`
+        // (`requirePreset: true`): a mode with a provider/model but no mode-level
+        // preset is still usable here because the user picks a preset in this sheet.
+        // Gating on the stricter flag would wrongly override such a capable mode.
+        let activeModeIsAICapable = availableModes.contains { $0.id == activeMode.id }
+        let shouldPreselect = !activeModeIsAICapable
             && availableModes.contains { $0.id == preselectedOverrideModeId }
         _overrideModeId = State(initialValue: shouldPreselect ? preselectedOverrideModeId : nil)
     }


### PR DESCRIPTION
## Summary

Adds a **Default AI Mode** picker so users can apply AI presets in a note even when the currently selected mode has no AI processing configured.

Previously, opening the **AI Actions** sheet on a note whose active mode lacked an AI provider showed the *"AI Processing Not Configured"* empty state. The user had to manually open the sheet's top-left mode picker and switch to a mode with AI configured before any preset would apply.

Now, a single **Default AI Mode** picker lives in **Advanced → Note Detail** (next to *Append with Voice*). When set, and the active mode can't do AI, the AI Actions sheet **pre-selects that default mode** and jumps straight to the preset list. The top-left mode picker still lets the user switch (including back to the unconfigured mode).

## Changes

- **`UserDefaultsStorage.swift`** - new app-private key `defaultAIModeId` (stores the mode's UUID string; empty = none).
- **`AdvancedSettingsView.swift`** - new `Default AI Mode` menu picker in the existing *Note Detail* section:
  - Options: **None** + every mode that is AI-configured (`isProperlyConfigured(for:requirePreset: false)` - the same filter the AI Actions sheet already uses for mode overrides).
  - A sanitizing binding snaps the selection back to **None** if the saved mode is later deleted or has AI disabled, so the picker never shows a stale/blank value.
- **`TranscriptionDetailView.swift`**:
  - Reads `defaultAIModeId` and passes it into `PresetPickerSheet` as `preselectedOverrideModeId`.
  - `PresetPickerSheet` gains an explicit `init` that seeds its existing `overrideModeId` with the default **only when** the active mode isn't AI-configured **and** the default mode is still present in `availableModes`. Seeding in `init` (via `State(initialValue:)`) avoids a one-frame flash of the empty state.

No data-model changes - this reuses the sheet's existing mode-override mechanism, so downstream variation generation already routes through the chosen mode.

## Behavior

- Active mode **has** AI → unchanged; uses the active mode.
- Active mode **lacks** AI + default set → sheet opens to presets with the default mode pre-selected.
- Default mode deleted / AI turned off → falls back to today's empty state.

## Testing

- `xcodebuild` Debug build for iOS Simulator (iPhone 17 Pro Max, OS 26.4): **BUILD SUCCEEDED**.
- Manual reasoning over the edge cases above (stale default, active-mode-configured, no configured modes).