### PR TITLE
Wire AIService non-streaming enhance to AIProviderRegistry (Phase 11b)

### DIFF
--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -16,6 +16,7 @@ import OAuth
 import CloudTranscription
 import AICore
 import AIProviders
+import AIKit
 
 /// Service responsible for AI-powered text enhancement of transcriptions.
 ///
@@ -182,6 +183,22 @@ class AIService {
     let oauthManager: any OAuthManager
     let copilotOAuthManager: any CopilotOAuthManager
     private let baseTimeout: TimeInterval = 300
+
+    /// The AI stack's composition point: turns a resolved `AIProviderRoute` into
+    /// a configured `any AITextProvider`. Built from this service's injected
+    /// dependencies so it reads the same Keychain / OAuth state the rest of
+    /// `AIService` does. Cheap to construct (it just binds references), so a
+    /// computed property keeps it always in sync with the current dependencies.
+    private var aiProviderRegistry: AIProviderRegistry {
+        AIProviderRegistry(
+            keychain: keychain,
+            oauthManager: oauthManager,
+            copilotOAuthManager: copilotOAuthManager,
+            networkService: networkService,
+            logger: logger,
+            baseTimeout: baseTimeout
+        )
+    }
 
     /// Service for Apple's on-device Foundation Models (type-erased for iOS version compatibility)
     private var _appleFoundationModelService: Any?
@@ -1350,16 +1367,9 @@ class AIService {
             lastSystemMessageSent = resolvedSystemMessage
             lastUserMessageSent = formattedText
             do {
-                let provider = OpenAIOAuthProvider()
-                let (token, accountId, _) = try await oauthManager.validAccessToken(for: provider)
                 let model = mode.aiModel.isEmpty ? OpenAIOAuthClient.defaultModel : mode.aiModel
-                let result = try await OpenAIOAuthClient.enhance(
-                    text: formattedText,
-                    systemPrompt: resolvedSystemMessage,
-                    model: model,
-                    accessToken: token,
-                    accountId: accountId
-                )
+                let provider = try await aiProviderRegistry.makeTextProvider(for: .openAIOAuth, model: model)
+                let result = try await provider.enhance(systemMessage: resolvedSystemMessage, userMessage: formattedText)
                 return AIEnhancementOutputFilter.filter(result)
             } catch let error as OAuthError {
                 // If OAuth fails, fall through to CLI or API key
@@ -1376,17 +1386,9 @@ class AIService {
             lastSystemMessageSent = resolvedSystemMessage
             lastUserMessageSent = formattedText
             do {
-                let provider = GeminiOAuthProvider()
-                let (token, _, projectId) = try await oauthManager.validAccessToken(for: provider)
                 let model = mode.aiModel.isEmpty ? GeminiAPIClient.defaultModel : mode.aiModel
-                let result = try await GeminiAPIClient.enhance(
-                    text: formattedText,
-                    systemPrompt: resolvedSystemMessage,
-                    model: model,
-                    accessToken: token,
-                    projectId: projectId,
-                    networkService: networkService
-                )
+                let provider = try await aiProviderRegistry.makeTextProvider(for: .geminiOAuth, model: model)
+                let result = try await provider.enhance(systemMessage: resolvedSystemMessage, userMessage: formattedText)
                 return AIEnhancementOutputFilter.filter(result)
             } catch let error as EnhancementError {
                 // Rate limit etc. - don't fall through, surface directly
@@ -1454,14 +1456,9 @@ class AIService {
             lastSystemMessageSent = resolvedSystemMessage
             lastUserMessageSent = formattedText
             do {
-                let token = try await copilotOAuthManager.validCopilotToken()
                 let model = mode.aiModel.isEmpty ? CopilotAPIClient.defaultModel : mode.aiModel
-                let result = try await CopilotAPIClient.enhance(
-                    text: formattedText,
-                    systemPrompt: resolvedSystemMessage,
-                    model: model,
-                    copilotToken: token
-                )
+                let provider = try await aiProviderRegistry.makeTextProvider(for: .copilot, model: model)
+                let result = try await provider.enhance(systemMessage: resolvedSystemMessage, userMessage: formattedText)
                 return AIEnhancementOutputFilter.filter(result)
             } catch let error as EnhancementError {
                 throw error
@@ -1471,7 +1468,7 @@ class AIService {
         }
 
         // Cloud providers require API key
-        guard let apiKey = self.getAPIKey(for: aiProvider) else {
+        guard self.getAPIKey(for: aiProvider) != nil else {
             throw EnhancementError.notConfigured
         }
 
@@ -1482,27 +1479,12 @@ class AIService {
         logger.logDebug("AI Processing - System Message: \(resolvedSystemMessage)")
         logger.logDebug("AI Processing - User Message: \(formattedText)")
 
-        switch aiProvider {
-        case .anthropic:
-            let service = AnthropicService(networkService: networkService, logger: logger, baseTimeout: baseTimeout)
-            return try await service.enhance(
-                systemMessage: resolvedSystemMessage,
-                userMessage: formattedText,
-                apiKey: apiKey,
-                model: mode.aiModel
-            )
-
-        default:
-            let service = OpenAICompatibleService(networkService: networkService, logger: logger)
-            return try await service.enhance(
-                url: URL(string: aiProvider.baseURL)!,
-                modelName: mode.aiModel,
-                systemMessage: resolvedSystemMessage,
-                userMessage: formattedText,
-                headers: ["Authorization": "Bearer \(apiKey)"],
-                timeout: baseTimeout
-            )
-        }
+        // Anthropic uses its own Messages API; every other cloud provider is
+        // OpenAI-compatible. The registry reads the API key from the Keychain
+        // and builds the configured provider (key existence is guarded above).
+        let route: AIProviderRoute = aiProvider == .anthropic ? .anthropic : .cloud(aiProvider)
+        let provider = try await aiProviderRegistry.makeTextProvider(for: route, model: mode.aiModel)
+        return try await provider.enhance(systemMessage: resolvedSystemMessage, userMessage: formattedText)
     }
 
     // MARK: - System Message (Cloud Providers)

--- a/VivaDictaTests/AIServiceEnhanceRoutingTests.swift
+++ b/VivaDictaTests/AIServiceEnhanceRoutingTests.swift
@@ -1,0 +1,73 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import Networking
+import NetworkingMocks
+import OAuth
+import OAuthMocks
+import Presets
+import Testing
+import AICore
+@testable import VivaDicta
+
+/// Characterization tests for `AIService`'s non-streaming enhancement routing.
+///
+/// They pin the outgoing request for the routes that are fully mockable through
+/// `AIService`'s injected `OAuthManager` + `NetworkService`, so the Phase 11
+/// move to `AIProviderRegistry` is provably behavior-preserving: the same
+/// request must still reach the same endpoint carrying the same credential.
+///
+/// (The Keychain-keyed cloud routes are not characterized here because
+/// `AIProvider.apiKey` reads a file-private `DefaultKeychainService`, not the
+/// injected one - so they can't be driven without touching the real Keychain.
+/// Those routes are covered by `AIProviderRegistry`'s own tests.)
+@Suite(.tags(.networking))
+@MainActor
+struct AIServiceEnhanceRoutingTests {
+
+    private let suiteName = "AIServiceEnhanceRoutingTests.\(UUID().uuidString)"
+
+    private func makeDefaults() -> UserDefaults {
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+
+    private func makeMode(aiProvider: AIProvider, aiModel: String) -> VivaMode {
+        VivaMode(
+            id: UUID(),
+            name: "Routing Test Mode",
+            transcriptionProvider: .whisperKit,
+            transcriptionModel: "test-whisper",
+            presetId: "regular",
+            aiProvider: aiProvider,
+            aiModel: aiModel,
+            aiEnhanceEnabled: true
+        )
+    }
+
+    /// Gemini OAuth is the one non-streaming route whose entire transport is
+    /// injectable (OAuth token via the mock manager, request via the mock
+    /// network), so it can pin the wiring end-to-end: signed-in Gemini must
+    /// fetch the *Gemini* OAuth token and send it to the cloudcode endpoint.
+    @Test func geminiOAuthRouteSendsOAuthTokenToCloudCodeEndpoint() async {
+        let oauth = MockOAuthManager()
+        oauth.stubValidAccessTokenResponse = .success((token: "GEM_TOKEN", accountId: nil, projectId: "proj-1"))
+        let net = MockNetworkService()
+        net.stubSendResponse = .failure(URLError(.badServerResponse)) // request is captured before the call; response irrelevant
+
+        let sut = AIService(
+            userDefaults: makeDefaults(),
+            networkService: net,
+            oauthManager: oauth
+        )
+        sut.isGeminiSignedIn = true
+        let mode = makeMode(aiProvider: .gemini, aiModel: "gemini-3-flash-preview")
+
+        _ = try? await sut.generateVariation(text: "hello world", preset: PresetCatalog.regular, modeOverride: mode)
+
+        #expect(oauth.capturedValidAccessTokenProviderKey == "geminiOAuthCredential")   // Gemini OAuth, not OpenAI
+        #expect(net.capturedRequest?.url?.absoluteString.contains("cloudcode-pa.googleapis.com") == true)
+        #expect(net.capturedRequest?.value(forHTTPHeaderField: "Authorization") == "Bearer GEM_TOKEN")
+    }
+}


### PR DESCRIPTION
## What

Replaces the four inline provider-construction branches in `AIService`'s non-streaming `makeRequest` with `AIProviderRegistry.makeTextProvider(for:model:)` + `provider.enhance(...)`. `AIService` no longer assembles per-backend config itself for these routes:

- **default cloud switch** (Anthropic Messages API + OpenAI-compatible `Bearer`) → `.anthropic` / `.cloud(provider)`
- **OpenAI OAuth** happy-path → `.openAIOAuth`
- **Gemini OAuth** happy-path → `.geminiOAuth`
- **Copilot** happy-path → `.copilot`

A private `aiProviderRegistry` computed property is built from `AIService`'s injected dependencies (`keychain`, `oauthManager`, `copilotOAuthManager`, `networkService`, `logger`, `baseTimeout`).

## Behavior preserved

Each rewritten branch keeps its exact surrounding logic:
- the OAuth → CLI-server / API-key **fallback** (the `OAuthError` from the registry's `validAccessToken` still propagates out of `makeTextProvider` into the same `catch`)
- the Gemini **rate-limit `EnhancementError` rethrow** that must precede the OAuth fallback
- output filtering (`AIEnhancementOutputFilter`) and the `lastSystemMessageSent` / `lastUserMessageSent` side-effect ordering

## Deliberately unchanged

Not `AITextProvider` routes (or behavior would shift), so left exactly as-is:
- **Apple Foundation Model** — uses a *cached* `appleFoundationModelService` instance; the registry's wrapper builds a fresh one per call
- **Ollama / Custom OpenAI** — separate `makeOllamaRequest` / `makeCustomOpenAIRequest` methods
- the three **VivAgents CLI-server** branches

## Tests

- New `AIServiceEnhanceRoutingTests` characterizes the **Gemini OAuth** route (the one fully-mockable non-streaming path) end-to-end: a signed-in Gemini mode fetches the *Gemini* OAuth token and sends `Bearer <token>` to the cloudcode endpoint. Written **test-first** — green before and after the wiring.
- 84 AIService-dependent tests + the full `VivaDictaTests` suite + full app build all green.

(The Keychain-keyed cloud routes aren't characterized here because `AIProvider.apiKey` reads a file-private `DefaultKeychainService`, not the injected one — those are covered by `AIProviderRegistry`'s own tests.)

## Note

The registry's `requireAPIKey` adds a `!isEmpty` precondition the old inline guard lacked, so a stored **empty-string** key now throws `.notConfigured` before any network call instead of round-tripping to a 401. This is not reachable through the app's own flows (keys are only saved after verification; clearing deletes the key rather than storing `""`), and failing fast is strictly better on the only path that could reach it (external keychain corruption).