### PR TITLE
Live Translation copy buttons + filler fix for translated transcriptions

### DIFF
--- a/VivaDicta/Services/Transcription/TranscriptionManager.swift
+++ b/VivaDicta/Services/Transcription/TranscriptionManager.swift
@@ -160,9 +160,16 @@ class TranscriptionManager {
             progress: progressHandler
         )
 
+        // When inline translation is active (e.g. Soniox Spanish → Russian) the
+        // output text is in the TARGET language, so the filler set must match the
+        // target, not the source transcription language - otherwise target-language
+        // fillers (e.g. Russian "э-э") survive.
         var result = TranscriptionOutputFilter.filter(
             transcriptionResult.text,
-            language: currentMode.transcriptionLanguage
+            language: Self.outputLanguage(
+                transcriptionLanguage: currentMode.transcriptionLanguage,
+                translationTargetLanguage: currentMode.translationTargetLanguage
+            )
         )
 
         if currentMode.isAutoTextFormattingEnabled && transcriptionResult.isSpeakerAttributed == false {
@@ -185,6 +192,22 @@ class TranscriptionManager {
         ))
 
         return result
+    }
+
+    /// Resolves the language of the transcription *output* for post-processing.
+    ///
+    /// When inline translation is active the output is in the translation target
+    /// language; otherwise it's the source transcription language. Returns the
+    /// target language whenever it's set (non-nil and non-empty), falling back to
+    /// the source language.
+    static func outputLanguage(
+        transcriptionLanguage: String?,
+        translationTargetLanguage: String?
+    ) -> String? {
+        if let target = translationTargetLanguage, !target.isEmpty {
+            return target
+        }
+        return transcriptionLanguage
     }
 
     /// Preloads the WhisperKit model if the current mode uses it. Best-effort

--- a/VivaDicta/Views/LiveTranslation/LiveTranslationView.swift
+++ b/VivaDicta/Views/LiveTranslation/LiveTranslationView.swift
@@ -561,7 +561,7 @@ private struct TranscriptColumn: View {
     let title: String
     let tokens: [LiveTranslationToken]
     let accent: Color
-    var copyButtonAlignment: HorizontalAlignment = .leading
+    var copyButtonAlignment: Alignment = .leading
 
     @State private var showCopied = false
 
@@ -609,7 +609,7 @@ private struct TranscriptColumn: View {
         .controlSize(.small)
         .tint(showCopied ? .green : accent)
         .contentTransition(.symbolEffect(.replace))
-        .frame(maxWidth: .infinity, alignment: copyButtonAlignment == .trailing ? .trailing : .leading)
+        .frame(maxWidth: .infinity, alignment: copyButtonAlignment)
         .padding(.horizontal, 12)
         .padding(.bottom, 12)
     }

--- a/VivaDicta/Views/LiveTranslation/LiveTranslationView.swift
+++ b/VivaDicta/Views/LiveTranslation/LiveTranslationView.swift
@@ -193,13 +193,15 @@ struct LiveTranslationView: View {
             TranscriptColumn(
                 title: service.config.sourceLanguage.displayName,
                 tokens: service.originalTokens,
-                accent: .secondary
+                accent: .secondary,
+                copyButtonAlignment: .leading
             )
             Divider()
             TranscriptColumn(
                 title: service.config.targetLanguage.displayName,
                 tokens: service.translatedTokens,
-                accent: .indigo
+                accent: .indigo,
+                copyButtonAlignment: .trailing
             )
         }
     }
@@ -559,6 +561,9 @@ private struct TranscriptColumn: View {
     let title: String
     let tokens: [LiveTranslationToken]
     let accent: Color
+    var copyButtonAlignment: HorizontalAlignment = .leading
+
+    @State private var showCopied = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -581,8 +586,32 @@ private struct TranscriptColumn: View {
                     withAnimation { proxy.scrollTo(scrollAnchor, anchor: .bottom) }
                 }
             }
