### PR TITLE
Scaffold AI module packages (AICore / AIProviders / AIKit)

### DIFF
--- a/Modules/AICore/.gitignore
+++ b/Modules/AICore/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Modules/AICore/Package.swift
+++ b/Modules/AICore/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version: 6.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "AICore",
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "AICore",
+            targets: ["AICore"]
+        ),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "AICore"
+        ),
+        .testTarget(
+            name: "AICoreTests",
+            dependencies: ["AICore"]
+        ),
+    ],
+    swiftLanguageModes: [.v6]
+)

--- a/Modules/AICore/Package.swift
+++ b/Modules/AICore/Package.swift
@@ -1,23 +1,18 @@
-// swift-tools-version: 6.3
-// The swift-tools-version declares the minimum version of Swift required to build this package.
+// swift-tools-version: 6.2
 
 import PackageDescription
 
 let package = Package(
     name: "AICore",
+    platforms: [
+        .iOS(.v18),
+        .macOS(.v14),
+    ],
     products: [
-        // Products define the executables and libraries a package produces, making them visible to other packages.
-        .library(
-            name: "AICore",
-            targets: ["AICore"]
-        ),
+        .library(name: "AICore", targets: ["AICore"]),
     ],
     targets: [
-        // Targets are the basic building blocks of a package, defining a module or a test suite.
-        // Targets can depend on other targets in this package and products from dependencies.
-        .target(
-            name: "AICore"
-        ),
+        .target(name: "AICore"),
         .testTarget(
             name: "AICoreTests",
             dependencies: ["AICore"]

--- a/Modules/AICore/Sources/AICore/AICore.swift
+++ b/Modules/AICore/Sources/AICore/AICore.swift
@@ -1,0 +1,2 @@
+// The Swift Programming Language
+// https://docs.swift.org/swift-book

--- a/Modules/AICore/Tests/AICoreTests/AICoreTests.swift
+++ b/Modules/AICore/Tests/AICoreTests/AICoreTests.swift
@@ -1,0 +1,8 @@
+import Testing
+@testable import AICore
+
+@Test func example() async throws {
+    // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    // Swift Testing Documentation
+    // https://developer.apple.com/documentation/testing
+}

--- a/Modules/AIKit/.gitignore
+++ b/Modules/AIKit/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Modules/AIKit/Package.swift
+++ b/Modules/AIKit/Package.swift
@@ -1,22 +1,27 @@
-// swift-tools-version: 6.3
-// The swift-tools-version declares the minimum version of Swift required to build this package.
+// swift-tools-version: 6.2
 
 import PackageDescription
 
 let package = Package(
     name: "AIKit",
+    platforms: [
+        .iOS(.v18),
+        .macOS(.v14),
+    ],
     products: [
-        // Products define the executables and libraries a package produces, making them visible to other packages.
-        .library(
-            name: "AIKit",
-            targets: ["AIKit"]
-        ),
+        .library(name: "AIKit", targets: ["AIKit"]),
+    ],
+    dependencies: [
+        // AIKit depends on the AICore API only - never on AIProviders (the impl).
+        // The composition root injects concrete providers into AIKit's registry.
+        .package(path: "../AICore"),
     ],
     targets: [
-        // Targets are the basic building blocks of a package, defining a module or a test suite.
-        // Targets can depend on other targets in this package and products from dependencies.
         .target(
-            name: "AIKit"
+            name: "AIKit",
+            dependencies: [
+                .product(name: "AICore", package: "AICore"),
+            ]
         ),
         .testTarget(
             name: "AIKitTests",

--- a/Modules/AIKit/Package.swift
+++ b/Modules/AIKit/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version: 6.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "AIKit",
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "AIKit",
+            targets: ["AIKit"]
+        ),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "AIKit"
+        ),
+        .testTarget(
+            name: "AIKitTests",
+            dependencies: ["AIKit"]
+        ),
+    ],
+    swiftLanguageModes: [.v6]
+)

--- a/Modules/AIKit/Sources/AIKit/AIKit.swift
+++ b/Modules/AIKit/Sources/AIKit/AIKit.swift
@@ -1,0 +1,2 @@
+// The Swift Programming Language
+// https://docs.swift.org/swift-book

--- a/Modules/AIKit/Tests/AIKitTests/AIKitTests.swift
+++ b/Modules/AIKit/Tests/AIKitTests/AIKitTests.swift
@@ -1,0 +1,8 @@
+import Testing
+@testable import AIKit
+
+@Test func example() async throws {
+    // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    // Swift Testing Documentation
+    // https://developer.apple.com/documentation/testing
+}

--- a/Modules/AIProviders/.gitignore
+++ b/Modules/AIProviders/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Modules/AIProviders/Package.swift
+++ b/Modules/AIProviders/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version: 6.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "AIProviders",
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "AIProviders",
+            targets: ["AIProviders"]
+        ),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "AIProviders"
+        ),
+        .testTarget(
+            name: "AIProvidersTests",
+            dependencies: ["AIProviders"]
+        ),
+    ],
+    swiftLanguageModes: [.v6]
+)

