### PR TITLE
Fix BGTaskScheduler handler crash from main-actor isolation mismatch

### DIFF
--- a/VivaDicta/Services/BackgroundTaskManager.swift
+++ b/VivaDicta/Services/BackgroundTaskManager.swift
@@ -110,9 +110,17 @@ final class BackgroundTaskManager {
     /// a BGProcessingTask, AppState (and thus BackgroundTaskManager) is always initialized
     /// because the task is scheduled from within the running app.
     static func registerBGTaskHandler() {
+        // `registerBGTaskHandler` is a static member of this @MainActor type, so the
+        // launch-handler closure below inherits @MainActor isolation. `BGTaskScheduler`'s
+        // launchHandler parameter is a non-isolated @Sendable closure, so the compiler
+        // inserts a *dynamic* main-executor assertion at the closure's entry. If iOS runs
+        // the handler off the main queue (which it does when `using:` is nil), that
+        // assertion fails and the runtime hard-crashes (dispatch_assert_queue_fail).
+        // Registering with `.main` guarantees the handler runs on the main queue so the
+        // inherited isolation actually holds.
         BGTaskScheduler.shared.register(
             forTaskWithIdentifier: bgTaskIdentifier,
-            using: nil
+            using: .main
         ) { task in
             guard let bgTask = task as? BGProcessingTask else { return }
             Task { @MainActor in


### PR DESCRIPTION
## Summary

Fixes a crash that fires the instant iOS wakes the app to run the `transcription-processing` BGProcessingTask. Reported by Crashlytics on both 3.4.0 (3006) and 3.3.0 (3005).

The crashing thread is `com.apple.BGTaskScheduler`, not main:

```
Crashed: com.apple.BGTaskScheduler (…transcription-processing)
0  _dispatch_assert_queue_fail
3  dispatch_assert_queue$V2
4  _swift_task_checkIsolatedSwift
5  swift_task_isCurrentExecutorWithFlagsImpl
6  closure #1 in static BackgroundTaskManager.registerBGTaskHandler()
```

### Root cause

`registerBGTaskHandler()` is a static member of the `@MainActor` `BackgroundTaskManager`, so the launch-handler closure it passes to `BGTaskScheduler.register` inherits `@MainActor` isolation. That API's `launchHandler` parameter is a *non-isolated* `@Sendable (BGTask) -> Void`, so the compiler inserts a **dynamic main-executor assertion** at the closure's entry instead of erroring.

With `using: nil`, iOS invokes the launch handler on its own background queue. The dynamic check (`swift_task_isCurrentExecutor` → `dispatch_assert_queue(main)`) then asserts "am I on the main executor?", the answer is no, and the Swift runtime hard-crashes. This assertion is enforced by the newer Swift concurrency runtime, which is why the code previously "worked" (it silently ran on the wrong executor) and only started crashing in the field.

### Fix

Register with `using: .main` so the launch handler runs on the main queue and the closure's inherited main-actor isolation actually holds. The handler body only casts the task and spins up `Task { @MainActor in … }`, so running it on main is trivial and does not block the actual queue-draining work.

The two Crashlytics issues are the same bug: `BackgroundTaskService` is the pre-rename name of `BackgroundTaskManager`, so this one-line change covers both.

## Testing

- `xcodebuild -scheme VivaDicta … build` → **BUILD SUCCEEDED**

## Notes

- One-line behavioral change (`using: nil` → `using: .main`) plus an explanatory comment.
- No API or data-model changes.