+
+            if !plainText.isEmpty {
+                copyButton
+            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    private var copyButton: some View {
+        Button(showCopied ? "Copied" : "Copy", systemImage: showCopied ? "checkmark" : "doc.on.doc") {
+            ClipboardManager.copyToClipboard(plainText)
+            HapticManager.success()
+            showCopied = true
+            Task {
+                try? await Task.sleep(for: .seconds(1.5))
+                showCopied = false
+            }
+        }
+        .font(.caption.weight(.medium))
+        .buttonStyle(.bordered)
+        .controlSize(.small)
+        .tint(showCopied ? .green : accent)
+        .contentTransition(.symbolEffect(.replace))
+        .frame(maxWidth: .infinity, alignment: copyButtonAlignment == .trailing ? .trailing : .leading)
+        .padding(.horizontal, 12)
+        .padding(.bottom, 12)
     }
 
     private var renderedText: AttributedString {
@@ -595,6 +624,10 @@ private struct TranscriptColumn: View {
             attributed.append(part)
         }
         return attributed
+    }
+
+    private var plainText: String {
+        tokens.map(\.text).joined().trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     private let scrollAnchor = "transcriptBottom"

--- a/VivaDictaTests/TextProcessingFilterTests.swift
+++ b/VivaDictaTests/TextProcessingFilterTests.swift
@@ -382,6 +382,17 @@ struct TranscriptionOutputLanguageTests {
         #expect(result == "ru")
     }
 
+    @Test func outputLanguage_translationTargetWithoutSource_usesTargetLanguage() {
+        // Target set with no explicit source ("auto" source) → still resolves
+        // to the target, since that's the language of the output text.
+        let result = TranscriptionManager.outputLanguage(
+            transcriptionLanguage: nil,
+            translationTargetLanguage: "ru"
+        )
+
+        #expect(result == "ru")
+    }
+
     @Test func filter_spanishToRussian_stripsRussianFillers() {
         // Regression: Soniox Spanish → Russian produced Russian text full of
         // "э-э" fillers because the filter was given the source language ("es").

--- a/VivaDictaTests/TextProcessingFilterTests.swift
+++ b/VivaDictaTests/TextProcessingFilterTests.swift
@@ -344,3 +344,58 @@ struct AIProcessingOutputFilterTests {
         #expect(result == "The final result.")
     }
 }
+
+// MARK: - Output Language Resolution (inline translation)
+
+// `TranscriptionManager.outputLanguage` inherits MainActor isolation from its
+// enclosing `@MainActor` type, so these tests run on the main actor to call it
+// synchronously.
+@MainActor
+struct TranscriptionOutputLanguageTests {
+
+    @Test func outputLanguage_noTranslation_usesTranscriptionLanguage() {
+        let result = TranscriptionManager.outputLanguage(
+            transcriptionLanguage: "es",
+            translationTargetLanguage: nil
+        )
+
+        #expect(result == "es")
+    }
+
+    @Test func outputLanguage_emptyTranslationTarget_usesTranscriptionLanguage() {
+        let result = TranscriptionManager.outputLanguage(
+            transcriptionLanguage: "es",
+            translationTargetLanguage: ""
+        )
+
+        #expect(result == "es")
+    }
+
+    @Test func outputLanguage_translationActive_usesTargetLanguage() {
+        // Spanish audio translated to Russian → output is Russian, so the
+        // filler set must be chosen from the target language.
+        let result = TranscriptionManager.outputLanguage(
+            transcriptionLanguage: "es",
+            translationTargetLanguage: "ru"
+        )
+
+        #expect(result == "ru")
+    }
+
+    @Test func filter_spanishToRussian_stripsRussianFillers() {
+        // Regression: Soniox Spanish → Russian produced Russian text full of
+        // "э-э" fillers because the filter was given the source language ("es").
+        // Resolving the output language to the translation target fixes it.
+        let translatedOutput = "Э-э, привет, э-э, сейчас я говорю по-испански."
+        let language = TranscriptionManager.outputLanguage(
+            transcriptionLanguage: "es",
+            translationTargetLanguage: "ru"
+        )
+
+        let result = TranscriptionOutputFilter.filter(translatedOutput, language: language)
+
+        #expect(result.contains("э-э") == false, "expected Russian fillers stripped; got: \(result)")
+        #expect(result.contains("привет"))
+        #expect(result.contains("по-испански"))
+    }
+}


### PR DESCRIPTION
Two related-area changes from one session, kept as separate commits for easy review.

## 1. Copy buttons in Live Translation (`9613f9a14`)

Each transcript column now shows a **Copy** button at its bottom once it has text:
- Left-aligned under the **source** column, right-aligned under the **translation** column.
- Copies that column's plain text via `ClipboardManager`, fires a success haptic, and briefly flips to a green **"Copied"** checkmark - the same idiom used in the transcription list (`TranscriptionRowView` / `AnimatedCopyButton`).
- Only appears when the column has content (mirrors how "Save as note" only shows with text).

## 2. Fix filler stripping for translated transcriptions (`d8b43730b`)

**Bug:** With inline translation (e.g. Soniox **Spanish → Russian**), the transcription output is in the *target* language, but `TranscriptionManager` passed the *source* language to `TranscriptionOutputFilter`. So Russian fillers (`э-э`, `ээ`, `эм`) were never stripped - output looked like:

> Э-э, привет, э-э, сейчас я говорю по-испански, но, э-э, давайте посмотрим...

**Fix:** Resolve the output language to the translation target when set, falling back to the source transcription language, and pass that to the filter. Added a `TranscriptionManager.outputLanguage(...)` helper plus regression tests (resolution logic + the Spanish→Russian filler-stripping case).

**Live Translation is unaffected** - its streaming screen renders raw Soniox tokens directly and never runs through `TranscriptionOutputFilter`, so streaming output keeps its fillers (intended, since it's a live stream).

## Testing
- App builds clean (`xcodebuild`, iPhone 17 Pro Max, iOS 26.4).
- New tests added in `TranscriptionOutputLanguageTests`. Note: the full `xcodebuild test` action currently can't run because of a **pre-existing, unrelated** Swift 6 actor-isolation compile error in the `VivaDictaUITests` target (not touched by this PR). The new logic is also covered transitively by the existing, passing `filter(..., language: "ru")` tests.

## Notes
- No breaking changes.