### PR TITLE
Tidy AIProviders provider doc comments

### DIFF
--- a/Modules/AIProviders/Sources/AIProviders/AnthropicService.swift
+++ b/Modules/AIProviders/Sources/AIProviders/AnthropicService.swift
@@ -8,9 +8,7 @@ import AICore
 /// Pure HTTP wrapper for Anthropic's Messages API. Stateless apart from
 /// its dependencies.
 ///
-/// Lives in the app target alongside `OllamaService` and `CustomOpenAIService`
-/// as the third step of the AIService decomposition (Phase 2a of the
-/// architecture migration). `AIService` retains ownership of routing
+/// Lives in the `AIProviders` module. `AIService` retains ownership of routing
 /// decisions (CLI Server fallback, model selection, API-key lookup) and
 /// the observable connection state; this struct just runs the HTTP calls.
 ///

--- a/Modules/AIProviders/Sources/AIProviders/CustomOpenAIService.swift
+++ b/Modules/AIProviders/Sources/AIProviders/CustomOpenAIService.swift
@@ -7,9 +7,7 @@ import os
 /// Pure HTTP wrapper for testing a user-configured "Custom OpenAI"
 /// endpoint. Stateless apart from its dependencies.
 ///
-/// Lives in the app target alongside `OllamaService` as the second step of
-/// the AIService decomposition (Phase 2a of the architecture migration).
-/// `AIService` retains ownership of the `@Observable` configuration state
+/// Lives in the `AIProviders` module. `AIService` retains ownership of the `@Observable` configuration state
 /// (`customOpenAIEndpointURL`, `customOpenAIModelName`,
 /// `customOpenAIIsVerified`); this struct just runs the HTTP probe and
 /// returns a structured result.

--- a/Modules/AIProviders/Sources/AIProviders/OllamaService.swift
+++ b/Modules/AIProviders/Sources/AIProviders/OllamaService.swift
@@ -7,8 +7,7 @@ import os
 /// Pure HTTP wrapper for the local Ollama server's model-discovery and
 /// connection-check endpoints. Stateless apart from its dependencies.
 ///
-/// Lives in the app target as the first step of the AIService decomposition
-/// (Phase 2a of the architecture migration). `AIService` retains ownership
+/// Lives in the `AIProviders` module. `AIService` retains ownership
 /// of the `@Observable` `ollamaModels` state and the user-configurable
 /// `ollamaServerURL`; `OllamaService` just runs the HTTP calls and returns
 /// values.

--- a/Modules/AIProviders/Sources/AIProviders/OpenAICompatibleService.swift
+++ b/Modules/AIProviders/Sources/AIProviders/OpenAICompatibleService.swift
@@ -9,8 +9,7 @@ import AICore
 /// (`POST /v1/chat/completions` with Bearer auth and standard `messages`
 /// body). Stateless apart from its dependencies.
 ///
-/// The fourth provider service in Phase 2a/2b of the AIService
-/// decomposition. Used by ~10 cloud providers (OpenAI, Groq, Cerebras,
+/// Lives in the `AIProviders` module. Used by ~10 cloud providers (OpenAI, Groq, Cerebras,
 /// Mistral, xAI/Grok, OpenRouter, Z.AI, Kimi, Vercel AI Gateway,
 /// HuggingFace) that all share the OpenAI shape. Indirectly used by
 /// Ollama and Custom OpenAI through the static `buildRequestBody` and

--- a/VivaDicta.xcodeproj/project.pbxproj
+++ b/VivaDicta.xcodeproj/project.pbxproj
@@ -32,14 +32,6 @@
 		18B497F22F268B2700538830 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = 18B497F12F268B2700538830 /* FirebaseCrashlytics */; };
 		18B89BC32FB875530007FA96 /* TranscriptionKit in Frameworks */ = {isa = PBXBuildFile; productRef = 18B89BC22FB875530007FA96 /* TranscriptionKit */; };
 		18B8BEB12FB8BD7D0007FA96 /* DesignSystem in Frameworks */ = {isa = PBXBuildFile; productRef = 18B8BEB02FB8BD7D0007FA96 /* DesignSystem */; };
-		BFBF000000000000000000C1 /* AICore in Frameworks */ = {isa = PBXBuildFile; productRef = AEAE000000000000000000C1 /* AICore */; };
-		BFBF000000000000000000C3 /* AICore in Frameworks */ = {isa = PBXBuildFile; productRef = AEAE000000000000000000C3 /* AICore */; };
-		BFBF000000000000000000C4 /* AICore in Frameworks */ = {isa = PBXBuildFile; productRef = AEAE000000000000000000C4 /* AICore */; };
-		BFBF000000000000000000C5 /* AICore in Frameworks */ = {isa = PBXBuildFile; productRef = AEAE000000000000000000C5 /* AICore */; };
-		BFBF000000000000000000D1 /* AIProviders in Frameworks */ = {isa = PBXBuildFile; productRef = AEAE000000000000000000D1 /* AIProviders */; };
-		BFBF000000000000000000E1 /* AIKit in Frameworks */ = {isa = PBXBuildFile; productRef = AEAE000000000000000000E1 /* AIKit */; };
-		BFBF000000000000000000C2 /* AICore in Frameworks */ = {isa = PBXBuildFile; productRef = AEAE000000000000000000C2 /* AICore */; };
-		BFBF000000000000000000D2 /* AIProviders in Frameworks */ = {isa = PBXBuildFile; productRef = AEAE000000000000000000D2 /* AIProviders */; };
 		18B8CF2C2FB8C4690007FA96 /* DesignSystem in Frameworks */ = {isa = PBXBuildFile; productRef = 18B8CF2B2FB8C4690007FA96 /* DesignSystem */; };
 		18BA24132F7ED0D700C4F68B /* VivaDictaWatch Watch App.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 18BA23F32F7ED0D500C4F68B /* VivaDictaWatch Watch App.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		18BA29262F7F29FD00C4F68B /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 18E1C7FB2E8E793E00BE8A11 /* WidgetKit.framework */; };
