### PR TITLE
Add production performance telemetry: device conditions + MetricKit

### DIFF
--- a/VivaDicta/AppDelegate.swift
+++ b/VivaDicta/AppDelegate.swift
@@ -17,6 +17,7 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         logger.logInfo("🚀 didFinishLaunchingWithOptions - state: \(application.applicationState.debugDescription)")
         FirebaseApp.configure()
+        PerformanceMonitoringService.shared.start()
         BackgroundTaskManager.registerBGTaskHandler()
         return true
     }

--- a/VivaDicta/Services/Analytics/AnalyticsService.swift
+++ b/VivaDicta/Services/Analytics/AnalyticsService.swift
@@ -98,6 +98,28 @@ enum AnalyticsEvent {
     /// Fires when a session fails (missing key, mic denied, WS error, etc.).
     /// `reason` is a stable category identifier, not the localized message.
     case liveTranslationFailed(reason: String)
+
+    // MARK: - Performance Monitoring (MetricKit, passive)
+
+    /// Daily MetricKit launch-time report: bucket-weighted average time to first
+    /// draw, with the number of launches the average is drawn from.
+    case appLaunchMetric(averageMs: Double, sampleCount: Int)
+
+    /// Daily MetricKit responsiveness report: bucket-weighted average hang time
+    /// across the reporting window.
+    case appHangMetric(averageMs: Double, sampleCount: Int)
+
+    /// Daily MetricKit memory report: peak footprint and average suspended
+    /// memory (both in MB).
+    case appMemoryMetric(peakMB: Int, averageSuspendedMB: Int)
+
+    /// A single MetricKit hang diagnostic - the app was unresponsive on the main
+    /// thread for `hangSeconds`.
+    case appHangDiagnostic(hangSeconds: Double)
+
+    /// A single MetricKit CPU-exception diagnostic - the app burned an unusual
+    /// amount of CPU over the sampling window.
+    case appCPUExceptionDiagnostic(cpuSeconds: Double, sampledSeconds: Double)
 }
 
 extension AnalyticsEvent {
@@ -122,6 +144,26 @@ extension AnalyticsEvent {
         case .liveTranslationStopped: "live_translation_stopped"
         case .liveTranslationSavedAsNote: "live_translation_saved_as_note"
         case .liveTranslationFailed: "live_translation_failed"
+        case .appLaunchMetric: "app_launch_metric"
+        case .appHangMetric: "app_hang_metric"
+        case .appMemoryMetric: "app_memory_metric"
+        case .appHangDiagnostic: "app_hang_diagnostic"
+        case .appCPUExceptionDiagnostic: "app_cpu_exception_diagnostic"
+        }
+    }
+
+    /// Whether ``DeviceConditions`` (thermal state, Low Power Mode, memory) are
+    /// merged into this event. True for interactive events, where the live
+    /// device state is meaningful. False for the MetricKit-sourced events, whose
+    /// payloads are aggregated over the past day - the device state at delivery
+    /// time is unrelated to when the metrics were recorded.
+    nonisolated var attachesDeviceConditions: Bool {
+        switch self {
+        case .appLaunchMetric, .appHangMetric, .appMemoryMetric,
+             .appHangDiagnostic, .appCPUExceptionDiagnostic:
+            false
+        default:
+            true
         }
     }
 
@@ -223,6 +265,21 @@ extension AnalyticsEvent {
 
         case .liveTranslationFailed(let reason):
             return ["reason": reason]
+
+        case .appLaunchMetric(let averageMs, let sampleCount):
+            return ["average_ms": averageMs, "sample_count": sampleCount]
+
+        case .appHangMetric(let averageMs, let sampleCount):
+            return ["average_ms": averageMs, "sample_count": sampleCount]
+
+        case .appMemoryMetric(let peakMB, let averageSuspendedMB):
+            return ["peak_mb": peakMB, "average_suspended_mb": averageSuspendedMB]
+
+        case .appHangDiagnostic(let hangSeconds):
+            return ["hang_seconds": hangSeconds]
+
+        case .appCPUExceptionDiagnostic(let cpuSeconds, let sampledSeconds):
+            return ["cpu_seconds": cpuSeconds, "sampled_seconds": sampledSeconds]
         }
     }
 }
