### PR TITLE
Lift non-streaming orchestration into AIKit TextEnhancer (Phase 12b)

### DIFF
--- a/Modules/AIKit/Sources/AIKit/Logger+AIKit.swift
+++ b/Modules/AIKit/Sources/AIKit/Logger+AIKit.swift
@@ -1,0 +1,17 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import os
+
+/// Internal logging convenience for the AIKit module. Methods are
+/// intentionally `internal` so they don't collide with the app target's
+/// identically named extensions on `Logger`.
+extension Logger {
+    func logDebug(_ message: String) {
+        self.debug("\(message, privacy: .public)")
+    }
+
+    func logWarning(_ message: String) {
+        self.warning("\(message, privacy: .public)")
+    }
+}

--- a/Modules/AIKit/Sources/AIKit/TextEnhancer.swift
+++ b/Modules/AIKit/Sources/AIKit/TextEnhancer.swift
@@ -1,0 +1,178 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import os
+import AICore
+import AIProviders
+import OAuth
+
+/// A resolved non-streaming enhancement request - everything `TextEnhancer`
+/// needs to run the cloud / CLI / OAuth routing, with the caller's runtime
+/// state already decided (`isOAuthSignedIn`, `hasAPIKey`).
+public struct EnhancementInput: Sendable {
+    public let provider: AIProvider
+    public let model: String
+    public let systemMessage: String
+    public let userMessage: String
+    /// Whether `provider` is OAuth-signed-in (the caller resolves which
+    /// provider this applies to).
+    public let isOAuthSignedIn: Bool
+    /// Whether an API key exists for `provider` (used for fallback decisions).
+    public let hasAPIKey: Bool
+
+    public init(
+        provider: AIProvider,
+        model: String,
+        systemMessage: String,
+        userMessage: String,
+        isOAuthSignedIn: Bool,
+        hasAPIKey: Bool
+    ) {
+        self.provider = provider
+        self.model = model
+        self.systemMessage = systemMessage
+        self.userMessage = userMessage
+        self.isOAuthSignedIn = isOAuthSignedIn
+        self.hasAPIKey = hasAPIKey
+    }
+}
+
+/// Runs the non-streaming enhancement state machine for a resolved request:
+/// the CLI-server / OAuth / cloud routing and the fallback chain
+/// (OAuth -> CLI -> API key). Lifted out of `AIService` so the orchestration is
+/// a unit-testable value in `AIKit`, depending on the registry + the CLI seam
+/// rather than the app's `@Observable` state.
+///
+/// Does NOT handle Apple Foundation Model or the locally-configured
+/// Ollama / Custom endpoints - those stay with the caller (Apple FM reuses a
+/// cached service; Ollama/Custom build their request from app config).
+@MainActor
+public struct TextEnhancer {
+    private let registry: AIProviderRegistry
+    private let cliServerEnhancer: any CLIServerEnhancer
+    private let logger: Logger
+
+    public init(registry: AIProviderRegistry, cliServerEnhancer: any CLIServerEnhancer, logger: Logger) {
+        self.registry = registry
+        self.cliServerEnhancer = cliServerEnhancer
+        self.logger = logger
+    }
+
+    public func enhance(_ input: EnhancementInput) async throws -> String {
+        // Anthropic CLI Server: route Anthropic requests through the remote server when enabled.
+        if input.provider == .anthropic && cliServerEnhancer.isCliActive(for: .anthropic),
+           let serverURL = cliServerEnhancer.serverURL, !serverURL.isEmpty {
+            logger.logDebug("AI Processing - Using Anthropic CLI Server at \(serverURL)")
+            do {
+                let result = try await cliServerEnhancer.enhance(
+                    text: input.userMessage, systemPrompt: input.systemMessage, model: input.model, provider: .anthropic
+                )
+                return AIEnhancementOutputFilter.filter(result.trimmingCharacters(in: .whitespacesAndNewlines))
+            } catch {
+                // Fall back to API key if the server fails and a key exists.
+                if input.hasAPIKey {
+                    logger.logWarning("Anthropic CLI Server failed, falling back to API key: \(error.localizedDescription)")
+                } else {
+                    throw EnhancementError.customError(error.localizedDescription)
+                }
+            }
+        }
+
+        // OpenAI OAuth: route OpenAI requests through the OpenAI backend API when signed in.
+        if input.provider == .openAI && input.isOAuthSignedIn {
+            do {
+                let model = input.model.isEmpty ? OpenAIOAuthClient.defaultModel : input.model
+                let provider = try await registry.makeTextProvider(for: .openAIOAuth, model: model)
+                let result = try await provider.enhance(systemMessage: input.systemMessage, userMessage: input.userMessage)
+                return AIEnhancementOutputFilter.filter(result)
+            } catch let error as OAuthError {
+                // If OAuth fails, fall through to CLI or API key.
+                if cliServerEnhancer.isCliActive(for: .codex) || input.hasAPIKey {
+                    logger.logWarning("OpenAI OAuth failed, falling back: \(error.localizedDescription)")
+                } else {
+                    throw EnhancementError.customError(error.errorDescription ?? "OpenAI OAuth error")
+                }
+            }
+        }
+
+        // Gemini OAuth: route Gemini requests through OAuth when signed in.
+        if input.provider == .gemini && input.isOAuthSignedIn {
+            do {
+                let model = input.model.isEmpty ? GeminiAPIClient.defaultModel : input.model
+                let provider = try await registry.makeTextProvider(for: .geminiOAuth, model: model)
+                let result = try await provider.enhance(systemMessage: input.systemMessage, userMessage: input.userMessage)
+                return AIEnhancementOutputFilter.filter(result)
+            } catch let error as EnhancementError {
+                // Rate limit etc. - don't fall through, surface directly.
+                throw error
+            } catch let error as OAuthError {
+                // If OAuth fails, fall through to CLI or API key.
+                if cliServerEnhancer.isCliActive(for: .gemini) || input.hasAPIKey {
+                    logger.logWarning("Gemini OAuth failed, falling back: \(error.localizedDescription)")
+                } else {
+                    throw EnhancementError.customError(error.errorDescription ?? "Gemini OAuth error")
+                }
+            }
+        }
+
+        // Codex CLI via Mac server: route OpenAI requests through the CLI server when enabled.
+        if input.provider == .openAI && cliServerEnhancer.isCliActive(for: .codex),
+           let serverURL = cliServerEnhancer.serverURL, !serverURL.isEmpty {
+            logger.logDebug("AI Processing - Using Codex CLI Server at \(serverURL)")
+            do {
+                let result = try await cliServerEnhancer.enhance(
+                    text: input.userMessage, systemPrompt: input.systemMessage, model: input.model, provider: .codex
+                )
+                return AIEnhancementOutputFilter.filter(result.trimmingCharacters(in: .whitespacesAndNewlines))
+            } catch {
+                if input.hasAPIKey {
+                    logger.logWarning("Codex CLI Server failed, falling back to API key: \(error.localizedDescription)")
+                } else {
+                    throw EnhancementError.customError(error.localizedDescription)
+                }
+            }
+        }
+
+        // Gemini CLI via Mac server: route Gemini requests through the CLI server when enabled.
+        if input.provider == .gemini && cliServerEnhancer.isCliActive(for: .gemini),
+           let serverURL = cliServerEnhancer.serverURL, !serverURL.isEmpty {
+            logger.logDebug("AI Processing - Using Gemini CLI Server at \(serverURL)")
+            do {
+                let result = try await cliServerEnhancer.enhance(
+                    text: input.userMessage, systemPrompt: input.systemMessage, model: input.model, provider: .gemini
+                )
+                return AIEnhancementOutputFilter.filter(result.trimmingCharacters(in: .whitespacesAndNewlines))
+            } catch {
+                if input.hasAPIKey {
+                    logger.logWarning("Gemini CLI Server failed, falling back to API key: \(error.localizedDescription)")
+                } else {
+                    throw EnhancementError.customError(error.localizedDescription)
+                }
+            }
+        }
+
+        // GitHub Copilot: route through the Copilot API when signed in.
+        if input.provider == .copilot && input.isOAuthSignedIn {
+            do {
+                let model = input.model.isEmpty ? CopilotAPIClient.defaultModel : input.model
+                let provider = try await registry.makeTextProvider(for: .copilot, model: model)
+                let result = try await provider.enhance(systemMessage: input.systemMessage, userMessage: input.userMessage)
+                return AIEnhancementOutputFilter.filter(result)
+            } catch let error as EnhancementError {
+                throw error
+            } catch {
+                throw EnhancementError.customError(error.localizedDescription)
+            }
+        }
+
+        // Cloud providers. Anthropic uses its own Messages API; every other cloud
+        // provider is OpenAI-compatible. The registry is the single source of the
+        // API-key precondition (throws `.notConfigured` when the key is missing).
+        logger.logDebug("AI Processing - System Message: \(input.systemMessage)")
+        logger.logDebug("AI Processing - User Message: \(input.userMessage)")
+
+        let route: AIProviderRoute = input.provider == .anthropic ? .anthropic : .cloud(input.provider)
+        let provider = try await registry.makeTextProvider(for: route, model: input.model)
+        return try await provider.enhance(systemMessage: input.systemMessage, userMessage: input.userMessage)
+    }
+}

