### PR TITLE
Wire Ollama/Custom streaming enhance to AIProviderRegistry (Phase 11d-streaming)

### DIFF
--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -1034,33 +1034,6 @@ class AIService {
         )
     }
 
-    private func makeOpenAICompatibleStreamingRequest(
-        url: URL,
-        modelName: String,
-        systemMessage: String,
-        userMessage: String,
-        headers: [String: String],
-        timeout: TimeInterval,
-        errorPrefix: String,
-        notFoundMessage: String? = nil,
-        unauthorizedMessage: String? = nil,
-        onPartialResponse: @escaping @MainActor (String) -> Void
-    ) async throws -> String {
-        let service = OpenAICompatibleService(networkService: networkService, logger: logger)
-        return try await service.enhanceStreaming(
-            url: url,
-            modelName: modelName,
-            systemMessage: systemMessage,
-            userMessage: userMessage,
-            headers: headers,
-            timeout: timeout,
-            errorPrefix: errorPrefix,
-            notFoundMessage: notFoundMessage,
-            unauthorizedMessage: unauthorizedMessage,
-            onPartialResponse: onPartialResponse
-        )
-    }
-
     static func openAICompatibleStreamingDelta(from line: String) -> String? {
         OpenAICompatibleService.streamingDelta(from: line)
     }
