### PR TITLE
Move ReasoningConfig into AICore

### DIFF
--- a/Modules/AICore/Sources/AICore/ReasoningConfig.swift
+++ b/Modules/AICore/Sources/AICore/ReasoningConfig.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct ReasoningConfig {
+public struct ReasoningConfig {
     // 2.5-flash and 2.5-flash-lite support "none" to fully turn off thinking
     static let geminiNoneReasoningModels: Set<String> = [
         "gemini-2.5-flash",
@@ -60,7 +60,7 @@ struct ReasoningConfig {
         "qwen/qwen3-32b"
     ]
 
-    static func getReasoningParameter(for modelName: String) -> String? {
+    public static func getReasoningParameter(for modelName: String) -> String? {
         if geminiNoneReasoningModels.contains(modelName) { return "none" }
         else if geminiMinimalReasoningModels.contains(modelName) { return "minimal" }
         else if openAINoneReasoningModels.contains(modelName) { return "none" }
@@ -72,7 +72,7 @@ struct ReasoningConfig {
     }
 
     // For models that need custom params instead of reasoning_effort
-    static func getExtraBodyParameters(for modelName: String) -> [String: Any]? {
+    public static func getExtraBodyParameters(for modelName: String) -> [String: Any]? {
         if cerebrasDisableReasoningModels.contains(modelName) {
             return ["disable_reasoning": true]
         }

--- a/Modules/AICore/Tests/AICoreTests/ReasoningConfigTests.swift
+++ b/Modules/AICore/Tests/AICoreTests/ReasoningConfigTests.swift
@@ -1,0 +1,29 @@
+import Testing
+import Foundation
+@testable import AICore
+
+/// Characterization tests locking the model -> reasoning-parameter mappings as
+/// ReasoningConfig moves into AICore.
+struct ReasoningConfigTests {
+
+    @Test func reasoningParameterMappings() {
+        // Gemini
+        #expect(ReasoningConfig.getReasoningParameter(for: "gemini-2.5-flash") == "none")
+        #expect(ReasoningConfig.getReasoningParameter(for: "gemini-2.5-pro") == "minimal")
+        // OpenAI GPT-5 series
+        #expect(ReasoningConfig.getReasoningParameter(for: "gpt-5.5") == "none")
+        #expect(ReasoningConfig.getReasoningParameter(for: "gpt-5-mini") == "minimal")
+        // Cerebras / Groq
+        #expect(ReasoningConfig.getReasoningParameter(for: "gpt-oss-120b") == "low")
+        #expect(ReasoningConfig.getReasoningParameter(for: "openai/gpt-oss-120b") == "low")
+        #expect(ReasoningConfig.getReasoningParameter(for: "qwen/qwen3-32b") == "none")
+        // Unknown model -> no override
+        #expect(ReasoningConfig.getReasoningParameter(for: "some-unknown-model") == nil)
+    }
+
+    @Test func extraBodyParametersForDisableReasoningModels() {
+        let zai = ReasoningConfig.getExtraBodyParameters(for: "zai-glm-4.7")
+        #expect(zai?["disable_reasoning"] as? Bool == true)
+        #expect(ReasoningConfig.getExtraBodyParameters(for: "gpt-5.5") == nil)
+    }
+}


### PR DESCRIPTION
## Move ReasoningConfig into AICore

Relocates `ReasoningConfig` - a pure (Foundation-only) lookup of model → reasoning-effort parameters for the GPT-5 / Gemini / Cerebras / Groq families - from the app target into `AICore` as a `public` type.

### Why now

A prerequisite for the next provider move: `OpenAICompatibleService` calls `ReasoningConfig.getReasoningParameter(...)` / `getExtraBodyParameters(...)` when building request bodies, so the config has to live in the shared module before that service can move into `AIProviders`. Same pattern as the earlier `EnhancementError` / `AIEnhancementOutputFilter` foundational moves.

### Changes

- `ReasoningConfig` moves into `AICore`; the `struct` and its two `static func` entry points become `public` (the internal `static let` model-set tables stay internal - consumers only call the two functions).
- Adds a characterization test locking the mappings (`gpt-5.5` → `none`, `gpt-5-mini` → `minimal`, `gemini-2.5-flash` → `none`, Cerebras/Groq `gpt-oss` → `low`, unknown → `nil`, and the `zai-glm-4.7` `disable_reasoning` extra-body case).
- All three consumers (`OpenAICompatibleService`, `AIService+Chat`, `CloudReminderExtractionProvider`) already import `AICore`, so no import changes were needed.

### Behavior

Pure relocation - **no behavior change**, no `project.pbxproj` change.

### Verification

- `AICore` tests pass (`swift test`, now 3 suites).
- App + all three extensions + test bundle build green (`build-for-testing`, iOS 26.4 simulator).

### Next

Move the `OpenAICompatibleService` cluster (with `OllamaService` / `CustomOpenAIService`) into `AIProviders`.
