### PR TITLE
Add Ollama Cloud AI provider for text processing

### DIFF
--- a/Modules/AppGroup/Sources/AppGroup/UserDefaultsStorage.swift
+++ b/Modules/AppGroup/Sources/AppGroup/UserDefaultsStorage.swift
@@ -63,6 +63,7 @@ public enum UserDefaultsStorage {
         public static let huggingFaceModels = "huggingFaceModels"
         public static let ollamaModels = "ollamaModels"
         public static let ollamaServerURL = "ollamaServerURL"
+        public static let ollamaCloudModels = "ollamaCloudModels"
 
         // iCloud
         public static let isICloudSyncEnabled = "isICloudSyncEnabled"

--- a/VivaDicta/Services/AIEnhance/AIProvider.swift
+++ b/VivaDicta/Services/AIEnhance/AIProvider.swift
@@ -234,6 +234,14 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
         .ollamaCloud,
         .customOpenAI]
 
+    /// Cloud providers eligible to act as a reminder extractor.
+    ///
+    /// Excludes Ollama Cloud: reminder extraction relies on structured
+    /// (`json_schema`) outputs, which Ollama Cloud does not support
+    /// (https://docs.ollama.com/capabilities/structured-outputs). Local Ollama
+    /// does support them, so it stays eligible.
+    static let reminderExtractorCloudProviders: [AIProvider] = cloudProviders.filter { $0 != .ollamaCloud }
+
     /// Local AI providers that run on-device or local network (no API key needed)
     static let localProviders: [AIProvider] = [
         .apple,

--- a/VivaDicta/Services/AIEnhance/AIProvider.swift
+++ b/VivaDicta/Services/AIEnhance/AIProvider.swift
@@ -33,6 +33,7 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
     case huggingFace
     case copilot
     case ollama
+    case ollamaCloud
     case customOpenAI
 
     var displayName: String {
@@ -83,6 +84,8 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
             "GitHub Copilot"
         case .ollama:
             "Ollama"
+        case .ollamaCloud:
+            "Ollama Cloud"
         case .customOpenAI:
             "Custom"
         }
@@ -137,6 +140,8 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
             "githubcopilot"
         case .ollama:
             "ollama"
+        case .ollamaCloud:
+            "ollama"
         case .customOpenAI:
             nil // Use SF Symbol "server.rack" directly in view
         }
@@ -166,6 +171,7 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
              .vercelAIGateway,
              .huggingFace,
              .ollama,
+             .ollamaCloud,
              .customOpenAI:
             true
         default:
@@ -196,6 +202,7 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
         case .minimax: URL(string: "https://platform.minimax.io/user-center/basic-information/interface-key")
         case .cohere: URL(string: "https://dashboard.cohere.com/api-keys")
         case .cartesia: URL(string: "https://play.cartesia.ai/keys")
+        case .ollamaCloud: URL(string: "https://ollama.com/settings/keys")
         default: nil
         }
     }
@@ -224,6 +231,7 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
         .vercelAIGateway,
         .huggingFace,
         .ollama,
+        .ollamaCloud,
         .customOpenAI]
 
     /// Local AI providers that run on-device or local network (no API key needed)
@@ -235,6 +243,7 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
     static let generalProviders: [AIProvider] = [
         .apple,
         .ollama,
+        .ollamaCloud,
         .customOpenAI,
         .anthropic,
         .openAI,
@@ -299,6 +308,8 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
             return "https://api.individual.githubcopilot.com/chat/completions"
         case .ollama:
             return "" // URL is configurable, stored in UserDefaults
+        case .ollamaCloud:
+            return "https://ollama.com/v1/chat/completions"
         case .customOpenAI:
             return "" // URL is configurable, stored in UserDefaults
         }
@@ -359,6 +370,8 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
             return "gpt-4o"
         case .ollama:
             return "llama3.2"
+        case .ollamaCloud:
+            return "gpt-oss:120b"
         case .customOpenAI:
             return "" // Model is configurable, stored in UserDefaults
         }
