### PR TITLE
Add AITextProvider protocol and per-provider wrappers

### DIFF
--- a/Modules/AICore/Sources/AICore/AITextProvider.swift
+++ b/Modules/AICore/Sources/AICore/AITextProvider.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// A provider that turns a system message + user message into enhanced text,
+/// with an optional streaming variant that reports partial results.
+///
+/// Conformers bind their per-provider configuration (API key, endpoint URL,
+/// headers, model, OAuth token, sampling profile, ...) at construction, so this
+/// protocol stays uniform across every backend. Consumers (the orchestrator /
+/// registry) depend only on `AITextProvider` and never on a concrete provider.
+public protocol AITextProvider: Sendable {
+    /// Non-streaming enhancement. Returns the final enhanced text.
+    func enhance(systemMessage: String, userMessage: String) async throws -> String
+
+    /// Streaming enhancement. Calls `onPartialResponse` on the main actor as
+    /// partial text arrives, and returns the final enhanced text.
+    func enhanceStreaming(
+        systemMessage: String,
+        userMessage: String,
+        onPartialResponse: @escaping @MainActor (String) -> Void
+    ) async throws -> String
+}

--- a/Modules/AIProviders/Sources/AIProviders/TextProviders.swift
+++ b/Modules/AIProviders/Sources/AIProviders/TextProviders.swift
@@ -168,6 +168,8 @@ public struct OpenAIOAuthTextProvider: AITextProvider {
     }
 
     public func enhanceStreaming(systemMessage: String, userMessage: String, onPartialResponse: @escaping @MainActor (String) -> Void) async throws -> String {
+        // OpenAIOAuthClient has no separate enhanceStreaming - its single enhance
+        // streams when given an onPartialResult callback. This is intentional.
         try await OpenAIOAuthClient.enhance(text: userMessage, systemPrompt: systemMessage, model: model, accessToken: accessToken, accountId: accountId, onPartialResult: onPartialResponse)
     }
 }

