### PR TITLE
Add AIProviderRegistry to AIKit (Phase 11a, additive)

### DIFF
--- a/Modules/AIKit/Package.swift
+++ b/Modules/AIKit/Package.swift
@@ -12,20 +12,36 @@ let package = Package(
         .library(name: "AIKit", targets: ["AIKit"]),
     ],
     dependencies: [
-        // AIKit depends on the AICore API only - never on AIProviders (the impl).
-        // The composition root injects concrete providers into AIKit's registry.
+        // AIKit is the AI orchestration module: it builds and routes providers,
+        // so it depends on the provider impls + the infra they need (mirroring
+        // how TranscriptionKit depends on Cloud/Local transcription).
         .package(path: "../AICore"),
+        .package(path: "../AIProviders"),
+        .package(path: "../Keychain"),
+        .package(path: "../OAuth"),
+        .package(path: "../Networking"),
     ],
     targets: [
         .target(
             name: "AIKit",
             dependencies: [
                 .product(name: "AICore", package: "AICore"),
+                .product(name: "AIProviders", package: "AIProviders"),
+                .product(name: "Keychain", package: "Keychain"),
+                .product(name: "OAuth", package: "OAuth"),
+                .product(name: "Networking", package: "Networking"),
             ]
         ),
         .testTarget(
             name: "AIKitTests",
-            dependencies: ["AIKit"]
+            dependencies: [
+                "AIKit",
+                .product(name: "AICore", package: "AICore"),
+                .product(name: "AIProviders", package: "AIProviders"),
+                .product(name: "KeychainMocks", package: "Keychain"),
+                .product(name: "OAuthMocks", package: "OAuth"),
+                .product(name: "NetworkingMocks", package: "Networking"),
+            ]
         ),
     ],
     swiftLanguageModes: [.v6]

--- a/Modules/AIKit/Sources/AIKit/AIKit.swift
+++ b/Modules/AIKit/Sources/AIKit/AIKit.swift
@@ -1,2 +1,0 @@
-// The Swift Programming Language
-// https://docs.swift.org/swift-book

