### PR TITLE
Make AIProviderRegistry the single source of the API-key precondition

### DIFF
--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -1106,13 +1106,10 @@ class AIService {
                 throw EnhancementError.notConfigured
             }
         case .anthropic:
-            guard self.getAPIKey(for: aiProvider) != nil else {
-                throw EnhancementError.notConfigured
-            }
-
             logger.logDebug("AI Processing - Using Anthropic streaming")
             logger.logDebug("AI Processing - Model: \(mode.aiModel)")
 
+            // The registry reads the API key and throws `.notConfigured` if it's missing.
             let provider = try await aiProviderRegistry.makeTextProvider(for: .anthropic, model: mode.aiModel)
             return try await provider.enhanceStreaming(systemMessage: sysMsg, userMessage: userMsg, onPartialResponse: onPartialResponse)
         case .copilot:
@@ -1151,13 +1148,10 @@ class AIService {
                 }
             }
         case .openAICompatibleCloud:
-            guard self.getAPIKey(for: aiProvider) != nil else {
-                throw EnhancementError.notConfigured
-            }
-
             logger.logDebug("AI Processing - Using \(aiProvider.displayName) streaming")
             logger.logDebug("AI Processing - Model: \(mode.aiModel)")
 
+            // The registry reads the API key and throws `.notConfigured` if it's missing.
             let provider = try await aiProviderRegistry.makeTextProvider(for: .cloud(aiProvider), model: mode.aiModel)
             return try await provider.enhanceStreaming(systemMessage: sysMsg, userMessage: userMsg, onPartialResponse: onPartialResponse)
         case .ollama:
@@ -1414,11 +1408,6 @@ class AIService {
             }
         }
 
-        // Cloud providers require API key
-        guard self.getAPIKey(for: aiProvider) != nil else {
-            throw EnhancementError.notConfigured
-        }
-
         // Store for TranscriptionVariation
         lastSystemMessageSent = resolvedSystemMessage
         lastUserMessageSent = formattedText
