### PR TITLE
Fix recording-orb freeze and add orb visualization picker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,6 +167,7 @@ Run `./build-docc.sh` from the project root on the `main` branch. The script bui
 - Never use `ObservableObject`; always prefer `@Observable` classes instead.
 - Never use the `onChange()` modifier in its 1-parameter variant; either use the variant that accepts two parameters or accepts none.
 - Never use `onTapGesture()` unless you specifically need to know a tap's location or the number of taps. All other usages should use `Button`.
+- Don't add `.pickerStyle(.menu)` or `.tint(.primary)` to a `Picker` inside a `Form` (or `List`). A `Form` `Picker` already defaults to a menu where the entire row is tappable; adding those modifiers is redundant and makes only part of the row tappable. Leave them off so the whole row stays tappable.
 - Never use `Task.sleep(nanoseconds:)`; always use `Task.sleep(for:)` instead.
 - Never use `UIScreen.main.bounds` to read the size of the available space.
 - Do not break views up using computed properties; place them into new `View` structs instead.

--- a/Modules/AppGroup/Sources/AppGroup/UserDefaultsStorage.swift
+++ b/Modules/AppGroup/Sources/AppGroup/UserDefaultsStorage.swift
@@ -85,7 +85,7 @@ public enum UserDefaultsStorage {
         public static let lastSeenWhatsNewVersion = "lastSeenWhatsNewVersion"
 
         // Recording sheet visualization
-        public static let isASCIIOrbEnabled = "isASCIIOrbEnabled"
+        public static let recordingOrbStyle = "recordingOrbStyle"
 
         // Advanced settings
         public static let appendWithVoiceStyle = "appendWithVoiceStyle"

--- a/VivaDicta/Models/RecordingOrbStyle.swift
+++ b/VivaDicta/Models/RecordingOrbStyle.swift
@@ -1,0 +1,27 @@
+//
+//  RecordingOrbStyle.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.05.30
+//
+
+import Foundation
+
+/// Visualization shown on the recording screen. `particles` is the default and
+/// lightest option; `ascii` is the audio-reactive ASCII orb (heavier per frame);
+/// `hidden` shows no visualization at all.
+enum RecordingOrbStyle: String, CaseIterable, Identifiable, Sendable {
+    case particles
+    case ascii
+    case hidden
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .particles: return "Particles"
+        case .ascii: return "ASCII"
+        case .hidden: return "None"
+        }
+    }
+}

--- a/VivaDicta/Views/Components/ASCIIOrbView.swift
+++ b/VivaDicta/Views/Components/ASCIIOrbView.swift
@@ -9,13 +9,13 @@ import SwiftUI
 
 /// Audio-reactive ASCII-rendered orb. Drop-in alternative to `ParticleOrbView`:
 /// same `audioPower` binding (0...1), same outer behavior. The orb is rendered