@@ -1163,17 +1136,17 @@ class AIService {
             logger.logDebug("AI Processing - Using Ollama streaming at \(serverURL)")
             logger.logDebug("AI Processing - Model: \(mode.aiModel)")
 
-            return try await makeOpenAICompatibleStreamingRequest(
-                url: url,
-                modelName: mode.aiModel,
-                systemMessage: sysMsg,
-                userMessage: userMsg,
-                headers: [:],
-                timeout: 120,
-                errorPrefix: "Ollama error",
-                notFoundMessage: "Model '\(mode.aiModel)' not found. Run 'ollama pull \(mode.aiModel)' on your Mac/server to download it.",
-                onPartialResponse: onPartialResponse
+            let provider = try await aiProviderRegistry.makeTextProvider(
+                for: .openAICompatibleEndpoint(
+                    url: url,
+                    headers: [:],
+                    timeout: 120,
+                    errorPrefix: "Ollama error",
+                    notFoundMessage: "Model '\(mode.aiModel)' not found. Run 'ollama pull \(mode.aiModel)' on your Mac/server to download it."
+                ),
+                model: mode.aiModel
             )
+            return try await provider.enhanceStreaming(systemMessage: sysMsg, userMessage: userMsg, onPartialResponse: onPartialResponse)
         case .customOpenAI:
             let endpointURL = customOpenAIRequestURL
             let modelName = customOpenAIModelName
@@ -1198,18 +1171,18 @@ class AIService {
             logger.logDebug("AI Processing - Using Custom OpenAI streaming at \(endpointURL)")
             logger.logDebug("AI Processing - Model: \(modelName)")
 
-            return try await makeOpenAICompatibleStreamingRequest(
-                url: url,
-                modelName: modelName,
-                systemMessage: sysMsg,
-                userMessage: userMsg,
-                headers: headers,
-                timeout: 120,
-                errorPrefix: "Custom AI provider error",
-                notFoundMessage: "Model '\(modelName)' not found on the server.",
-                unauthorizedMessage: "Authentication failed. Check your API key.",
-                onPartialResponse: onPartialResponse
+            let provider = try await aiProviderRegistry.makeTextProvider(
+                for: .openAICompatibleEndpoint(
+                    url: url,
+                    headers: headers,
+                    timeout: 120,
+                    errorPrefix: "Custom AI provider error",
+                    notFoundMessage: "Model '\(modelName)' not found on the server.",
+                    unauthorizedMessage: "Authentication failed. Check your API key."
+                ),
+                model: modelName
             )
+            return try await provider.enhanceStreaming(systemMessage: sysMsg, userMessage: userMsg, onPartialResponse: onPartialResponse)
         case nil:
             break
         }

--- a/VivaDictaTests/AIServiceEnhanceRoutingTests.swift
+++ b/VivaDictaTests/AIServiceEnhanceRoutingTests.swift
@@ -195,6 +195,33 @@ struct AIServiceEnhanceRoutingTests {
         #expect(net.capturedRequest?.value(forHTTPHeaderField: "x-api-key") == "ANTHROPIC_STREAM_KEY")
     }
 
+    /// Ollama streams via the `.openAICompatibleEndpoint` route, which must carry
+    /// the caller's server URL, the local-inference timeout (120s, not the cloud
+    /// 300s), and no auth header. `MockNetworkService.bytes` captures the request
+    /// before throwing, so the route config is assertable.
+    @Test func ollamaStreamingRouteSendsToServerEndpointWithLocalTimeout() async {
+        let net = MockNetworkService()
+        let sut = AIService(
+            userDefaults: makeDefaults(),
+            keychain: MockKeychainService(),
+            networkService: net,
+            oauthManager: MockOAuthManager()
+        )
+        sut.ollamaServerURL = "http://localhost:11434"
+        let mode = makeMode(aiProvider: .ollama, aiModel: "llama3")
+
+        _ = try? await sut.generateVariation(
+            text: "hello world",
+            preset: PresetCatalog.regular,
+            modeOverride: mode,
+            onPartialResult: { _ in }
+        )
+
+        #expect(net.capturedRequest?.url?.absoluteString == "http://localhost:11434/v1/chat/completions")
+        #expect(net.capturedRequest?.timeoutInterval == 120)                              // local-inference timeout from the route
+        #expect(net.capturedRequest?.value(forHTTPHeaderField: "Authorization") == nil)   // Ollama needs no auth
+    }
+
     private func http(_ code: Int) -> HTTPURLResponse {
         HTTPURLResponse(url: URL(string: "https://example.com")!, statusCode: code, httpVersion: nil, headerFields: nil)!
     }


### PR DESCRIPTION
## What

Routes the streaming `.ollama` and `.customOpenAI` cases in `makeStreamingRequest` through `AIProviderRegistry.makeTextProvider(for: .openAICompatibleEndpoint(...))` + `provider.enhanceStreaming(...)`, replacing the `makeOpenAICompatibleStreamingRequest` helper.

`AIService` keeps what it owns - the Ollama server URL construction, the Custom endpoint validation guards, and the Custom conditional-`Bearer` header building (all from UserDefaults). The registry builds the provider. The `.openAICompatibleEndpoint` route carries the explicit **120s** local-inference timeout (added when the route was introduced, for exactly this), so the request is identical.

## Cleanup

Removes the now-orphaned `makeOpenAICompatibleStreamingRequest` helper - its last caller (the cloud streaming case) moved to the registry in the previous phase. `buildOpenAICompatibleRequestBody` stays (the non-streaming Ollama/Custom paths still use it; those move in a follow-up).

## Why mechanical / behavior-preserving

The streaming Ollama/Custom paths *already* went through `OpenAICompatibleService` (via the helper), and the registry's `.openAICompatibleEndpoint` route builds an `OpenAICompatibleTextProvider` whose `enhanceStreaming` calls the same `OpenAICompatibleService.enhanceStreaming` with the same `url` / `headers` / `timeout` / `errorPrefix` / `notFoundMessage` / `unauthorizedMessage`.

## Tests

- New `ollamaStreamingRouteSendsToServerEndpointWithLocalTimeout`: asserts the streaming Ollama route reaches the configured server URL with the **120s** timeout and **no** auth header.
- All routing tests + the full `VivaDictaTests` suite + the app build are green.

## Note

The **non-streaming** Ollama/Custom paths (`makeOllamaRequest` / `makeCustomOpenAIRequest`) are *not* in this PR - they're hand-rolled (inline request + bespoke 404/500 parsing, not via `OpenAICompatibleService`), so they need a characterization test pinning the "ollama pull" / status-code behavior before the swap. That's the next step.