### PR TITLE
Move AppleFoundationModelService into AIProviders

### DIFF
--- a/Modules/AIProviders/Sources/AIProviders/AppleFoundationModelService.swift
+++ b/Modules/AIProviders/Sources/AIProviders/AppleFoundationModelService.swift
@@ -10,13 +10,13 @@ import FoundationModels
 import os
 import AICore
 
-enum AppleFoundationModelSamplingProfile: Equatable {
+public enum AppleFoundationModelSamplingProfile: Equatable, Sendable {
     case extractive
     case balanced
     case conversational
     case creative
 
-    static func profile(for presetID: String?) -> Self {
+    public static func profile(for presetID: String?) -> Self {
         switch presetID {
         case "summary", "action_points", "key_points", "takeaways", "mind_map":
             .extractive
@@ -31,8 +31,8 @@ enum AppleFoundationModelSamplingProfile: Equatable {
         }
     }
 
-    @available(iOS 26, *)
-    var generationOptions: GenerationOptions {
+    @available(iOS 26, macOS 26, *)
+    public var generationOptions: GenerationOptions {
         switch self {
         case .extractive:
             GenerationOptions(sampling: .greedy)
@@ -61,10 +61,12 @@ enum AppleFoundationModelSamplingProfile: Equatable {
 ///
 /// Uses the same system message + user message pattern as cloud providers.
 /// The system message becomes session instructions, the user message becomes the prompt.
-@available(iOS 26, *)
+@available(iOS 26, macOS 26, *)
 @MainActor
-final class AppleFoundationModelService {
-    private let logger = Logger(category: .aiService)
+public final class AppleFoundationModelService {
+    private let logger = Logger(aiProvidersCategory: "AppleFoundationModel")
+
+    public init() {}
 
     /// Enhance text using Apple's on-device Foundation Model.
     /// - Parameters:
@@ -72,7 +74,7 @@ final class AppleFoundationModelService {
     ///   - userMessage: The formatted user message (transcript, optionally wrapped in tags)
     ///   - samplingProfile: Sampling profile chosen for the current preset goal
     /// - Returns: The enhanced text
-    func enhance(
+    public func enhance(
         systemMessage: String,
         userMessage: String,
         samplingProfile: AppleFoundationModelSamplingProfile = .balanced
@@ -132,7 +134,7 @@ final class AppleFoundationModelService {
     ///   - samplingProfile: Sampling profile chosen for the current preset goal
     ///   - onPartialResponse: Called with the latest partial response snapshot.
     /// - Returns: The final enhanced text
-    func enhanceStreaming(
+    public func enhanceStreaming(
         systemMessage: String,
         userMessage: String,
         samplingProfile: AppleFoundationModelSamplingProfile = .balanced,
@@ -201,14 +203,14 @@ final class AppleFoundationModelService {
 
 // MARK: - Availability Status
 
-enum AppleFoundationModelAvailability {
+public enum AppleFoundationModelAvailability: Sendable {
     case available
     case deviceNotEligible
     case appleIntelligenceNotEnabled
     case modelNotReady
     case unavailable
 
-    var description: String {
+    public var description: String {
         switch self {
         case .available:
             return "Apple Intelligence is available"
@@ -225,8 +227,8 @@ enum AppleFoundationModelAvailability {
 
     /// Check if Apple Foundation Models are available on this device
     @MainActor
-    static var isAvailable: Bool {
-        if #available(iOS 26, *) {
+    public static var isAvailable: Bool {
+        if #available(iOS 26, macOS 26, *) {
             return SystemLanguageModel.default.availability == .available
         }
         return false
@@ -234,8 +236,8 @@ enum AppleFoundationModelAvailability {
 
     /// Detailed availability status for UI display
     @MainActor
-    static var currentStatus: AppleFoundationModelAvailability {
-        if #available(iOS 26, *) {
+    public static var currentStatus: AppleFoundationModelAvailability {
+        if #available(iOS 26, macOS 26, *) {
             switch SystemLanguageModel.default.availability {
             case .available:
                 return .available
@@ -258,13 +260,13 @@ enum AppleFoundationModelAvailability {
 
 // MARK: - Errors
 
-enum AppleFoundationModelError: LocalizedError {
+public enum AppleFoundationModelError: LocalizedError, Sendable {
     case notAvailable
     case generationFailed(String)
     case guardrailViolation
     case refusal(String)
 
-    var errorDescription: String? {
+    public var errorDescription: String? {
         switch self {
         case .notAvailable:
             return "Apple Foundation Model not available"
@@ -277,7 +279,7 @@ enum AppleFoundationModelError: LocalizedError {
         }
     }
 
-    var failureReason: String {
+    public var failureReason: String {
         switch self {
         case .notAvailable:
             return "Apple Intelligence is not available on this device. Please ensure you have a compatible device with Apple Intelligence enabled."

--- a/Modules/AIProviders/Sources/AIProviders/Logger+AIProviders.swift
+++ b/Modules/AIProviders/Sources/AIProviders/Logger+AIProviders.swift
@@ -7,6 +7,10 @@ import os
 /// intentionally `internal` so they don't collide with the app target's
 /// identically named extensions on `Logger`.
 extension Logger {
+    init(aiProvidersCategory category: String) {
+        self.init(subsystem: "com.antonnovoselov.VivaDicta", category: category)
+    }
+
     func logInfo(_ message: String) {
         self.info("\(message, privacy: .public)")
     }

--- a/VivaDicta.xcodeproj/project.pbxproj
+++ b/VivaDicta.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		BFBF000000000000000000D1 /* AIProviders in Frameworks */ = {isa = PBXBuildFile; productRef = AEAE000000000000000000D1 /* AIProviders */; };
 		BFBF000000000000000000E1 /* AIKit in Frameworks */ = {isa = PBXBuildFile; productRef = AEAE000000000000000000E1 /* AIKit */; };
 		BFBF000000000000000000C2 /* AICore in Frameworks */ = {isa = PBXBuildFile; productRef = AEAE000000000000000000C2 /* AICore */; };
+		BFBF000000000000000000D2 /* AIProviders in Frameworks */ = {isa = PBXBuildFile; productRef = AEAE000000000000000000D2 /* AIProviders */; };
 		18B8CF2C2FB8C4690007FA96 /* DesignSystem in Frameworks */ = {isa = PBXBuildFile; productRef = 18B8CF2B2FB8C4690007FA96 /* DesignSystem */; };
 		18BA24132F7ED0D700C4F68B /* VivaDictaWatch Watch App.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 18BA23F32F7ED0D500C4F68B /* VivaDictaWatch Watch App.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		18BA29262F7F29FD00C4F68B /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 18E1C7FB2E8E793E00BE8A11 /* WidgetKit.framework */; };
@@ -523,6 +524,7 @@
 				E1938683EE7E439ABF4FE3EA /* TranscriptionKitMocks in Frameworks */,
 				188E02592FC3BCC1007B8BC1 /* AudioRecordingMocks in Frameworks */,
 				BFBF000000000000000000C2 /* AICore in Frameworks */,
+				BFBF000000000000000000D2 /* AIProviders in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -752,6 +754,7 @@
 				F4E0FCBD69B741548F9F6B15 /* TranscriptionKitMocks */,
 				188E02582FC3BCC1007B8BC1 /* AudioRecordingMocks */,
 				AEAE000000000000000000C2 /* AICore */,
+				AEAE000000000000000000D2 /* AIProviders */,
 			);
 			productName = VivaDictaTests;
 			productReference = 18351E572E634FF000944940 /* VivaDictaTests.xctest */;
@@ -2526,6 +2529,10 @@
 		AEAE000000000000000000C2 /* AICore */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = AICore;
+		};
+		AEAE000000000000000000D2 /* AIProviders */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AIProviders;
 		};
 		18B8BEB02FB8BD7D0007FA96 /* DesignSystem */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/VivaDicta/Services/AIEnhance/CrossNoteSearchPlanner.swift
+++ b/VivaDicta/Services/AIEnhance/CrossNoteSearchPlanner.swift
@@ -9,6 +9,7 @@ import Foundation
 import FoundationModels
 import os
 import AICore
+import AIProviders
 
 struct CrossNoteSearchPlan: Codable, Sendable {
     let shouldSearch: Bool

--- a/VivaDicta/Services/AIEnhance/SmartSearchQueryPlanner.swift
+++ b/VivaDicta/Services/AIEnhance/SmartSearchQueryPlanner.swift
@@ -9,6 +9,7 @@ import Foundation
 import FoundationModels
 import os
 import AICore
+import AIProviders
 
 struct SmartSearchQueryPlan: Codable, Sendable {
     let shouldSearch: Bool

--- a/VivaDicta/Services/AIEnhance/WebSearchPlanner.swift
+++ b/VivaDicta/Services/AIEnhance/WebSearchPlanner.swift
@@ -9,6 +9,7 @@ import Foundation
 import FoundationModels
 import os
 import AICore
+import AIProviders
 
 struct WebSearchPlan: Codable, Sendable {
     let shouldSearch: Bool

--- a/VivaDicta/Services/Reminders/AppleFMReminderExtractionProvider.swift
+++ b/VivaDicta/Services/Reminders/AppleFMReminderExtractionProvider.swift
@@ -8,6 +8,7 @@
 import Foundation
 import FoundationModels
 import os
+import AIProviders
 
 @available(iOS 26, *)
 @MainActor

--- a/VivaDicta/Services/Reminders/ReminderExtractionService.swift
+++ b/VivaDicta/Services/Reminders/ReminderExtractionService.swift
@@ -10,6 +10,7 @@ import NaturalLanguage
 import SwiftData
 import os
 import AICore
+import AIProviders
 
 enum ReminderExtractionError: LocalizedError {
     case unsupportedOS

--- a/VivaDicta/Views/Chat/ChatViewModel.swift
+++ b/VivaDicta/Views/Chat/ChatViewModel.swift
@@ -10,6 +10,7 @@ import FoundationModels
 import SwiftData
 import os
 import AICore
+import AIProviders
 
 /// View model for the "Chat with Note" feature.
 ///

--- a/VivaDicta/Views/MultiNoteChat/MultiNoteChatViewModel.swift
+++ b/VivaDicta/Views/MultiNoteChat/MultiNoteChatViewModel.swift
@@ -10,6 +10,7 @@ import FoundationModels
 import SwiftData
 import os
 import AICore
+import AIProviders
 
 /// View model for multi-note chat conversations.
 ///

--- a/VivaDicta/Views/RecordViewModel.swift
+++ b/VivaDicta/Views/RecordViewModel.swift
@@ -16,6 +16,7 @@ import os
 import TipKit
 import Presets
 import AICore
+import AIProviders
 
 enum RecordingDestination: Equatable {
     case newNote

--- a/VivaDicta/Views/SettingsScreen/AIProvidersView.swift
+++ b/VivaDicta/Views/SettingsScreen/AIProvidersView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import AICore
+import AIProviders
 
 struct AIProviders: View {
     @Environment(AppState.self) private var appState

--- a/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
@@ -9,6 +9,7 @@ import SwiftUI
 import os
 import Presets
 import AICore
+import AIProviders
 
 @Observable
 class ModeEditViewModel {

--- a/VivaDicta/Views/SmartSearch/SmartSearchChatViewModel.swift
+++ b/VivaDicta/Views/SmartSearch/SmartSearchChatViewModel.swift
@@ -11,6 +11,7 @@ import SwiftData
 import TipKit
 import os
 import AICore
+import AIProviders
 
 /// View model for RAG-powered Smart Search conversations.
 ///

--- a/VivaDicta/Views/TranscriptionDetailView.swift
+++ b/VivaDicta/Views/TranscriptionDetailView.swift
@@ -14,6 +14,7 @@ import TipKit
 import os
 import Presets
 import AICore
+import AIProviders
 
 private let logger = Logger(category: .transcriptionDetailView)
 

--- a/VivaDictaTests/AIServiceConfigurationTests.swift
+++ b/VivaDictaTests/AIServiceConfigurationTests.swift
@@ -10,6 +10,7 @@ import Testing
 import Presets
 @testable import VivaDicta
 import AICore
+import AIProviders
 
 struct AIServiceConfigurationTests {
 


### PR DESCRIPTION
## Phase 6: move AppleFoundationModelService into AIProviders

Relocates the four Apple Foundation Model types - the on-device provider service plus `AppleFoundationModelSamplingProfile`, `AppleFoundationModelAvailability`, and `AppleFoundationModelError` - from the app target into `AIProviders`, all `public`. This is the second provider in the impl module (the first on-device one).

### Behavior

Verified behavior-preserving for the iOS app: after factoring out the access-control changes, the diff is **empty** - the preset→profile mapping, the sampling/temperature values (`.greedy`, `0.8/0.3`, `0.9/0.5`, `0.95/0.7`), the `enhance`/`enhanceStreaming` bodies, the availability `isAvailable`/`currentStatus` logic, and the error cases/messages are byte-identical.

### Three deliberate adaptations (beyond `public`)

1. **macOS 26 availability** - four `@available(iOS 26, *)` / `#available(iOS 26, *)` guards became `iOS 26, macOS 26, *` so the module compiles for its declared macOS platform. FoundationModels exists on macOS 26, and the iOS app never takes the macOS path, so this is a **no-op for the app**.
2. **Logger** - this service *self-creates* its logger (unlike `AnthropicService`, which receives one), so `Logger(category: .aiService)` became `Logger(aiProvidersCategory: "AppleFoundationModel")`, using the module's internal `Logger+AIProviders` extension. (This re-adds the `init(aiProvidersCategory:)` removed last PR as "unused" - it turned out genuinely needed here.) Only the log *category label* changes; output level and `privacy: .public` are unchanged.
3. **`Sendable`** added to the three enums - going `public` disables implicit `Sendable` inference, and `AIServiceConfigurationTests` passes `SamplingProfile` as a parameterized test argument (which requires `Sendable`). All three are trivially `Sendable` (no / `String` associated values).

### Wiring

- **13 files** gain `import AIProviders` (12 app + `AIServiceConfigurationTests`). `AIService` needed no change - it already imports `AIProviders` from the previous phase.
- **`AIProviders` linked into `VivaDictaTests`** (pbxproj) because `AIServiceConfigurationTests` characterizes the `SamplingProfile.profile(for:)` preset mapping.

### Verification

- `AIProviders` builds in isolation (`swift build`) and its tests pass.
- App + all three extensions + test bundle build green (`build-for-testing`, iOS 26.4 simulator).

### Next phase

Move the `OpenAICompatibleService` cluster (with its `Ollama` / `CustomOpenAI` delegators, which route through it) into `AIProviders`.