--- a/Modules/AIKit/Tests/AIKitTests/TextEnhancerTests.swift
+++ b/Modules/AIKit/Tests/AIKitTests/TextEnhancerTests.swift
@@ -1,0 +1,125 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Testing
+import Foundation
+import os
+import AICore
+import AIProviders
+import Keychain
+import KeychainMocks
+import OAuth
+import OAuthMocks
+import Networking
+import NetworkingMocks
+@testable import AIKit
+
+/// Test double for the CLI-server seam.
+@MainActor
+private final class MockCLIServerEnhancer: CLIServerEnhancer {
+    var activeProviders: Set<CLIServerProvider> = []
+    var serverURL: String?
+    var stubResult = ""
+    var stubError: Error?
+    private(set) var enhanceCallCount = 0
+    private(set) var capturedProvider: CLIServerProvider?
+
+    func isCliActive(for provider: CLIServerProvider) -> Bool { activeProviders.contains(provider) }
+
+    func enhance(text: String, systemPrompt: String, model: String, provider: CLIServerProvider) async throws -> String {
+        enhanceCallCount += 1
+        capturedProvider = provider
+        if let stubError { throw stubError }
+        return stubResult
+    }
+}
+
+/// Unit tests for the non-streaming orchestration now that it lives in AIKit
+/// rather than `AIService` - the cloud-default route, the CLI routes, and the
+/// CLI->API-key fallback decisions, driven through mocked infra.
+@MainActor
+@Suite("TextEnhancer", .tags(.networking))
+struct TextEnhancerTests {
+
+    private struct CLIError: Error {}
+
+    private func http(_ code: Int) -> HTTPURLResponse {
+        HTTPURLResponse(url: URL(string: "https://example.com")!, statusCode: code, httpVersion: nil, headerFields: nil)!
+    }
+
+    private func makeSUT(
+        keychain: MockKeychainService = MockKeychainService(),
+        net: MockNetworkService = MockNetworkService(),
+        cli: MockCLIServerEnhancer = MockCLIServerEnhancer()
+    ) -> TextEnhancer {
+        let registry = AIProviderRegistry(
+            keychain: keychain,
+            oauthManager: MockOAuthManager(),
+            copilotOAuthManager: MockCopilotOAuthManager(),
+            networkService: net,
+            logger: Logger(subsystem: "test", category: "TextEnhancerTests"),
+            baseTimeout: 30
+        )
+        return TextEnhancer(registry: registry, cliServerEnhancer: cli, logger: Logger(subsystem: "test", category: "TextEnhancerTests"))
+    }
+
+    private func input(provider: AIProvider, isOAuthSignedIn: Bool = false, hasAPIKey: Bool = true) -> EnhancementInput {
+        EnhancementInput(provider: provider, model: "m", systemMessage: "S", userMessage: "U", isOAuthSignedIn: isOAuthSignedIn, hasAPIKey: hasAPIKey)
+    }
+
+    @Test func cloudDefaultRouteEnhancesViaRegistry() async throws {
+        let keychain = MockKeychainService()
+        _ = keychain.save("ANTHROPIC_KEY", forKey: "anthropicAPIKey")
+        let net = MockNetworkService()
+        net.stubSendResponse = .success((Data(#"{"content":[{"text":"OK"}]}"#.utf8), http(200)))
+        let sut = makeSUT(keychain: keychain, net: net)
+
+        let result = try await sut.enhance(input(provider: .anthropic))
+
+        #expect(result == "OK")
+        #expect(net.capturedRequest?.url?.absoluteString == "https://api.anthropic.com/v1/messages")
+    }
+
+    @Test func anthropicCliActiveRoutesThroughCliServer() async throws {
+        let cli = MockCLIServerEnhancer()
+        cli.activeProviders = [.anthropic]
+        cli.serverURL = "http://mac:4000"
+        cli.stubResult = "CLI_RESULT"
+        let sut = makeSUT(cli: cli)
+
+        let result = try await sut.enhance(input(provider: .anthropic, hasAPIKey: false))
+
+        #expect(cli.enhanceCallCount == 1)
+        #expect(cli.capturedProvider == .anthropic)
+        #expect(result == "CLI_RESULT")
+    }
+
+    @Test func cliFailureWithoutKeyThrows() async {
+        let cli = MockCLIServerEnhancer()
+        cli.activeProviders = [.anthropic]
+        cli.serverURL = "http://mac:4000"
+        cli.stubError = CLIError()
+        let sut = makeSUT(cli: cli)
+
+        await #expect(throws: EnhancementError.self) {
+            _ = try await sut.enhance(input(provider: .anthropic, hasAPIKey: false))
+        }
+    }
+
+    @Test func cliFailureWithKeyFallsThroughToCloud() async throws {
+        let keychain = MockKeychainService()
+        _ = keychain.save("ANTHROPIC_KEY", forKey: "anthropicAPIKey")
+        let net = MockNetworkService()
+        net.stubSendResponse = .success((Data(#"{"content":[{"text":"CLOUD_OK"}]}"#.utf8), http(200)))
+        let cli = MockCLIServerEnhancer()
+        cli.activeProviders = [.anthropic]
+        cli.serverURL = "http://mac:4000"
+        cli.stubError = CLIError()
+        let sut = makeSUT(keychain: keychain, net: net, cli: cli)
+
+        let result = try await sut.enhance(input(provider: .anthropic, hasAPIKey: true))
+
+        #expect(cli.enhanceCallCount == 1)            // CLI was attempted
+        #expect(result == "CLOUD_OK")                 // then fell through to the cloud route
+        #expect(net.capturedRequest?.url?.absoluteString == "https://api.anthropic.com/v1/messages")
+    }
+}

--- a/Modules/AIKit/Tests/AIKitTests/TextEnhancerTests.swift
+++ b/Modules/AIKit/Tests/AIKitTests/TextEnhancerTests.swift
@@ -49,11 +49,12 @@ struct TextEnhancerTests {
     private func makeSUT(
         keychain: MockKeychainService = MockKeychainService(),
         net: MockNetworkService = MockNetworkService(),
-        cli: MockCLIServerEnhancer = MockCLIServerEnhancer()
+        cli: MockCLIServerEnhancer = MockCLIServerEnhancer(),
+        oauth: MockOAuthManager = MockOAuthManager()
     ) -> TextEnhancer {
         let registry = AIProviderRegistry(
             keychain: keychain,
-            oauthManager: MockOAuthManager(),
+            oauthManager: oauth,
             copilotOAuthManager: MockCopilotOAuthManager(),
             networkService: net,
             logger: Logger(subsystem: "test", category: "TextEnhancerTests"),
@@ -121,5 +122,54 @@ struct TextEnhancerTests {
         #expect(cli.enhanceCallCount == 1)            // CLI was attempted
         #expect(result == "CLOUD_OK")                 // then fell through to the cloud route
         #expect(net.capturedRequest?.url?.absoluteString == "https://api.anthropic.com/v1/messages")
+    }
+
+    // MARK: - OAuth branches (the subtle rethrow / fallthrough behavior)
+
+    /// Gemini OAuth throwing an `EnhancementError` (e.g. a 429 rate limit) must
+    /// surface directly - the `catch EnhancementError` precedes `catch OAuthError`,
+    /// so it does NOT fall through to the cloud route.
+    @Test func geminiOAuthEnhancementErrorSurfacesDirectlyWithoutFallthrough() async {
+        let oauth = MockOAuthManager()
+        oauth.stubValidAccessTokenResponse = .success((token: "GEM_TOK", accountId: nil, projectId: nil))
+        let net = MockNetworkService()
+        net.stubSendResponse = .success((Data("rate limited".utf8), http(429))) // Gemini maps 429 -> EnhancementError
+        let sut = makeSUT(net: net, oauth: oauth)
+
+        await #expect(throws: EnhancementError.self) {
+            _ = try await sut.enhance(input(provider: .gemini, isOAuthSignedIn: true, hasAPIKey: true))
+        }
+        // Only the Gemini OAuth (cloudcode) request was made - no cloud fallthrough.
+        #expect(net.capturedRequest?.url?.absoluteString.contains("cloudcode-pa.googleapis.com") == true)
+    }
+
+    /// OAuth token failure (an `OAuthError`) falls through to the cloud route when
+    /// an API key exists.
+    @Test func geminiOAuthFailureFallsThroughToCloudWhenKeyExists() async throws {
+        let oauth = MockOAuthManager()
+        oauth.stubValidAccessTokenResponse = .failure(OAuthError.noCredential)
+        let keychain = MockKeychainService()
+        _ = keychain.save("GEMINI_KEY", forKey: "geminiAPIKey")
+        let net = MockNetworkService()
+        net.stubSendResponse = .success((Data(#"{"choices":[{"message":{"content":"CLOUD_OK"}}]}"#.utf8), http(200)))
+        let sut = makeSUT(keychain: keychain, net: net, oauth: oauth)
+
+        let result = try await sut.enhance(input(provider: .gemini, isOAuthSignedIn: true, hasAPIKey: true))
+
+        #expect(result == "CLOUD_OK")
+        // Fell through to the cloud (OpenAI-compatible) Gemini endpoint with the Bearer key.
+        #expect(net.capturedRequest?.value(forHTTPHeaderField: "Authorization") == "Bearer GEMINI_KEY")
+    }
+
+    /// OAuth token failure with no API key and no active CLI surfaces as
+    /// `EnhancementError.customError` (no silent fall-through).
+    @Test func openAIOAuthFailureWithoutKeyOrCliThrowsCustomError() async {
+        let oauth = MockOAuthManager()
+        oauth.stubValidAccessTokenResponse = .failure(OAuthError.noCredential)
+        let sut = makeSUT(oauth: oauth) // no CLI active, no key
+
+        await #expect(throws: EnhancementError.self) {
+            _ = try await sut.enhance(input(provider: .openAI, isOAuthSignedIn: true, hasAPIKey: false))
+        }
     }
 }

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -201,6 +201,24 @@ class AIService {
         )
     }
 
+    /// Runs the non-streaming cloud/CLI/OAuth routing + fallback chain for a
+    /// resolved request. Built from the registry + the injected CLI seam.
+    private var textEnhancer: TextEnhancer {
+        TextEnhancer(registry: aiProviderRegistry, cliServerEnhancer: cliServerEnhancer, logger: logger)
+    }
+
+    /// Whether `provider` is currently OAuth-signed-in (used to resolve an
+    /// `EnhancementInput`). Mirrors the per-provider sign-in checks the routing
+    /// previously inlined.
+    private func isOAuthSignedIn(for provider: AIProvider) -> Bool {
+        switch provider {
+        case .openAI: return isOpenAISignedIn
+        case .gemini: return isGeminiSignedIn
+        case .copilot: return isCopilotSignedIn
+        default: return false
+        }
+    }
+
     /// Service for Apple's on-device Foundation Models (type-erased for iOS version compatibility)
     private var _appleFoundationModelService: Any?
 
@@ -1250,157 +1268,24 @@ class AIService {
             return try await makeCustomOpenAIRequest(text: text, systemMessage: systemMessage, preFormattedUserMessage: preFormattedUserMessage)
         }
 
-        // Cloud providers - compute system message only when needed
+        // Cloud / CLI / OAuth providers: resolve the messages, then hand off
+        // to the AIKit enhancer, which runs the routing + fallback chain.
         let resolvedSystemMessage = systemMessage ?? getSystemMessage()
-
-        // Anthropic CLI Server: route Anthropic requests through remote server when enabled
-        if aiProvider == .anthropic && cliServerEnhancer.isCliActive(for: .anthropic),
-           let serverURL = cliServerEnhancer.serverURL, !serverURL.isEmpty {
-            let formattedText = preFormattedUserMessage ?? formatTranscriptForLLM(text)
-            lastSystemMessageSent = resolvedSystemMessage
-            lastUserMessageSent = formattedText
-            logger.logDebug("AI Processing - Using Anthropic CLI Server at \(serverURL)")
-            do {
-                let result = try await cliServerEnhancer.enhance(
-                    text: formattedText,
-                    systemPrompt: resolvedSystemMessage,
-                    model: mode.aiModel,
-                    provider: .anthropic
-                )
-                let filteredResult = AIEnhancementOutputFilter.filter(result.trimmingCharacters(in: .whitespacesAndNewlines))
-                return filteredResult
-            } catch {
-                // Fall back to API key if server fails and key exists
-                if self.getAPIKey(for: aiProvider) != nil {
-                    logger.logWarning("Anthropic CLI Server failed, falling back to API key: \(error.localizedDescription)")
-                } else {
-                    throw EnhancementError.customError(error.localizedDescription)
-                }
-            }
-        }
-
-        // Use pre-formatted text if provided (variation mode), otherwise format using selected mode's preset
         let formattedText = preFormattedUserMessage ?? formatTranscriptForLLM(text)
 
-        // OpenAI OAuth: route OpenAI requests through OpenAI backend API when signed in
-        if aiProvider == .openAI && isOpenAISignedIn {
-            lastSystemMessageSent = resolvedSystemMessage
-            lastUserMessageSent = formattedText
-            do {
-                let model = mode.aiModel.isEmpty ? OpenAIOAuthClient.defaultModel : mode.aiModel
-                let provider = try await aiProviderRegistry.makeTextProvider(for: .openAIOAuth, model: model)
-                let result = try await provider.enhance(systemMessage: resolvedSystemMessage, userMessage: formattedText)
-                return AIEnhancementOutputFilter.filter(result)
-            } catch let error as OAuthError {
-                // If OAuth fails, fall through to CLI or API key
-                if cliServerEnhancer.isCliActive(for: .codex) || self.getAPIKey(for: aiProvider) != nil {
-                    logger.logWarning("OpenAI OAuth failed, falling back: \(error.localizedDescription)")
-                } else {
-                    throw EnhancementError.customError(error.errorDescription ?? "OpenAI OAuth error")
-                }
-            }
-        }
-
-        // Gemini OAuth: route Gemini requests through OAuth when signed in
-        if aiProvider == .gemini && isGeminiSignedIn {
-            lastSystemMessageSent = resolvedSystemMessage
-            lastUserMessageSent = formattedText
-            do {
-                let model = mode.aiModel.isEmpty ? GeminiAPIClient.defaultModel : mode.aiModel
-                let provider = try await aiProviderRegistry.makeTextProvider(for: .geminiOAuth, model: model)
-                let result = try await provider.enhance(systemMessage: resolvedSystemMessage, userMessage: formattedText)
-                return AIEnhancementOutputFilter.filter(result)
-            } catch let error as EnhancementError {
-                // Rate limit etc. - don't fall through, surface directly
-                throw error
-            } catch let error as OAuthError {
-                // If OAuth fails, fall through to CLI or API key
-                if cliServerEnhancer.isCliActive(for: .gemini) || self.getAPIKey(for: aiProvider) != nil {
-                    logger.logWarning("Gemini OAuth failed, falling back: \(error.localizedDescription)")
-                } else {
-                    throw EnhancementError.customError(error.errorDescription ?? "Gemini OAuth error")
-                }
-            }
-        }
-
-        // Codex CLI via Mac server: route OpenAI requests through CLI server when enabled
-        if aiProvider == .openAI && cliServerEnhancer.isCliActive(for: .codex),
-           let serverURL = cliServerEnhancer.serverURL, !serverURL.isEmpty {
-            lastSystemMessageSent = resolvedSystemMessage
-            lastUserMessageSent = formattedText
-            logger.logDebug("AI Processing - Using Codex CLI Server at \(serverURL)")
-            do {
-                let result = try await cliServerEnhancer.enhance(
-                    text: formattedText,
-                    systemPrompt: resolvedSystemMessage,
-                    model: mode.aiModel,
-                    provider: .codex
-                )
-                let filteredResult = AIEnhancementOutputFilter.filter(result.trimmingCharacters(in: .whitespacesAndNewlines))
-                return filteredResult
-            } catch {
-                if self.getAPIKey(for: aiProvider) != nil {
-                    logger.logWarning("Codex CLI Server failed, falling back to API key: \(error.localizedDescription)")
-                } else {
-                    throw EnhancementError.customError(error.localizedDescription)
-                }
-            }
-        }
-
-        // Gemini CLI via Mac server: route Gemini requests through CLI server when enabled
-        if aiProvider == .gemini && cliServerEnhancer.isCliActive(for: .gemini),
-           let serverURL = cliServerEnhancer.serverURL, !serverURL.isEmpty {
-            lastSystemMessageSent = resolvedSystemMessage
-            lastUserMessageSent = formattedText
-            logger.logDebug("AI Processing - Using Gemini CLI Server at \(serverURL)")
-            do {
-                let result = try await cliServerEnhancer.enhance(
-                    text: formattedText,
-                    systemPrompt: resolvedSystemMessage,
-                    model: mode.aiModel,
-                    provider: .gemini
-                )
-                let filteredResult = AIEnhancementOutputFilter.filter(result.trimmingCharacters(in: .whitespacesAndNewlines))
-                return filteredResult
-            } catch {
-                if self.getAPIKey(for: aiProvider) != nil {
-                    logger.logWarning("Gemini CLI Server failed, falling back to API key: \(error.localizedDescription)")
-                } else {
-                    throw EnhancementError.customError(error.localizedDescription)
-                }
-            }
-        }
-
-        // GitHub Copilot: route through Copilot API when signed in
-        if aiProvider == .copilot && isCopilotSignedIn {
-            lastSystemMessageSent = resolvedSystemMessage
-            lastUserMessageSent = formattedText
-            do {
-                let model = mode.aiModel.isEmpty ? CopilotAPIClient.defaultModel : mode.aiModel
-                let provider = try await aiProviderRegistry.makeTextProvider(for: .copilot, model: model)
-                let result = try await provider.enhance(systemMessage: resolvedSystemMessage, userMessage: formattedText)
-                return AIEnhancementOutputFilter.filter(result)
-            } catch let error as EnhancementError {
-                throw error
-            } catch {
-                throw EnhancementError.customError(error.localizedDescription)
-            }
-        }
-
-        // Store for TranscriptionVariation
+        // Store for TranscriptionVariation (every route below recorded these same values).
         lastSystemMessageSent = resolvedSystemMessage
         lastUserMessageSent = formattedText
 
-        logger.logDebug("AI Processing - System Message: \(resolvedSystemMessage)")
-        logger.logDebug("AI Processing - User Message: \(formattedText)")
-
-        // Anthropic uses its own Messages API; every other cloud provider is
-        // OpenAI-compatible. The registry is the single source of the API-key
-        // precondition: it reads the key from the Keychain and throws
-        // `.notConfigured` if it's missing.
-        let route: AIProviderRoute = aiProvider == .anthropic ? .anthropic : .cloud(aiProvider)
-        let provider = try await aiProviderRegistry.makeTextProvider(for: route, model: mode.aiModel)
-        return try await provider.enhance(systemMessage: resolvedSystemMessage, userMessage: formattedText)
+        let input = EnhancementInput(
+            provider: aiProvider,
+            model: mode.aiModel,
+            systemMessage: resolvedSystemMessage,
+            userMessage: formattedText,
+            isOAuthSignedIn: isOAuthSignedIn(for: aiProvider),
+            hasAPIKey: getAPIKey(for: aiProvider) != nil
+        )
+        return try await textEnhancer.enhance(input)
     }
 
     // MARK: - System Message (Cloud Providers)


### PR DESCRIPTION
## What

Extracts `makeRequest`'s ~150-line cloud/CLI/OAuth fallback state machine out of `AIService` into `AIKit`.

- **AIKit:** `EnhancementInput` (a resolved-request value type) + `@MainActor struct TextEnhancer`. `enhance(_:)` runs the routing + fallback chain — **Anthropic CLI → OpenAI/Gemini OAuth → Codex/Gemini CLI → Copilot → cloud default** — depending on `AIProviderRegistry` + the `CLIServerEnhancer` seam rather than `AIService`'s `@Observable` state. It owns the per-provider model defaults, output filtering, and the exact fallback control flow (incl. Gemini's `EnhancementError`-before-`OAuthError` rethrow and Copilot's rethrow-else-`customError`). Adds `Logger+AIKit` for `logDebug`/`logWarning`.
- **AIService.makeRequest** now: Apple FM / Ollama / Custom early returns → resolve system + user messages → set `lastMessages` once (every route previously recorded the *same* values) → `textEnhancer.enhance(input)`. Adds `isOAuthSignedIn(for:)` + a `textEnhancer` computed property.

`makeRequest` drops from ~180 to ~67 lines.

## Behavior-preserving

The 10 `AIService` routing/CLI characterization tests — which drive `makeRequest` end-to-end through `generateVariation` (anthropic/codex/gemini CLI, gemini OAuth, cloud, missing-key, …) — stay green. The per-branch `lastSystemMessageSent`/`lastUserMessageSent` writes collapse to one because every route recorded identical values; the timing only shifts earlier, which is unobservable (they're read only on the success path).

## Tests

Adds 4 AIKit-level `TextEnhancer` unit tests — cloud-default via the registry (mock keychain + network), the CLI route via `MockCLIServerEnhancer`, CLI-failure-throws, and CLI-failure-falls-through-to-cloud — so the orchestration is now **unit-testable in isolation**, the goal of Phase 12.

Full `VivaDictaTests` suite + AIKit package tests + app build all green.

## Not in scope

Streaming (`makeStreamingRequest`) is unchanged — it moves to `TextEnhancer.enhanceStreaming` next (12c). Apple FM / Ollama / Custom stay in `AIService` (cached service / hand-rolled request paths).