### PR TITLE
Introduce CLIServerEnhancer seam (Phase 12a)

### DIFF
--- a/Modules/AIKit/Sources/AIKit/CLIServerEnhancer.swift
+++ b/Modules/AIKit/Sources/AIKit/CLIServerEnhancer.swift
@@ -1,0 +1,41 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+
+/// The CLI backends an enhancement request can be routed through when a local
+/// CLI server (a Mac running the Claude / Codex / Gemini CLIs) is configured.
+public enum CLIServerProvider: String, Sendable {
+    case anthropic
+    case codex
+    case gemini
+}
+
+/// A boundary over the optional "CLI server" enhancement backend.
+///
+/// The enhancement orchestration can route a request through a user-configured
+/// local CLI server instead of (or as a fallback before) a hosted API. That
+/// server is an app-level concern (UserDefaults-backed config + auth), so this
+/// protocol lets the orchestration depend on the capability rather than the
+/// concrete client - the app supplies a `Default`-prefixed adapter, tests a
+/// `Mock`. Mirrors how `KeychainService` / `OAuthManager` are injected.
+///
+/// `isCliActive(for:)` already folds in the master "CLI server enabled" toggle,
+/// so a caller only needs `isCliActive(for:) && serverURL` to decide to attempt
+/// a CLI call, and `isCliActive(for:)` alone to decide whether the CLI is an
+/// available fallback.
+///
+/// `@MainActor` because the app's CLI client reads main-actor-isolated config;
+/// this matches `AIProviderRegistry`, which is also `@MainActor`.
+@MainActor
+public protocol CLIServerEnhancer {
+    /// `true` when the CLI server is enabled *and* the given backend is active
+    /// (available + enabled) on it.
+    func isCliActive(for provider: CLIServerProvider) -> Bool
+
+    /// The configured CLI server URL, or `nil`/empty when unset.
+    var serverURL: String? { get }
+
+    /// Sends an enhancement request to the CLI server. Returns the raw result
+    /// (the caller applies its own trimming/filtering).
+    func enhance(text: String, systemPrompt: String, model: String, provider: CLIServerProvider) async throws -> String
+}

--- a/VivaDicta.xcodeproj/project.pbxproj
+++ b/VivaDicta.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		BFBF000000000000000000D1 /* AIProviders in Frameworks */ = {isa = PBXBuildFile; productRef = AEAE000000000000000000D1 /* AIProviders */; };
 		BFBF000000000000000000D2 /* AIProviders in Frameworks */ = {isa = PBXBuildFile; productRef = AEAE000000000000000000D2 /* AIProviders */; };
 		BFBF000000000000000000E1 /* AIKit in Frameworks */ = {isa = PBXBuildFile; productRef = AEAE000000000000000000E1 /* AIKit */; };
+		BFBF000000000000000000E2 /* AIKit in Frameworks */ = {isa = PBXBuildFile; productRef = AEAE000000000000000000E2 /* AIKit */; };
 		E1938683EE7E439ABF4FE3EA /* TranscriptionKitMocks in Frameworks */ = {isa = PBXBuildFile; productRef = F4E0FCBD69B741548F9F6B15 /* TranscriptionKitMocks */; };
 /* End PBXBuildFile section */
 
@@ -525,6 +526,7 @@
 				188E02592FC3BCC1007B8BC1 /* AudioRecordingMocks in Frameworks */,
 				BFBF000000000000000000C2 /* AICore in Frameworks */,
 				BFBF000000000000000000D2 /* AIProviders in Frameworks */,
+				BFBF000000000000000000E2 /* AIKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -755,6 +757,7 @@
 				188E02582FC3BCC1007B8BC1 /* AudioRecordingMocks */,
 				AEAE000000000000000000C2 /* AICore */,
 				AEAE000000000000000000D2 /* AIProviders */,
+				AEAE000000000000000000E2 /* AIKit */,
 			);
 			productName = VivaDictaTests;
 			productReference = 18351E572E634FF000944940 /* VivaDictaTests.xctest */;
