### PR TITLE
Move AIEnhancementOutputFilter into AICore

### DIFF
--- a/Modules/AICore/Sources/AICore/AIEnhancementOutputFilter.swift
+++ b/Modules/AICore/Sources/AICore/AIEnhancementOutputFilter.swift
@@ -7,8 +7,8 @@
 
 import Foundation
 
-struct AIEnhancementOutputFilter {
-    static func filter(_ text: String) -> String {
+public struct AIEnhancementOutputFilter {
+    public static func filter(_ text: String) -> String {
         var processedText = text
 
         // Step 1: Remove thinking/reasoning tags WITH their content (discard AI's chain-of-thought)

--- a/VivaDicta/Services/AIEnhance/AppleFoundationModelService.swift
+++ b/VivaDicta/Services/AIEnhance/AppleFoundationModelService.swift
@@ -8,6 +8,7 @@
 import Foundation
 import FoundationModels
 import os
+import AICore
 
 enum AppleFoundationModelSamplingProfile: Equatable {
     case extractive

--- a/VivaDictaTests/TextProcessingFilterTests.swift
+++ b/VivaDictaTests/TextProcessingFilterTests.swift
@@ -8,6 +8,7 @@
 import Foundation
 import Testing
 @testable import VivaDicta
+import AICore
 
 struct TranscriptionOutputFilterTests {
 


### PR DESCRIPTION
## Phase 4: move AIEnhancementOutputFilter into AICore

Relocates `AIEnhancementOutputFilter` (a pure, Foundation-only string/regex filter that strips AI "thinking" tags and unwraps stray XML wrappers from model output) from the app target into `AICore` as a `public` type.

### Why now

Scoping the first provider move (`AnthropicService` → `AIProviders`) surfaced two app-only dependencies the providers share: this output filter, and a per-module logger. This PR handles the first - the filter must live in the shared module before any provider that calls `AIEnhancementOutputFilter.filter(...)` can move. (The logger is a `Logger+AIProviders.swift` extension that lands with the first provider move, following the existing `Logger+CloudTranscription` / `Logger+OAuth` per-module pattern.)

### Changes

- `AIEnhancementOutputFilter` moves into `AICore`; the `struct` and its `filter(_:)` entry point become `public` (private helpers stay private).
- `import AICore` added to the 2 consumers that lacked it; the other 9 already import it from earlier phases.
- It's always called via the type name (`AIEnhancementOutputFilter.filter(...)`), so there's no inferred-type / member-access import blind spot, and no extension `membershipExceptions` involvement.

### Behavior

Pure relocation - **no behavior change**, no `project.pbxproj` change.

### Verification

- `AICore` builds (`swift build`).
- App + all three extensions + test bundle build green (`build-for-testing`, iOS 26.4 simulator) on the first pass.

### Next phase

Move `AnthropicService` into `AIProviders` (the standalone provider; adds a `Logger+AIProviders` extension and a `Networking` dependency to `AIProviders`, and `AIService` imports `AIProviders`).