-/// as a 50×50 grid of monospaced characters whose density follows a sphere
+/// as a 32×32 grid of monospaced characters whose density follows a sphere
 /// SDF + diffuse lighting + animated 3D value noise. Audio level drives noise
 /// speed, density, color saturation, and a subtle radius pulse.
 struct ASCIIOrbView: View {
     @Binding var audioPower: Double
 
-    private let gridSize: Int = 40
+    private let gridSize: Int = 32
 
     /// Ramp from light to dense. ~12 stops give a smooth shaded sphere
     /// without noticeable banding at this grid size.
@@ -30,12 +30,21 @@ struct ASCIIOrbView: View {
     private let smoothingSpeed: Double = 1.0
 
     var body: some View {
-        TimelineView(.animation) { timeline in
+        // Cap at ~20 fps. `.animation` alone drives one frame per display
+        // refresh, so on a 120 Hz ProMotion device the orb rendered up to 6x
+        // as often per second as this capped rate - a major contributor to the
+        // recording-screen freeze on lower-headroom devices.
+        TimelineView(.animation(minimumInterval: 1.0 / 20.0, paused: false)) { timeline in
             let now = timeline.date.timeIntervalSinceReferenceDate
             let power = interpolatedPower(at: now)
             let elapsed = now - startTime
 
-            Canvas(rendersAsynchronously: true) { context, size in
+            // Synchronous Canvas: each frame finishes before the next is
+            // requested. With `rendersAsynchronously: true`, TimelineView queued
+            // draw closures faster than the heavy per-frame work could complete,
+            // building an unbounded backlog that progressively collapsed the
+            // frame rate and ultimately froze the app while recording.
+            Canvas { context, size in
                 drawOrb(in: &context, size: size, time: elapsed, power: power)
             }
         }
@@ -155,13 +164,9 @@ struct ASCIIOrbView: View {
 
                 // Ambient noise texture - same time axis at every cell, so the
                 // noise itself doesn't carry directional flow; only the wave does.
-                let n0 = Self.valueNoise3D(nx * 2.5, ny * 2.5, ambientTime)
-                let n1 = Self.valueNoise3D(
-                    nx * 5.0 + 13.7,
-                    ny * 5.0 - 7.2,
-                    ambientTime * 1.4 + 4.1
-                )
-                let baseNoise = n0 * 0.65 + n1 * 0.35
+                // Single octave: the high-frequency detail layer was dropped to
+                // halve the ambient-noise cost per cell during recording.
+                let baseNoise = Self.valueNoise3D(nx * 2.5, ny * 2.5, ambientTime)
 
                 // Mix: texture under, ripple on top.
                 let noise = baseNoise * 0.55 + ripple * 0.45

--- a/VivaDicta/Views/RecordingSheetView.swift
+++ b/VivaDicta/Views/RecordingSheetView.swift
@@ -14,8 +14,8 @@ struct RecordingSheetView: View {
     @Environment(\.modelContext) var modelContext
     @Environment(AppState.self) var appState
 
-    @AppStorage(UserDefaultsStorage.Keys.isASCIIOrbEnabled)
-    private var isASCIIOrbEnabled: Bool = true
+    @AppStorage(UserDefaultsStorage.Keys.recordingOrbStyle)
+    private var orbStyle: RecordingOrbStyle = .particles
 
     @Query(sort: \TranscriptionTag.sortOrder) private var allTags: [TranscriptionTag]
 
@@ -32,11 +32,14 @@ struct RecordingSheetView: View {
         ZStack(alignment: .center) {
             
             Group {
-                if isASCIIOrbEnabled {
+                switch orbStyle {
+                case .particles:
+                    ParticleOrbView(audioPower: $appState.recordViewModel.audioPower)
+                case .ascii:
                     ASCIIOrbView(audioPower: $appState.recordViewModel.audioPower)
                         .offset(y: 10)
-                } else {
-                    ParticleOrbView(audioPower: $appState.recordViewModel.audioPower)
+                case .hidden:
+                    EmptyView()
                 }
             }
             .accessibilityHidden(true)
@@ -121,7 +124,7 @@ struct RecordingSheetView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .presentationDetents([.height(340)])
+        .presentationDetents([.height(orbStyle == .hidden ? 220 : 340)])
         .presentationDragIndicator(.hidden)
         .onAppear { recordingStartDate = Date() }
         .interactiveDismissDisabled(vm.recordingState == .recording)

--- a/VivaDicta/Views/SettingsScreen/AdvancedSettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/AdvancedSettingsView.swift
@@ -88,8 +88,6 @@ struct AdvancedSettingsView: View {
                             Text(style.displayName).tag(style)
                         }
                     }
-                    .pickerStyle(.menu)
-                    .tint(.primary)
                     .onChange(of: appendWithVoiceStyle.wrappedValue) { _, _ in
                         HapticManager.selectionChanged()
                     }
@@ -105,8 +103,6 @@ struct AdvancedSettingsView: View {
                             Text(mode.name).tag(mode.id.uuidString)
                         }
                     }
-                    .pickerStyle(.menu)
-                    .tint(.primary)
                     .onChange(of: defaultAIMode.wrappedValue) { _, _ in
                         HapticManager.selectionChanged()
                     }

--- a/VivaDicta/Views/SettingsScreen/ExportSettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/ExportSettingsView.swift
@@ -46,8 +46,6 @@ struct ExportSettingsView: View {
                             Text(option.displayName).tag(option)
                         }
                     }
-                    .pickerStyle(.menu)
-                    .tint(.primary)
                     Text("Choose what to include when exporting notes as Markdown. Applies to manual share, the Export to Folder button, and the auto-export below.")
                         .font(.caption)
                         .foregroundStyle(.secondary)

--- a/VivaDicta/Views/SettingsScreen/Presets/PresetFormView.swift
+++ b/VivaDicta/Views/SettingsScreen/Presets/PresetFormView.swift
@@ -139,7 +139,6 @@ struct PresetFormView: View {
                                 Text(cat).tag(cat)
                             }
                         }
-                        .pickerStyle(.menu)
                     }
                 }
 

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -60,8 +60,8 @@ struct SettingsView: View {
     @State private var showRestartAlert = false
     @AppStorage(AppGroupCoordinator.isHapticsEnabled, store: UserDefaultsStorage.shared)
     private var isHapticsEnabled = true
-    @AppStorage(UserDefaultsStorage.Keys.isASCIIOrbEnabled)
-    private var isASCIIOrbEnabled: Bool = true
+    @AppStorage(UserDefaultsStorage.Keys.recordingOrbStyle)
+    private var orbStyle: RecordingOrbStyle = .particles
 
     @State private var showAddMode = false
     @State private var showMailCompose = false
@@ -237,8 +237,6 @@ struct SettingsView: View {
                                     Text(option.displayName).tag(option)
                                 }
                             }
-                            .pickerStyle(.menu)
-                            .tint(.primary)
                             Text("Applied to AI-enhanced output when it's in Chinese.")
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
@@ -316,8 +314,6 @@ struct SettingsView: View {
                             Text("30 minutes").tag(1800)
                             Text("1 hour").tag(3600)
                         }
-                        .pickerStyle(.menu)
-                        .tint(.primary)
                         .onChange(of: audioSessionTimeout) { _, _ in
                             HapticManager.selectionChanged()
                         }
@@ -370,16 +366,17 @@ struct SettingsView: View {
                         }
                     }
 
-                    Toggle(isOn: $isASCIIOrbEnabled) {
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text("ASCII Recording Orb")
-                                .font(.body)
-                            Text("Show the recording sheet with an audio-reactive ASCII orb. Turn off to use the original particle visualization.")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
+                    VStack(alignment: .leading, spacing: 4) {
+                        Picker("Recording Orb", selection: $orbStyle) {
+                            ForEach(RecordingOrbStyle.allCases) { style in
+                                Text(style.displayName).tag(style)
+                            }
                         }
+                        Text("The animation shown on the recording screen. Select None to hide it entirely.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
                     }
-                    .onChange(of: isASCIIOrbEnabled) { _, _ in
+                    .onChange(of: orbStyle) { _, _ in
                         HapticManager.selectionChanged()
                     }
                 }
@@ -410,9 +407,7 @@ struct SettingsView: View {
                             Text("14 days").tag(14)
                             Text("30 days").tag(30)
                         }
-                        .pickerStyle(.menu)
                         .padding(.leading)
-                        .tint(.primary)
                         .onChange(of: noteRetentionDays) { _, _ in
                             HapticManager.selectionChanged()
                         }
@@ -440,9 +435,7 @@ struct SettingsView: View {
                                 Text("14 days").tag(14)
                                 Text("30 days").tag(30)
                             }
-                            .pickerStyle(.menu)
                             .padding(.leading)
-                            .tint(.primary)
                             .onChange(of: audioRetentionDays) { _, _ in
                                 HapticManager.selectionChanged()
                             }
@@ -470,9 +463,7 @@ struct SettingsView: View {
                             Text("14 days").tag(14)
                             Text("30 days").tag(30)
                         }
-                        .pickerStyle(.menu)
                         .padding(.leading)
-                        .tint(.primary)
                         .onChange(of: chatRetentionDays) { _, _ in
                             HapticManager.selectionChanged()
                         }


### PR DESCRIPTION
## Summary

Fixes a recording-screen freeze caused by the ASCII recording orb overloading the CPU, reworks the orb setting into a three-way picker defaulting to the lighter visualization, and applies a Form-picker styling convention.

### Recording-orb freeze fix
A user reported the app freezing roughly 6 seconds into every recording with on-device models on an iPhone 15 Pro Max (iOS 26.5). Root cause: the ASCII orb's `Canvas` was far too expensive per frame and used `rendersAsynchronously: true`, which let `TimelineView(.animation)` queue draw closures faster than they could complete - an unbounded backlog that progressively collapsed the frame rate and froze the app once thermal headroom was reduced (charging + first-launch on-device model loads).

`ASCIIOrbView` changes:
- Synchronous `Canvas` (removes the async frame backlog - the actual runaway mechanism)
- Cap the render cadence at 20 fps (a 120 Hz ProMotion display no longer renders up to 6x as often)
- Grid reduced from 40×40 to 32×32
- Drop the high-frequency noise octave (3 → 2 noise evaluations per cell)

Net: ~90% less per-second work on a 120 Hz device, and the runaway backlog is gone.

### Recording Orb picker
- Replaces the "ASCII Recording Orb" on/off toggle with a "Recording Orb" picker: **Particles** (default), **ASCII**, **None**
- Defaults everyone to the lighter Particles orb; **None** hides the visualization entirely (and shrinks the recording sheet)
- New `recordingOrbStyle` preference, no migration - existing installs simply fall through to the Particles default

### Form-picker convention
- Removes redundant `.pickerStyle(.menu)` / `.tint(.primary)` from `Form` pickers so the entire row stays tappable, and documents the rule in `AGENTS.md`

## Testing
- Debug build passes (`xcodebuild`, iPhone 17 Pro Max simulator, OS 26.4)
- Root cause confirmed externally: the reporting user verified that disabling the ASCII orb eliminated the freeze; these changes remove the orb's runaway cost so it no longer needs disabling
- Picker wiring verified to compile; not yet visually QA'd on a 120 Hz device under load

## Notes
- No data migration. The legacy `isASCIIOrbEnabled` key is removed and unused.
