### PR TITLE
Move AnthropicService into AIProviders

### DIFF
--- a/Modules/AIProviders/Package.swift
+++ b/Modules/AIProviders/Package.swift
@@ -13,17 +13,24 @@ let package = Package(
     ],
     dependencies: [
         .package(path: "../AICore"),
+        .package(path: "../Networking"),
     ],
     targets: [
         .target(
             name: "AIProviders",
             dependencies: [
                 .product(name: "AICore", package: "AICore"),
+                .product(name: "Networking", package: "Networking"),
             ]
         ),
         .testTarget(
             name: "AIProvidersTests",
-            dependencies: ["AIProviders"]
+            dependencies: [
+                "AIProviders",
+                .product(name: "AICore", package: "AICore"),
+                .product(name: "Networking", package: "Networking"),
+                .product(name: "NetworkingMocks", package: "Networking"),
+            ]
         ),
     ],
     swiftLanguageModes: [.v6]

--- a/Modules/AIProviders/Sources/AIProviders/AIProviders.swift
+++ b/Modules/AIProviders/Sources/AIProviders/AIProviders.swift
@@ -1,2 +1,0 @@
-// The Swift Programming Language
-// https://docs.swift.org/swift-book

--- a/Modules/AIProviders/Sources/AIProviders/AnthropicService.swift
+++ b/Modules/AIProviders/Sources/AIProviders/AnthropicService.swift
@@ -27,12 +27,12 @@ import AICore
 /// - Streaming uses `content_block_delta` SSE events with a `delta.text`
 ///   payload, not OpenAI's `data: {choices: [{delta: {content: ...}}]}`
 ///   shape