--- a/Modules/AIProviders/Package.swift
+++ b/Modules/AIProviders/Package.swift
@@ -1,22 +1,25 @@
-// swift-tools-version: 6.3
-// The swift-tools-version declares the minimum version of Swift required to build this package.
+// swift-tools-version: 6.2
 
 import PackageDescription
 
 let package = Package(
     name: "AIProviders",
+    platforms: [
+        .iOS(.v18),
+        .macOS(.v14),
+    ],
     products: [
-        // Products define the executables and libraries a package produces, making them visible to other packages.
-        .library(
-            name: "AIProviders",
-            targets: ["AIProviders"]
-        ),
+        .library(name: "AIProviders", targets: ["AIProviders"]),
+    ],
+    dependencies: [
+        .package(path: "../AICore"),
     ],
     targets: [
-        // Targets are the basic building blocks of a package, defining a module or a test suite.
-        // Targets can depend on other targets in this package and products from dependencies.
         .target(
-            name: "AIProviders"
+            name: "AIProviders",
+            dependencies: [
+                .product(name: "AICore", package: "AICore"),
+            ]
         ),
         .testTarget(
             name: "AIProvidersTests",

--- a/Modules/AIProviders/Sources/AIProviders/AIProviders.swift
+++ b/Modules/AIProviders/Sources/AIProviders/AIProviders.swift
@@ -1,0 +1,2 @@
+// The Swift Programming Language
+// https://docs.swift.org/swift-book

--- a/Modules/AIProviders/Tests/AIProvidersTests/AIProvidersTests.swift
+++ b/Modules/AIProviders/Tests/AIProvidersTests/AIProvidersTests.swift
@@ -1,0 +1,8 @@
+import Testing
+@testable import AIProviders
+
+@Test func example() async throws {
+    // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    // Swift Testing Documentation
+    // https://developer.apple.com/documentation/testing
+}

--- a/VivaDicta.xcodeproj/project.pbxproj
+++ b/VivaDicta.xcodeproj/project.pbxproj
@@ -197,6 +197,9 @@
 		186C04412FB7762100102432 /* Exceptions for "Modules" folder in "VivaDicta" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
+				AICore,
+				AIKit,
+				AIProviders,
 				AppGroup,
 				AudioRecording,
 				CloudTranscription,
@@ -215,6 +218,9 @@
 		186C04422FB7762100102432 /* Exceptions for "Modules" folder in "ActionExtension" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
+				AICore,
+				AIKit,
+				AIProviders,
 				AppGroup,
 				AudioRecording,
 				CloudTranscription,

--- a/VivaDicta.xcodeproj/project.pbxproj
+++ b/VivaDicta.xcodeproj/project.pbxproj
@@ -32,6 +32,10 @@
 		18B497F22F268B2700538830 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = 18B497F12F268B2700538830 /* FirebaseCrashlytics */; };
 		18B89BC32FB875530007FA96 /* TranscriptionKit in Frameworks */ = {isa = PBXBuildFile; productRef = 18B89BC22FB875530007FA96 /* TranscriptionKit */; };
 		18B8BEB12FB8BD7D0007FA96 /* DesignSystem in Frameworks */ = {isa = PBXBuildFile; productRef = 18B8BEB02FB8BD7D0007FA96 /* DesignSystem */; };
+		BFBF000000000000000000C1 /* AICore in Frameworks */ = {isa = PBXBuildFile; productRef = AEAE000000000000000000C1 /* AICore */; };
+		BFBF000000000000000000D1 /* AIProviders in Frameworks */ = {isa = PBXBuildFile; productRef = AEAE000000000000000000D1 /* AIProviders */; };
+		BFBF000000000000000000E1 /* AIKit in Frameworks */ = {isa = PBXBuildFile; productRef = AEAE000000000000000000E1 /* AIKit */; };
+		BFBF000000000000000000C2 /* AICore in Frameworks */ = {isa = PBXBuildFile; productRef = AEAE000000000000000000C2 /* AICore */; };
 		18B8CF2C2FB8C4690007FA96 /* DesignSystem in Frameworks */ = {isa = PBXBuildFile; productRef = 18B8CF2B2FB8C4690007FA96 /* DesignSystem */; };
 		18BA24132F7ED0D700C4F68B /* VivaDictaWatch Watch App.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 18BA23F32F7ED0D500C4F68B /* VivaDictaWatch Watch App.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		18BA29262F7F29FD00C4F68B /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 18E1C7FB2E8E793E00BE8A11 /* WidgetKit.framework */; };
@@ -496,6 +500,9 @@
 				188E02572FC3BCB4007B8BC1 /* AudioRecording in Frameworks */,
 				18B89BC32FB875530007FA96 /* TranscriptionKit in Frameworks */,
 				18B8BEB12FB8BD7D0007FA96 /* DesignSystem in Frameworks */,
+				BFBF000000000000000000C1 /* AICore in Frameworks */,
+				BFBF000000000000000000D1 /* AIProviders in Frameworks */,
+				BFBF000000000000000000E1 /* AIKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -515,6 +522,7 @@
 				186C05892FB779BA00102432 /* PresetsMocks in Frameworks */,
 				E1938683EE7E439ABF4FE3EA /* TranscriptionKitMocks in Frameworks */,
 				188E02592FC3BCC1007B8BC1 /* AudioRecordingMocks in Frameworks */,
+				BFBF000000000000000000C2 /* AICore in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -702,6 +710,9 @@
 				18B89BC22FB875530007FA96 /* TranscriptionKit */,
 				18B8BEB02FB8BD7D0007FA96 /* DesignSystem */,
 				188E02562FC3BCB4007B8BC1 /* AudioRecording */,
+				AEAE000000000000000000C1 /* AICore */,
+				AEAE000000000000000000D1 /* AIProviders */,
+				AEAE000000000000000000E1 /* AIKit */,
 			);
 			productName = VivaDicta;
 			productReference = 181D04D72E3E55E400D357A6 /* VivaDicta.app */;
