### PR TITLE
Move EnhancementError into AICore

### DIFF
--- a/Modules/AICore/Sources/AICore/EnhancementError.swift
+++ b/Modules/AICore/Sources/AICore/EnhancementError.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// Errors that can occur during AI text enhancement.
+public enum EnhancementError: LocalizedError, Sendable {
+    case notConfigured
+    case invalidResponse
+    case enhancementFailed
+    case networkError
+    case serverError
+    case rateLimitExceeded
+    case customError(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .notConfigured:
+            return "AI provider not configured"
+        case .invalidResponse:
+            return "Invalid response from AI"
+        case .enhancementFailed:
+            return "AI processing failed"
+        case .networkError:
+            return "Network connection failed"
+        case .serverError:
+            return "Server error occurred"
+        case .rateLimitExceeded:
+            return "Rate limit exceeded"
+        case .customError(let message):
+            return message
+        }
+    }
+
+    public var failureReason: String {
+        switch self {
+        case .notConfigured:
+            return "No AI provider API key is configured. Go to Settings and add your API key for the selected AI provider."
+        case .invalidResponse:
+            return "The AI provider returned an unexpected response format. Please try again or contact support if the issue persists."
+        case .enhancementFailed:
+            return "The AI service could not process the transcription. The text may be too short or contain unsupported content."
+        case .networkError:
+            return "Unable to connect to the AI service. Please check your internet connection and try again."
+        case .serverError:
+            return "The AI provider's server is temporarily unavailable. Please wait a few minutes and try again."
+        case .rateLimitExceeded:
+            return "You've exceeded the rate limit for the AI service. Please wait a moment before trying again, or upgrade your API plan."
+        case .customError(let message):
+            return "An error occurred: \(message)"
+        }
+    }
+}

--- a/Modules/AICore/Tests/AICoreTests/EnhancementErrorTests.swift
+++ b/Modules/AICore/Tests/AICoreTests/EnhancementErrorTests.swift
@@ -1,0 +1,28 @@
+import Testing
+import Foundation
+@testable import AICore
+
+/// Characterization tests for the AI enhancement error type as it moves into
+/// `AICore`. They lock the behavior (custom-message passthrough, structural
+/// completeness) without over-asserting user-facing copy that may legitimately
+/// change.
+struct EnhancementErrorTests {
+
+    private static let allCases: [EnhancementError] = [
+        .notConfigured, .invalidResponse, .enhancementFailed,
+        .networkError, .serverError, .rateLimitExceeded, .customError("x"),
+    ]
+
+    @Test func customErrorPassesItsMessageThroughBothDescriptions() {
+        let sut = EnhancementError.customError("rate limited by upstream")
+        #expect(sut.errorDescription == "rate limited by upstream")
+        #expect(sut.failureReason == "An error occurred: rate limited by upstream")
+    }
+
+    @Test func everyCaseProducesNonEmptyDescriptions() {
+        for sut in Self.allCases {
+            #expect(sut.errorDescription?.isEmpty == false, "errorDescription for \(sut)")
+            #expect(!sut.failureReason.isEmpty, "failureReason for \(sut)")
+        }
+    }
+}

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -2392,55 +2392,6 @@ class AIService {
     }
 }
 