-struct AnthropicService: Sendable {
+public struct AnthropicService: Sendable {
     private let networkService: any NetworkService
     private let logger: Logger
     private let baseTimeout: TimeInterval
 
-    init(networkService: any NetworkService, logger: Logger, baseTimeout: TimeInterval) {
+    public init(networkService: any NetworkService, logger: Logger, baseTimeout: TimeInterval) {
         self.networkService = networkService
         self.logger = logger
         self.baseTimeout = baseTimeout
@@ -44,7 +44,7 @@ struct AnthropicService: Sendable {
     /// Throws `EnhancementError.rateLimitExceeded` on 429,
     /// `.serverError` on 5xx, `.customError(_)` on other non-200,
     /// `.enhancementFailed` on malformed body.
-    func enhance(
+    public func enhance(
         systemMessage: String,
         userMessage: String,
         apiKey: String,
@@ -113,7 +113,7 @@ struct AnthropicService: Sendable {
     /// Calls `onPartialResponse` on the main actor as each delta arrives,
     /// then once more if the post-filter text differs from the raw
     /// aggregate. Returns the filtered/trimmed final text.
-    func enhanceStreaming(
+    public func enhanceStreaming(
         systemMessage: String,
         userMessage: String,
         apiKey: String,
@@ -210,7 +210,7 @@ struct AnthropicService: Sendable {
 
     /// Probes the Anthropic API with a minimal Messages request and
     /// returns whether the key is accepted. Never throws.
-    func verifyAPIKey(_ key: String) async -> Bool {
+    public func verifyAPIKey(_ key: String) async -> Bool {
         let url = URL(string: AIProvider.anthropic.baseURL)!
         var request = URLRequest(url: url)
         request.httpMethod = "POST"

--- a/Modules/AIProviders/Sources/AIProviders/Logger+AIProviders.swift
+++ b/Modules/AIProviders/Sources/AIProviders/Logger+AIProviders.swift
@@ -7,10 +7,6 @@ import os
 /// intentionally `internal` so they don't collide with the app target's
 /// identically named extensions on `Logger`.
 extension Logger {
-    init(aiProvidersCategory category: String) {
-        self.init(subsystem: "com.antonnovoselov.VivaDicta", category: category)
-    }
-
     func logInfo(_ message: String) {
         self.info("\(message, privacy: .public)")
     }

--- a/Modules/AIProviders/Sources/AIProviders/Logger+AIProviders.swift
+++ b/Modules/AIProviders/Sources/AIProviders/Logger+AIProviders.swift
@@ -1,0 +1,29 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import os
+
+/// Internal logging convenience for the AIProviders module. Methods are
+/// intentionally `internal` so they don't collide with the app target's
+/// identically named extensions on `Logger`.
+extension Logger {
+    init(aiProvidersCategory category: String) {
+        self.init(subsystem: "com.antonnovoselov.VivaDicta", category: category)
+    }
+
+    func logInfo(_ message: String) {
+        self.info("\(message, privacy: .public)")
+    }
+
+    func logWarning(_ message: String) {
+        self.warning("\(message, privacy: .public)")
+    }
+
+    func logError(_ message: String) {
+        self.error("\(message, privacy: .public)")
+    }
+
+    func logNotice(_ message: String) {
+        self.notice("\(message, privacy: .public)")
+    }
+}

--- a/Modules/AIProviders/Tests/AIProvidersTests/AIProvidersTests.swift
+++ b/Modules/AIProviders/Tests/AIProvidersTests/AIProvidersTests.swift
@@ -1,8 +1,0 @@
-import Testing
-@testable import AIProviders
-
-@Test func example() async throws {
-    // Write your test here and use APIs like `#expect(...)` to check expected conditions.
-    // Swift Testing Documentation
-    // https://developer.apple.com/documentation/testing
-}

--- a/Modules/AIProviders/Tests/AIProvidersTests/AnthropicServiceTests.swift
+++ b/Modules/AIProviders/Tests/AIProvidersTests/AnthropicServiceTests.swift
@@ -5,7 +5,7 @@ import Networking
 import NetworkingMocks
 import os
 import Testing
-@testable import VivaDicta
+import AIProviders
 import AICore
 
 /// Tests cover `AnthropicService` in isolation: the request shape

--- a/Modules/AIProviders/Tests/AIProvidersTests/TestTags.swift
+++ b/Modules/AIProviders/Tests/AIProvidersTests/TestTags.swift
@@ -1,0 +1,11 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Testing
+
+extension Tag {
+    /// Marks suites that exercise networking through a mocked transport.
+    /// No real network calls happen - the tag exists so the suites can be
+    /// selected/excluded as a group (e.g. via an Xcode Test Plan, or
+    /// `swift test --filter-tag networking` when running this package alone).
+    @Tag static var networking: Self
+}

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -15,6 +15,7 @@ import os
 import OAuth
 import CloudTranscription
 import AICore
+import AIProviders
 
 /// Service responsible for AI-powered text enhancement of transcriptions.
 ///


### PR DESCRIPTION
## Phase 5: move AnthropicService into AIProviders

Relocates `AnthropicService` - the standalone Anthropic Messages API client (`POST /v1/messages`, non-streaming + SSE streaming + key verification) - from the app target into the `AIProviders` module as a `public` struct. **This is the first concrete provider to land in the impl module**, making `AIProviders` a real module rather than scaffolding.

### Changes

- **`AnthropicService` → `AIProviders`**, made `public` (struct + init + `enhance` / `enhanceStreaming` / `verifyAPIKey`). Only access-control modifiers were added - the HTTP headers (`x-api-key`, `anthropic-version`), status-code mapping (429/5xx/other), JSON body shape, and `content_block_delta` SSE parsing are byte-for-byte unchanged.
- **`AIProviders` gains a `Networking` dependency** (for `NetworkService`) and an internal `Logger+AIProviders.swift` extension, following the existing per-module logging pattern (`Logger+CloudTranscription`, `Logger+OAuth`) - methods are `internal` so they don't collide with the app's identically-named `Logger` extension.
- **`AnthropicServiceTests` (12 tests) → `AIProvidersTests`**, with its own `TestTags.swift` (`.networking`). `@testable import VivaDicta` becomes `import AIProviders`; test deps `AICore` / `Networking` / `NetworkingMocks` are wired.
- The empty `AIProviders` module/test placeholder files are removed now that the module has real content.
- `AIService` constructs the provider via `import AIProviders`; its three `AnthropicService(networkService:logger:baseTimeout:)` call sites are unchanged.

### Behavior

Pure relocation - **no behavior change.** The diff against the old file is exactly five `public` additions; a byte-level and whitespace-insensitive comparison confirms no other line changed.

### Verification

- 12 `AIProviders` tests pass (`swift test`); `AIProviders` also builds in isolation (`swift build`), proving no app symbol is required.
- App + all three extensions + test bundle build green (`build-for-testing`, iOS 26.4 simulator). No `project.pbxproj` change (synchronized-folder move).

### Next phase

Move `AppleFoundationModelService` (the other standalone provider, on-device) into `AIProviders`, then the `OpenAICompatibleService` cluster (with its `Ollama`/`CustomOpenAI` delegators).
