### PR TITLE
Move AIProvider catalog into AICore

### DIFF
--- a/ActionExtension/ActionViewController.swift
+++ b/ActionExtension/ActionViewController.swift
@@ -11,6 +11,7 @@ import AppGroup
 import UniformTypeIdentifiers
 import os
 import Presets
+import AICore
 
 // MARK: - Action Extension View Model
 

--- a/Modules/AICore/Sources/AICore/AIProvider.swift
+++ b/Modules/AICore/Sources/AICore/AIProvider.swift
@@ -7,8 +7,8 @@
 
 import Foundation
 
-enum AIProvider: String, CaseIterable, Identifiable, Codable {
-    var id: Self { self }
+public enum AIProvider: String, CaseIterable, Identifiable, Codable, Sendable {
+    public var id: Self { self }
 
     case apple
     case cerebras
@@ -37,7 +37,7 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
     case ollamaCloud
     case customOpenAI
 
-    var displayName: String {
+    public var displayName: String {
         switch self {
         case .apple:
             "Apple"
@@ -95,7 +95,7 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
     }
 
     /// Returns the icon name for this provider (SF Symbol for Apple, asset name for others)
-    var iconName: String? {
+    public var iconName: String? {
         switch self {
         case .apple:
             nil // Use SF Symbol "apple.logo" directly in view
@@ -153,12 +153,12 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
     }
 
     /// Returns true if this provider uses an SF Symbol instead of an asset
-    var usesSFSymbol: Bool {
+    public var usesSFSymbol: Bool {
         self == .apple || self == .customOpenAI
     }
 
     /// Returns true when the selected model can stream text responses incrementally.
-    func supportsResponseStreaming(model: String) -> Bool {
+    public func supportsResponseStreaming(model: String) -> Bool {
         switch self {
         case .apple,
              .anthropic,
@@ -185,7 +185,7 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
     }
 
     /// URL to obtain an API key for this provider.
-    var apiKeyURL: URL? {
+    public var apiKeyURL: URL? {
         switch self {
         case .groq: URL(string: "https://console.groq.com/keys")
         case .openAI: URL(string: "https://platform.openai.com/api-keys")
@@ -215,13 +215,13 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
 
     /// Returns true if this provider requires an API key
     /// Note: customOpenAI doesn't require API key through the standard flow - it's handled separately
-    var requiresAPIKey: Bool {
+    public var requiresAPIKey: Bool {
         self != .apple && self != .ollama && self != .customOpenAI && self != .copilot
     }
 
     /// Cloud-based AI providers (require API key, network connection)
     /// Note: Ollama and customOpenAI are included here for UI purposes but don't require API key through standard flow
-    static let cloudProviders: [AIProvider] = [
+    public static let cloudProviders: [AIProvider] = [
         .anthropic,
         .openAI,
         .gemini,
@@ -246,15 +246,15 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
     /// (`json_schema`) outputs, which Ollama Cloud does not support
     /// (https://docs.ollama.com/capabilities/structured-outputs). Local Ollama
     /// does support them, so it stays eligible.
-    static let reminderExtractorCloudProviders: [AIProvider] = cloudProviders.filter { $0 != .ollamaCloud }
+    public static let reminderExtractorCloudProviders: [AIProvider] = cloudProviders.filter { $0 != .ollamaCloud }
 
     /// Local AI providers that run on-device or local network (no API key needed)
-    static let localProviders: [AIProvider] = [
+    public static let localProviders: [AIProvider] = [
         .apple,
         .ollama]
 
     /// All general-purpose AI providers including on-device and local
-    static let generalProviders: [AIProvider] = [
+    public static let generalProviders: [AIProvider] = [
         .apple,
         .ollama,
         .ollamaCloud,
@@ -274,7 +274,7 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
         .vercelAIGateway,
         .huggingFace]
     
-    var baseURL: String {
+    public var baseURL: String {
         switch self {
         case .apple:
             return "" // On-device, no URL needed
@@ -332,9 +332,9 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
     }
 
     /// Default Ollama server URL
-    static let ollamaDefaultServerURL = "http://host:11434"
+    public static let ollamaDefaultServerURL = "http://host:11434"
 
-    var defaultModel: String {
+    public var defaultModel: String {
         switch self {
         case .apple:
             return "foundation-model"
@@ -399,7 +399,7 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
 
     /// Keychain account name for this provider's API key.
     /// Must match the macOS app's `APIKeyManager` key identifiers for iCloud Keychain sync.
-    var keychainKey: String {
+    public var keychainKey: String {
         switch self {
         case .cerebras: "cerebrasAPIKey"
         case .groq: "groqAPIKey"
@@ -428,7 +428,7 @@ enum AIProvider: String, CaseIterable, Identifiable, Codable {
         }
     }
 
-    var availableModels: [String] {
+    public var availableModels: [String] {
         switch self {
         case .apple:
             return ["foundation-model"]

--- a/Modules/AICore/Tests/AICoreTests/AICoreTests.swift
+++ b/Modules/AICore/Tests/AICoreTests/AICoreTests.swift
@@ -1,8 +1,125 @@
 import Testing
+import Foundation
 @testable import AICore
 
-@Test func example() async throws {
-    // Write your test here and use APIs like `#expect(...)` to check expected conditions.
-    // Swift Testing Documentation
-    // https://developer.apple.com/documentation/testing
+/// Characterization tests that lock the `AIProvider` catalog contract as it
+/// moves into `AICore`. They assert the current behavior verbatim so the move
+/// (and every later edit) is provably behavior-preserving.
+struct AIProviderTests {
+
+    // MARK: - Catalog integrity
+
+    @Test func allCasesCountIsStable() {
+        #expect(AIProvider.allCases.count == 26)
+    }
+
+    @Test func rawValuesRoundTripForCodableAndDefaultsCompatibility() {
+        // Raw values are persisted (UserDefaults / SwiftData / Codable), so they
+        // must survive the module move unchanged.
+        for provider in AIProvider.allCases {
+            #expect(AIProvider(rawValue: provider.rawValue) == provider)
+        }
+        #expect(AIProvider.anthropic.rawValue == "anthropic")
+        #expect(AIProvider.openAI.rawValue == "openAI")
+        #expect(AIProvider.customOpenAI.rawValue == "customOpenAI")
+        #expect(AIProvider.ollamaCloud.rawValue == "ollamaCloud")
+    }
+
+    // MARK: - Keychain keys
+
+    /// These strings must match the macOS app's `APIKeyManager` identifiers for
+    /// iCloud Keychain sync. A new provider added without a mapping fails the
+    /// completeness check below.
+    @Test func keychainKeysMatchCrossPlatformContract() {
+        let expected: [AIProvider: String] = [
+            .apple: "",
+            .cerebras: "cerebrasAPIKey",
+            .groq: "groqAPIKey",
+            .gemini: "geminiAPIKey",
+            .anthropic: "anthropicAPIKey",
+            .openAI: "openAIAPIKey",
+            .openRouter: "openRouterAPIKey",
+            .grok: "grokAPIKey",
+            .elevenLabs: "elevenLabsAPIKey",
+            .deepgram: "deepgramAPIKey",
+            .mistral: "mistralAPIKey",
+            .soniox: "sonioxAPIKey",
+            .gladia: "gladiaAPIKey",
+            .speechmatics: "speechmaticsAPIKey",
+            .cohere: "cohereAPIKey",
+            .cartesia: "cartesiaAPIKey",
+            .assemblyAI: "assemblyaiAPIKey",
+            .zai: "zaiAPIKey",
+            .kimi: "kimiAPIKey",
+            .minimax: "minimaxAPIKey",
+            .vercelAIGateway: "vercelAIGatewayAPIKey",
+            .huggingFace: "huggingFaceAPIKey",
+            .copilot: "",
+            .ollama: "",
+            .ollamaCloud: "ollamaCloudAPIKey",
+            .customOpenAI: "customOpenAIAPIKey",
+        ]
+        #expect(Set(expected.keys) == Set(AIProvider.allCases), "every provider must have a keychain-key expectation")
+        for (provider, key) in expected {
+            #expect(provider.keychainKey == key, "keychainKey for \(provider)")
+        }
+    }
+
+    // MARK: - Endpoints and default models
+
+    @Test func baseURLsAreStable() {
+        #expect(AIProvider.openAI.baseURL == "https://api.openai.com/v1/chat/completions")
+        #expect(AIProvider.anthropic.baseURL == "https://api.anthropic.com/v1/messages")
+        #expect(AIProvider.gemini.baseURL == "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions")
+        // On-device / locally-configured providers carry no compiled base URL.
+        #expect(AIProvider.apple.baseURL == "")
+        #expect(AIProvider.ollama.baseURL == "")
+        #expect(AIProvider.customOpenAI.baseURL == "")
+    }
+
+    @Test func defaultModelsAreStable() {
+        #expect(AIProvider.apple.defaultModel == "foundation-model")
+        #expect(AIProvider.anthropic.defaultModel == "claude-sonnet-4-6")
+        #expect(AIProvider.openAI.defaultModel == "gpt-5.5")
+    }
+
+    // MARK: - Capability flags
+
+    @Test func requiresAPIKeyMatchesProviderKind() {
+        #expect(AIProvider.openAI.requiresAPIKey)
+        #expect(AIProvider.anthropic.requiresAPIKey)
+        #expect(!AIProvider.apple.requiresAPIKey)
+        #expect(!AIProvider.ollama.requiresAPIKey)
+        #expect(!AIProvider.customOpenAI.requiresAPIKey)
+        #expect(!AIProvider.copilot.requiresAPIKey)
+    }
+
+    @Test func responseStreamingSupport() {
+        #expect(AIProvider.apple.supportsResponseStreaming(model: "foundation-model"))
+        #expect(AIProvider.openAI.supportsResponseStreaming(model: "gpt-5.5"))
+        #expect(AIProvider.anthropic.supportsResponseStreaming(model: "claude-sonnet-4-6"))
+        // Speech-only providers do not stream chat responses.
+        #expect(!AIProvider.deepgram.supportsResponseStreaming(model: "whisper-1"))
+    }
+
+    // MARK: - Curated provider groups
+
+    @Test func localProvidersAreAppleAndOllama() {
+        #expect(AIProvider.localProviders == [.apple, .ollama])
+    }
+
+    @Test func cloudProvidersContainAnthropicButNotApple() {
+        #expect(AIProvider.cloudProviders.contains(.anthropic))
+        #expect(!AIProvider.cloudProviders.contains(.apple))
+    }
+
+    @Test func reminderExtractorExcludesOllamaCloudButKeepsLocalOllama() {
+        #expect(!AIProvider.reminderExtractorCloudProviders.contains(.ollamaCloud))
+        #expect(AIProvider.reminderExtractorCloudProviders.contains(.ollama))
+    }
+
+    @Test func generalProvidersContainAppleAndOpenAI() {
+        #expect(AIProvider.generalProviders.contains(.apple))
+        #expect(AIProvider.generalProviders.contains(.openAI))
+    }
 }

--- a/ShareExtension/ShareViewController.swift
+++ b/ShareExtension/ShareViewController.swift
@@ -11,6 +11,7 @@ import AppGroup
 import UniformTypeIdentifiers
 import os
 import Presets
+import AICore
 
 // MARK: - Share Extension View Model
 

--- a/VivaDicta.xcodeproj/project.pbxproj
+++ b/VivaDicta.xcodeproj/project.pbxproj
@@ -33,6 +33,9 @@
 		18B89BC32FB875530007FA96 /* TranscriptionKit in Frameworks */ = {isa = PBXBuildFile; productRef = 18B89BC22FB875530007FA96 /* TranscriptionKit */; };
 		18B8BEB12FB8BD7D0007FA96 /* DesignSystem in Frameworks */ = {isa = PBXBuildFile; productRef = 18B8BEB02FB8BD7D0007FA96 /* DesignSystem */; };
 		BFBF000000000000000000C1 /* AICore in Frameworks */ = {isa = PBXBuildFile; productRef = AEAE000000000000000000C1 /* AICore */; };
+		BFBF000000000000000000C3 /* AICore in Frameworks */ = {isa = PBXBuildFile; productRef = AEAE000000000000000000C3 /* AICore */; };
+		BFBF000000000000000000C4 /* AICore in Frameworks */ = {isa = PBXBuildFile; productRef = AEAE000000000000000000C4 /* AICore */; };
+		BFBF000000000000000000C5 /* AICore in Frameworks */ = {isa = PBXBuildFile; productRef = AEAE000000000000000000C5 /* AICore */; };
 		BFBF000000000000000000D1 /* AIProviders in Frameworks */ = {isa = PBXBuildFile; productRef = AEAE000000000000000000D1 /* AIProviders */; };
 		BFBF000000000000000000E1 /* AIKit in Frameworks */ = {isa = PBXBuildFile; productRef = AEAE000000000000000000E1 /* AIKit */; };
 		BFBF000000000000000000C2 /* AICore in Frameworks */ = {isa = PBXBuildFile; productRef = AEAE000000000000000000C2 /* AICore */; };
@@ -266,7 +269,6 @@
 				Models/TranscriptionModelProvider.swift,
 				Models/WhisperKitModel.swift,
 				PrivacyInfo.xcprivacy,
-				Services/AIEnhance/AIProvider.swift,
 				Services/AIEnhance/UserPrompt.swift,
 				Services/AIEnhance/VivaMode.swift,
 				Utilities/LoggerExtension.swift,
@@ -292,7 +294,6 @@
 				Models/TranscriptionModelProvider.swift,
 				Models/WhisperKitModel.swift,
 				PrivacyInfo.xcprivacy,
-				Services/AIEnhance/AIProvider.swift,
 				Services/AIEnhance/UserPrompt.swift,
 				Services/AIEnhance/VivaMode.swift,
 				Utilities/LoggerExtension.swift,
@@ -374,7 +375,6 @@
 				Models/WhisperKitModel.swift,
 				PrivacyInfo.xcprivacy,
 				Resources/Haptics/TranscriptionComplete.ahap,
-				Services/AIEnhance/AIProvider.swift,
 				Services/AIEnhance/UserPrompt.swift,
 				Services/AIEnhance/VivaMode.swift,
 				Shared/MicButton.swift,
@@ -532,6 +532,7 @@
 			files = (
 				18F76A3A2FB85C2300280269 /* AppGroup in Frameworks */,
 				186C058B2FB779C200102432 /* Presets in Frameworks */,
+				BFBF000000000000000000C3 /* AICore in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -542,6 +543,7 @@
 				186C058D2FB779CB00102432 /* Presets in Frameworks */,
 				18F76A3C2FB85C2A00280269 /* AppGroup in Frameworks */,
 				189C7AB02F0D84E2004BAFBF /* UniformTypeIdentifiers.framework in Frameworks */,
+				BFBF000000000000000000C4 /* AICore in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -576,6 +578,7 @@
 				18E1B4AF2E8C875A00BE8A11 /* KeyboardKit in Frameworks */,
 				18F76D862FB8617C00280269 /* AppGroup in Frameworks */,
 				18B8CF2C2FB8C4690007FA96 /* DesignSystem in Frameworks */,
+				BFBF000000000000000000C5 /* AICore in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -773,6 +776,7 @@
 			packageProductDependencies = (
 				186C058A2FB779C200102432 /* Presets */,
 				18F76A392FB85C2300280269 /* AppGroup */,
+				AEAE000000000000000000C3 /* AICore */,
 			);
 			productName = ShareExtension;
 			productReference = 189C7A8B2F0C6822004BAFBF /* ShareExtension.appex */;
@@ -798,6 +802,7 @@
 			packageProductDependencies = (
 				186C058C2FB779CB00102432 /* Presets */,
 				18F76A3B2FB85C2A00280269 /* AppGroup */,
+				AEAE000000000000000000C4 /* AICore */,
 			);
 			productName = ActionExtension;
 			productReference = 189C7AAE2F0D84E2004BAFBF /* ActionExtension.appex */;
@@ -893,6 +898,7 @@
 				186C058E2FB779D200102432 /* Presets */,
 				18F76D852FB8617C00280269 /* AppGroup */,
 				18B8CF2B2FB8C4690007FA96 /* DesignSystem */,
+				AEAE000000000000000000C5 /* AICore */,
 			);
 			productName = VivaDictaKeyboard;
 			productReference = 18E1B49E2E8C6FF400BE8A11 /* VivaDictaKeyboard.appex */;
@@ -2504,6 +2510,18 @@
 		AEAE000000000000000000E1 /* AIKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = AIKit;
+		};
+		AEAE000000000000000000C3 /* AICore */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AICore;
+		};
+		AEAE000000000000000000C4 /* AICore */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AICore;
+		};
+		AEAE000000000000000000C5 /* AICore */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AICore;
 		};
 		AEAE000000000000000000C2 /* AICore */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/VivaDicta/Models/CloudModel+APIKey.swift
+++ b/VivaDicta/Models/CloudModel+APIKey.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import AICore
 
 // This extension lives in a main-target-only file because it transitively
 // depends on `AIProvider.apiKey`, which uses the Keychain package that

--- a/VivaDicta/Models/TranscriptionModelProvider+Discovery.swift
+++ b/VivaDicta/Models/TranscriptionModelProvider+Discovery.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import AICore
 
 // Main-target-only extension because it transitively depends on
 // `AIProvider.apiKey`, which uses the Keychain package that extensions

--- a/VivaDicta/Models/TranscriptionModelProvider.swift
+++ b/VivaDicta/Models/TranscriptionModelProvider.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import AICore
 
 enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identifiable {
     case parakeet

--- a/VivaDicta/Services/AIEnhance/AIChatService.swift
+++ b/VivaDicta/Services/AIEnhance/AIChatService.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import AICore
 
 /// Narrow chat-request surface of ``AIService`` consumed by chat view models.
 ///

--- a/VivaDicta/Services/AIEnhance/AIService+Chat.swift
+++ b/VivaDicta/Services/AIEnhance/AIService+Chat.swift
@@ -10,6 +10,7 @@ import FoundationModels
 import Networking
 import os
 import OAuth
+import AICore
 
 /// Multi-turn chat support for AIService.
 ///

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -14,6 +14,7 @@ import TipKit
 import os
 import OAuth
 import CloudTranscription
+import AICore
 
 /// Service responsible for AI-powered text enhancement of transcriptions.
 ///

--- a/VivaDicta/Services/AIEnhance/ChatContextManager.swift
+++ b/VivaDicta/Services/AIEnhance/ChatContextManager.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import FoundationModels
+import AICore
 
 /// Manages context window for "Chat with Note" conversations.
 ///

--- a/VivaDicta/Services/AIEnhance/CrossNoteSearchPlanner.swift
+++ b/VivaDicta/Services/AIEnhance/CrossNoteSearchPlanner.swift
@@ -8,6 +8,7 @@
 import Foundation
 import FoundationModels
 import os
+import AICore
 
 struct CrossNoteSearchPlan: Codable, Sendable {
     let shouldSearch: Bool

--- a/VivaDicta/Services/AIEnhance/MultiNoteContextManager.swift
+++ b/VivaDicta/Services/AIEnhance/MultiNoteContextManager.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import FoundationModels
+import AICore
 
 /// Manages context window for multi-note chat conversations.
 ///

--- a/VivaDicta/Services/AIEnhance/Providers/AnthropicService.swift
+++ b/VivaDicta/Services/AIEnhance/Providers/AnthropicService.swift
@@ -3,6 +3,7 @@
 import Foundation
 import Networking
 import os
+import AICore
 
 /// Pure HTTP wrapper for Anthropic's Messages API. Stateless apart from
 /// its dependencies.

--- a/VivaDicta/Services/AIEnhance/SmartSearchQueryPlanner.swift
+++ b/VivaDicta/Services/AIEnhance/SmartSearchQueryPlanner.swift
@@ -8,6 +8,7 @@
 import Foundation
 import FoundationModels
 import os
+import AICore
 
 struct SmartSearchQueryPlan: Codable, Sendable {
     let shouldSearch: Bool

--- a/VivaDicta/Services/AIEnhance/VivaMode.swift
+++ b/VivaDicta/Services/AIEnhance/VivaMode.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import AppGroup
+import AICore
 
 /// A configuration preset combining transcription and AI processing settings.
 ///

--- a/VivaDicta/Services/AIEnhance/WebSearchPlanner.swift
+++ b/VivaDicta/Services/AIEnhance/WebSearchPlanner.swift
@@ -8,6 +8,7 @@
 import Foundation
 import FoundationModels
 import os
+import AICore
 
 struct WebSearchPlan: Codable, Sendable {
     let shouldSearch: Bool

--- a/VivaDicta/Services/AIProvider+APIKey.swift
+++ b/VivaDicta/Services/AIProvider+APIKey.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Keychain
+import AICore
 
 // File-private keychain instance so the extension can read API keys
 // without forcing every consumer of `AIProvider.apiKey` to inject one.

--- a/VivaDicta/Services/OAuth/GeminiAPIClient.swift
+++ b/VivaDicta/Services/OAuth/GeminiAPIClient.swift
@@ -4,6 +4,7 @@ import Foundation
 import Networking
 import os
 import OAuth
+import AICore
 
 /// Client for Gemini API using OAuth tokens.
 /// Uses the Cloud Code Assist endpoint (same as Gemini CLI / VS Code extension),

--- a/VivaDicta/Services/Reminders/CloudReminderExtractionProvider.swift
+++ b/VivaDicta/Services/Reminders/CloudReminderExtractionProvider.swift
@@ -9,6 +9,7 @@ import Foundation
 import Networking
 import os
 import OAuth
+import AICore
 
 private struct CloudReminderDraftPayload: Codable {
     var title: String

--- a/VivaDicta/Services/Reminders/ReminderExtractionService.swift
+++ b/VivaDicta/Services/Reminders/ReminderExtractionService.swift
@@ -9,6 +9,7 @@ import Foundation
 import NaturalLanguage
 import SwiftData
 import os
+import AICore
 
 enum ReminderExtractionError: LocalizedError {
     case unsupportedOS

--- a/VivaDicta/Services/Transcription/TranscriptionManager.swift
+++ b/VivaDicta/Services/Transcription/TranscriptionManager.swift
@@ -13,6 +13,7 @@ import SwiftUI
 import TranscriptionCore
 import TranscriptionKit
 import os
+import AICore
 
 /// Central manager coordinating all transcription services in VivaDicta.
 ///

--- a/VivaDicta/Services/WatchAudioProcessor.swift
+++ b/VivaDicta/Services/WatchAudioProcessor.swift
@@ -11,6 +11,7 @@ import AVFoundation
 import CoreMedia
 import os
 import TipKit
+import AICore
 
 /// Processes audio files received from Apple Watch in the background.
 ///

--- a/VivaDicta/Views/Chat/ChatView.swift
+++ b/VivaDicta/Views/Chat/ChatView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import DesignSystem
 import SwiftData
+import AICore
 
 private struct ChatSourceCitationDisplay: Identifiable {
     let transcription: Transcription

--- a/VivaDicta/Views/Chat/ChatViewModel.swift
+++ b/VivaDicta/Views/Chat/ChatViewModel.swift
@@ -9,6 +9,7 @@ import Foundation
 import FoundationModels
 import SwiftData
 import os
+import AICore
 
 /// View model for the "Chat with Note" feature.
 ///

--- a/VivaDicta/Views/ModelsScreen/CloudModelCard.swift
+++ b/VivaDicta/Views/ModelsScreen/CloudModelCard.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import DesignSystem
+import AICore
 
 struct CloudModelCard: View {
     let model: CloudModel

--- a/VivaDicta/Views/ModelsScreen/CloudModelConfigurationView.swift
+++ b/VivaDicta/Views/ModelsScreen/CloudModelConfigurationView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import AICore
 
 struct CloudModelConfigurationView: View {
     @Environment(\.dismiss) var dismiss

--- a/VivaDicta/Views/MultiNoteChat/MultiNoteChatView.swift
+++ b/VivaDicta/Views/MultiNoteChat/MultiNoteChatView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import DesignSystem
 import SwiftData
+import AICore
 
 private struct MultiNoteSourceCitationDisplay: Identifiable {
     let transcription: Transcription

--- a/VivaDicta/Views/MultiNoteChat/MultiNoteChatViewModel.swift
+++ b/VivaDicta/Views/MultiNoteChat/MultiNoteChatViewModel.swift
@@ -9,6 +9,7 @@ import Foundation
 import FoundationModels
 import SwiftData
 import os
+import AICore
 
 /// View model for multi-note chat conversations.
 ///

--- a/VivaDicta/Views/MultiNoteChat/MultiNoteChatsListViewModel.swift
+++ b/VivaDicta/Views/MultiNoteChat/MultiNoteChatsListViewModel.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import SwiftData
+import AICore
 
 /// View model for the chats list screen (multi-note, single-note, and smart search).
 @Observable

--- a/VivaDicta/Views/RecordViewModel.swift
+++ b/VivaDicta/Views/RecordViewModel.swift
@@ -15,6 +15,7 @@ import SwiftData
 import os
 import TipKit
 import Presets
+import AICore
 
 enum RecordingDestination: Equatable {
     case newNote

--- a/VivaDicta/Views/SettingsScreen/AIProvidersView.swift
+++ b/VivaDicta/Views/SettingsScreen/AIProvidersView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import AICore
 
 struct AIProviders: View {
     @Environment(AppState.self) private var appState

--- a/VivaDicta/Views/SettingsScreen/AddAPIKeyView.swift
+++ b/VivaDicta/Views/SettingsScreen/AddAPIKeyView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import AICore
 
 struct AddAPIKeyView: View {
     @Environment(\.dismiss) var dismiss

--- a/VivaDicta/Views/SettingsScreen/AnthropicConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/AnthropicConfigurationView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import AICore
 
 struct AnthropicConfigurationView: View {
     @Environment(\.dismiss) private var dismiss

--- a/VivaDicta/Views/SettingsScreen/CopilotConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/CopilotConfigurationView.swift
@@ -2,6 +2,7 @@
 
 import SwiftUI
 import OAuth
+import AICore
 
 struct CopilotConfigurationView: View {
     @Environment(\.dismiss) private var dismiss

--- a/VivaDicta/Views/SettingsScreen/CustomOpenAIConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/CustomOpenAIConfigurationView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import os
+import AICore
 
 private let logger = Logger(subsystem: "com.antonnovoselov.VivaDicta", category: "CustomOpenAIConfig")
 

--- a/VivaDicta/Views/SettingsScreen/GeminiConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/GeminiConfigurationView.swift
@@ -2,6 +2,7 @@
 
 import SwiftUI
 import OAuth
+import AICore
 
 struct GeminiConfigurationView: View {
     @Environment(\.dismiss) private var dismiss

--- a/VivaDicta/Views/SettingsScreen/ModeEditView.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 import AppGroup
 import TipKit
 import Presets
+import AICore
 
 struct ModeEditView: View {
     @Environment(\.dismiss) private var dismiss

--- a/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import os
 import Presets
+import AICore
 
 @Observable
 class ModeEditViewModel {

--- a/VivaDicta/Views/SettingsScreen/OpenAIConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/OpenAIConfigurationView.swift
@@ -2,6 +2,7 @@
 
 import SwiftUI
 import OAuth
+import AICore
 
 struct OpenAIConfigurationView: View {
     @Environment(\.dismiss) private var dismiss

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -11,6 +11,7 @@ import AppIntents
 import TipKit
 import MessageUI
 import Presets
+import AICore
 
 struct SettingsView: View {
     @Environment(AppState.self) var appState

--- a/VivaDicta/Views/SmartSearch/SmartSearchChatView.swift
+++ b/VivaDicta/Views/SmartSearch/SmartSearchChatView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import DesignSystem
 import SwiftData
+import AICore
 
 private struct SmartSearchCitationDisplay: Identifiable {
     let transcription: Transcription

--- a/VivaDicta/Views/SmartSearch/SmartSearchChatViewModel.swift
+++ b/VivaDicta/Views/SmartSearch/SmartSearchChatViewModel.swift
@@ -10,6 +10,7 @@ import FoundationModels
 import SwiftData
 import TipKit
 import os
+import AICore
 
 /// View model for RAG-powered Smart Search conversations.
 ///

--- a/VivaDicta/Views/SmartSearch/SmartSearchContextManager.swift
+++ b/VivaDicta/Views/SmartSearch/SmartSearchContextManager.swift
@@ -8,6 +8,7 @@
 import Foundation
 import FoundationModels
 import os
+import AICore
 
 /// Manages context assembly for RAG-powered Smart Search conversations.
 ///

--- a/VivaDicta/Views/TranscriptionDetailView.swift
+++ b/VivaDicta/Views/TranscriptionDetailView.swift
@@ -13,6 +13,7 @@ import CoreSpotlight
 import TipKit
 import os
 import Presets
+import AICore
 
 private let logger = Logger(category: .transcriptionDetailView)
 

--- a/VivaDictaKeyboard/KeyboardDictationState.swift
+++ b/VivaDictaKeyboard/KeyboardDictationState.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import AppGroup
+import AICore
 
 @MainActor
 @Observable

--- a/VivaDictaKeyboard/KeyboardViewController.swift
+++ b/VivaDictaKeyboard/KeyboardViewController.swift
@@ -11,6 +11,7 @@ import KeyboardKit
 import SwiftUI
 import AppGroup
 import os
+import AICore
 
 class KeyboardViewController: KeyboardInputViewController {
 

--- a/VivaDictaKeyboard/Models/VivaModeManager.swift
+++ b/VivaDictaKeyboard/Models/VivaModeManager.swift
@@ -8,6 +8,7 @@
 import Foundation
 import AppGroup
 import os
+import AICore
 
 @Observable
 final class VivaModeManager {

--- a/VivaDictaKeyboard/Services/KeyboardTextProcessor.swift
+++ b/VivaDictaKeyboard/Services/KeyboardTextProcessor.swift
@@ -8,6 +8,7 @@
 import UIKit
 import AppGroup
 import os
+import AICore
 
 /// Orchestrates the text processing pipeline from the keyboard extension:
 /// 1. Read text from host text field via `UITextDocumentProxy`

--- a/VivaDictaKeyboard/Views/RewriteModesView.swift
+++ b/VivaDictaKeyboard/Views/RewriteModesView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import DesignSystem
 import Presets
+import AICore
 
 /// Displays a VivaMode picker and categorized preset list for AI text processing in the keyboard.
 ///

--- a/VivaDictaTests/AIServiceConfigurationTests.swift
+++ b/VivaDictaTests/AIServiceConfigurationTests.swift
@@ -9,6 +9,7 @@ import Foundation
 import Testing
 import Presets
 @testable import VivaDicta
+import AICore
 
 struct AIServiceConfigurationTests {
 

--- a/VivaDictaTests/AIServiceModeTests.swift
+++ b/VivaDictaTests/AIServiceModeTests.swift
@@ -8,6 +8,7 @@
 import Foundation
 import Testing
 @testable import VivaDicta
+import AICore
 
 struct AIServiceModeTests {
 

--- a/VivaDictaTests/AnthropicServiceTests.swift
+++ b/VivaDictaTests/AnthropicServiceTests.swift
@@ -6,6 +6,7 @@ import NetworkingMocks
 import os
 import Testing
 @testable import VivaDicta
+import AICore
 
 /// Tests cover `AnthropicService` in isolation: the request shape
 /// (`x-api-key`, `anthropic-version`, system top-level, max_tokens

--- a/VivaDictaTests/ChatViewModelTests.swift
+++ b/VivaDictaTests/ChatViewModelTests.swift
@@ -9,6 +9,7 @@ import Foundation
 import SwiftData
 import Testing
 @testable import VivaDicta
+import AICore
 
 /// Proof-of-pattern: tests the real ``ChatViewModel`` against a
 /// hand-rolled ``MockAIChatService`` injected through ``AIChatService``.

--- a/VivaDictaTests/Mocks/MockAIChatService.swift
+++ b/VivaDictaTests/Mocks/MockAIChatService.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 @testable import VivaDicta
+import AICore
 
 /// Hand-rolled mock for ``AIChatService`` following the Bev pattern:
 /// per-method `stub...` for return values, `...CallCount` for invocation

--- a/VivaDictaTests/ModeEditViewModelTests.swift
+++ b/VivaDictaTests/ModeEditViewModelTests.swift
@@ -9,6 +9,7 @@ import Foundation
 import Testing
 import Presets
 @testable import VivaDicta
+import AICore
 
 struct ModeEditViewModelTests {
 

--- a/VivaDictaTests/MultiNoteChatViewModelTests.swift
+++ b/VivaDictaTests/MultiNoteChatViewModelTests.swift
@@ -9,6 +9,7 @@ import Foundation
 import SwiftData
 import Testing
 @testable import VivaDicta
+import AICore
 
 /// Proof-of-pattern: tests the real ``MultiNoteChatViewModel`` against a
 /// hand-rolled ``MockAIChatService`` injected through ``AIChatService``.

--- a/VivaDictaTests/ReminderExtractionServiceTests.swift
+++ b/VivaDictaTests/ReminderExtractionServiceTests.swift
@@ -8,6 +8,7 @@
 import Foundation
 import Testing
 @testable import VivaDicta
+import AICore
 
 /// `ReminderExtractionService.extractAndPersist` makes real cloud/Apple FM
 /// calls and is out of scope for unit tests. `canExtractReminders` is the

--- a/VivaDictaTests/SmartSearchChatViewModelTests.swift
+++ b/VivaDictaTests/SmartSearchChatViewModelTests.swift
@@ -9,6 +9,7 @@ import Foundation
 import SwiftData
 import Testing
 @testable import VivaDicta
+import AICore
 
 /// Proof-of-pattern: tests the real ``SmartSearchChatViewModel`` against a
 /// hand-rolled ``MockAIChatService`` injected through the ``AIChatService``

--- a/VivaDictaTests/VivaModeModelNormalizationTests.swift
+++ b/VivaDictaTests/VivaModeModelNormalizationTests.swift
@@ -8,6 +8,7 @@
 import Foundation
 import Testing
 @testable import VivaDicta
+import AICore
 
 struct VivaModeModelNormalizationTests {
 


### PR DESCRIPTION
## Phase 2: move the AIProvider catalog into AICore

Relocates the `AIProvider` provider-catalog enum (provider ids + display names, icons, base URLs, default models, keychain keys, available models, and capability flags) out of the app target and into the `AICore` module, then repoints every consumer. This is the first real type extracted into the AI module stack scaffolded in #323.

### Changes

- **`AIProvider` moves into `AICore`** as a `public`, `Sendable` enum. (Going `public` disables implicit `Sendable` inference, which the `static let` provider arrays rely on under Swift 6 - hence the explicit conformance.)
- **Characterization tests** added in `AICoreTests` locking the contract verbatim: the full 26-provider `keychainKey` map (with a completeness check), base URLs, default models, capability flags, streaming support, the curated provider groups, and raw-value round-trips.
- **58 app / test / extension files** gain `import AICore` - both files that name the type and files that only reach its members (e.g. `selectedMode.aiProvider?.displayName`).
- **`AICore` is linked into `ShareExtension`, `ActionExtension`, and `VivaDictaKeyboard`.** These extensions compile a shared subset of the app's source directly, so they reference the enum and its members; the now-stale `Services/AIEnhance/AIProvider.swift` `membershipExceptions` are removed.

### Behavior

Pure relocation - **no behavior change.** Raw values are unchanged, so `Codable` / `UserDefaults` / SwiftData persistence stays compatible. Every `keychainKey` string is byte-identical, preserving iCloud Keychain sync with the macOS app (locked by the characterization test).

### Verification

- `AICoreTests` green (`swift test`).
- App + all three extensions + the test bundle build green (`build-for-testing`, iOS 26.4 simulator).

### Next phase

Phase 3: define the `AITextProvider` service protocol + a chat-message DTO in `AICore`, and conform the existing provider clients in place.