@@ -1427,8 +1416,9 @@ class AIService {
         logger.logDebug("AI Processing - User Message: \(formattedText)")
 
         // Anthropic uses its own Messages API; every other cloud provider is
-        // OpenAI-compatible. The registry reads the API key from the Keychain
-        // and builds the configured provider (key existence is guarded above).
+        // OpenAI-compatible. The registry is the single source of the API-key
+        // precondition: it reads the key from the Keychain and throws
+        // `.notConfigured` if it's missing.
         let route: AIProviderRoute = aiProvider == .anthropic ? .anthropic : .cloud(aiProvider)
         let provider = try await aiProviderRegistry.makeTextProvider(for: route, model: mode.aiModel)
         return try await provider.enhance(systemMessage: resolvedSystemMessage, userMessage: formattedText)

--- a/VivaDictaTests/AIServiceEnhanceRoutingTests.swift
+++ b/VivaDictaTests/AIServiceEnhanceRoutingTests.swift
@@ -167,6 +167,34 @@ struct AIServiceEnhanceRoutingTests {
         #expect(net.capturedRequest == nil)   // failed the precondition before any network call
     }
 
+    /// Streaming counterpart of the Anthropic cloud route - covers the streaming
+    /// `.anthropic` guard removal. `MockNetworkService.bytes` can't return a
+    /// stubbed `AsyncBytes`, but it captures the request before throwing, so we
+    /// can still assert the request reached `/v1/messages` with the `x-api-key`.
+    @Test func anthropicStreamingCloudRouteSendsApiKeyHeaderToMessagesEndpoint() async {
+        let keychain = MockKeychainService()
+        _ = keychain.save("ANTHROPIC_STREAM_KEY", forKey: "anthropicAPIKey")
+        let net = MockNetworkService()
+
+        let sut = AIService(
+            userDefaults: makeDefaults(),
+            keychain: keychain,
+            networkService: net,
+            oauthManager: MockOAuthManager()
+        )
+        let mode = makeMode(aiProvider: .anthropic, aiModel: "claude-sonnet-4-6")
+
+        _ = try? await sut.generateVariation(
+            text: "hello world",
+            preset: PresetCatalog.regular,
+            modeOverride: mode,
+            onPartialResult: { _ in }
+        )
+
+        #expect(net.capturedRequest?.url?.absoluteString == "https://api.anthropic.com/v1/messages")
+        #expect(net.capturedRequest?.value(forHTTPHeaderField: "x-api-key") == "ANTHROPIC_STREAM_KEY")
+    }
+
     private func http(_ code: Int) -> HTTPURLResponse {
         HTTPURLResponse(url: URL(string: "https://example.com")!, statusCode: code, httpVersion: nil, headerFields: nil)!
     }

--- a/VivaDictaTests/AIServiceEnhanceRoutingTests.swift
+++ b/VivaDictaTests/AIServiceEnhanceRoutingTests.swift
@@ -1,6 +1,8 @@
 // Copyright © 2026 Anton Novoselov. All rights reserved.
 
 import Foundation
+import Keychain
+import KeychainMocks
 import Networking
 import NetworkingMocks
 import OAuth
@@ -10,17 +12,17 @@ import Testing
 import AICore
 @testable import VivaDicta
 
-/// Characterization tests for `AIService`'s non-streaming enhancement routing.
+/// Characterization tests for `AIService`'s enhancement routing.
 ///
-/// They pin the outgoing request for the routes that are fully mockable through
-/// `AIService`'s injected `OAuthManager` + `NetworkService`, so the Phase 11
-/// move to `AIProviderRegistry` is provably behavior-preserving: the same
-/// request must still reach the same endpoint carrying the same credential.
+/// They pin the outgoing request for each route through `AIService`'s injected
+/// dependencies (`KeychainService` / `OAuthManager` / `NetworkService`), so the
+/// Phase 11 move to `AIProviderRegistry` is provably behavior-preserving: the
+/// same request must still reach the same endpoint carrying the same credential.
 ///
-/// (The Keychain-keyed cloud routes are not characterized here because
-/// `AIProvider.apiKey` reads a file-private `DefaultKeychainService`, not the
-/// injected one - so they can't be driven without touching the real Keychain.
-/// Those routes are covered by `AIProviderRegistry`'s own tests.)
+/// The Keychain-keyed cloud routes became drivable here once the registry
+/// (reading the injected `KeychainService`) became the single source of the
+/// API-key precondition - before that, `AIService`'s guard read the file-private
+/// `DefaultKeychainService`, which a mock couldn't reach.
 @Suite(.tags(.networking))
 @MainActor
 struct AIServiceEnhanceRoutingTests {
@@ -99,5 +101,73 @@ struct AIServiceEnhanceRoutingTests {
         #expect(oauth.capturedValidAccessTokenProviderKey == "geminiOAuthCredential")
         #expect(net.capturedRequest?.url?.absoluteString.contains("cloudcode-pa.googleapis.com") == true)
         #expect(net.capturedRequest?.value(forHTTPHeaderField: "Authorization") == "Bearer GEM_STREAM_TOKEN")
+    }
+
+    // MARK: - Keychain-keyed cloud routes
+    //
+    // Drivable now that the registry (reading the injected KeychainService) is
+    // the single source of the API-key precondition. A fresh MockOAuthManager
+    // reports "not signed in", so these modes take the cloud path, not OAuth.
+
+    @Test func cloudRouteSendsBearerKeyToProviderEndpoint() async throws {
+        let keychain = MockKeychainService()
+        _ = keychain.save("OPENAI_KEY", forKey: "openAIAPIKey")
+        let net = MockNetworkService()
+        net.stubSendResponse = .success((Data(#"{"choices":[{"message":{"content":"OK"}}]}"#.utf8), http(200)))
+
+        let sut = AIService(
+            userDefaults: makeDefaults(),
+            keychain: keychain,
+            networkService: net,
+            oauthManager: MockOAuthManager()
+        )
+        let mode = makeMode(aiProvider: .openAI, aiModel: "gpt-test")
+
+        _ = try await sut.generateVariation(text: "hello world", preset: PresetCatalog.regular, modeOverride: mode)
+
+        #expect(net.capturedRequest?.url?.absoluteString == "https://api.openai.com/v1/chat/completions")
+        #expect(net.capturedRequest?.value(forHTTPHeaderField: "Authorization") == "Bearer OPENAI_KEY")
+    }
+
+    @Test func anthropicCloudRouteSendsApiKeyHeaderToMessagesEndpoint() async throws {
+        let keychain = MockKeychainService()
+        _ = keychain.save("ANTHROPIC_KEY", forKey: "anthropicAPIKey")
+        let net = MockNetworkService()
+        net.stubSendResponse = .success((Data(#"{"content":[{"text":"OK"}]}"#.utf8), http(200)))
+
+        let sut = AIService(
+            userDefaults: makeDefaults(),
+            keychain: keychain,
+            networkService: net,
+            oauthManager: MockOAuthManager()
+        )
+        let mode = makeMode(aiProvider: .anthropic, aiModel: "claude-sonnet-4-6")
+
+        _ = try await sut.generateVariation(text: "hello world", preset: PresetCatalog.regular, modeOverride: mode)
+
+        #expect(net.capturedRequest?.url?.absoluteString == "https://api.anthropic.com/v1/messages")
+        #expect(net.capturedRequest?.value(forHTTPHeaderField: "x-api-key") == "ANTHROPIC_KEY")
+    }
+
+    /// The registry is now the single source of the API-key precondition: with no
+    /// key in the (injected) Keychain, the cloud route throws `.notConfigured`.
+    @Test func cloudRouteThrowsNotConfiguredWhenKeyMissing() async {
+        let net = MockNetworkService()
+        let sut = AIService(
+            userDefaults: makeDefaults(),
+            keychain: MockKeychainService(),   // empty - no key
+            networkService: net,
+            oauthManager: MockOAuthManager()
+        )
+        let mode = makeMode(aiProvider: .anthropic, aiModel: "claude-sonnet-4-6")
+
+        await #expect(throws: EnhancementError.self) {
+            _ = try await sut.generateVariation(text: "hello world", preset: PresetCatalog.regular, modeOverride: mode)
+        }
+        #expect(net.capturedRequest == nil)   // failed the precondition before any network call
+    }
+
+    private func http(_ code: Int) -> HTTPURLResponse {
+        HTTPURLResponse(url: URL(string: "https://example.com")!, statusCode: code, httpVersion: nil, headerFields: nil)!
     }
 }


### PR DESCRIPTION
## What

Removes the three now-redundant cloud-path API-key guards in `AIService` so `AIProviderRegistry.requireAPIKey` is the **single source** of the API-key precondition:

- the non-streaming `makeRequest` cloud switch
- the streaming `.anthropic` case
- the streaming `.openAICompatibleCloud` case

Each was a `guard self.getAPIKey(for:) != nil else { throw .notConfigured }` immediately followed by `makeTextProvider(...)`, which calls `requireAPIKey` itself — so the key was read **twice, from two backends** (the guard via the file-private `DefaultKeychainService` inside `AIProvider.apiKey`; the registry via `AIService`'s injected `KeychainService`). In production both are the same `DefaultKeychainService`, so this only drops a redundant double-read.

This was flagged by the @claude reviews on #335/#336 and by the adversarial verification on each phase.

## Why it matters: it closes the cloud-route test gap

Because the cloud path no longer reads the file-private keychain via `AIProvider.apiKey`, a `MockKeychainService` can finally drive it end-to-end through `AIService`. New characterization tests:

- `cloudRouteSendsBearerKeyToProviderEndpoint` — OpenAI route reads the injected key and sends `Bearer <key>` to the OpenAI endpoint
- `anthropicCloudRouteSendsApiKeyHeaderToMessagesEndpoint` — Anthropic route sends `x-api-key` to `/v1/messages`
- `cloudRouteThrowsNotConfiguredWhenKeyMissing` — a missing key throws `.notConfigured` before any network call

These are the routes that previously *couldn't* be characterized through `AIService` (the doc comment in the test file used to say so).

## Behavior preserved

Adversarial verification (multi-agent): **PASS.**
- Missing key → identical `EnhancementError.notConfigured` (now from the registry).
- Present key → identical provider build / request.
- Same production keychain backend; only the redundant read is gone.
- The non-streaming `lastSystemMessageSent`/`lastUserMessageSent` are now assigned just before a missing-key throw instead of just after — **not observable** (they're only read on the success path to build a `TranscriptionVariation`).
- Scope is exactly the three guards: the OAuth/CLI fallback `getAPIKey != nil` checks, `resolvedStreamingRoute`, Apple/Ollama/Custom branches, and all debug logging are untouched.

The file-private `AIProvider.apiKey` stays for the OAuth/CLI **fallback-decision** checks — a separate concern from building the provider.

The full `VivaDictaTests` suite and the app build are green.