### PR TITLE
Construct LiveTranslationService lazily to avoid rebuilding audio graph on re-render

### DIFF
--- a/VivaDicta/Views/LiveTranslation/LiveTranslationView.swift
+++ b/VivaDicta/Views/LiveTranslation/LiveTranslationView.swift
@@ -9,12 +9,37 @@ import AVFoundation
 import SwiftData
 import SwiftUI
 
+/// Thin wrapper that constructs ``LiveTranslationService`` exactly once.
+///
+/// `@State`'s default-value initializer is not an `@autoclosure`, so an inline
+/// `@State private var service = LiveTranslationService()` re-runs the service's
+/// `init` - rebuilding its `AVAudioEngine` node graph - every time SwiftUI
+/// re-creates this view, which `.fullScreenCover` does on each parent body
+/// re-render. Holding the service in an optional and building it in `onAppear`
+/// constructs the audio graph a single time per presentation.
 struct LiveTranslationView: View {
+    @State private var service: LiveTranslationService?
+
+    var body: some View {
+        ZStack {
+            if let service {
+                LiveTranslationSessionView(service: service)
+            }
+        }
+        .onAppear {
+            if service == nil {
+                service = LiveTranslationService()
+            }
+        }
+    }
+}
+
+private struct LiveTranslationSessionView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.modelContext) private var modelContext
     @Environment(AppState.self) private var appState
 
-    @State private var service = LiveTranslationService()
+    let service: LiveTranslationService
     @State private var savedSnapshot: SavedSnapshot?
     @State private var saveError: SaveErrorAlert?
     @State private var headphonesConnected = LiveTranslationAudio.isHeadphonesRouteActive


### PR DESCRIPTION
## Summary

`LiveTranslationView` held its service via an inline `@State` default (`= LiveTranslationService()`). That default value is **eager** - SwiftUI re-evaluates it on every re-creation of the View struct and discards all but the first instance. Since the view is the content of a `.fullScreenCover`, it is re-created on every parent (`MainView`) body pass while presented, so the service's `AVAudioEngine` node graph (`attach`/`connect`) was being built repeatedly only to be thrown away.

## Change

- New thin `LiveTranslationView` wrapper holds the service in an optional `@State` and constructs it **once** in `onAppear`.
- The previous view becomes `LiveTranslationSessionView`, receiving the service as an injected `let`. Body and all computed properties are unchanged.
- Observation still drives view updates because the observable properties are read during `body`.

## Result

The audio node graph is now constructed once per presentation instead of on every parent re-render. Call site (`MainView`) is untouched.

## Test plan

- [x] Builds clean (`xcodebuild ... build`)
- [ ] Open Live Translation, change languages, start/stop a session, save as note