### PR TITLE
Move OpenAICompatibleService cluster into AIProviders

### DIFF
--- a/Modules/AIProviders/Sources/AIProviders/CustomOpenAIService.swift
+++ b/Modules/AIProviders/Sources/AIProviders/CustomOpenAIService.swift
@@ -21,20 +21,20 @@ import os
 /// "user", "content": "test" }]`). Verifies the endpoint responds with
 /// `200`; maps other status codes and `URLError` cases to user-readable
 /// failure messages so the settings UI can surface them directly.
-struct CustomOpenAIService: Sendable {
+public struct CustomOpenAIService: Sendable {
     /// Structured outcome of a Custom OpenAI endpoint test. Either side
     /// carries a user-facing message suitable for display in the settings
     /// UI.
-    enum TestResult: Equatable, Sendable {
+    public enum TestResult: Equatable, Sendable {
         case success(message: String)
         case failure(message: String)
 
-        var isSuccess: Bool {
+        public var isSuccess: Bool {
             if case .success = self { return true }
             return false
         }
 
-        var message: String {
+        public var message: String {
             switch self {
             case let .success(message), let .failure(message):
                 return message
@@ -45,7 +45,7 @@ struct CustomOpenAIService: Sendable {
     private let networkService: any NetworkService
     private let logger: Logger
 
-    init(networkService: any NetworkService, logger: Logger) {
+    public init(networkService: any NetworkService, logger: Logger) {
         self.networkService = networkService
         self.logger = logger
     }
@@ -53,7 +53,7 @@ struct CustomOpenAIService: Sendable {
     /// Probes a Custom OpenAI endpoint with a minimal chat-completions
     /// request and returns a structured result. Never throws - all errors
     /// (URLError, bad status, bad body) map to `.failure(message:)`.
-    func testEndpoint(
+    public func testEndpoint(
         endpointURL: String,
         modelName: String,
         apiKey: String?

--- a/Modules/AIProviders/Sources/AIProviders/OllamaService.swift
+++ b/Modules/AIProviders/Sources/AIProviders/OllamaService.swift
@@ -22,11 +22,11 @@ import os
 /// `fetchModels` tries the OpenAI-compatible endpoint first and falls back
 /// to the native endpoint. `checkConnection` always uses the native endpoint
 /// because that one is guaranteed to exist on every Ollama install.
-struct OllamaService: Sendable {
+public struct OllamaService: Sendable {
     private let networkService: any NetworkService
     private let logger: Logger
 
-    init(networkService: any NetworkService, logger: Logger) {
+    public init(networkService: any NetworkService, logger: Logger) {
         self.networkService = networkService
         self.logger = logger
     }
@@ -37,7 +37,7 @@ struct OllamaService: Sendable {
     ///
     /// Returns the (sorted) model names. Throws only if both endpoints fail
     /// to produce a usable response.
-    func fetchModels(serverURL: String) async throws -> [String] {
+    public func fetchModels(serverURL: String) async throws -> [String] {
         do {
             return try await fetchModelsViaOpenAICompatibleEndpoint(serverURL: serverURL)
         } catch {
@@ -49,7 +49,7 @@ struct OllamaService: Sendable {
     /// Lightweight reachability check. Pings the native `/api/tags` endpoint
     /// with a 3s timeout. Returns `false` for any non-200 / transport error,
     /// never throws.
-    func checkConnection(serverURL: String) async -> Bool {
+    public func checkConnection(serverURL: String) async -> Bool {
         guard let url = URL(string: "\(serverURL)/api/tags") else {
             return false
         }
@@ -121,7 +121,7 @@ struct OllamaService: Sendable {
     }
 }
 
-enum OllamaServiceError: Error, Equatable {
+public enum OllamaServiceError: Error, Equatable, Sendable {
     case unexpectedStatus(Int)
     case malformedResponse
 }

--- a/Modules/AIProviders/Sources/AIProviders/OpenAICompatibleService.swift
+++ b/Modules/AIProviders/Sources/AIProviders/OpenAICompatibleService.swift
@@ -26,11 +26,11 @@ import AICore
 /// the body shape and the SSE delta parser. Cloud providers that match
 /// the standard 429/5xx/default error mapping can call the instance
 /// `enhance` / `enhanceStreaming` methods directly.
-struct OpenAICompatibleService: Sendable {
+public struct OpenAICompatibleService: Sendable {
     private let networkService: any NetworkService
     private let logger: Logger
 
-    init(networkService: any NetworkService, logger: Logger) {
+    public init(networkService: any NetworkService, logger: Logger) {
         self.networkService = networkService
         self.logger = logger
     }
@@ -41,7 +41,7 @@ struct OpenAICompatibleService: Sendable {
     /// quirks: GPT-5 series omits `temperature` (uses `reasoning_effort`
     /// instead); reasoning models pick up extra body parameters from
     /// `ReasoningConfig`.
-    static func buildRequestBody(
+    public static func buildRequestBody(
         modelName: String,
         systemMessage: String,
         userMessage: String,
@@ -80,7 +80,7 @@ struct OpenAICompatibleService: Sendable {
     /// non-data lines, the `[DONE]` sentinel, or malformed payloads.
     /// Handles both string-content deltas and the newer array-of-text
     /// deltas (responses-API shape).
-    static func streamingDelta(from line: String) -> String? {
+    public static func streamingDelta(from line: String) -> String? {
         guard line.hasPrefix("data:") else {
             return nil
         }
@@ -120,7 +120,7 @@ struct OpenAICompatibleService: Sendable {
     ///
     /// Returns the filtered/trimmed `choices[0].message.content`. Throws
     /// `.enhancementFailed` on a malformed 200 body.
-    func enhance(
+    public func enhance(
         url: URL,
         modelName: String,
         systemMessage: String,
@@ -195,7 +195,7 @@ struct OpenAICompatibleService: Sendable {
     /// Calls `onPartialResponse` on the main actor as each SSE delta
     /// arrives. Returns the filtered/trimmed final text. Throws
     /// `.enhancementFailed` if no deltas arrived.
-    func enhanceStreaming(
+    public func enhanceStreaming(
         url: URL,
         modelName: String,
         systemMessage: String,
@@ -284,7 +284,7 @@ struct OpenAICompatibleService: Sendable {
     /// Gateway (`/v1/credits`).
     ///
     /// Never throws. `providerName` is used only for log lines.
-    func verifyGETEndpoint(
+    public func verifyGETEndpoint(
         _ key: String,
         url: URL,
         providerName: String
@@ -330,7 +330,7 @@ struct OpenAICompatibleService: Sendable {
     /// can be slow enough to risk false-negative timeouts.
     ///
     /// Never throws. `providerName` is used only for log lines.
-    func verifyChatCompletionsAPIKey(
+    public func verifyChatCompletionsAPIKey(
         _ key: String,
         baseURL: String,
         defaultModel: String,

--- a/Modules/AIProviders/Tests/AIProvidersTests/CustomOpenAIServiceTests.swift
+++ b/Modules/AIProviders/Tests/AIProvidersTests/CustomOpenAIServiceTests.swift
@@ -5,7 +5,7 @@ import Networking
 import NetworkingMocks
 import os
 import Testing
-@testable import VivaDicta
+import AIProviders
 
 /// Tests cover `CustomOpenAIService` in isolation: the status-code mapping,
 /// API-key forwarding, body shape, and URLError handling - both raw and

--- a/Modules/AIProviders/Tests/AIProvidersTests/OllamaServiceTests.swift
+++ b/Modules/AIProviders/Tests/AIProvidersTests/OllamaServiceTests.swift
@@ -5,7 +5,7 @@ import Networking
 import NetworkingMocks
 import os
 import Testing
-@testable import VivaDicta
+import AIProviders
 
 /// Tests cover `OllamaService` in isolation: the HTTP shape of model
 /// fetching (OpenAI-compatible + native fallback) and connection checks.

--- a/Modules/AIProviders/Tests/AIProvidersTests/OpenAICompatibleServiceTests.swift
+++ b/Modules/AIProviders/Tests/AIProvidersTests/OpenAICompatibleServiceTests.swift
@@ -5,7 +5,7 @@ import Networking
 import NetworkingMocks
 import os
 import Testing
-@testable import VivaDicta
+import AIProviders
 import AICore
 
 /// Tests cover `OpenAICompatibleService` in isolation: the static body


### PR DESCRIPTION
## Move the OpenAICompatibleService cluster into AIProviders

Relocates the three remaining HTTP provider services from the app target into `AIProviders`, all `public`:

- **`OpenAICompatibleService`** - the shared `POST /v1/chat/completions` client that ~10 cloud providers (OpenAI, Groq, Cerebras, Mistral, xAI, OpenRouter, Z.AI, Kimi, Vercel AI Gateway, HuggingFace) route through, plus its `static buildRequestBody` / `streamingDelta` helpers.
- **`OllamaService`** - local/cloud Ollama model discovery + reachability.
- **`CustomOpenAIService`** - custom-endpoint probe returning a structured `TestResult`.

Plus their three test files. The three services are independent - they don't call each other; `AIService` orchestrates them - so they move together but as peers.

### Behavior

Pure relocation - **no behavior change.** All three files are unchanged in line count (377 / 127 / 185); after stripping the `public` additions (and the single `Sendable` added to `OllamaServiceError`), the bodies are byte-identical. No change to request-body building, SSE `streamingDelta` parsing, status/error mapping, Ollama `fetchModels`/`checkConnection`, or `CustomOpenAIService.testEndpoint`.

### Wiring

- All three services already had the right shape (`struct … : Sendable`, receive `NetworkService` + `Logger` via `init`), so no logger or dependency changes were needed - `AIProviders`' existing `AICore` + `Networking` deps cover them.
- The 3 tests move into `AIProvidersTests` (`@testable import VivaDicta` → `import AIProviders`); the target now has **68 tests** across 4 suites.
- `AIService` constructs them via the `import AIProviders` it already had; the `static` helper calls (`buildRequestBody` / `streamingDelta`) resolve against the now-`public` methods.
- **No `Package.swift` or `project.pbxproj` change** (`AIProviders` was already linked to the app + `VivaDictaTests`; the tests now live in the package).

### Verification

- `AIProviders` builds in isolation (`swift build`) and its 68 tests pass.
- App + all three extensions + test bundle build green (`build-for-testing`, iOS 26.4 simulator).

### Next

`AIProviders` now holds 5 providers. Remaining: the OAuth-routed clients (`Gemini` / `Copilot` / `OpenAIOAuth`), then defining the `AITextProvider` protocol and introducing the registry + orchestration in `AIKit`.