--- a/Modules/AIKit/Sources/AIKit/AIProviderRegistry.swift
+++ b/Modules/AIKit/Sources/AIKit/AIProviderRegistry.swift
@@ -1,0 +1,104 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import os
+import AICore
+import AIProviders
+import Keychain
+import OAuth
+import Networking
+
+/// Builds a configured `any AITextProvider` for a resolved `AIProviderRoute`.
+///
+/// This is the AI stack's composition point: it owns the per-backend config
+/// assembly (Keychain API-key lookup, OAuth token retrieval) and constructs the
+/// matching wrapper. Callers depend only on `AITextProvider` once they hold the
+/// result. Dependencies mirror `TranscriptionKit` (the orchestrator depends on
+/// its impls + the infra they need).
+///
+/// `@MainActor` because the injected `OAuthManager` / `CopilotOAuthManager` are
+/// not `Sendable` (reference types used on the main actor in the app). The async
+/// OAuth calls suspend, so this never blocks the main thread.
+@MainActor
+public struct AIProviderRegistry {
+    private let keychain: any KeychainService
+    private let oauthManager: any OAuthManager
+    private let copilotOAuthManager: any CopilotOAuthManager
+    private let networkService: any NetworkService
+    private let logger: Logger
+    private let baseTimeout: TimeInterval
+
+    public init(
+        keychain: any KeychainService,
+        oauthManager: any OAuthManager,
+        copilotOAuthManager: any CopilotOAuthManager,
+        networkService: any NetworkService,
+        logger: Logger,
+        baseTimeout: TimeInterval = 300
+    ) {
+        self.keychain = keychain
+        self.oauthManager = oauthManager
+        self.copilotOAuthManager = copilotOAuthManager
+        self.networkService = networkService
+        self.logger = logger
+        self.baseTimeout = baseTimeout
+    }
+
+    /// Builds the configured provider for `route`. Throws `EnhancementError.notConfigured`
+    /// when a required API key is missing, or rethrows an OAuth error when a token
+    /// cannot be obtained.
+    public func makeTextProvider(for route: AIProviderRoute, model: String) async throws -> any AITextProvider {
+        switch route {
+        case .appleFoundationModel(let samplingProfile):
+            if #available(iOS 26, macOS 26, *) {
+                return AppleFMTextProvider(samplingProfile: samplingProfile)
+            }
+            throw AppleFoundationModelError.notAvailable
+
+        case .anthropic:
+            let apiKey = try requireAPIKey(for: .anthropic)
+            return AnthropicTextProvider(
+                networkService: networkService, logger: logger, baseTimeout: baseTimeout,
+                apiKey: apiKey, model: model
+            )
+
+        case .cloud(let provider):
+            let apiKey = try requireAPIKey(for: provider)
+            guard let url = URL(string: provider.baseURL) else { throw EnhancementError.notConfigured }
+            return OpenAICompatibleTextProvider(
+                networkService: networkService, logger: logger,
+                url: url, modelName: model,
+                headers: ["Authorization": "Bearer \(apiKey)"],
+                timeout: baseTimeout, errorPrefix: "\(provider.displayName) error"
+            )
+
+        case .openAIOAuth:
+            let (token, accountId, _) = try await oauthManager.validAccessToken(for: OpenAIOAuthProvider())
+            return OpenAIOAuthTextProvider(model: model, accessToken: token, accountId: accountId)
+
+        case .geminiOAuth:
+            let (token, _, projectId) = try await oauthManager.validAccessToken(for: GeminiOAuthProvider())
+            return GeminiTextProvider(model: model, accessToken: token, projectId: projectId, networkService: networkService)
+
+        case .copilot:
+            let token = try await copilotOAuthManager.validCopilotToken()
+            return CopilotTextProvider(model: model, copilotToken: token)
+
+        case .openAICompatibleEndpoint(let url, let headers, let timeout, let errorPrefix, let notFoundMessage, let unauthorizedMessage):
+            return OpenAICompatibleTextProvider(
+                networkService: networkService, logger: logger,
+                url: url, modelName: model, headers: headers, timeout: timeout,
+                errorPrefix: errorPrefix, notFoundMessage: notFoundMessage, unauthorizedMessage: unauthorizedMessage
+            )
+        }
+    }
+
+    /// Reads the provider's API key from the Keychain, mirroring `AIProvider.apiKey`.
+    private func requireAPIKey(for provider: AIProvider) throws -> String {
+        let key = provider.keychainKey
+        guard !key.isEmpty, let apiKey = keychain.getString(forKey: key), !apiKey.isEmpty else {
+            throw EnhancementError.notConfigured
+        }
+        return apiKey
+    }
+}

--- a/Modules/AIKit/Sources/AIKit/AIProviderRoute.swift
+++ b/Modules/AIKit/Sources/AIKit/AIProviderRoute.swift
@@ -1,0 +1,48 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import AICore
+import AIProviders
+
+/// A resolved enhancement route - the decision of *which* backend to use,
+/// already made by the caller (it depends on runtime state: OAuth sign-in,
+/// CLI-server availability, streaming support). `AIProviderRegistry` turns a
+/// route + model into a configured `any AITextProvider`.
+///
+/// Routes that are not `AITextProvider`s (e.g. a CLI-server fallback) are not
+/// represented here - the caller handles those separately.
+public enum AIProviderRoute: Sendable {
+    /// On-device Apple Foundation Model with the given sampling profile.
+    case appleFoundationModel(samplingProfile: AppleFoundationModelSamplingProfile)
+
+    /// Anthropic Messages API, keyed from the Keychain.
+    case anthropic
+
+    /// An OpenAI-compatible cloud provider keyed from the Keychain. The
+    /// associated provider supplies the base URL and Keychain key.
+    case cloud(AIProvider)
+
+    /// OpenAI via OAuth (ChatGPT sign-in).
+    case openAIOAuth
+
+    /// Gemini via OAuth (Google sign-in).
+    case geminiOAuth
+
+    /// GitHub Copilot via its device-code OAuth.
+    case copilot
+
+    /// A locally-configured OpenAI-compatible endpoint (Ollama / Custom),
+    /// whose URL and headers are supplied by the caller (from UserDefaults).
+    /// `timeout` is explicit because these self-hosted endpoints use a longer
+    /// request timeout than the hosted cloud providers (slow local inference) -
+    /// the caller carries it so the registry doesn't silently substitute its
+    /// cloud `baseTimeout`.
+    case openAICompatibleEndpoint(
+        url: URL,
+        headers: [String: String],
+        timeout: TimeInterval,
+        errorPrefix: String,
+        notFoundMessage: String? = nil,
+        unauthorizedMessage: String? = nil
+    )
+}

