### PR TITLE
Wire AIService streaming enhance to AIProviderRegistry (Phase 11c)

### DIFF
--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -1065,23 +1065,6 @@ class AIService {
         OpenAICompatibleService.streamingDelta(from: line)
     }
 
-    private func makeAnthropicStreamingRequest(
-        systemMessage: String,
-        userMessage: String,
-        apiKey: String,
-        model: String,
-        onPartialResponse: @escaping @MainActor (String) -> Void
-    ) async throws -> String {
-        let service = AnthropicService(networkService: networkService, logger: logger, baseTimeout: baseTimeout)
-        return try await service.enhanceStreaming(
-            systemMessage: systemMessage,
-            userMessage: userMessage,
-            apiKey: apiKey,
-            model: model,
-            onPartialResponse: onPartialResponse
-        )
-    }
-
     private func makeStreamingRequest(
         text: String,
         mode: VivaMode,
@@ -1123,45 +1106,25 @@ class AIService {
                 throw EnhancementError.notConfigured
             }
         case .anthropic:
-            guard let apiKey = self.getAPIKey(for: aiProvider) else {
+            guard self.getAPIKey(for: aiProvider) != nil else {
                 throw EnhancementError.notConfigured
             }
 
             logger.logDebug("AI Processing - Using Anthropic streaming")
             logger.logDebug("AI Processing - Model: \(mode.aiModel)")
 
-            return try await makeAnthropicStreamingRequest(
-                systemMessage: sysMsg,
-                userMessage: userMsg,
-                apiKey: apiKey,
-                model: mode.aiModel,
-                onPartialResponse: onPartialResponse
-            )
+            let provider = try await aiProviderRegistry.makeTextProvider(for: .anthropic, model: mode.aiModel)
+            return try await provider.enhanceStreaming(systemMessage: sysMsg, userMessage: userMsg, onPartialResponse: onPartialResponse)
         case .copilot:
-            let token = try await copilotOAuthManager.validCopilotToken()
             let model = mode.aiModel.isEmpty ? CopilotAPIClient.defaultModel : mode.aiModel
-            let result = try await CopilotAPIClient.enhanceStreaming(
-                text: userMsg,
-                systemPrompt: sysMsg,
-                model: model,
-                copilotToken: token,
-                onPartialResult: onPartialResponse
-            )
+            let provider = try await aiProviderRegistry.makeTextProvider(for: .copilot, model: model)
+            let result = try await provider.enhanceStreaming(systemMessage: sysMsg, userMessage: userMsg, onPartialResponse: onPartialResponse)
             return await finalizeStreamingResult(result, onPartialResponse: onPartialResponse)
         case .geminiOAuth:
             do {
-                let provider = GeminiOAuthProvider()
-                let (token, _, projectId) = try await oauthManager.validAccessToken(for: provider)
                 let model = mode.aiModel.isEmpty ? GeminiAPIClient.defaultModel : mode.aiModel
-                let result = try await GeminiAPIClient.enhanceStreaming(
-                    text: userMsg,
-                    systemPrompt: sysMsg,
-                    model: model,
-                    accessToken: token,
-                    projectId: projectId,
-                    onPartialResult: onPartialResponse,
-                    networkService: networkService
-                )
+                let provider = try await aiProviderRegistry.makeTextProvider(for: .geminiOAuth, model: model)
+                let result = try await provider.enhanceStreaming(systemMessage: sysMsg, userMessage: userMsg, onPartialResponse: onPartialResponse)
                 return await finalizeStreamingResult(result, onPartialResponse: onPartialResponse)
             } catch let error as EnhancementError {
                 throw error
@@ -1175,17 +1138,9 @@ class AIService {
             }
         case .openAIOAuth:
             do {
-                let provider = OpenAIOAuthProvider()
-                let (token, accountId, _) = try await oauthManager.validAccessToken(for: provider)
                 let model = mode.aiModel.isEmpty ? OpenAIOAuthClient.defaultModel : mode.aiModel
-                let result = try await OpenAIOAuthClient.enhance(
-                    text: userMsg,
-                    systemPrompt: sysMsg,
-                    model: model,
-                    accessToken: token,
-                    accountId: accountId,
-                    onPartialResult: onPartialResponse
-                )
+                let provider = try await aiProviderRegistry.makeTextProvider(for: .openAIOAuth, model: model)
+                let result = try await provider.enhanceStreaming(systemMessage: sysMsg, userMessage: userMsg, onPartialResponse: onPartialResponse)
                 return await finalizeStreamingResult(result, onPartialResponse: onPartialResponse)
             } catch let error as OAuthError {
                 if (VivAgentsClient.isEnabled && VivAgentsClient.isCodexCliActive) || self.getAPIKey(for: aiProvider) != nil {
@@ -1196,23 +1151,15 @@ class AIService {
                 }
             }
         case .openAICompatibleCloud:
-            guard let apiKey = self.getAPIKey(for: aiProvider) else {
+            guard self.getAPIKey(for: aiProvider) != nil else {
                 throw EnhancementError.notConfigured
             }
 
             logger.logDebug("AI Processing - Using \(aiProvider.displayName) streaming")
             logger.logDebug("AI Processing - Model: \(mode.aiModel)")
 
-            return try await makeOpenAICompatibleStreamingRequest(
-                url: URL(string: aiProvider.baseURL)!,
-                modelName: mode.aiModel,
-                systemMessage: sysMsg,
-                userMessage: userMsg,
-                headers: ["Authorization": "Bearer \(apiKey)"],
-                timeout: baseTimeout,
-                errorPrefix: "\(aiProvider.displayName) error",
-                onPartialResponse: onPartialResponse
-            )
+            let provider = try await aiProviderRegistry.makeTextProvider(for: .cloud(aiProvider), model: mode.aiModel)
+            return try await provider.enhanceStreaming(systemMessage: sysMsg, userMessage: userMsg, onPartialResponse: onPartialResponse)
         case .ollama:
             let serverURL = ollamaServerURL
             guard let url = URL(string: "\(serverURL)/v1/chat/completions") else {

--- a/VivaDictaTests/AIServiceEnhanceRoutingTests.swift
+++ b/VivaDictaTests/AIServiceEnhanceRoutingTests.swift
@@ -70,4 +70,34 @@ struct AIServiceEnhanceRoutingTests {
         #expect(net.capturedRequest?.url?.absoluteString.contains("cloudcode-pa.googleapis.com") == true)
         #expect(net.capturedRequest?.value(forHTTPHeaderField: "Authorization") == "Bearer GEM_TOKEN")
     }
+
+    /// Streaming counterpart: passing an `onPartialResult` to a signed-in Gemini
+    /// mode routes through `makeStreamingRequest`'s `.geminiOAuth` case, which
+    /// must still fetch the Gemini OAuth token and stream from the cloudcode
+    /// streaming endpoint with that token.
+    @Test func geminiOAuthStreamingRouteSendsOAuthTokenToCloudCodeEndpoint() async {
+        let oauth = MockOAuthManager()
+        oauth.stubValidAccessTokenResponse = .success((token: "GEM_STREAM_TOKEN", accountId: nil, projectId: "proj-1"))
+        let net = MockNetworkService()
+        net.stubSendResponse = .failure(URLError(.badServerResponse)) // request is captured before the call; response irrelevant
+
+        let sut = AIService(
+            userDefaults: makeDefaults(),
+            networkService: net,
+            oauthManager: oauth
+        )
+        sut.isGeminiSignedIn = true
+        let mode = makeMode(aiProvider: .gemini, aiModel: "gemini-3-flash-preview")
+
+        _ = try? await sut.generateVariation(
+            text: "hello world",
+            preset: PresetCatalog.regular,
+            modeOverride: mode,
+            onPartialResult: { _ in }
+        )
+
+        #expect(oauth.capturedValidAccessTokenProviderKey == "geminiOAuthCredential")
+        #expect(net.capturedRequest?.url?.absoluteString.contains("cloudcode-pa.googleapis.com") == true)
+        #expect(net.capturedRequest?.value(forHTTPHeaderField: "Authorization") == "Bearer GEM_STREAM_TOKEN")
+    }
 }


### PR DESCRIPTION
## What

Completes the AI request layer's move onto `AIProviderRegistry`. Replaces the five streaming `switch resolvedStreamingRoute` cases in `makeStreamingRequest` that built a provider/client inline with `AIProviderRegistry.makeTextProvider(for:model:)` + `provider.enhanceStreaming(...)`:

- `.anthropic` → `.anthropic`
- `.openAICompatibleCloud` → `.cloud(provider)`
- `.copilot` → `.copilot`
- `.geminiOAuth` → `.geminiOAuth`
- `.openAIOAuth` → `.openAIOAuth`

This is the streaming counterpart to #335 (non-streaming). After it, both request paths source their `AITextProvider`s from the registry.

## Behavior preserved

- **Filter layering** is kept exactly: `finalizeStreamingResult` (trim + `AIEnhancementOutputFilter` + re-emit) stays on **Copilot/Gemini/OpenAI-OAuth** (whose clients return raw text) and is **not** added to **Anthropic/cloud** (those services filter internally).
- The **OAuth → CLI / API-key fallback** (`catch OAuthError { … break }` → post-switch `makeRequest`) and the **Gemini rate-limit `EnhancementError` rethrow** that must precede the OAuth fallback are unchanged — the `OAuthError` from the registry's `validAccessToken` still propagates out of `makeTextProvider` into the same `catch`.
- Cloud streaming keeps `Authorization: Bearer <key>`, `baseTimeout`, and `errorPrefix: "<displayName> error"` (the registry's `.cloud` `errorPrefix` was aligned to this in the registry PR).

## Cleanup

- Removed the now-orphaned `makeAnthropicStreamingRequest` helper.
- `makeOpenAICompatibleStreamingRequest` stays — Ollama/Custom still use it.

## Deliberately unchanged

`.apple` (cached service instance), `.ollama` / `.customOpenAI` (separate request paths), and the CLI-server / `case nil` fallthrough.

## Tests

- New `geminiOAuthStreamingRouteSendsOAuthTokenToCloudCodeEndpoint` alongside the non-streaming one: a signed-in Gemini mode with an `onPartialResult` callback streams the Gemini OAuth token to the cloudcode endpoint. Written **test-first** — green before and after the wiring.
- The AIService suites + the full `VivaDictaTests` suite + the full app build are all green.

## Note

As in #335, the registry's `requireAPIKey` adds a non-empty precondition the old inline guard lacked, so a stored **empty-string** key now throws `.notConfigured` before any network call instead of issuing a guaranteed-401 request. Unreachable via app flows (keys are only saved after verification), and it makes streaming **consistent** with the already-shipped non-streaming registry path.