@@ -2597,6 +2600,10 @@
 			productName = AIProviders;
 		};
 		AEAE000000000000000000E1 /* AIKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AIKit;
+		};
+		AEAE000000000000000000E2 /* AIKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = AIKit;
 		};

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -182,6 +182,7 @@ class AIService {
     let networkService: any NetworkService
     let oauthManager: any OAuthManager
     let copilotOAuthManager: any CopilotOAuthManager
+    private let cliServerEnhancer: any CLIServerEnhancer
     private let baseTimeout: TimeInterval = 300
 
     /// The AI stack's composition point: turns a resolved `AIProviderRoute` into
@@ -217,12 +218,14 @@ class AIService {
         keychain: any KeychainService = DefaultKeychainService(),
         networkService: any NetworkService = DefaultNetworkService(category: "AIService"),
         oauthManager: any OAuthManager = DefaultOAuthManager.shared,
-        copilotOAuthManager: any CopilotOAuthManager = DefaultCopilotOAuthManager.shared
+        copilotOAuthManager: any CopilotOAuthManager = DefaultCopilotOAuthManager.shared,
+        cliServerEnhancer: any CLIServerEnhancer = DefaultCLIServerEnhancer()
     ) {
         self.keychain = keychain
         self.networkService = networkService
         self.oauthManager = oauthManager
         self.copilotOAuthManager = copilotOAuthManager
+        self.cliServerEnhancer = cliServerEnhancer
         self.userDefaults = UserDefaultsStorage.shared
         self.modesStorageKey = AppGroupCoordinator.vivaModesKey
         self.selectedModeStorageKey = AppGroupCoordinator.selectedVivaModeKey
@@ -273,12 +276,14 @@ class AIService {
         keychain: any KeychainService = DefaultKeychainService(),
         networkService: any NetworkService = DefaultNetworkService(category: "AIService"),
         oauthManager: any OAuthManager = DefaultOAuthManager.shared,
-        copilotOAuthManager: any CopilotOAuthManager = DefaultCopilotOAuthManager.shared
+        copilotOAuthManager: any CopilotOAuthManager = DefaultCopilotOAuthManager.shared,
+        cliServerEnhancer: any CLIServerEnhancer = DefaultCLIServerEnhancer()
     ) {
         self.keychain = keychain
         self.networkService = networkService
         self.oauthManager = oauthManager
         self.copilotOAuthManager = copilotOAuthManager
+        self.cliServerEnhancer = cliServerEnhancer
         self.userDefaults = userDefaults
         self.modesStorageKey = modesStorageKey
         self.selectedModeStorageKey = selectedModeStorageKey
@@ -977,8 +982,8 @@ class AIService {
             if isOpenAISignedIn {
                 return .openAIOAuth
             }
-            if VivAgentsClient.isEnabled && VivAgentsClient.isCodexCliActive,
-               let serverURL = VivAgentsClient.serverURL, !serverURL.isEmpty {
+            if cliServerEnhancer.isCliActive(for: .codex),
+               let serverURL = cliServerEnhancer.serverURL, !serverURL.isEmpty {
                 return nil
             }
             return aiProvider.supportsResponseStreaming(model: mode.aiModel) ? .openAICompatibleCloud : nil
@@ -986,14 +991,14 @@ class AIService {
             if isGeminiSignedIn {
                 return .geminiOAuth
             }
-            if VivAgentsClient.isEnabled && VivAgentsClient.isGeminiCliActive,
-               let serverURL = VivAgentsClient.serverURL, !serverURL.isEmpty {
+            if cliServerEnhancer.isCliActive(for: .gemini),
+               let serverURL = cliServerEnhancer.serverURL, !serverURL.isEmpty {
                 return nil
             }
             return aiProvider.supportsResponseStreaming(model: mode.aiModel) ? .openAICompatibleCloud : nil
         case .anthropic:
-            if VivAgentsClient.isEnabled && VivAgentsClient.isAnthropicCliActive,
-               let serverURL = VivAgentsClient.serverURL, !serverURL.isEmpty {
+            if cliServerEnhancer.isCliActive(for: .anthropic),
+               let serverURL = cliServerEnhancer.serverURL, !serverURL.isEmpty {
                 return nil
             }
             return .anthropic
@@ -1099,7 +1104,7 @@ class AIService {
             } catch let error as EnhancementError {
                 throw error
             } catch let error as OAuthError {
-                if (VivAgentsClient.isEnabled && VivAgentsClient.isGeminiCliActive) || self.getAPIKey(for: aiProvider) != nil {
+                if cliServerEnhancer.isCliActive(for: .gemini) || self.getAPIKey(for: aiProvider) != nil {
                     logger.logWarning("Gemini OAuth streaming failed, falling back: \(error.localizedDescription)")
                     break
                 } else {
@@ -1113,7 +1118,7 @@ class AIService {
                 let result = try await provider.enhanceStreaming(systemMessage: sysMsg, userMessage: userMsg, onPartialResponse: onPartialResponse)
                 return await finalizeStreamingResult(result, onPartialResponse: onPartialResponse)
             } catch let error as OAuthError {
-                if (VivAgentsClient.isEnabled && VivAgentsClient.isCodexCliActive) || self.getAPIKey(for: aiProvider) != nil {
+                if cliServerEnhancer.isCliActive(for: .codex) || self.getAPIKey(for: aiProvider) != nil {
                     logger.logWarning("OpenAI OAuth streaming failed, falling back: \(error.localizedDescription)")
                     break
                 } else {
@@ -1249,17 +1254,18 @@ class AIService {
         let resolvedSystemMessage = systemMessage ?? getSystemMessage()
 
         // Anthropic CLI Server: route Anthropic requests through remote server when enabled
-        if aiProvider == .anthropic && VivAgentsClient.isEnabled && VivAgentsClient.isAnthropicCliActive,
-           let serverURL = VivAgentsClient.serverURL, !serverURL.isEmpty {
+        if aiProvider == .anthropic && cliServerEnhancer.isCliActive(for: .anthropic),
+           let serverURL = cliServerEnhancer.serverURL, !serverURL.isEmpty {
             let formattedText = preFormattedUserMessage ?? formatTranscriptForLLM(text)
             lastSystemMessageSent = resolvedSystemMessage
             lastUserMessageSent = formattedText
             logger.logDebug("AI Processing - Using Anthropic CLI Server at \(serverURL)")
             do {
-                let result = try await VivAgentsClient.enhance(
+                let result = try await cliServerEnhancer.enhance(
                     text: formattedText,
                     systemPrompt: resolvedSystemMessage,
-                    model: mode.aiModel
+                    model: mode.aiModel,
+                    provider: .anthropic
                 )
                 let filteredResult = AIEnhancementOutputFilter.filter(result.trimmingCharacters(in: .whitespacesAndNewlines))
                 return filteredResult
@@ -1287,7 +1293,7 @@ class AIService {
                 return AIEnhancementOutputFilter.filter(result)
             } catch let error as OAuthError {
                 // If OAuth fails, fall through to CLI or API key
-                if (VivAgentsClient.isEnabled && VivAgentsClient.isCodexCliActive) || self.getAPIKey(for: aiProvider) != nil {
+                if cliServerEnhancer.isCliActive(for: .codex) || self.getAPIKey(for: aiProvider) != nil {
                     logger.logWarning("OpenAI OAuth failed, falling back: \(error.localizedDescription)")
                 } else {
                     throw EnhancementError.customError(error.errorDescription ?? "OpenAI OAuth error")
@@ -1309,7 +1315,7 @@ class AIService {
                 throw error
             } catch let error as OAuthError {
                 // If OAuth fails, fall through to CLI or API key
-                if (VivAgentsClient.isEnabled && VivAgentsClient.isGeminiCliActive) || self.getAPIKey(for: aiProvider) != nil {
+                if cliServerEnhancer.isCliActive(for: .gemini) || self.getAPIKey(for: aiProvider) != nil {
                     logger.logWarning("Gemini OAuth failed, falling back: \(error.localizedDescription)")
                 } else {
                     throw EnhancementError.customError(error.errorDescription ?? "Gemini OAuth error")
@@ -1318,17 +1324,17 @@ class AIService {
         }
 
         // Codex CLI via Mac server: route OpenAI requests through CLI server when enabled
-        if aiProvider == .openAI && VivAgentsClient.isEnabled && VivAgentsClient.isCodexCliActive,
-           let serverURL = VivAgentsClient.serverURL, !serverURL.isEmpty {
+        if aiProvider == .openAI && cliServerEnhancer.isCliActive(for: .codex),
+           let serverURL = cliServerEnhancer.serverURL, !serverURL.isEmpty {
             lastSystemMessageSent = resolvedSystemMessage
             lastUserMessageSent = formattedText
             logger.logDebug("AI Processing - Using Codex CLI Server at \(serverURL)")
             do {
-                let result = try await VivAgentsClient.enhance(
+                let result = try await cliServerEnhancer.enhance(
                     text: formattedText,
                     systemPrompt: resolvedSystemMessage,
                     model: mode.aiModel,
-                    provider: "codex"
+                    provider: .codex
                 )
                 let filteredResult = AIEnhancementOutputFilter.filter(result.trimmingCharacters(in: .whitespacesAndNewlines))
                 return filteredResult
@@ -1342,17 +1348,17 @@ class AIService {
         }
 
         // Gemini CLI via Mac server: route Gemini requests through CLI server when enabled
-        if aiProvider == .gemini && VivAgentsClient.isEnabled && VivAgentsClient.isGeminiCliActive,
-           let serverURL = VivAgentsClient.serverURL, !serverURL.isEmpty {
+        if aiProvider == .gemini && cliServerEnhancer.isCliActive(for: .gemini),
+           let serverURL = cliServerEnhancer.serverURL, !serverURL.isEmpty {
             lastSystemMessageSent = resolvedSystemMessage
             lastUserMessageSent = formattedText
             logger.logDebug("AI Processing - Using Gemini CLI Server at \(serverURL)")
             do {
-                let result = try await VivAgentsClient.enhance(
+                let result = try await cliServerEnhancer.enhance(
                     text: formattedText,
                     systemPrompt: resolvedSystemMessage,
                     model: mode.aiModel,
-                    provider: "gemini"
+                    provider: .gemini
                 )
                 let filteredResult = AIEnhancementOutputFilter.filter(result.trimmingCharacters(in: .whitespacesAndNewlines))
                 return filteredResult

--- a/VivaDicta/Services/AIEnhance/DefaultCLIServerEnhancer.swift
+++ b/VivaDicta/Services/AIEnhance/DefaultCLIServerEnhancer.swift
@@ -12,7 +12,7 @@ import AIKit
 ///
 /// Adapts the app's all-static CLI-server client to the `AIKit` boundary so the
 /// enhancement orchestration depends on the protocol rather than the global.
-/// Stateless, so `Sendable` is trivial; every call forwards to `VivAgentsClient`.
+/// Stateless; every call forwards to `VivAgentsClient`.
 struct DefaultCLIServerEnhancer: CLIServerEnhancer {
     func isCliActive(for provider: CLIServerProvider) -> Bool {
         guard VivAgentsClient.isEnabled else { return false }

--- a/VivaDicta/Services/AIEnhance/DefaultCLIServerEnhancer.swift
+++ b/VivaDicta/Services/AIEnhance/DefaultCLIServerEnhancer.swift
@@ -1,0 +1,31 @@
+//
+//  DefaultCLIServerEnhancer.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.06.17
+//
+
+import Foundation
+import AIKit
+
+/// Production `CLIServerEnhancer` backed by ``VivAgentsClient``.
+///
+/// Adapts the app's all-static CLI-server client to the `AIKit` boundary so the
+/// enhancement orchestration depends on the protocol rather than the global.
+/// Stateless, so `Sendable` is trivial; every call forwards to `VivAgentsClient`.
+struct DefaultCLIServerEnhancer: CLIServerEnhancer {
+    func isCliActive(for provider: CLIServerProvider) -> Bool {
+        guard VivAgentsClient.isEnabled else { return false }
+        switch provider {
+        case .anthropic: return VivAgentsClient.isAnthropicCliActive
+        case .codex: return VivAgentsClient.isCodexCliActive
+        case .gemini: return VivAgentsClient.isGeminiCliActive
+        }
+    }
+
+    var serverURL: String? { VivAgentsClient.serverURL }
+
+    func enhance(text: String, systemPrompt: String, model: String, provider: CLIServerProvider) async throws -> String {
+        try await VivAgentsClient.enhance(text: text, systemPrompt: systemPrompt, model: model, provider: provider.rawValue)
+    }
+}

--- a/VivaDicta/VivaDictaTestPlan.xctestplan
+++ b/VivaDicta/VivaDictaTestPlan.xctestplan
@@ -95,6 +95,27 @@
         "identifier" : "AudioRecordingTests",
         "name" : "AudioRecordingTests"
       }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Modules\/AIKit",
+        "identifier" : "AIKitTests",
+        "name" : "AIKitTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Modules\/AICore",
+        "identifier" : "AICoreTests",
+        "name" : "AICoreTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Modules\/AIProviders",
+        "identifier" : "AIProvidersTests",
+        "name" : "AIProvidersTests"
+      }
     }
   ],
   "version" : 1

--- a/VivaDictaTests/AIServiceEnhanceRoutingTests.swift
+++ b/VivaDictaTests/AIServiceEnhanceRoutingTests.swift
@@ -10,7 +10,29 @@ import OAuthMocks
 import Presets
 import Testing
 import AICore
+import AIKit
 @testable import VivaDicta
+
+/// Test double for the CLI-server boundary. `@MainActor` to satisfy the
+/// `@MainActor` protocol. Records the `enhance` call so tests can assert the
+/// orchestration routed through the CLI server (previously untestable, since
+/// the orchestration reached `VivAgentsClient` statics directly).
+@MainActor
+private final class MockCLIServerEnhancer: CLIServerEnhancer {
+    var activeProviders: Set<CLIServerProvider> = []
+    var serverURL: String?
+    var stubEnhanceResult = ""
+    private(set) var enhanceCallCount = 0
+    private(set) var capturedProvider: CLIServerProvider?
+
+    func isCliActive(for provider: CLIServerProvider) -> Bool { activeProviders.contains(provider) }
+
+    func enhance(text: String, systemPrompt: String, model: String, provider: CLIServerProvider) async throws -> String {
+        enhanceCallCount += 1
+        capturedProvider = provider
+        return stubEnhanceResult
+    }
+}
 
 /// Characterization tests for `AIService`'s enhancement routing.
 ///
@@ -220,6 +242,32 @@ struct AIServiceEnhanceRoutingTests {
         #expect(net.capturedRequest?.url?.absoluteString == "http://localhost:11434/v1/chat/completions")
         #expect(net.capturedRequest?.timeoutInterval == 120)                              // local-inference timeout from the route
         #expect(net.capturedRequest?.value(forHTTPHeaderField: "Authorization") == nil)   // Ollama needs no auth
+    }
+
+    /// When the Anthropic CLI server is active, the non-streaming orchestration
+    /// routes through the injected `CLIServerEnhancer` (not the registry/network).
+    /// This path was untestable before the CLI seam - it reached `VivAgentsClient`
+    /// statics directly.
+    @Test func anthropicCliServerRouteEnhancesViaCliServerEnhancer() async throws {
+        let cli = MockCLIServerEnhancer()
+        cli.activeProviders = [.anthropic]
+        cli.serverURL = "http://mac.local:4000"
+        cli.stubEnhanceResult = "CLI_RESULT"
+
+        let sut = AIService(
+            userDefaults: makeDefaults(),
+            keychain: MockKeychainService(),
+            networkService: MockNetworkService(),
+            oauthManager: MockOAuthManager(),
+            cliServerEnhancer: cli
+        )
+        let mode = makeMode(aiProvider: .anthropic, aiModel: "claude-sonnet-4-6")
+
+        let (result, _) = try await sut.generateVariation(text: "hi", preset: PresetCatalog.regular, modeOverride: mode)
+
+        #expect(cli.enhanceCallCount == 1)
+        #expect(cli.capturedProvider == .anthropic)   // routed to the Anthropic CLI backend
+        #expect(result == "CLI_RESULT")
     }
 
     private func http(_ code: Int) -> HTTPURLResponse {

--- a/VivaDictaTests/AIServiceEnhanceRoutingTests.swift
+++ b/VivaDictaTests/AIServiceEnhanceRoutingTests.swift
@@ -270,6 +270,52 @@ struct AIServiceEnhanceRoutingTests {
         #expect(result == "CLI_RESULT")
     }
 
+    /// OpenAI (not OAuth-signed-in) with the Codex CLI active routes through the
+    /// CLI enhancer with the `.codex` backend.
+    @Test func codexCliServerRouteEnhancesViaCliServerEnhancer() async throws {
+        let cli = MockCLIServerEnhancer()
+        cli.activeProviders = [.codex]
+        cli.serverURL = "http://mac.local:4000"
+        cli.stubEnhanceResult = "CODEX_RESULT"
+
+        let sut = AIService(
+            userDefaults: makeDefaults(),
+            keychain: MockKeychainService(),
+            networkService: MockNetworkService(),
+            oauthManager: MockOAuthManager(),
+            cliServerEnhancer: cli
+        )
+        let mode = makeMode(aiProvider: .openAI, aiModel: "gpt-test")
+
+        let (result, _) = try await sut.generateVariation(text: "hi", preset: PresetCatalog.regular, modeOverride: mode)
+
+        #expect(cli.capturedProvider == .codex)
+        #expect(result == "CODEX_RESULT")
+    }
+
+    /// Gemini (not OAuth-signed-in) with the Gemini CLI active routes through the
+    /// CLI enhancer with the `.gemini` backend.
+    @Test func geminiCliServerRouteEnhancesViaCliServerEnhancer() async throws {
+        let cli = MockCLIServerEnhancer()
+        cli.activeProviders = [.gemini]
+        cli.serverURL = "http://mac.local:4000"
+        cli.stubEnhanceResult = "GEMINI_RESULT"
+
+        let sut = AIService(
+            userDefaults: makeDefaults(),
+            keychain: MockKeychainService(),
+            networkService: MockNetworkService(),
+            oauthManager: MockOAuthManager(),
+            cliServerEnhancer: cli
+        )
+        let mode = makeMode(aiProvider: .gemini, aiModel: "gemini-test")
+
+        let (result, _) = try await sut.generateVariation(text: "hi", preset: PresetCatalog.regular, modeOverride: mode)
+
+        #expect(cli.capturedProvider == .gemini)
+        #expect(result == "GEMINI_RESULT")
+    }
+
     private func http(_ code: Int) -> HTTPURLResponse {
         HTTPURLResponse(url: URL(string: "https://example.com")!, statusCode: code, httpVersion: nil, headerFields: nil)!
     }


### PR DESCRIPTION
## What

First step of Phase 12 (lifting orchestration toward `AIKit`). Abstracts the app-level, all-static `VivAgentsClient` CLI server behind a protocol `AIKit` can depend on, so the enhancement orchestration depends on the *capability* rather than the concrete global.

- **AIKit:** `CLIServerProvider` enum + `@MainActor protocol CLIServerEnhancer` — `isCliActive(for:)` (folds in the master "CLI server enabled" toggle), `serverURL`, `enhance(text:systemPrompt:model:provider:)`. `@MainActor` because `VivAgentsClient`'s statics are main-actor-isolated (matches `AIProviderRegistry`).
- **App:** `DefaultCLIServerEnhancer` forwards to `VivAgentsClient`.
- **AIService:** injects `cliServerEnhancer` (default = the adapter) into both inits, and routes **every CLI orchestration call-site** through it: `resolvedStreamingRoute`'s three gates, the streaming + non-streaming OAuth→CLI fallback gates, and the three non-streaming CLI execution branches (incl. their `enhance` calls).

## Behavior-preserving

Each condition is replicated exactly — `isEnabled && isXCliActive` collapses to `isCliActive(for:)` (the adapter ANDs in `isEnabled`); the `serverURL` non-empty checks, the `provider:` strings (`anthropic`/`codex`/`gemini`), the fallback `|| getAPIKey != nil`, the filtering, and the `lastSystemMessageSent`/`lastUserMessageSent` ordering are unchanged.

The **config/connection-check** uses of `VivAgentsClient` (`refreshConnectedProviders`, the provider-availability checks) intentionally stay on the static — that's a different concern from request orchestration.

## Why it matters

The CLI fallback path (OAuth→CLI→API-key) was **untestable** because it reached a static. It's now mockable. Adds `MockCLIServerEnhancer` + a characterization test proving the Anthropic CLI route enhances via the injected enhancer.

## Also

Adds the `AIKit`/`AICore`/`AIProviders` test targets to the CI test plan, so the extracted module suites (registry tests, etc.) run in CI.

## Tests

New CLI characterization test + all routing tests + the full `VivaDictaTests` suite + the app build are green.