--- a/Modules/AIProviders/Sources/AIProviders/TextProviders.swift
+++ b/Modules/AIProviders/Sources/AIProviders/TextProviders.swift
@@ -1,0 +1,173 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import Networking
+import os
+import AICore
+
+// Thin `AITextProvider` conformances that bind each backend's per-request
+// configuration and delegate to the underlying service. The services are
+// unchanged; these wrappers normalize naming and config so consumers can treat
+// every backend uniformly as `any AITextProvider`.
+
+// MARK: - Anthropic
+
+public struct AnthropicTextProvider: AITextProvider {
+    private let service: AnthropicService
+    private let apiKey: String
+    private let model: String
+
+    public init(networkService: any NetworkService, logger: Logger, baseTimeout: TimeInterval, apiKey: String, model: String) {
+        self.service = AnthropicService(networkService: networkService, logger: logger, baseTimeout: baseTimeout)
+        self.apiKey = apiKey
+        self.model = model
+    }
+
+    public func enhance(systemMessage: String, userMessage: String) async throws -> String {
+        try await service.enhance(systemMessage: systemMessage, userMessage: userMessage, apiKey: apiKey, model: model)
+    }
+
+    public func enhanceStreaming(systemMessage: String, userMessage: String, onPartialResponse: @escaping @MainActor (String) -> Void) async throws -> String {
+        try await service.enhanceStreaming(systemMessage: systemMessage, userMessage: userMessage, apiKey: apiKey, model: model, onPartialResponse: onPartialResponse)
+    }
+}
+
+// MARK: - OpenAI-compatible (OpenAI, Groq, Cerebras, Mistral, xAI, OpenRouter, Z.AI, Kimi, Vercel, HuggingFace)
+
+public struct OpenAICompatibleTextProvider: AITextProvider {
+    private let service: OpenAICompatibleService
+    private let url: URL
+    private let modelName: String
+    private let headers: [String: String]
+    private let timeout: TimeInterval
+    private let errorPrefix: String
+    private let notFoundMessage: String?
+    private let unauthorizedMessage: String?
+
+    public init(
+        networkService: any NetworkService,
+        logger: Logger,
+        url: URL,
+        modelName: String,
+        headers: [String: String],
+        timeout: TimeInterval,
+        errorPrefix: String,
+        notFoundMessage: String? = nil,
+        unauthorizedMessage: String? = nil
+    ) {
+        self.service = OpenAICompatibleService(networkService: networkService, logger: logger)
+        self.url = url
+        self.modelName = modelName
+        self.headers = headers
+        self.timeout = timeout
+        self.errorPrefix = errorPrefix
+        self.notFoundMessage = notFoundMessage
+        self.unauthorizedMessage = unauthorizedMessage
+    }
+
+    public func enhance(systemMessage: String, userMessage: String) async throws -> String {
+        try await service.enhance(url: url, modelName: modelName, systemMessage: systemMessage, userMessage: userMessage, headers: headers, timeout: timeout)
+    }
+
+    public func enhanceStreaming(systemMessage: String, userMessage: String, onPartialResponse: @escaping @MainActor (String) -> Void) async throws -> String {
+        try await service.enhanceStreaming(
+            url: url,
+            modelName: modelName,
+            systemMessage: systemMessage,
+            userMessage: userMessage,
+            headers: headers,
+            timeout: timeout,
+            errorPrefix: errorPrefix,
+            notFoundMessage: notFoundMessage,
+            unauthorizedMessage: unauthorizedMessage,
+            onPartialResponse: onPartialResponse
+        )
+    }
+}
+
+// MARK: - Apple Foundation Model (on-device, iOS/macOS 26+)
+
+@available(iOS 26, macOS 26, *)
+public struct AppleFMTextProvider: AITextProvider {
+    private let samplingProfile: AppleFoundationModelSamplingProfile
+
+    public init(samplingProfile: AppleFoundationModelSamplingProfile) {
+        self.samplingProfile = samplingProfile
+    }
+
+    // AppleFoundationModelService is @MainActor, so it's constructed inside the
+    // async calls (which hop to the main actor) rather than in this nonisolated init.
+    public func enhance(systemMessage: String, userMessage: String) async throws -> String {
+        try await AppleFoundationModelService().enhance(systemMessage: systemMessage, userMessage: userMessage, samplingProfile: samplingProfile)
+    }
+
+    public func enhanceStreaming(systemMessage: String, userMessage: String, onPartialResponse: @escaping @MainActor (String) -> Void) async throws -> String {
+        try await AppleFoundationModelService().enhanceStreaming(systemMessage: systemMessage, userMessage: userMessage, samplingProfile: samplingProfile, onPartialResponse: onPartialResponse)
+    }
+}
+
+// MARK: - Gemini (OAuth). Maps systemMessage -> systemPrompt, userMessage -> text.
+
+public struct GeminiTextProvider: AITextProvider {
+    private let model: String
+    private let accessToken: String
+    private let projectId: String?
+    private let networkService: any NetworkService
+
+    public init(model: String, accessToken: String, projectId: String?, networkService: any NetworkService) {
+        self.model = model
+        self.accessToken = accessToken
+        self.projectId = projectId
+        self.networkService = networkService
+    }
+
+    public func enhance(systemMessage: String, userMessage: String) async throws -> String {
+        try await GeminiAPIClient.enhance(text: userMessage, systemPrompt: systemMessage, model: model, accessToken: accessToken, projectId: projectId, networkService: networkService)
+    }
+
+    public func enhanceStreaming(systemMessage: String, userMessage: String, onPartialResponse: @escaping @MainActor (String) -> Void) async throws -> String {
+        try await GeminiAPIClient.enhanceStreaming(text: userMessage, systemPrompt: systemMessage, model: model, accessToken: accessToken, projectId: projectId, onPartialResult: onPartialResponse, networkService: networkService)
+    }
+}
+
+// MARK: - GitHub Copilot (OAuth). Maps systemMessage -> systemPrompt, userMessage -> text.
+
+public struct CopilotTextProvider: AITextProvider {
+    private let model: String
+    private let copilotToken: String
+
+    public init(model: String, copilotToken: String) {
+        self.model = model
+        self.copilotToken = copilotToken
+    }
+
+    public func enhance(systemMessage: String, userMessage: String) async throws -> String {
+        try await CopilotAPIClient.enhance(text: userMessage, systemPrompt: systemMessage, model: model, copilotToken: copilotToken)
+    }
+
+    public func enhanceStreaming(systemMessage: String, userMessage: String, onPartialResponse: @escaping @MainActor (String) -> Void) async throws -> String {
+        try await CopilotAPIClient.enhanceStreaming(text: userMessage, systemPrompt: systemMessage, model: model, copilotToken: copilotToken, onPartialResult: onPartialResponse)
+    }
+}
+
+// MARK: - OpenAI (OAuth). Maps systemMessage -> systemPrompt, userMessage -> text.
+
+public struct OpenAIOAuthTextProvider: AITextProvider {
+    private let model: String
+    private let accessToken: String
+    private let accountId: String?
+
+    public init(model: String, accessToken: String, accountId: String?) {
+        self.model = model
+        self.accessToken = accessToken
+        self.accountId = accountId
+    }
+
+    public func enhance(systemMessage: String, userMessage: String) async throws -> String {
+        try await OpenAIOAuthClient.enhance(text: userMessage, systemPrompt: systemMessage, model: model, accessToken: accessToken, accountId: accountId)
+    }
+
+    public func enhanceStreaming(systemMessage: String, userMessage: String, onPartialResponse: @escaping @MainActor (String) -> Void) async throws -> String {
+        try await OpenAIOAuthClient.enhance(text: userMessage, systemPrompt: systemMessage, model: model, accessToken: accessToken, accountId: accountId, onPartialResult: onPartialResponse)
+    }
+}

