### PR TITLE
Add speaker diarization to ElevenLabs and xAI transcription

### DIFF
--- a/Modules/CloudTranscription/Sources/CloudTranscription/ElevenLabsTranscriptionService.swift
+++ b/Modules/CloudTranscription/Sources/CloudTranscription/ElevenLabsTranscriptionService.swift
@@ -16,11 +16,18 @@ public struct ElevenLabsTranscriptionService: TranscriptionService, Sendable {
         public let modelName: String
         /// BCP-47 code, or `"auto"` to let ElevenLabs detect.
         public let language: String
+        public let isSpeakerDiarizationEnabled: Bool
 
-        public init(apiKey: String, modelName: String, language: String = "auto") {
+        public init(
+            apiKey: String,
+            modelName: String,
+            language: String = "auto",
+            isSpeakerDiarizationEnabled: Bool = false
+        ) {
             self.apiKey = apiKey
             self.modelName = modelName
             self.language = language
+            self.isSpeakerDiarizationEnabled = isSpeakerDiarizationEnabled
         }
     }
 
@@ -36,13 +43,12 @@ public struct ElevenLabsTranscriptionService: TranscriptionService, Sendable {
     }
 
     public func transcribe(audioURL: URL) async throws -> TranscriptionServiceResult {
-        let text = try await NetworkRetry.withRetry(logger: logger) {
+        try await NetworkRetry.withRetry(logger: logger) {
             try await makeTranscriptionRequest(audioURL: audioURL)
         }
-        return .plain(text)
     }
 
-    private func makeTranscriptionRequest(audioURL: URL) async throws -> String {
+    private func makeTranscriptionRequest(audioURL: URL) async throws -> TranscriptionServiceResult {
         guard !config.apiKey.isEmpty else {
             throw CloudTranscriptionError.missingAPIKey
         }
@@ -65,7 +71,13 @@ public struct ElevenLabsTranscriptionService: TranscriptionService, Sendable {
 
         do {
             let transcriptionResponse = try JSONDecoder().decode(ElevenLabsTranscriptionResponse.self, from: data)
-            return transcriptionResponse.text
+
+            if config.isSpeakerDiarizationEnabled,
+               let diarizedText = makeSpeakerAttributedText(from: transcriptionResponse.words) {
+                return .speakerAttributed(diarizedText)
+            }
+
+            return .plain(transcriptionResponse.text)
         } catch {
             throw CloudTranscriptionError.noTranscriptionReturned
         }
@@ -79,6 +91,10 @@ public struct ElevenLabsTranscriptionService: TranscriptionService, Sendable {
         body.append(formField: "temperature", value: "0.0", boundary: boundary)
         body.append(formField: "tag_audio_events", value: "false", boundary: boundary)
 
+        if config.isSpeakerDiarizationEnabled {
+            body.append(formField: "diarize", value: "true", boundary: boundary)
+        }
+
         if config.language != "auto", !config.language.isEmpty {
             body.append(formField: "language_code", value: config.language, boundary: boundary)
         }
@@ -88,8 +104,56 @@ public struct ElevenLabsTranscriptionService: TranscriptionService, Sendable {
         return body
     }
 
+    /// ElevenLabs reports speakers only at the word level (no segment grouping),
+    /// so consecutive words sharing a `speaker_id` are merged into turns. The
+    /// `words` array interleaves `spacing` entries whose `text` is a literal
+    /// space, so concatenating `text` directly preserves word boundaries.
+    private func makeSpeakerAttributedText(from words: [ElevenLabsTranscriptionResponse.Word]?) -> String? {
+        guard let words, !words.isEmpty else {
+            return nil
+        }
+
+        var turns: [SpeakerTurn] = []
+        var currentSpeaker: String?
+        var currentText = ""
+
+        for word in words {
+            let wordSpeaker = word.speakerID
+            if turns.isEmpty && currentText.isEmpty {
+                currentSpeaker = wordSpeaker
+                currentText = word.text
+                continue
+            }
+
+            if wordSpeaker == currentSpeaker || wordSpeaker == nil {
+                currentText += word.text
+            } else {
+                turns.append(SpeakerTurn(speakerID: currentSpeaker, text: currentText))
+                currentSpeaker = wordSpeaker
+                currentText = word.text
+            }
+        }
+
+        if !currentText.isEmpty {
+            turns.append(SpeakerTurn(speakerID: currentSpeaker, text: currentText))
+        }
+
+        return SpeakerDiarizationFormatter.format(turns)
+    }
+
     private struct ElevenLabsTranscriptionResponse: Decodable {
         let text: String
+        let words: [Word]?
+
+        struct Word: Decodable {
+            let text: String
+            let speakerID: String?
+
+            enum CodingKeys: String, CodingKey {
+                case text
+                case speakerID = "speaker_id"
+            }
+        }
     }
 }
 

--- a/Modules/CloudTranscription/Sources/CloudTranscription/XaiTranscriptionService.swift
+++ b/Modules/CloudTranscription/Sources/CloudTranscription/XaiTranscriptionService.swift
@@ -22,11 +22,18 @@ public struct XaiTranscriptionService: TranscriptionService, Sendable {
         /// When true the API returns naturally formatted text with Inverse
         /// Text Normalization (e.g. "$100" instead of "one hundred dollars").
         public let formatted: Bool
+        public let isSpeakerDiarizationEnabled: Bool
 
-        public init(apiKey: String, language: String, formatted: Bool = true) {
+        public init(
+            apiKey: String,
+            language: String,
+            formatted: Bool = true,
+            isSpeakerDiarizationEnabled: Bool = false
+        ) {
             self.apiKey = apiKey
             self.language = language
             self.formatted = formatted
+            self.isSpeakerDiarizationEnabled = isSpeakerDiarizationEnabled
         }
     }
 
@@ -42,13 +49,12 @@ public struct XaiTranscriptionService: TranscriptionService, Sendable {
     }
 
     public func transcribe(audioURL: URL) async throws -> TranscriptionServiceResult {
-        let text = try await NetworkRetry.withRetry(logger: logger) {
+        try await NetworkRetry.withRetry(logger: logger) {
             try await makeTranscriptionRequest(audioURL: audioURL)
         }
-        return .plain(text)
     }
 
-    private func makeTranscriptionRequest(audioURL: URL) async throws -> String {
+    private func makeTranscriptionRequest(audioURL: URL) async throws -> TranscriptionServiceResult {
         guard !config.apiKey.isEmpty else {
             throw CloudTranscriptionError.missingAPIKey
         }
@@ -72,7 +78,13 @@ public struct XaiTranscriptionService: TranscriptionService, Sendable {
 
         do {
             let transcriptionResponse = try JSONDecoder().decode(TranscriptionResponse.self, from: data)
-            return transcriptionResponse.text
+
+            if config.isSpeakerDiarizationEnabled,
+               let diarizedText = makeSpeakerAttributedText(from: transcriptionResponse.words) {
+                return .speakerAttributed(diarizedText)
+            }
+
+            return .plain(transcriptionResponse.text)
         } catch {
             logger.logError("Failed to decode xAI STT response: \(error.localizedDescription)")
             throw CloudTranscriptionError.noTranscriptionReturned
@@ -97,6 +109,13 @@ public struct XaiTranscriptionService: TranscriptionService, Sendable {
         body.append(config.language.data(using: .utf8)!)
         body.append(crlf.data(using: .utf8)!)
 
+        if config.isSpeakerDiarizationEnabled {
+            body.append("--\(boundary)\(crlf)".data(using: .utf8)!)
+            body.append("Content-Disposition: form-data; name=\"diarize\"\(crlf)\(crlf)".data(using: .utf8)!)
+            body.append("true".data(using: .utf8)!)
+            body.append(crlf.data(using: .utf8)!)
+        }
+
         // `file` must be the last field per xAI docs.
         body.append("--\(boundary)\(crlf)".data(using: .utf8)!)
         body.append("Content-Disposition: form-data; name=\"file\"; filename=\"\(audioURL.lastPathComponent)\"\(crlf)".data(using: .utf8)!)
@@ -108,7 +127,50 @@ public struct XaiTranscriptionService: TranscriptionService, Sendable {
         return body
     }
 
+    /// xAI reports a 0-based integer `speaker` per word (only when `diarize=true`)
+    /// and, unlike ElevenLabs, emits no spacing tokens - so words in a turn are
+    /// re-joined with single spaces and `SpeakerDiarizationFormatter` normalizes
+    /// the result.
+    private func makeSpeakerAttributedText(from words: [TranscriptionResponse.Word]?) -> String? {
+        guard let words, !words.isEmpty else {
+            return nil
+        }
+
+        var turns: [SpeakerTurn] = []
+        var currentSpeaker: Int?
+        var currentWords: [String] = []
+
+        for word in words {
+            let wordSpeaker = word.speaker
+            if turns.isEmpty && currentWords.isEmpty {
+                currentSpeaker = wordSpeaker
+                currentWords = [word.text]
+                continue
+            }
+
+            if wordSpeaker == currentSpeaker || wordSpeaker == nil {
+                currentWords.append(word.text)
+            } else {
+                turns.append(SpeakerTurn(speakerID: currentSpeaker.map(String.init), text: currentWords.joined(separator: " ")))
+                currentSpeaker = wordSpeaker
+                currentWords = [word.text]
+            }
+        }
+
+        if !currentWords.isEmpty {
+            turns.append(SpeakerTurn(speakerID: currentSpeaker.map(String.init), text: currentWords.joined(separator: " ")))
+        }
+
+        return SpeakerDiarizationFormatter.format(turns)
+    }
+
     private struct TranscriptionResponse: Decodable {
         let text: String
+        let words: [Word]?
+
+        struct Word: Decodable {
+            let text: String
+            let speaker: Int?
+        }
     }
 }

--- a/Modules/CloudTranscription/Tests/CloudTranscriptionTests/ElevenLabsTranscriptionServiceTests.swift
+++ b/Modules/CloudTranscription/Tests/CloudTranscriptionTests/ElevenLabsTranscriptionServiceTests.swift
@@ -1,0 +1,166 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import Networking
+import NetworkingMocks
+import Testing
+@testable import CloudTranscription
+import TranscriptionCore
+
+/// Tests exercise `ElevenLabsTranscriptionService` end-to-end with a stubbed
+/// `MockNetworkService`. Verifies request shape (endpoint, `xi-api-key` header,
+/// multipart body) and response handling, plus the word-level speaker
+/// diarization grouping.
+@Suite(.tags(.networking))
+struct ElevenLabsTranscriptionServiceTests {
+
+    // MARK: - Test Helpers
+
+    private func makeAudioFile() throws -> URL {
+        let url = URL.temporaryDirectory.appending(path: "\(UUID().uuidString).wav")
+        try Data([0x52, 0x49, 0x46, 0x46]).write(to: url) // "RIFF"
+        return url
+    }
+
+    private func makeHTTPResponse(_ statusCode: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: URL(string: "https://api.elevenlabs.io/v1/speech-to-text")!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/json"]
+        )!
+    }
+
+    private func stubSuccess(on networkService: MockNetworkService, text: String) {
+        let body = Data(#"{"text":"\#(text)"}"#.utf8)
+        networkService.stubUploadResponse = .success((body, makeHTTPResponse(200)))
+    }
+
+    private func makeService(
+        networkService: MockNetworkService,
+        apiKey: String = "el-test-key",
+        modelName: String = "scribe_v1",
+        language: String = "auto",
+        isSpeakerDiarizationEnabled: Bool = false
+    ) -> ElevenLabsTranscriptionService {
+        ElevenLabsTranscriptionService(
+            config: .init(
+                apiKey: apiKey,
+                modelName: modelName,
+                language: language,
+                isSpeakerDiarizationEnabled: isSpeakerDiarizationEnabled
+            ),
+            networkService: networkService
+        )
+    }
+
+    // MARK: - Success path
+
+    @Test func successReturnsPlainText() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "eleven hello")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        let result = try await sut.transcribe(audioURL: audio)
+
+        #expect(result.text == "eleven hello")
+        #expect(result.isSpeakerAttributed == false)
+        #expect(networkService.uploadCallCount == 1)
+    }
+
+    // MARK: - Request shape
+
+    @Test func requestTargetsSpeechToTextEndpointWithApiKeyHeader() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, apiKey: "el-abc123")
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let req = try #require(networkService.capturedRequest)
+        #expect(req.url?.absoluteString == "https://api.elevenlabs.io/v1/speech-to-text")
+        #expect(req.httpMethod == "POST")
+        #expect(req.value(forHTTPHeaderField: "xi-api-key") == "el-abc123")
+    }
+
+    // MARK: - Diarization
+
+    @Test func bodyOmitsDiarizeFieldByDefault() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let body = try #require(networkService.capturedBody)
+        let bodyString = try #require(String(data: body, encoding: .utf8))
+        #expect(bodyString.contains("name=\"diarize\"") == false)
+    }
+
+    @Test func bodyIncludesDiarizeTrueWhenEnabled() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, isSpeakerDiarizationEnabled: true)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let body = try #require(networkService.capturedBody)
+        let bodyString = try #require(String(data: body, encoding: .utf8))
+        #expect(bodyString.range(of: "name=\"diarize\"\\s*\\r\\n\\r\\ntrue", options: .regularExpression) != nil)
+    }
+
+    @Test func diarizationGroupsConsecutiveWordsBySpeaker() async throws {
+        let networkService = MockNetworkService()
+        // ElevenLabs interleaves `spacing` entries whose text is a literal space.
+        let json = #"""
+        {"text":"Hello there Hi","words":[
+        {"text":"Hello","type":"word","speaker_id":"speaker_0"},
+        {"text":" ","type":"spacing","speaker_id":"speaker_0"},
+        {"text":"there","type":"word","speaker_id":"speaker_0"},
+        {"text":" ","type":"spacing","speaker_id":"speaker_0"},
+        {"text":"Hi","type":"word","speaker_id":"speaker_1"}
+        ]}
+        """#
+        networkService.stubUploadResponse = .success((Data(json.utf8), makeHTTPResponse(200)))
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, isSpeakerDiarizationEnabled: true)
+
+        let result = try await sut.transcribe(audioURL: audio)
+
+        #expect(result.isSpeakerAttributed)
+        #expect(result.text == "Speaker A: Hello there\n\nSpeaker B: Hi")
+    }
+
+    @Test func diarizationEnabledButNoWordsFallsBackToPlainText() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "no words here")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, isSpeakerDiarizationEnabled: true)
+
+        let result = try await sut.transcribe(audioURL: audio)
+
+        #expect(result.isSpeakerAttributed == false)
+        #expect(result.text == "no words here")
+    }
+
+    // MARK: - Response handling
+
+    @Test func undecodableJSONOn200ThrowsNoTranscriptionReturned() async throws {
+        let networkService = MockNetworkService()
+        networkService.stubUploadResponse = .success((Data("not json".utf8), makeHTTPResponse(200)))
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        let error = try await #require(throws: CloudTranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: audio)
+        }
+        guard case .noTranscriptionReturned = error else {
+            Issue.record("expected noTranscriptionReturned, got \(error)")
+            return
+        }
+    }
+}

--- a/Modules/CloudTranscription/Tests/CloudTranscriptionTests/XaiTranscriptionServiceTests.swift
+++ b/Modules/CloudTranscription/Tests/CloudTranscriptionTests/XaiTranscriptionServiceTests.swift
@@ -40,13 +40,15 @@ struct XaiTranscriptionServiceTests {
         networkService: MockNetworkService,
         apiKey: String = "xai-test-key",
         language: String = "en",
-        formatted: Bool = true
+        formatted: Bool = true,
+        isSpeakerDiarizationEnabled: Bool = false
     ) -> XaiTranscriptionService {
         XaiTranscriptionService(
             config: .init(
                 apiKey: apiKey,
                 language: language,
-                formatted: formatted
+                formatted: formatted,
+                isSpeakerDiarizationEnabled: isSpeakerDiarizationEnabled
             ),
             networkService: networkService
         )
@@ -179,6 +181,66 @@ struct XaiTranscriptionServiceTests {
         // reshuffle that happens to keep file last but breaks the rest.
         #expect(formatRange.lowerBound < languageRange.lowerBound)
         #expect(languageRange.lowerBound < fileRange.lowerBound)
+    }
+
+    // MARK: - Diarization
+
+    @Test func bodyOmitsDiarizeFieldByDefault() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let body = try #require(networkService.capturedBody)
+        let bodyString = try #require(String(data: body, encoding: .utf8))
+        #expect(bodyString.contains("name=\"diarize\"") == false)
+    }
+
+    @Test func bodyIncludesDiarizeTrueWhenEnabled() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, isSpeakerDiarizationEnabled: true)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let body = try #require(networkService.capturedBody)
+        let bodyString = try #require(String(data: body, encoding: .utf8))
+        #expect(bodyString.range(of: "name=\"diarize\"\\s*\\r\\n\\r\\ntrue", options: .regularExpression) != nil)
+    }
+
+    @Test func diarizationGroupsConsecutiveWordsBySpeaker() async throws {
+        let networkService = MockNetworkService()
+        let json = #"""
+        {"text":"Hello there Hi","words":[
+        {"text":"Hello","speaker":0},
+        {"text":"there","speaker":0},
+        {"text":"Hi","speaker":1}
+        ]}
+        """#
+        networkService.stubUploadResponse = .success((Data(json.utf8), makeHTTPResponse(200)))
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, isSpeakerDiarizationEnabled: true)
+
+        let result = try await sut.transcribe(audioURL: audio)
+
+        #expect(result.isSpeakerAttributed)
+        #expect(result.text == "Speaker A: Hello there\n\nSpeaker B: Hi")
+    }
+
+    @Test func diarizationDisabledReturnsPlainTextEvenWithSpeakerWords() async throws {
+        let networkService = MockNetworkService()
+        let json = #"{"text":"Hello there","words":[{"text":"Hello","speaker":0},{"text":"there","speaker":1}]}"#
+        networkService.stubUploadResponse = .success((Data(json.utf8), makeHTTPResponse(200)))
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, isSpeakerDiarizationEnabled: false)
+
+        let result = try await sut.transcribe(audioURL: audio)
+
+        #expect(result.isSpeakerAttributed == false)
+        #expect(result.text == "Hello there")
     }
 
     // MARK: - Validation / short-circuit

--- a/VivaDicta/Services/Transcription/TranscriptionManager.swift
+++ b/VivaDicta/Services/Transcription/TranscriptionManager.swift
@@ -257,7 +257,12 @@ class TranscriptionManager {
             ))
 
         case .elevenLabs:
-            return .elevenLabs(.init(apiKey: try requireAPIKey(model), modelName: model.name, language: selectedLanguage))
+            return .elevenLabs(.init(
+                apiKey: try requireAPIKey(model),
+                modelName: model.name,
+                language: selectedLanguage,
+                isSpeakerDiarizationEnabled: diarizationEnabled
+            ))
 
         case .deepgram:
             // The app exposes `nova-3-multilingual` as a friendly alias; Deepgram
@@ -355,7 +360,8 @@ class TranscriptionManager {
             )
             return .xai(.init(
                 apiKey: try requireAPIKey(model),
-                language: language
+                language: language,
+                isSpeakerDiarizationEnabled: diarizationEnabled
             ))
 
         case .customTranscription:

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -172,7 +172,7 @@ struct SettingsView: View {
                         VStack(alignment: .leading, spacing: 4) {
                             Text("Speaker Labels")
                                 .font(.body)
-                            Text("Identify and label different speakers for local Whisper, Deepgram, Mistral, Soniox, Gladia, Speechmatics, and AssemblyAI")
+                            Text("Identify and label different speakers for local Whisper, Deepgram, Mistral, Soniox, Gladia, Speechmatics, AssemblyAI, ElevenLabs, and xAI")
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                         }


### PR DESCRIPTION
## Summary

ElevenLabs Scribe and xAI grok-stt both support speaker diarization, but their transcription services only ever returned plain text - so the global **Speaker Labels** toggle silently did nothing for those two providers. This wires both into the existing diarization path, closing the gap.

After this change, every transcription provider whose API supports diarization implements it: AssemblyAI, Deepgram, Mistral, Gladia, Soniox, Speechmatics, WhisperKit (local), **ElevenLabs**, and **xAI**.

## Changes

- **ElevenLabs** (`ElevenLabsTranscriptionService`): sends `diarize=true` when enabled, parses the word-level `speaker_id`, and groups consecutive words per speaker. ElevenLabs interleaves `spacing` tokens, so word `text` is concatenated directly to preserve boundaries.
- **xAI** (`XaiTranscriptionService`): sends `diarize=true` (before the mandatory-last `file` field), parses the 0-based integer `speaker` per word. xAI emits no spacing tokens, so words in a turn are re-joined with single spaces. Confirmed against xAI's REST reference that the batch `/v1/stt` endpoint has no `model` field, so the existing request shape is unchanged.
- Both reuse the shared `SpeakerDiarizationFormatter` and return `.speakerAttributed(...)`, matching the 7 providers that already do.
- `TranscriptionManager.makeProvider` passes the global `diarizationEnabled` flag through to both providers.
- `SettingsView`: the Speaker Labels toggle description now lists ElevenLabs and xAI.

## Testing

- `swift test` on the CloudTranscription package: **24 tests pass** across both suites.
- Added 4 diarization cases to `XaiTranscriptionServiceTests` (field omitted by default, sent when enabled, word grouping, disabled-stays-plain).
- Added a new `ElevenLabsTranscriptionServiceTests` suite (none existed) covering success path, request shape, and the same diarization scenarios.
- Full app target builds: **BUILD SUCCEEDED** (iOS Simulator, iPhone 17 Pro Max, OS 26.4).

## Notes / out of scope

- **Parakeet (local/FluidAudio)**: FluidAudio ships a diarizer, but that's a separate local-pipeline integration (model wiring + download), not a one-field cloud change. Candidate for a follow-up to reach local parity with WhisperKit.
- **OpenAI**: current models (`gpt-4o-transcribe`, `whisper-1`) genuinely don't diarize. Unlocking it means adding `gpt-4o-transcribe-diarize` as a selectable model - a product decision, not a gap.
- **Gemini**: prompt-only diarization, no structured API - left as plain.
- **Cartesia, Cohere, Groq, Custom**: confirmed no diarization support; correctly plain.

No breaking changes.