### PR TITLE
Move OAuth provider clients into AIProviders

### DIFF
--- a/Modules/AIProviders/Package.swift
+++ b/Modules/AIProviders/Package.swift
@@ -14,6 +14,7 @@ let package = Package(
     dependencies: [
         .package(path: "../AICore"),
         .package(path: "../Networking"),
+        .package(path: "../OAuth"),
     ],
     targets: [
         .target(
@@ -21,6 +22,7 @@ let package = Package(
             dependencies: [
                 .product(name: "AICore", package: "AICore"),
                 .product(name: "Networking", package: "Networking"),
+                .product(name: "OAuth", package: "OAuth"),
             ]
         ),
         .testTarget(

--- a/Modules/AIProviders/Sources/AIProviders/CopilotAPIClient.swift
+++ b/Modules/AIProviders/Sources/AIProviders/CopilotAPIClient.swift
@@ -8,17 +8,17 @@ import AICore
 
 /// Client for GitHub Copilot's OpenAI-compatible API.
 /// Uses the Copilot token obtained via device code OAuth flow.
-enum CopilotAPIClient {
-    private static let logger = Logger(category: .copilotAPI)
+public enum CopilotAPIClient {
+    private static let logger = Logger(aiProvidersCategory: "CopilotAPIClient")
 
     /// URL session used for all Copilot API calls. Override only from tests.
     nonisolated(unsafe) static var networkService: any NetworkService = DefaultNetworkService(category: "AppClient")
 
     /// Base URL for Copilot's API.
-    static let baseURL = "https://api.individual.githubcopilot.com"
+    public static let baseURL = "https://api.individual.githubcopilot.com"
 
     /// Default model for Copilot requests.
-    static let defaultModel = "gpt-4o"
+    public static let defaultModel = "gpt-4o"
 
     /// Headers required by Copilot API.
     private static let staticHeaders: [String: String] = [
@@ -30,14 +30,14 @@ enum CopilotAPIClient {
     ]
 
     /// Returns headers for chat requests including the Copilot token.
-    static func chatHeaders(copilotToken: String) -> [String: String] {
+    public static func chatHeaders(copilotToken: String) -> [String: String] {
         var headers = staticHeaders
         headers["Authorization"] = "Bearer \(copilotToken)"
         return headers
     }
 
     /// Sends an AI enhancement request via Copilot's API.
-    static func enhance(
+    public static func enhance(
         text: String,
         systemPrompt: String,
         model: String,
@@ -52,7 +52,7 @@ enum CopilotAPIClient {
         }
     }
 
-    static func enhanceStreaming(
+    public static func enhanceStreaming(
         text: String,
         systemPrompt: String,
         model: String,
@@ -282,7 +282,7 @@ enum CopilotAPIClient {
         for try await line in bytes.lines {
             if let delta = streamingDelta(from: line) {
                 aggregatedText += delta
-                onPartialResult(aggregatedText)
+                await onPartialResult(aggregatedText)
             }
         }
 
@@ -291,11 +291,11 @@ enum CopilotAPIClient {
         }
 
         let finalResult = aggregatedText.trimmingCharacters(in: .whitespacesAndNewlines)
-        onPartialResult(finalResult)
+        await onPartialResult(finalResult)
         return finalResult
     }
 
-    static func streamingDelta(from line: String) -> String? {
+    public static func streamingDelta(from line: String) -> String? {
         guard line.hasPrefix("data:") else {
             return nil
         }
@@ -331,7 +331,7 @@ enum CopilotAPIClient {
     // MARK: - Fetch Available Models
 
     /// Fetches the list of models available for the user's Copilot plan.
-    static func fetchModels(copilotToken: String) async -> [String] {
+    public static func fetchModels(copilotToken: String) async -> [String] {
         guard let url = URL(string: "\(baseURL)/models") else { return [defaultModel] }
 
         var request = URLRequest(url: url)

--- a/Modules/AIProviders/Sources/AIProviders/GeminiAPIClient.swift
+++ b/Modules/AIProviders/Sources/AIProviders/GeminiAPIClient.swift
@@ -9,17 +9,17 @@ import AICore
 /// Client for Gemini API using OAuth tokens.
 /// Uses the Cloud Code Assist endpoint (same as Gemini CLI / VS Code extension),
 /// NOT the standard generativelanguage.googleapis.com endpoint.
-enum GeminiAPIClient {
-    private static let logger = Logger(category: .geminiOAuthAPI)
+public enum GeminiAPIClient {
+    private static let logger = Logger(aiProvidersCategory: "GeminiAPIClient")
 
     /// Default model for Gemini OAuth requests.
     /// Matches `AIProvider.gemini.defaultModel` so picker defaults agree across auth modes.
-    static let defaultModel = "gemini-3.5-flash"
+    public static let defaultModel = "gemini-3.5-flash"
 
     /// Models available via Gemini OAuth (Cloud Code Assist endpoint).
     /// Kept in sync with `AIProvider.gemini.availableModels` since the Cloud Code Assist
     /// endpoint exposes the same generateContent surface as the standard API.
-    static let supportedModels: [String] = [
+    public static let supportedModels: [String] = [
         "gemini-3.1-pro-preview",
         "gemini-3.5-flash",
         "gemini-3-flash-preview",
@@ -35,13 +35,13 @@ enum GeminiAPIClient {
     private static let streamingEndpoint = "https://cloudcode-pa.googleapis.com/v1internal:streamGenerateContent?alt=sse"
 
     /// Returns the model to use. Falls back to default if empty.
-    static func resolveModel(_ requestedModel: String) -> String {
+    public static func resolveModel(_ requestedModel: String) -> String {
         if requestedModel.isEmpty { return defaultModel }
         return requestedModel
     }
 
     /// Sends an AI enhancement request via Cloud Code Assist API using OAuth token.
-    static func enhance(
+    public static func enhance(
         text: String,
         systemPrompt: String,
         model: String,
@@ -135,7 +135,7 @@ enum GeminiAPIClient {
         return resultText.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    static func enhanceStreaming(
+    public static func enhanceStreaming(
         text: String,
         systemPrompt: String,
         model: String,
@@ -240,7 +240,7 @@ enum GeminiAPIClient {
         }
 
         let finalResult = aggregatedText.trimmingCharacters(in: .whitespacesAndNewlines)
-        onPartialResult(finalResult)
+        await onPartialResult(finalResult)
         return finalResult
     }
 
@@ -272,13 +272,13 @@ enum GeminiAPIClient {
             } else {
                 aggregatedText += chunkText
             }
-            onPartialResult(aggregatedText)
+            await onPartialResult(aggregatedText)
         }
 
         return aggregatedText
     }
 
-    static func streamingText(from event: [String: Any]) -> String? {
+    public static func streamingText(from event: [String: Any]) -> String? {
         let geminiResponse: [String: Any]
         if let wrapped = event["response"] as? [String: Any] {
             geminiResponse = wrapped
@@ -304,7 +304,7 @@ enum GeminiAPIClient {
     /// - Parameter messages: conversation turns as `[{"role": "user"|"assistant", "content": "..."}]`.
     ///   System entries are ignored; the system prompt goes into `systemInstruction`.
     ///   The `assistant` role is translated to Gemini's `model` role.
-    static func chatStreaming(
+    public static func chatStreaming(
         systemMessage: String,
         messages: [[String: String]],
         model: String,
@@ -426,7 +426,7 @@ enum GeminiAPIClient {
                 } else {
                     aggregatedText += chunkText
                 }
-                onPartialResponse(aggregatedText)
+                await onPartialResponse(aggregatedText)
             }
         }
 
@@ -438,13 +438,13 @@ enum GeminiAPIClient {
         let trimmed = aggregatedText.trimmingCharacters(in: .whitespacesAndNewlines)
         let filtered = AIEnhancementOutputFilter.filter(trimmed)
         if filtered != aggregatedText {
-            onPartialResponse(filtered)
+            await onPartialResponse(filtered)
         }
         return filtered
     }
 
     /// Multi-turn non-streaming chat. Implemented by buffering the streaming helper.
-    static func chat(
+    public static func chat(
         systemMessage: String,
         messages: [[String: String]],
         model: String,

--- a/Modules/AIProviders/Sources/AIProviders/OpenAIOAuthClient.swift
+++ b/Modules/AIProviders/Sources/AIProviders/OpenAIOAuthClient.swift
@@ -7,8 +7,8 @@ import OAuth
 import AICore
 
 /// Client for OpenAI's backend API using OAuth tokens.
-enum OpenAIOAuthClient {
-    private static let logger = Logger(category: .openAIOAuthAPI)
+public enum OpenAIOAuthClient {
+    private static let logger = Logger(aiProvidersCategory: "OpenAIOAuthClient")
 
     /// URL session used for all OpenAI OAuth API calls. Override only from tests.
     nonisolated(unsafe) static var networkService: any NetworkService = DefaultNetworkService(category: "AppClient")
@@ -17,10 +17,10 @@ enum OpenAIOAuthClient {
     private static let originator = "codex_cli_rs"
 
     /// Default model for OpenAI OAuth requests.
-    static let defaultModel = "gpt-5.4-mini"
+    public static let defaultModel = "gpt-5.4-mini"
 
     /// Models supported by the Codex endpoint (OpenAI OAuth).
-    static let supportedModels: [String] = [
+    public static let supportedModels: [String] = [
         "gpt-5.5",
         "gpt-5.4",
         "gpt-5.4-mini",
@@ -30,7 +30,7 @@ enum OpenAIOAuthClient {
 
     /// Returns the model to use for the Codex endpoint.
     /// Falls back to default if the requested model isn't supported.
-    static func resolveModel(_ requestedModel: String) -> String {
+    public static func resolveModel(_ requestedModel: String) -> String {
         if requestedModel.isEmpty {
             return defaultModel
         }
@@ -41,7 +41,7 @@ enum OpenAIOAuthClient {
     }
 
     /// Sends a single-turn AI enhancement request via OpenAI's backend API.
-    static func enhance(
+    public static func enhance(
         text: String,
         systemPrompt: String,
         model: String,
@@ -80,7 +80,7 @@ enum OpenAIOAuthClient {
     ///
     /// - Parameter messages: conversation turns as `[{"role": "user"|"assistant", "content": "..."}]`.
     ///   System entries are ignored here; the system prompt goes into `instructions`.
-    static func chatStreaming(
+    public static func chatStreaming(
         systemMessage: String,
         messages: [[String: String]],
         model: String,
@@ -117,13 +117,13 @@ enum OpenAIOAuthClient {
 
         let filtered = AIEnhancementOutputFilter.filter(raw)
         if filtered != raw {
-            onPartialResponse(filtered)
+            await onPartialResponse(filtered)
         }
         return filtered
     }
 
     /// Multi-turn non-streaming chat. Implemented by buffering the streaming helper.
-    static func chat(
+    public static func chat(
         systemMessage: String,
         messages: [[String: String]],
         model: String,
@@ -141,7 +141,7 @@ enum OpenAIOAuthClient {
     }
 
     /// Fetches available models from OpenAI's backend.
-    static func fetchModels(accessToken: String) async throws -> [String] {
+    public static func fetchModels(accessToken: String) async throws -> [String] {
         guard let url = URL(string: OpenAIOAuthProvider.modelsEndpoint) else {
             return [defaultModel]
         }
@@ -235,7 +235,7 @@ enum OpenAIOAuthClient {
                let delta = event["delta"] as? String {
                 result += delta
                 if let onPartialResult {
-                    onPartialResult(result)
+                    await onPartialResult(result)
                 }
             }
         }
@@ -247,7 +247,7 @@ enum OpenAIOAuthClient {
 
         let finalResult = result.trimmingCharacters(in: .whitespacesAndNewlines)
         if let onPartialResult {
-            onPartialResult(finalResult)
+            await onPartialResult(finalResult)
         }
 
         return finalResult

--- a/VivaDicta/Services/AIEnhance/AIService+Chat.swift
+++ b/VivaDicta/Services/AIEnhance/AIService+Chat.swift
@@ -11,6 +11,7 @@ import Networking
 import os
 import OAuth
 import AICore
+import AIProviders
 
 /// Multi-turn chat support for AIService.
 ///

--- a/VivaDicta/Services/Reminders/CloudReminderExtractionProvider.swift
+++ b/VivaDicta/Services/Reminders/CloudReminderExtractionProvider.swift
@@ -10,6 +10,7 @@ import Networking
 import os
 import OAuth
 import AICore
+import AIProviders
 
 private struct CloudReminderDraftPayload: Codable {
     var title: String


### PR DESCRIPTION
## Move the OAuth provider clients into AIProviders

Relocates the three OAuth-routed provider clients - `GeminiAPIClient`, `CopilotAPIClient`, `OpenAIOAuthClient` (each an `enum` namespace of `static func`s) - from the app target into `AIProviders`. **This completes the provider extraction: all eight providers now live in `AIProviders`.**

### Behavior

Pure relocation in intent - verified behavior-preserving. After factoring out the changes below, the three bodies are byte-identical: endpoint URLs, HTTP headers/method/timeouts, JSON request bodies, SSE/stream parsing, error mapping (429/401/5xx → `EnhancementError`/`OAuthError`), and model resolution are all unchanged.

### Changes beyond access control (`public` on the enums + non-private static members)

1. **`OAuth` dependency added to `AIProviders`** - the clients use `OAuthError` (Gemini), `OpenAIOAuthProvider` (OpenAIOAuth), and `CopilotOAuthError` (Copilot). No dependency cycle: `OAuth` depends only on `Keychain`/`Networking`.
2. **Logger redirect** - these clients *self-create* their logger, so `Logger(category: .geminiOAuthAPI/…)` → `Logger(aiProvidersCategory: "GeminiAPIClient"/…)`. The category strings equal the old `LogCategory` rawValues and the subsystem is identical, so **OS-log labels are unchanged**.
3. **`await` on 9 `@MainActor` closure calls** - the partial-result callbacks (`onPartialResult`/`onPartialResponse`) are `@MainActor`; the funcs are nonisolated in the module (the app compiled them under MainActor default-isolation), so the calls now need `await` - the same isolation shift the already-extracted `AnthropicService` has. Only the call sites changed; no closure declaration became `async`.

### Wiring

- `import AIProviders` added to `AIService+Chat` and `CloudReminderExtractionProvider` (`AIService` and `AIServiceConfigurationTests` already had it). The `VivaMode` reference is a doc comment and the `LoggerExtension` ones are `LogCategory` rawValue strings - neither needs an import.
- No tests existed for these clients, so none moved. **No `project.pbxproj` change** (synchronized-folder move; `AIProviders` already linked to app + tests).

### Verification

- `AIProviders` builds in isolation (fresh build, zero warnings) and its 68 tests pass.
- App + all three extensions + test bundle build green (`build-for-testing`, iOS 26.4 simulator).

### Next

The impl layer is complete. Remaining is the architecture layer: define the `AITextProvider` protocol in `AICore` (Phase 10), introduce the `AIProviderRegistry` in `AIKit` (Phase 11), then lift the enhance/chat orchestration out of `AIService` into `AIKit` (Phase 12 - where `AIKit` fills and `AIService` finally shrinks).