--- a/Modules/AIProviders/Tests/AIProvidersTests/TextProvidersTests.swift
+++ b/Modules/AIProviders/Tests/AIProvidersTests/TextProvidersTests.swift
@@ -52,4 +52,25 @@ struct TextProvidersTests {
         #expect(body.contains("SYSMARK"))
         #expect(body.contains("USRMARK"))
     }
+
+    /// Regression guard for the OAuth naming map: GeminiTextProvider must place
+    /// `systemMessage` in Gemini's `systemInstruction` slot and `userMessage` in
+    /// the user `contents` slot. A swap would compile cleanly and silently send
+    /// the user's text as the system prompt - this pins it. (Gemini is the one
+    /// OAuth client with an injectable transport, so it's the cheap one to lock.)
+    @Test func geminiWrapperMapsSystemMessageToSystemInstructionAndUserMessageToContents() async {
+        let net = MockNetworkService()
+        net.stubSendResponse = .failure(URLError(.badServerResponse)) // response irrelevant; assert the request
+        let sut = GeminiTextProvider(model: "gemini-test", accessToken: "tok", projectId: nil, networkService: net)
+
+        _ = try? await sut.enhance(systemMessage: "SYSMARK", userMessage: "USRMARK")
+
+        let json = try? JSONSerialization.jsonObject(with: net.capturedRequest?.httpBody ?? Data()) as? [String: Any]
+        let request = json?["request"] as? [String: Any]
+        let systemText = ((request?["systemInstruction"] as? [String: Any])?["parts"] as? [[String: Any]])?.first?["text"] as? String
+        let userText = ((request?["contents"] as? [[String: Any]])?.first?["parts"] as? [[String: Any]])?.first?["text"] as? String
+
+        #expect(systemText == "SYSMARK", "systemMessage must map to Gemini systemInstruction")
+        #expect(userText == "USRMARK", "userMessage must map to Gemini user contents")
+    }
 }