--- a/Modules/AIKit/Tests/AIKitTests/AIKitTests.swift
+++ b/Modules/AIKit/Tests/AIKitTests/AIKitTests.swift
@@ -1,8 +1,0 @@
-import Testing
-@testable import AIKit
-
-@Test func example() async throws {
-    // Write your test here and use APIs like `#expect(...)` to check expected conditions.
-    // Swift Testing Documentation
-    // https://developer.apple.com/documentation/testing
-}

--- a/Modules/AIKit/Tests/AIKitTests/AIProviderRegistryTests.swift
+++ b/Modules/AIKit/Tests/AIKitTests/AIProviderRegistryTests.swift
@@ -1,0 +1,181 @@
+import Testing
+import Foundation
+import os
+import AICore
+import AIProviders
+import Keychain
+import KeychainMocks
+import OAuth
+import OAuthMocks
+import Networking
+import NetworkingMocks
+@testable import AIKit
+
+/// Verifies `AIProviderRegistry`'s sole responsibility: turning a resolved
+/// `AIProviderRoute` + model into a *correctly-configured* `any AITextProvider`.
+///
+/// The wrappers and underlying services are tested in `AIProvidersTests`; here
+/// we assert the registry's config assembly - that the Keychain key / OAuth
+/// token / base URL each route needs actually reaches the provider it builds.
+/// Where a route's provider has an injectable transport (`MockNetworkService`)
+/// we build it then drive `enhance` and inspect the outgoing request; for the
+/// OAuth-static clients (OpenAI/Copilot) we assert the token retrieval the
+/// registry performs, which is the part it owns.
+@MainActor
+@Suite("AIProviderRegistry", .tags(.networking))
+struct AIProviderRegistryTests {
+
+    private struct TestError: Error {}
+
+    private func http(_ code: Int) -> HTTPURLResponse {
+        HTTPURLResponse(url: URL(string: "https://example.com")!, statusCode: code, httpVersion: nil, headerFields: nil)!
+    }
+
+    /// Stores a key under its *real* Keychain key name so the test fails if the
+    /// registry looks up the wrong key (the blanket `stubGetString` would hide a
+    /// key-name swap by returning the same value for any key).
+    private func seed(_ keychain: MockKeychainService, _ value: String, forKey key: String) {
+        _ = keychain.save(value, forKey: key)
+    }
+
+    private func makeSUT(
+        keychain: MockKeychainService = MockKeychainService(),
+        oauth: MockOAuthManager = MockOAuthManager(),
+        copilot: MockCopilotOAuthManager = MockCopilotOAuthManager(),
+        net: MockNetworkService = MockNetworkService()
+    ) -> AIProviderRegistry {
+        AIProviderRegistry(
+            keychain: keychain,
+            oauthManager: oauth,
+            copilotOAuthManager: copilot,
+            networkService: net,
+            logger: Logger(subsystem: "test", category: "AIProviderRegistryTests"),
+            baseTimeout: 30
+        )
+    }
+
+    // MARK: - Keychain-keyed routes
+
+    @Test func anthropicRouteBuildsProviderConfiguredWithKeychainKey() async throws {
+        let keychain = MockKeychainService()
+        seed(keychain, "ANTHROPIC_KEY", forKey: "anthropicAPIKey") // real key name -> catches a key-name swap
+        let net = MockNetworkService()
+        net.stubSendResponse = .success((Data(#"{"content":[{"text":"OK"}]}"#.utf8), http(200)))
+        let sut = makeSUT(keychain: keychain, net: net)
+
+        let provider = try await sut.makeTextProvider(for: .anthropic, model: "claude-sonnet-4-6")
+        _ = try await provider.enhance(systemMessage: "S", userMessage: "U")
+
+        #expect(net.capturedRequest?.url?.absoluteString == "https://api.anthropic.com/v1/messages")
+        #expect(net.capturedRequest?.value(forHTTPHeaderField: "x-api-key") == "ANTHROPIC_KEY")
+        let body = String(data: net.capturedRequest?.httpBody ?? Data(), encoding: .utf8) ?? ""
+        #expect(body.contains("claude-sonnet-4-6"))   // model bound into the request
+    }
+
+    @Test func cloudRouteBuildsBearerKeyedProviderAtProviderBaseURL() async throws {
+        let keychain = MockKeychainService()
+        seed(keychain, "OPENAI_KEY", forKey: "openAIAPIKey") // real key name -> catches a key-name swap
+        let net = MockNetworkService()
+        net.stubSendResponse = .success((Data(#"{"choices":[{"message":{"content":"OK"}}]}"#.utf8), http(200)))
+        let sut = makeSUT(keychain: keychain, net: net)
+
+        let provider = try await sut.makeTextProvider(for: .cloud(.openAI), model: "gpt-test")
+        _ = try await provider.enhance(systemMessage: "S", userMessage: "U")
+
+        #expect(net.capturedRequest?.url?.absoluteString == "https://api.openai.com/v1/chat/completions")
+        #expect(net.capturedRequest?.value(forHTTPHeaderField: "Authorization") == "Bearer OPENAI_KEY")
+    }
+
+    @Test func missingAPIKeyThrowsNotConfigured() async {
+        // Fresh keychain: no stub, no stored value -> getString returns nil.
+        let sut = makeSUT()
+
+        await #expect(throws: EnhancementError.self) {
+            _ = try await sut.makeTextProvider(for: .anthropic, model: "claude-sonnet-4-6")
+        }
+    }
+
+    // MARK: - OAuth routes
+
+    @Test func geminiOAuthRouteRetrievesGeminiTokenAndForwardsIt() async throws {
+        let oauth = MockOAuthManager()
+        oauth.stubValidAccessTokenResponse = .success((token: "GEM_TOK", accountId: nil, projectId: "proj"))
+        let net = MockNetworkService()
+        net.stubSendResponse = .failure(URLError(.badServerResponse)) // request is built before the call; response irrelevant
+        let sut = makeSUT(oauth: oauth, net: net)
+
+        let provider = try await sut.makeTextProvider(for: .geminiOAuth, model: "gemini-test")
+        _ = try? await provider.enhance(systemMessage: "S", userMessage: "U")
+
+        #expect(oauth.validAccessTokenCallCount == 1)
+        #expect(oauth.capturedValidAccessTokenProviderKey == "geminiOAuthCredential") // asked for Gemini, not OpenAI
+        #expect(net.capturedRequest?.value(forHTTPHeaderField: "Authorization") == "Bearer GEM_TOK")
+    }
+
+    @Test func openAIOAuthRouteRetrievesTokenForOpenAIProvider() async throws {
+        let oauth = MockOAuthManager()
+        oauth.stubValidAccessTokenResponse = .success((token: "OAI_TOK", accountId: "acct", projectId: nil))
+        let sut = makeSUT(oauth: oauth)
+
+        // OpenAIOAuthClient has an internal transport, so we assert the token
+        // retrieval the registry owns rather than the outgoing request.
+        _ = try await sut.makeTextProvider(for: .openAIOAuth, model: "gpt-5")
+
+        #expect(oauth.validAccessTokenCallCount == 1)
+        #expect(oauth.capturedValidAccessTokenProviderKey == "chatGPTOAuthCredential")
+    }
+
+    @Test func oauthRoutePropagatesTokenError() async {
+        let oauth = MockOAuthManager()
+        oauth.stubValidAccessTokenResponse = .failure(TestError())
+        let sut = makeSUT(oauth: oauth)
+
+        await #expect(throws: TestError.self) {
+            _ = try await sut.makeTextProvider(for: .geminiOAuth, model: "gemini-test")
+        }
+    }
+
+    @Test func copilotRouteRetrievesCopilotToken() async throws {
+        let copilot = MockCopilotOAuthManager()
+        copilot.stubValidCopilotTokenResponse = .success("ghu_token")
+        let sut = makeSUT(copilot: copilot)
+
+        _ = try await sut.makeTextProvider(for: .copilot, model: "gpt-4o")
+
+        #expect(copilot.validCopilotTokenCallCount == 1)
+    }
+
+    @Test func copilotRoutePropagatesTokenError() async {
+        let copilot = MockCopilotOAuthManager()
+        copilot.stubValidCopilotTokenResponse = .failure(TestError())
+        let sut = makeSUT(copilot: copilot)
+
+        await #expect(throws: TestError.self) {
+            _ = try await sut.makeTextProvider(for: .copilot, model: "gpt-4o")
+        }
+    }
+
+    // MARK: - Locally-configured endpoint (Ollama / Custom)
+
+    @Test func openAICompatibleEndpointForwardsCallerSuppliedURLAndHeaders() async throws {
+        let net = MockNetworkService()
+        net.stubSendResponse = .success((Data(#"{"choices":[{"message":{"content":"OK"}}]}"#.utf8), http(200)))
+        let sut = makeSUT(net: net)
+        let url = URL(string: "http://localhost:11434/v1/chat/completions")!
+
+        let provider = try await sut.makeTextProvider(
+            for: .openAICompatibleEndpoint(
+                url: url,
+                headers: ["Authorization": "Bearer custom-token"],
+                timeout: 120,
+                errorPrefix: "Ollama"
+            ),
+            model: "llama3"
+        )
+        _ = try await provider.enhance(systemMessage: "S", userMessage: "U")
+
+        #expect(net.capturedRequest?.url == url)                                                  // caller URL, no Keychain lookup
+        #expect(net.capturedRequest?.value(forHTTPHeaderField: "Authorization") == "Bearer custom-token")
+        #expect(net.capturedRequest?.timeoutInterval == 120)                                       // caller timeout, not the cloud baseTimeout (300)
+    }
+}

--- a/Modules/AIKit/Tests/AIKitTests/AIProviderRegistryTests.swift
+++ b/Modules/AIKit/Tests/AIKitTests/AIProviderRegistryTests.swift
@@ -1,3 +1,5 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
 import Testing
 import Foundation
 import os

--- a/Modules/AIKit/Tests/AIKitTests/TestTags.swift
+++ b/Modules/AIKit/Tests/AIKitTests/TestTags.swift
@@ -1,0 +1,11 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Testing
+
+extension Tag {
+    /// Marks suites that exercise networking through a mocked transport.
+    /// No real network calls happen - the tag exists so the suites can be
+    /// selected/excluded as a group (e.g. via an Xcode Test Plan, or
+    /// `swift test --filter-tag networking` when running this package alone).
+    @Tag static var networking: Self
+}


### PR DESCRIPTION
## What

Introduces the AI stack's composition point in `AIKit`:

- **`AIProviderRoute`** - the resolved-route enum (`appleFoundationModel`, `anthropic`, `cloud`, `openAIOAuth`, `geminiOAuth`, `copilot`, and the locally-configured `openAICompatibleEndpoint` for Ollama/Custom). The local-endpoint case carries an explicit `timeout` so self-hosted endpoints keep their longer request timeout (120s) instead of inheriting the cloud `baseTimeout` (300s).
- **`AIProviderRegistry`** - a `@MainActor struct` (the injected `OAuthManager` / `CopilotOAuthManager` are non-`Sendable`). `makeTextProvider(for:model:)` switches on the route, reads the API key via the injected `KeychainService` (mirroring `AIProvider.apiKey`), and retrieves OAuth tokens via `validAccessToken` / `validCopilotToken`. A missing key throws `EnhancementError.notConfigured`.

`AIKit` now depends on `AICore` + `AIProviders` + `Keychain` + `OAuth` + `Networking`, mirroring how `TranscriptionKit` depends on its impls + the infra they need.

## Why

This is the registry that the upcoming wiring phases will route enhancement through. It owns the per-backend config assembly that `AIService` currently does inline, so the next phases can replace that inline construction with a single `makeTextProvider` call.

## Scope

**Purely additive.** `AIService` is unchanged - it is not yet wired to the registry (that lands in the following phases). The app builds and the registry replicates `AIService`'s existing per-route config exactly.

## Tests

9 tests (`KeychainMocks` / `OAuthMocks` / `NetworkingMocks`) assert each route builds the correctly-configured provider:
- Anthropic and cloud routes seed the Keychain under the **real key name**, so a key-name swap fails the test; assertions check the outgoing endpoint, auth header, and bound model.
- OAuth routes assert the **correct OAuth provider per route** (a Gemini/OpenAI swap fails) and that token errors propagate.
- The local-endpoint route asserts the caller-supplied URL, headers, and **forwarded timeout** reach the request.
- A missing API key throws `EnhancementError.notConfigured`.

`swift test --package-path Modules/AIKit` and the full app build are green.