@@ -391,6 +404,7 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
         case .vercelAIGateway: "vercelAIGatewayAPIKey"
         case .huggingFace: "huggingFaceAPIKey"
         case .customOpenAI: "customOpenAIAPIKey"
+        case .ollamaCloud: "ollamaCloudAPIKey"
         case .apple, .ollama, .copilot: ""
         }
     }
@@ -512,6 +526,19 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
             return [] // Models are fetched dynamically from Copilot API
         case .ollama:
             return [] // Models are fetched dynamically from Ollama server
+        case .ollamaCloud:
+            // Curated fallback list of Ollama Cloud models. Refreshed at runtime
+            // via `AIService.fetchOllamaCloudModels()` once an API key is added.
+            return [
+                "gpt-oss:120b",
+                "gpt-oss:20b",
+                "deepseek-v3.1:671b",
+                "qwen3-coder:480b",
+                "qwen3-vl:235b",
+                "glm-4.6",
+                "kimi-k2:1t",
+                "minimax-m2"
+            ]
         case .customOpenAI:
             return [] // Model is configured by user
         }

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -86,6 +86,7 @@ class AIService {
     public var vercelAIGatewayModels: [String] = []
     public var huggingFaceModels: [String] = []
     public var ollamaModels: [String] = []
+    public var ollamaCloudModels: [String] = []
     public var modes: [VivaMode] = []
 
     /// Ollama server URL (configurable, defaults to localhost:11434)
@@ -219,6 +220,7 @@ class AIService {
         loadSavedVercelAIGatewayModels()
         loadSavedHuggingFaceModels()
         loadSavedOllamaModels()
+        loadSavedOllamaCloudModels()
 
         // Refresh connected providers on main actor (needed for Apple availability check)
         Task {
@@ -236,6 +238,9 @@ class AIService {
             }
             if connectedProviders.contains(.huggingFace) {
                 await fetchHuggingFaceModels()
+            }
+            if connectedProviders.contains(.ollamaCloud) {
+                await fetchOllamaCloudModels()
             }
             // Ollama models are fetched on-demand when user configures Ollama
         }
@@ -648,6 +653,16 @@ class AIService {
 
     private func saveOllamaModels() {
         userDefaults.set(ollamaModels, forKey: UserDefaultsStorage.Keys.ollamaModels)
+    }
+
+    private func loadSavedOllamaCloudModels() {
+        if let savedModels = userDefaults.array(forKey: UserDefaultsStorage.Keys.ollamaCloudModels) as? [String] {
+            ollamaCloudModels = savedModels
+        }
+    }
+
+    private func saveOllamaCloudModels() {
+        userDefaults.set(ollamaCloudModels, forKey: UserDefaultsStorage.Keys.ollamaCloudModels)
     }
 
     // MARK: - Configuration validation
@@ -1892,6 +1907,9 @@ class AIService {
         if isValid && provider == .huggingFace {
             await fetchHuggingFaceModels()
         }
+        if isValid && provider == .ollamaCloud {
+            await fetchOllamaCloudModels()
+        }
 
         return isValid
     }
@@ -2134,6 +2152,11 @@ class AIService {
         if provider == .ollama {
             return ollamaModels
         }
+        if provider == .ollamaCloud {
+            // Use the live catalog once fetched, falling back to the curated
+            // static list so the picker is never empty before the first fetch.
+            return ollamaCloudModels.isEmpty ? provider.availableModels : ollamaCloudModels
+        }
         if provider == .customOpenAI {
             // Return the configured model name as a single-item array
             return customOpenAIModelName.isEmpty ? [] : [customOpenAIModelName]
@@ -2291,6 +2314,54 @@ class AIService {
 
         } catch {
             logger.logError("Error fetching HuggingFace models: \(error.localizedDescription)")
+            // Preserve existing cached models on failure
+        }
+    }
+
+    /// Fetches the available Ollama Cloud models from the OpenAI-compatible
+    /// `/v1/models` endpoint, then publishes them to the `@Observable`
+    /// `ollamaCloudModels` property. Unlike the other model catalogs, Ollama
+    /// Cloud's listing requires the API key, so the Bearer header is attached.
+    public func fetchOllamaCloudModels() async {
+        guard let apiKey = AIProvider.ollamaCloud.apiKey else {
+            logger.logError("Cannot fetch Ollama Cloud models: no API key configured")
+            return
+        }
+
+        let url = URL(string: "https://ollama.com/v1/models")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+
+        do {
+            let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
+
+            guard httpResponse.statusCode == 200 else {
+                logger.logError("Failed to fetch Ollama Cloud models: Invalid HTTP response")
+                // Preserve existing cached models on failure
+                return
+            }
+
+            guard let jsonResponse = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let dataArray = jsonResponse["data"] as? [[String: Any]] else {
+                logger.logError("Failed to parse Ollama Cloud models JSON")
+                // Preserve existing cached models on failure
+                return
+            }
+
+            let models = dataArray.compactMap { $0["id"] as? String }
+            guard !models.isEmpty else {
+                logger.logWarning("Ollama Cloud returned no models; keeping existing list.")
+                return
+            }
+
+            self.ollamaCloudModels = models.sorted()
+            self.saveOllamaCloudModels()
+            logger.logInfo("Successfully fetched \(models.count) Ollama Cloud models.")
+
+        } catch {
+            logger.logError("Error fetching Ollama Cloud models: \(error.localizedDescription)")
             // Preserve existing cached models on failure
         }
     }

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -2323,8 +2323,9 @@ class AIService {
     /// `ollamaCloudModels` property. Unlike the other model catalogs, Ollama
     /// Cloud's listing requires the API key, so the Bearer header is attached.
     public func fetchOllamaCloudModels() async {
-        guard let apiKey = AIProvider.ollamaCloud.apiKey else {
-            logger.logError("Cannot fetch Ollama Cloud models: no API key configured")
+        guard let apiKey = AIProvider.ollamaCloud.apiKey, !apiKey.isEmpty else {
+            // No key yet (pre-config or just deleted) is an expected state, not an error.
+            logger.logDebug("Skipping Ollama Cloud model fetch: no API key configured")
             return
         }
 

--- a/VivaDicta/Services/Reminders/CloudReminderExtractionProvider.swift
+++ b/VivaDicta/Services/Reminders/CloudReminderExtractionProvider.swift
@@ -88,6 +88,11 @@ final class CloudReminderExtractionProvider {
             return false
         case .ollama:
             return true
+        case .ollamaCloud:
+            // Reminder extraction sends `response_format: json_schema`, which
+            // Ollama Cloud does not support (only local Ollama does).
+            // https://docs.ollama.com/capabilities/structured-outputs
+            return false
         case .customOpenAI:
             return !aiService.customOpenAIEndpointURL.isEmpty && !aiService.customOpenAIModelName.isEmpty
         case .copilot:

--- a/VivaDicta/Views/SettingsScreen/ModeEditView.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditView.swift
@@ -667,7 +667,7 @@ struct ModeEditView: View {
                                 }
 
                                 Section("Cloud") {
-                                    ForEach(AIProvider.cloudProviders) { provider in
+                                    ForEach(AIProvider.reminderExtractorCloudProviders) { provider in
                                         if viewModel.isProviderReady(provider) {
                                             Text(provider.displayName).tag(provider)
                                         } else {

--- a/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
@@ -494,7 +494,7 @@ class ModeEditViewModel {
     func selectFirstReminderExtractorProviderIfNeeded() {
         guard reminderExtractorProvider == nil else { return }
 
-        if let provider = preferredProviderForSelection() {
+        if let provider = preferredProviderForSelection(from: AIProvider.reminderExtractorCloudProviders) {
             reminderExtractorProvider = provider
             reminderExtractorModel = defaultModel(for: provider)
             logger.logInfo("Auto-selected reminder extractor provider: \(provider.rawValue)")
@@ -522,6 +522,7 @@ class ModeEditViewModel {
         if reminderExtractorProvider == nil {
             if let provider = aiProvider,
                isProviderReady(provider),
+               provider == .apple || AIProvider.reminderExtractorCloudProviders.contains(provider),
                let model = aiModel,
                !model.isEmpty {
                 reminderExtractorProvider = provider
@@ -569,16 +570,18 @@ class ModeEditViewModel {
         refreshModelSelection(for: provider, target: .reminderExtraction)
     }
 
-    private func preferredProviderForSelection() -> AIProvider? {
+    private func preferredProviderForSelection(
+        from candidates: [AIProvider] = AIProvider.cloudProviders
+    ) -> AIProvider? {
         if aiService.connectedProviders.contains(.apple) {
             return .apple
         }
 
-        let firstConnectedProvider = AIProvider.cloudProviders.first { provider in
+        let firstConnectedProvider = candidates.first { provider in
             aiService.connectedProviders.contains(provider)
         }
 
-        return firstConnectedProvider ?? AIProvider.cloudProviders.first
+        return firstConnectedProvider ?? candidates.first
     }
 
     private func defaultModel(for provider: AIProvider?) -> String? {


### PR DESCRIPTION
## Summary

Adds **Ollama Cloud** as a new cloud-based AI text provider, distinct from the existing local **Ollama** provider. Both reuse the same Ollama icon asset.

Ollama Cloud authenticates with an API key (Bearer token, obtained from https://ollama.com/settings/keys) against the OpenAI-compatible endpoint at `https://ollama.com/v1/chat/completions`.

### Why this approach

Ollama Cloud is modeled as a standard OpenAI-compatible cloud provider. As a result, request handling, response streaming, multi-turn chat, reminder extraction, and API-key verification all flow through the existing `default` code paths - so **no changes were needed in the request layer or the UI**. The provider list, API-key entry screen, and mode editor are already generic over `AIProvider`.

The cloud model catalog changes over time, so models are fetched dynamically from the `/v1/models` endpoint (which requires the API key) after a key is verified and on launch when connected, mirroring the OpenRouter/HuggingFace pattern. A curated static fallback list keeps the model picker populated before the first fetch.

## Changes

**`AIProvider.swift`** - new `.ollamaCloud` case wired into every switch and array:
- `displayName` -> "Ollama Cloud"; `iconName` -> "ollama" (shared asset)
- `baseURL` -> `https://ollama.com/v1/chat/completions`; `defaultModel` -> `gpt-oss:120b`
- `keychainKey` -> `ollamaCloudAPIKey`; `apiKeyURL` -> settings/keys page
- Added to `supportsResponseStreaming`, `cloudProviders`, `generalProviders`
- `requiresAPIKey` returns `true` automatically (not in the exclusion list)
- `availableModels` -> curated fallback list of known cloud models

**`AIService.swift`**:
- New `ollamaCloudModels` observable property + load/save helpers + UserDefaults persistence
- `fetchOllamaCloudModels()` - fetches `/v1/models` with the Bearer key (the cloud listing requires auth, unlike the other catalogs)
- Fetches after key verification and on launch when connected
- `getAvailableModels(for:)` returns the live list, falling back to the static one

**`UserDefaultsStorage.swift`** - new `ollamaCloudModels` key.

## Behavior

Settings -> AI Providers -> Cloud now shows both "Ollama" (local, server config) and "Ollama Cloud" (Add API Key) adjacent, both with the Ollama logo. Adding a key verifies it against the cloud endpoint, then populates the live model list for the mode editor's model picker.

## Testing

- `xcodebuild` build succeeds with no new errors or warnings.
- Manual verification on device/simulator with a real Ollama Cloud API key is still recommended to confirm the live `/v1/models` response shape and end-to-end enhancement.

## Notes

- The static fallback model names are a best-effort snapshot of the current cloud catalog and may drift over time, but the dynamic fetch replaces them with the live list once a valid key is entered. `gpt-oss:120b` (the verification/default model) is the documented flagship cloud model.
- The local Ollama provider is unchanged.