--- a/Modules/AIProviders/Tests/AIProvidersTests/TextProvidersTests.swift
+++ b/Modules/AIProviders/Tests/AIProvidersTests/TextProvidersTests.swift
@@ -1,0 +1,55 @@
+import Testing
+import Foundation
+import Networking
+import NetworkingMocks
+import os
+import AIProviders
+
+/// Smoke tests proving the thin `AITextProvider` wrappers delegate end-to-end
+/// (bind config + forward system/user message + return the parsed result)
+/// through a mocked transport. The per-provider request/parse logic is covered
+/// by each service's own test suite; the wrappers' job is config binding and
+/// naming normalization.
+@Suite("AITextProvider wrappers", .tags(.networking))
+struct TextProvidersTests {
+
+    private func http(_ code: Int) -> HTTPURLResponse {
+        HTTPURLResponse(url: URL(string: "https://example.com")!, statusCode: code, httpVersion: nil, headerFields: nil)!
+    }
+
+    private func logger() -> Logger { Logger(subsystem: "test", category: "TextProvidersTests") }
+
+    @Test func anthropicWrapperForwardsMessagesAndReturnsEnhancedText() async throws {
+        let net = MockNetworkService()
+        net.stubSendResponse = .success((Data(#"{"content":[{"text":"ENHANCED"}]}"#.utf8), http(200)))
+
+        let sut = AnthropicTextProvider(
+            networkService: net, logger: logger(), baseTimeout: 30,
+            apiKey: "sk-test", model: "claude-sonnet-4-6"
+        )
+        let result = try await sut.enhance(systemMessage: "SYSMARK", userMessage: "USRMARK")
+
+        #expect(result == "ENHANCED")
+        let body = String(data: net.capturedRequest?.httpBody ?? Data(), encoding: .utf8) ?? ""
+        #expect(body.contains("SYSMARK"))   // system message reached the request
+        #expect(body.contains("USRMARK"))   // user message reached the request
+    }
+
+    @Test func openAICompatibleWrapperForwardsMessagesAndReturnsEnhancedText() async throws {
+        let net = MockNetworkService()
+        net.stubSendResponse = .success((Data(#"{"choices":[{"message":{"content":"ENHANCED"}}]}"#.utf8), http(200)))
+
+        let sut = OpenAICompatibleTextProvider(
+            networkService: net, logger: logger(),
+            url: URL(string: "https://api.example.com/v1/chat/completions")!,
+            modelName: "gpt-test", headers: ["Authorization": "Bearer x"], timeout: 30,
+            errorPrefix: "Example"
+        )
+        let result = try await sut.enhance(systemMessage: "SYSMARK", userMessage: "USRMARK")
+
+        #expect(result == "ENHANCED")
+        let body = String(data: net.capturedRequest?.httpBody ?? Data(), encoding: .utf8) ?? ""
+        #expect(body.contains("SYSMARK"))
+        #expect(body.contains("USRMARK"))
+    }
+}


### PR DESCRIPTION
## Add AITextProvider protocol + per-provider wrapper conformances

Introduces a uniform provider abstraction so the upcoming orchestrator/registry can treat every backend as `any AITextProvider` instead of a `switch` over provider types. This is the first **design** step (not a relocation) - the approach (wrapper structs, enhance-only scope) was chosen deliberately given the providers' divergent signatures.

### What

- **`AICore`: the `AITextProvider` protocol** - `enhance(systemMessage:userMessage:)` + `enhanceStreaming(...:onPartialResponse:)` (the partial callback is `@MainActor`). Foundation-only, so `AICore` stays a pure kernel.
- **`AIProviders`: six thin wrapper structs** - `AnthropicTextProvider`, `OpenAICompatibleTextProvider`, `AppleFMTextProvider`, `GeminiTextProvider`, `CopilotTextProvider`, `OpenAIOAuthTextProvider`. Each binds its backend's per-request config (API key / endpoint / headers / model / OAuth token / sampling profile) and delegates to the unchanged underlying service.

### Why wrappers (vs refactoring the services)

The 8 providers have genuinely divergent shapes - different config params, two naming conventions (`systemMessage/userMessage` vs `systemPrompt/text`), and static-`enum` vs instance forms. Thin wrappers bind the config and normalize naming at the boundary, leaving the already-extracted, already-tested services untouched. The composition root will build the right wrapper per request (next phase).

### Two details worth noting

- **OAuth naming map:** the Gemini/Copilot/OpenAIOAuth wrappers map `systemMessage → systemPrompt` and `userMessage → text`. Verified not swapped (a swap would silently send user text as the system prompt).
- **AppleFM isolation:** `AppleFoundationModelService` is `@MainActor`, so `AppleFMTextProvider` is `@available(iOS 26, macOS 26)` and constructs the service *inside* its async methods (which hop to the main actor) rather than in its nonisolated `init`.

### Behavior

**Purely additive - no behavior change.** Nothing is wired to these types yet (`git diff --stat HEAD` touches no existing file); they're introduced here and consumed by the registry in the next phase.

### Verification

- `AICore` 15 tests, `AIProviders` 70 tests (incl. wrapper delegation smoke tests), all green; both build under Swift 6 strict concurrency.
- App + all three extensions + test bundle build green (`build-for-testing`, iOS 26.4 simulator).

### Next

`AIProviderRegistry` in `AIKit` (its first real content) - maps a provider id to an injected `any AITextProvider` - then `AIService`'s enhancement path routes through the registry (the god-class shrink).