@@ -737,6 +748,7 @@
 				18F76A332FB85C0B00280269 /* AppGroup */,
 				F4E0FCBD69B741548F9F6B15 /* TranscriptionKitMocks */,
 				188E02582FC3BCC1007B8BC1 /* AudioRecordingMocks */,
+				AEAE000000000000000000C2 /* AICore */,
 			);
 			productName = VivaDictaTests;
 			productReference = 18351E572E634FF000944940 /* VivaDictaTests.xctest */;
@@ -2480,6 +2492,22 @@
 		18B89BC22FB875530007FA96 /* TranscriptionKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = TranscriptionKit;
+		};
+		AEAE000000000000000000C1 /* AICore */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AICore;
+		};
+		AEAE000000000000000000D1 /* AIProviders */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AIProviders;
+		};
+		AEAE000000000000000000E1 /* AIKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AIKit;
+		};
+		AEAE000000000000000000C2 /* AICore */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AICore;
 		};
 		18B8BEB02FB8BD7D0007FA96 /* DesignSystem */ = {
 			isa = XCSwiftPackageProductDependency;


### PR DESCRIPTION
## Phase 1: scaffold the AI module packages

Introduces three Swift package modules under `Modules/` and links their products into the targets that will consume them. This is the foundation for extracting the AI text-processing stack (today a ~3,500-line `AIService` plus per-provider clients) out of the monolithic app target, mirroring the shape of the existing transcription stack (`TranscriptionCore` / `CloudTranscription` / `TranscriptionKit`).

### Modules

| Module | Role | Depends on |
|---|---|---|
| `AICore` | Stable API + value-type kernel: the provider catalog, shared DTOs, the text-provider protocol, error types. Foundation only. | nothing |
| `AIProviders` | Concrete per-provider clients (to be populated). | `AICore` |
| `AIKit` | Orchestration + provider registry (to be populated). | `AICore` only |

Dependency direction points inward. `AIKit` depends on `AICore` (the API) and **never** on `AIProviders` (the implementation) - concrete providers are injected at the composition root, so the orchestrator is insulated from provider-implementation churn.

### What this PR does

- Wires the three `Package.swift` manifests to the repo conventions: `swift-tools 6.2`, iOS 18 / macOS 14 platforms, Swift 6 language mode.
- Links `AICore`, `AIProviders`, `AIKit` into the app target and `AICore` into the test target.

The modules are intentionally empty scaffolding in this PR. No application code moves yet, so there is **no behavior change**.

### Verification

- Each package builds and tests green in isolation (`swift build` / `swift test`).
- `build-for-testing` of the app + test bundle succeeds on the iOS 26.4 simulator.
- `project.pbxproj` passes `plutil -lint`.

### Next phases (separate PRs)

1. Move the `AIProvider` catalog enum into `AICore` (incl. the share/action/keyboard extension targets that compile it directly).
2. Extract the `AITextProvider` protocol + chat-message DTO into `AICore`.
3. Move the per-provider clients into `AIProviders`, one per PR.
4. Introduce the provider registry in `AIKit`.
5. Lift enhancement/chat orchestration out of `AIService` into `AIKit`.
