### PR TITLE
Fix iOS 26 MetricKit subscriber main-actor crash

### DIFF
--- a/VivaDicta/Services/Analytics/PerformanceMonitoringService.swift
+++ b/VivaDicta/Services/Analytics/PerformanceMonitoringService.swift
@@ -45,7 +45,16 @@ final class PerformanceMonitoringService: NSObject, MXMetricManagerSubscriber, @
 
     // MARK: - MXMetricManagerSubscriber
 
-    func didReceive(_ payloads: [MXMetricPayload]) {
+    // `nonisolated` is load-bearing: with `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`
+    // these would be implicitly `@MainActor`, and the `@objc` thunk for an
+    // `@MainActor` method runs a runtime executor precondition on entry. MetricKit
+    // calls subscribers synchronously on its own background queue, so on iOS 26
+    // (trapping variant) that precondition crashes before the body runs. The bodies
+    // only read the payload and call the `nonisolated` `AnalyticsService.track`, so
+    // running off the main actor is safe. The helpers below are `nonisolated` for
+    // the same reason (they're reached only from here).
+
+    nonisolated func didReceive(_ payloads: [MXMetricPayload]) {
         for payload in payloads {
             reportLaunchTime(payload)
             reportHangTime(payload)
@@ -53,7 +62,7 @@ final class PerformanceMonitoringService: NSObject, MXMetricManagerSubscriber, @
         }
     }
 
-    func didReceive(_ payloads: [MXDiagnosticPayload]) {
+    nonisolated func didReceive(_ payloads: [MXDiagnosticPayload]) {
         for payload in payloads {
             for hang in payload.hangDiagnostics ?? [] {
                 let seconds = hang.hangDuration.converted(to: .seconds).value
@@ -70,19 +79,19 @@ final class PerformanceMonitoringService: NSObject, MXMetricManagerSubscriber, @
 
     // MARK: - Metric extraction
 
-    private func reportLaunchTime(_ payload: MXMetricPayload) {
+    nonisolated private func reportLaunchTime(_ payload: MXMetricPayload) {
         guard let launch = payload.applicationLaunchMetrics,
               let stats = weightedAverageMs(launch.histogrammedTimeToFirstDraw) else { return }
         AnalyticsService.track(.appLaunchMetric(averageMs: stats.averageMs, sampleCount: stats.count))
     }
 
-    private func reportHangTime(_ payload: MXMetricPayload) {
+    nonisolated private func reportHangTime(_ payload: MXMetricPayload) {
         guard let responsiveness = payload.applicationResponsivenessMetrics,
               let stats = weightedAverageMs(responsiveness.histogrammedApplicationHangTime) else { return }
         AnalyticsService.track(.appHangMetric(averageMs: stats.averageMs, sampleCount: stats.count))
     }
 
-    private func reportMemory(_ payload: MXMetricPayload) {
+    nonisolated private func reportMemory(_ payload: MXMetricPayload) {
         guard let memory = payload.memoryMetrics else { return }
         // Report MiB (bytes / 1024²), not Measurement's decimal `.megabytes`
         // (1e6 bytes), so these line up with DeviceConditions.currentMemoryFootprintMB
@@ -95,7 +104,7 @@ final class PerformanceMonitoringService: NSObject, MXMetricManagerSubscriber, @
     /// Collapses a duration histogram into a single bucket-weighted average (in
     /// milliseconds) plus the total sample count. MetricKit reports distributions
     /// rather than scalars, so we approximate each bucket by its midpoint.
-    private func weightedAverageMs(_ histogram: MXHistogram<UnitDuration>) -> (averageMs: Double, count: Int)? {
+    nonisolated private func weightedAverageMs(_ histogram: MXHistogram<UnitDuration>) -> (averageMs: Double, count: Int)? {
         let enumerator = histogram.bucketEnumerator
         var totalCount = 0
         var weightedSum = 0.0

--- a/VivaDicta/Views/AudioPlayerView.swift
+++ b/VivaDicta/Views/AudioPlayerView.swift
@@ -132,7 +132,16 @@ class AudioPlayerManager: NSObject, AVAudioPlayerDelegate {
     }
     
     // MARK: - AVAudioPlayerDelegate
-    
+
+    // Deliberately NOT `nonisolated`: this stays `@MainActor` (the target builds
+    // with SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor) so it can touch `isPlaying`
+    // / the timer / `seek` directly. `AVAudioPlayer` delivers its delegate
+    // callbacks on the run loop of the thread that started playback - main here,
+    // since playback always starts on the main actor - so the `@objc` thunk's
+    // main-actor precondition passes. If playback is ever started off the main
+    // actor, this would hit the same trap as the MetricKit subscriber and must
+    // become `nonisolated` with a `Task { @MainActor in ... }` hop (see
+    // RecordViewModel.audioPlayerDidFinishPlaying).
     func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
         isPlaying = false
         stopTimer()


### PR DESCRIPTION
## The crash

`Crashlytics 4d6edf4f…`, 3.6.0 (3008), iOS 26.5, crashed thread `com.apple.metrickit.manager.queue`, `EXC_BREAKPOINT`:

```
0  _dispatch_assert_queue_fail
2  dispatch_assert_queue$V2
4  _swift_task_checkIsolatedSwift
5  swift_task_isCurrentExecutorWithFlagsImpl(...)
6  @objc PerformanceMonitoringService.didReceive(_:)   <- traps on ENTRY
7  -[MXMetricManager deliverDiagnosticPayload:]_block_invoke
```

## Root cause

The target builds with `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, so `PerformanceMonitoringService` and both `didReceive` overloads are **implicitly `@MainActor`**. `MXMetricManagerSubscriber` is an `@objc` protocol, so the compiler emits an `@objc` thunk that runs a runtime executor precondition on entry (`swift_task_isCurrentExecutor` → `dispatch_assert_queue(main)`).

MetricKit invokes subscribers **synchronously on its own background queue**, never main. On iOS 26 (which ships the *trapping* variant of that check, vs. iOS 18's warn-and-continue) the precondition fails and the process traps **before the method body runs**. Background-only, invisible to users, but fires ~daily per iOS 26+ device once 3.6.0 ships - it hurts crash-free-session metrics and wastes background-wake budget. App Review won't catch it (a short session doesn't trigger a daily background MetricKit delivery).

## The fix

Mark both `didReceive` overloads and the private metric-extraction helpers they call `nonisolated`, so the `@objc` thunk drops the main-actor precondition and the callbacks run on MetricKit's queue. The bodies only read the payload and call the `nonisolated static` `AnalyticsService.track`, so off-main execution is safe. `start()` stays `@MainActor` (it guards `isStarted` and runs once on main at launch); `@unchecked Sendable` stays.

## Off-main conformance audit

Per the "this can bite any `@objc`/system-delegate conformance under MainActor-default isolation" guardrail, I audited the other system-delegate conformance: `PhoneWatchConnectivityService`'s `WCSessionDelegate` methods (WCSession also delivers on a background queue) are **already `nonisolated`** with `@MainActor` hops where needed - no change needed. No other at-risk conformances found.

## Verification

App build green. Repro/verify locally with Xcode **Debug ▸ Simulate MetricKit Payloads** on an iOS 26 simulator (before: traps; after: both callbacks run clean). MetricKit never delivers on a plain simulator run, so that menu command is the only local repro.