-/// Errors that can occur during AI text enhancement.
-enum EnhancementError: LocalizedError {
-    case notConfigured
-    case invalidResponse
-    case enhancementFailed
-    case networkError
-    case serverError
-    case rateLimitExceeded
-    case customError(String)
-
-    var errorDescription: String? {
-        switch self {
-        case .notConfigured:
-            return "AI provider not configured"
-        case .invalidResponse:
-            return "Invalid response from AI"
-        case .enhancementFailed:
-            return "AI processing failed"
-        case .networkError:
-            return "Network connection failed"
-        case .serverError:
-            return "Server error occurred"
-        case .rateLimitExceeded:
-            return "Rate limit exceeded"
-        case .customError(let message):
-            return message
-        }
-    }
-
-    var failureReason: String {
-        switch self {
-        case .notConfigured:
-            return "No AI provider API key is configured. Go to Settings and add your API key for the selected AI provider."
-        case .invalidResponse:
-            return "The AI provider returned an unexpected response format. Please try again or contact support if the issue persists."
-        case .enhancementFailed:
-            return "The AI service could not process the transcription. The text may be too short or contain unsupported content."
-        case .networkError:
-            return "Unable to connect to the AI service. Please check your internet connection and try again."
-        case .serverError:
-            return "The AI provider's server is temporarily unavailable. Please wait a few minutes and try again."
-        case .rateLimitExceeded:
-            return "You've exceeded the rate limit for the AI service. Please wait a moment before trying again, or upgrade your API plan."
-        case .customError(let message):
-            return "An error occurred: \(message)"
-        }
-    }
-}
-
 // MARK: - OpenAI OAuth
 
 extension AIService {

--- a/VivaDicta/Services/AIEnhance/Providers/OpenAICompatibleService.swift
+++ b/VivaDicta/Services/AIEnhance/Providers/OpenAICompatibleService.swift
@@ -3,6 +3,7 @@
 import Foundation
 import Networking
 import os
+import AICore
 
 /// Pure HTTP wrapper for OpenAI-compatible chat-completions endpoints
 /// (`POST /v1/chat/completions` with Bearer auth and standard `messages`

--- a/VivaDicta/Services/OAuth/CopilotAPIClient.swift
+++ b/VivaDicta/Services/OAuth/CopilotAPIClient.swift
@@ -4,6 +4,7 @@ import Foundation
 import Networking
 import os
 import OAuth
+import AICore
 
 /// Client for GitHub Copilot's OpenAI-compatible API.
 /// Uses the Copilot token obtained via device code OAuth flow.

--- a/VivaDicta/Services/OAuth/OpenAIOAuthClient.swift
+++ b/VivaDicta/Services/OAuth/OpenAIOAuthClient.swift
@@ -4,6 +4,7 @@ import Foundation
 import Networking
 import os
 import OAuth
+import AICore
 
 /// Client for OpenAI's backend API using OAuth tokens.
 enum OpenAIOAuthClient {

--- a/VivaDictaTests/OpenAICompatibleServiceTests.swift
+++ b/VivaDictaTests/OpenAICompatibleServiceTests.swift
@@ -6,6 +6,7 @@ import NetworkingMocks
 import os
 import Testing
 @testable import VivaDicta
+import AICore
 
 /// Tests cover `OpenAICompatibleService` in isolation: the static body
 /// builder and SSE delta parser (pure functions, fully exercised),


### PR DESCRIPTION
## Phase 3: move EnhancementError into AICore

Relocates the `EnhancementError` `LocalizedError` enum from `AIService.swift` into the `AICore` module as a `public`, `Sendable` type. This is a small foundational move that **unblocks** moving the provider services into `AIProviders` - they all throw `EnhancementError`, so it has to live in the shared module first.

### Why this, and not the protocol (a plan reorder)

The original plan had Phase 3 define an `AITextProvider` protocol and conform the provider services in place. On inspection the services' `enhance`/`enhanceStreaming` signatures diverge too much for a clean "conform in place" (Anthropic takes `apiKey`/`model`; OpenAICompatible takes `url`/`headers`/`timeout`; Apple FM takes `samplingProfile`). So the providers move into `AIProviders` **first**, and the protocol is defined later once they're co-located and can be refactored to config-bound `init`. This PR is the foundational error-type move that the provider moves depend on.

### Changes

- `EnhancementError` moves into `AICore` (`public`, `Sendable`). It was a file-scope enum in `AIService.swift`, app-only, so - unlike the catalog enum - there is **no** extension `membershipExceptions` involvement.
- Behavior tests added: custom-message passthrough (`errorDescription` / `failureReason`) and structural completeness across every case. Copy is intentionally not over-asserted, since user-facing error strings may legitimately change.
- `import AICore` added to the 4 remaining consumers; the rest already import it from the catalog-enum move.

### Behavior

Pure relocation - **no behavior change.** Every case and message string is unchanged.

### Verification

- `AICoreTests` green (`swift test`).
- App + all three extensions + test bundle build green (`build-for-testing`, iOS 26.4 simulator) on the first pass.

### Next phase

Begin moving provider services into `AIProviders`, starting with the standalone `AnthropicService` (`AIProviders` gains a `Networking` dependency; `AIService` imports `AIProviders`).