@@ -237,7 +294,14 @@ enum AnalyticsService {
 
     nonisolated static func track(_ event: AnalyticsEvent) {
         let name = event.name
-        let params = event.parameters
+
+        var merged = event.parameters ?? [:]
+        if event.attachesDeviceConditions {
+            // Event-specific keys win on the (unexpected) collision.
+            merged.merge(DeviceConditions.parameters) { current, _ in current }
+        }
+        let params: [String: Any]? = merged.isEmpty ? nil : merged
+
         Analytics.logEvent(name, parameters: params)
 
         if let params {

--- a/VivaDicta/Services/Analytics/DeviceConditions.swift
+++ b/VivaDicta/Services/Analytics/DeviceConditions.swift
@@ -1,0 +1,65 @@
+//
+//  DeviceConditions.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.06.14
+//
+
+import Foundation
+
+/// A point-in-time snapshot of device runtime conditions, attached to every
+/// interactive analytics event.
+///
+/// Instruments only sees one device under one configuration; the user base runs
+/// thousands of device / OS / thermal / power combinations. Tagging each event
+/// with the thermal state, Low Power Mode flag, and app memory footprint turns
+/// the analytics pipeline into a lightweight Xcode memory-and-thermal gauge
+/// running across every user's device - so any event can later be sliced to find
+/// "hot" screens, memory-heavy flows, or behaviour that only degrades in Low
+/// Power Mode.
+enum DeviceConditions {
+
+    /// Snapshot of current conditions as snake_case analytics parameters.
+    nonisolated static var parameters: [String: Any] {
+        var params: [String: Any] = [
+            "thermal_state": ProcessInfo.processInfo.thermalState.analyticsValue,
+            "low_power_mode": ProcessInfo.processInfo.isLowPowerModeEnabled
+        ]
+        if let footprintMB = currentMemoryFootprintMB() {
+            params["memory_mb"] = footprintMB
+        }
+        return params
+    }
+
+    /// The app's physical memory footprint in MB, read via `TASK_VM_INFO`.
+    ///
+    /// `phys_footprint` is the same figure Xcode's memory gauge reports and the
+    /// value the system compares against the Jetsam limit, making it a more
+    /// faithful "how close are we to being killed" signal than `resident_size`.
+    /// Returns nil if the Mach call fails.
+    nonisolated static func currentMemoryFootprintMB() -> Int? {
+        var info = task_vm_info_data_t()
+        var count = mach_msg_type_number_t(MemoryLayout<task_vm_info_data_t>.size / MemoryLayout<integer_t>.size)
+        let result = withUnsafeMutablePointer(to: &info) { infoPtr in
+            infoPtr.withMemoryRebound(to: integer_t.self, capacity: Int(count)) { intPtr in
+                task_info(mach_task_self_, task_flavor_t(TASK_VM_INFO), intPtr, &count)
+            }
+        }
+        guard result == KERN_SUCCESS else { return nil }
+        return Int(info.phys_footprint) / (1024 * 1024)
+    }
+}
+
+extension ProcessInfo.ThermalState {
+    /// Stable numeric encoding for analytics: `.nominal` = 0 ... `.critical` = 3.
+    /// Kept stable so historical reporting doesn't break.
+    nonisolated var analyticsValue: Int {
+        switch self {
+        case .nominal: 0
+        case .fair: 1
+        case .serious: 2
+        case .critical: 3
+        @unknown default: -1
+        }
+    }
+}

--- a/VivaDicta/Services/Analytics/PerformanceMonitoringService.swift
+++ b/VivaDicta/Services/Analytics/PerformanceMonitoringService.swift
@@ -28,10 +28,17 @@ final class PerformanceMonitoringService: NSObject, MXMetricManagerSubscriber, @
 
     private let logger = Logger(category: .analytics)
 
+    /// Guards against double registration, which would make MetricKit deliver
+    /// every payload twice and double all reported counts. Only ever touched
+    /// from `start()`, which is called on the main thread at launch.
+    private var isStarted = false
+
     private override init() { super.init() }
 
-    /// Registers as a MetricKit subscriber. Call once at launch.
+    /// Registers as a MetricKit subscriber. Idempotent; call once at launch.
     func start() {
+        guard !isStarted else { return }
+        isStarted = true
         MXMetricManager.shared.add(self)
         logger.logInfo("📈 MetricKit subscriber registered")
     }
@@ -77,8 +84,11 @@ final class PerformanceMonitoringService: NSObject, MXMetricManagerSubscriber, @
 
     private func reportMemory(_ payload: MXMetricPayload) {
         guard let memory = payload.memoryMetrics else { return }
-        let peakMB = Int(memory.peakMemoryUsage.converted(to: .megabytes).value)
-        let suspendedMB = Int(memory.averageSuspendedMemory.averageMeasurement.converted(to: .megabytes).value)
+        // Report MiB (bytes / 1024²), not Measurement's decimal `.megabytes`
+        // (1e6 bytes), so these line up with DeviceConditions.currentMemoryFootprintMB
+        // and the Jetsam limit, both of which are MiB-based.
+        let peakMB = Int(memory.peakMemoryUsage.converted(to: .bytes).value) / (1024 * 1024)
+        let suspendedMB = Int(memory.averageSuspendedMemory.averageMeasurement.converted(to: .bytes).value) / (1024 * 1024)
         AnalyticsService.track(.appMemoryMetric(peakMB: peakMB, averageSuspendedMB: suspendedMB))
     }
 

--- a/VivaDicta/Services/Analytics/PerformanceMonitoringService.swift
+++ b/VivaDicta/Services/Analytics/PerformanceMonitoringService.swift
@@ -1,0 +1,102 @@
+//
+//  PerformanceMonitoringService.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.06.14
+//
+
+import Foundation
+import MetricKit
+import os
+
+/// Subscribes to MetricKit so the app receives passive, aggregated production
+/// performance reports from the entire user base - data Instruments cannot
+/// provide because it only profiles one connected device at a time.
+///
+/// MetricKit delivers `MXMetricPayload`s roughly once per day (launch time,
+/// hang time, memory) and `MXDiagnosticPayload`s when incidents occur (long
+/// hangs, CPU exceptions). Reports only arrive on real devices in real usage,
+/// never the simulator - use Xcode's *Debug ▸ Simulate MetricKit Payloads* to
+/// exercise the callbacks locally.
+///
+/// `MXMetricManager` does not retain its subscribers, so this service is a
+/// process-lifetime singleton. It holds no mutable state, hence `@unchecked
+/// Sendable`.
+final class PerformanceMonitoringService: NSObject, MXMetricManagerSubscriber, @unchecked Sendable {
+
+    static let shared = PerformanceMonitoringService()
+
+    private let logger = Logger(category: .analytics)
+
+    private override init() { super.init() }
+
+    /// Registers as a MetricKit subscriber. Call once at launch.
+    func start() {
+        MXMetricManager.shared.add(self)
+        logger.logInfo("📈 MetricKit subscriber registered")
+    }
+
+    // MARK: - MXMetricManagerSubscriber
+
+    func didReceive(_ payloads: [MXMetricPayload]) {
+        for payload in payloads {
+            reportLaunchTime(payload)
+            reportHangTime(payload)
+            reportMemory(payload)
+        }
+    }
+
+    func didReceive(_ payloads: [MXDiagnosticPayload]) {
+        for payload in payloads {
+            for hang in payload.hangDiagnostics ?? [] {
+                let seconds = hang.hangDuration.converted(to: .seconds).value
+                AnalyticsService.track(.appHangDiagnostic(hangSeconds: seconds))
+            }
+            for cpu in payload.cpuExceptionDiagnostics ?? [] {
+                AnalyticsService.track(.appCPUExceptionDiagnostic(
+                    cpuSeconds: cpu.totalCPUTime.converted(to: .seconds).value,
+                    sampledSeconds: cpu.totalSampledTime.converted(to: .seconds).value
+                ))
+            }
+        }
+    }
+
+    // MARK: - Metric extraction
+
+    private func reportLaunchTime(_ payload: MXMetricPayload) {
+        guard let launch = payload.applicationLaunchMetrics,
+              let stats = weightedAverageMs(launch.histogrammedTimeToFirstDraw) else { return }
+        AnalyticsService.track(.appLaunchMetric(averageMs: stats.averageMs, sampleCount: stats.count))
+    }
+
+    private func reportHangTime(_ payload: MXMetricPayload) {
+        guard let responsiveness = payload.applicationResponsivenessMetrics,
+              let stats = weightedAverageMs(responsiveness.histogrammedApplicationHangTime) else { return }
+        AnalyticsService.track(.appHangMetric(averageMs: stats.averageMs, sampleCount: stats.count))
+    }
+
+    private func reportMemory(_ payload: MXMetricPayload) {
+        guard let memory = payload.memoryMetrics else { return }
+        let peakMB = Int(memory.peakMemoryUsage.converted(to: .megabytes).value)
+        let suspendedMB = Int(memory.averageSuspendedMemory.averageMeasurement.converted(to: .megabytes).value)
+        AnalyticsService.track(.appMemoryMetric(peakMB: peakMB, averageSuspendedMB: suspendedMB))
+    }
+
+    /// Collapses a duration histogram into a single bucket-weighted average (in
+    /// milliseconds) plus the total sample count. MetricKit reports distributions
+    /// rather than scalars, so we approximate each bucket by its midpoint.
+    private func weightedAverageMs(_ histogram: MXHistogram<UnitDuration>) -> (averageMs: Double, count: Int)? {
+        let enumerator = histogram.bucketEnumerator
+        var totalCount = 0
+        var weightedSum = 0.0
+        while let bucket = enumerator.nextObject() as? MXHistogramBucket<UnitDuration> {
+            let start = bucket.bucketStart.converted(to: .milliseconds).value
+            let end = bucket.bucketEnd.converted(to: .milliseconds).value
+            let midpoint = (start + end) / 2
+            weightedSum += midpoint * Double(bucket.bucketCount)
+            totalCount += bucket.bucketCount
+        }
+        guard totalCount > 0 else { return nil }
+        return (weightedSum / Double(totalCount), totalCount)
+    }
+}


### PR DESCRIPTION
## Summary

Instruments only profiles one connected device, while the user base runs thousands of device / OS / thermal / network combinations. This adds lightweight production performance monitoring so real-world behaviour becomes observable in analytics.

### Device conditions on every event
Every interactive analytics event now carries a snapshot of current runtime conditions, so any existing event (transcription, chat, variation, ...) can be sliced by them:
- `thermal_state` (0 nominal → 3 critical)
- `low_power_mode` (~10% of usage happens here, and it slows UI rendering)
- `memory_mb` - app physical footprint via `TASK_VM_INFO.phys_footprint` (the figure Xcode's gauge and Jetsam use)

### MetricKit
New `PerformanceMonitoringService` (an `MXMetricManagerSubscriber` singleton) turns MetricKit's passive production reports into typed analytics events:
- **Daily metrics:** launch time-to-first-draw, hang time (bucket-weighted averages from the histograms), peak + average-suspended memory
- **Diagnostics:** individual hang durations, CPU-exception time

New events: `app_launch_metric`, `app_hang_metric`, `app_memory_metric`, `app_hang_diagnostic`, `app_cpu_exception_diagnostic`. These bypass the device-condition merge (an `attachesDeviceConditions` flag) because their payloads are aggregated over the prior day, so live device state would be misleading.

## Files
- `DeviceConditions.swift` (new) - runtime-condition snapshot + Mach memory footprint
- `PerformanceMonitoringService.swift` (new) - MetricKit subscriber
- `AnalyticsService.swift` - device-condition merge in `track()`, 5 typed events, `attachesDeviceConditions` flag
- `AppDelegate.swift` - registers the subscriber after `FirebaseApp.configure()`

## Testing
- [x] `BUILD SUCCEEDED`, no warnings (verified the MetricKit generic histogram cast, `@unchecked Sendable`, and `nonisolated` reads)
- [ ] MetricKit `didReceive` callbacks cannot be exercised from the simulator/CLI - they only fire on a real device or via Xcode's *Debug ▸ Simulate MetricKit Payloads*. The device-condition merge on regular events is active immediately.

## Notes
- No `#if DEBUG` gating was added - the existing `AnalyticsService` fires in all configs, so this matches it. Easy to add a debug guard if desired.
- Everything stays behind the typed `AnalyticsEvent` API so call sites can't drift.