@@ -63,6 +55,14 @@
 		18F76A3A2FB85C2300280269 /* AppGroup in Frameworks */ = {isa = PBXBuildFile; productRef = 18F76A392FB85C2300280269 /* AppGroup */; };
 		18F76A3C2FB85C2A00280269 /* AppGroup in Frameworks */ = {isa = PBXBuildFile; productRef = 18F76A3B2FB85C2A00280269 /* AppGroup */; };
 		18F76D862FB8617C00280269 /* AppGroup in Frameworks */ = {isa = PBXBuildFile; productRef = 18F76D852FB8617C00280269 /* AppGroup */; };
+		BFBF000000000000000000C1 /* AICore in Frameworks */ = {isa = PBXBuildFile; productRef = AEAE000000000000000000C1 /* AICore */; };
+		BFBF000000000000000000C2 /* AICore in Frameworks */ = {isa = PBXBuildFile; productRef = AEAE000000000000000000C2 /* AICore */; };
+		BFBF000000000000000000C3 /* AICore in Frameworks */ = {isa = PBXBuildFile; productRef = AEAE000000000000000000C3 /* AICore */; };
+		BFBF000000000000000000C4 /* AICore in Frameworks */ = {isa = PBXBuildFile; productRef = AEAE000000000000000000C4 /* AICore */; };
+		BFBF000000000000000000C5 /* AICore in Frameworks */ = {isa = PBXBuildFile; productRef = AEAE000000000000000000C5 /* AICore */; };
+		BFBF000000000000000000D1 /* AIProviders in Frameworks */ = {isa = PBXBuildFile; productRef = AEAE000000000000000000D1 /* AIProviders */; };
+		BFBF000000000000000000D2 /* AIProviders in Frameworks */ = {isa = PBXBuildFile; productRef = AEAE000000000000000000D2 /* AIProviders */; };
+		BFBF000000000000000000E1 /* AIKit in Frameworks */ = {isa = PBXBuildFile; productRef = AEAE000000000000000000E1 /* AIKit */; };
 		E1938683EE7E439ABF4FE3EA /* TranscriptionKitMocks in Frameworks */ = {isa = PBXBuildFile; productRef = F4E0FCBD69B741548F9F6B15 /* TranscriptionKitMocks */; };
 /* End PBXBuildFile section */
 
@@ -2502,38 +2502,6 @@
 			isa = XCSwiftPackageProductDependency;
 			productName = TranscriptionKit;
 		};
-		AEAE000000000000000000C1 /* AICore */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = AICore;
-		};
-		AEAE000000000000000000D1 /* AIProviders */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = AIProviders;
-		};
-		AEAE000000000000000000E1 /* AIKit */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = AIKit;
-		};
-		AEAE000000000000000000C3 /* AICore */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = AICore;
-		};
-		AEAE000000000000000000C4 /* AICore */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = AICore;
-		};
-		AEAE000000000000000000C5 /* AICore */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = AICore;
-		};
-		AEAE000000000000000000C2 /* AICore */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = AICore;
-		};
-		AEAE000000000000000000D2 /* AIProviders */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = AIProviders;
-		};
 		18B8BEB02FB8BD7D0007FA96 /* DesignSystem */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = DesignSystem;
@@ -2599,6 +2567,38 @@
 		18F76D852FB8617C00280269 /* AppGroup */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = AppGroup;
+		};
+		AEAE000000000000000000C1 /* AICore */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AICore;
+		};
+		AEAE000000000000000000C2 /* AICore */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AICore;
+		};
+		AEAE000000000000000000C3 /* AICore */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AICore;
+		};
+		AEAE000000000000000000C4 /* AICore */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AICore;
+		};
+		AEAE000000000000000000C5 /* AICore */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AICore;
+		};
+		AEAE000000000000000000D1 /* AIProviders */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AIProviders;
+		};
+		AEAE000000000000000000D2 /* AIProviders */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AIProviders;
+		};
+		AEAE000000000000000000E1 /* AIKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AIKit;
 		};
 		F4E0FCBD69B741548F9F6B15 /* TranscriptionKitMocks */ = {
 			isa = XCSwiftPackageProductDependency;


### PR DESCRIPTION
Doc-only cleanup. The provider files moved into `AIProviders` over the last few PRs still carried `// Lives in the app target ... as the Nth step of the AIService decomposition (Phase 2a ...)` headers, which are now inaccurate. Reworded the four affected files (`AnthropicService`, `OpenAICompatibleService`, `CustomOpenAIService`, `OllamaService`) to `// Lives in the AIProviders module` and dropped the transient migration-step language. No code change; `AIProviders` builds.