### PR TITLE
Drop redundant nonisolated keywords on already-nonisolated declarations

### DIFF
--- a/Modules/AppGroup/Sources/AppGroup/AppGroupCoordinator.swift
+++ b/Modules/AppGroup/Sources/AppGroup/AppGroupCoordinator.swift
@@ -83,7 +83,7 @@ public final class AppGroupCoordinator: @unchecked Sendable {
     public static let kPendingLanguageOverride = "pendingLanguageOverride"
     public static let kPendingSourceTag = "pendingSourceTag"
 
-    nonisolated private enum UserDefaultsKeys {
+    private enum UserDefaultsKeys {
         static let isRecording = "isRecording"
         static let lastRecordingTimestamp = "lastRecordingTimestamp"
         static let transcribedText = "transcribedText"
@@ -111,7 +111,7 @@ public final class AppGroupCoordinator: @unchecked Sendable {
         static let pendingObsidianClipboard = "pendingObsidianClipboard"
     }
 
-    nonisolated private enum NotificationNames {
+    private enum NotificationNames {
         static let startRecording = "com.antonnovoselov.VivaDicta.startRecording"
         static let stopRecording = "com.antonnovoselov.VivaDicta.stopRecording"
         static let cancelRecording = "com.antonnovoselov.VivaDicta.cancelRecording"
@@ -148,7 +148,7 @@ public final class AppGroupCoordinator: @unchecked Sendable {
 
     // MARK: - Properties
     private let sharedDefaults: UserDefaults?
-    nonisolated private let notificationCenter = CFNotificationCenterGetDarwinNotifyCenter()
+    private let notificationCenter = CFNotificationCenterGetDarwinNotifyCenter()
 
     @MainActor public var onStartRecordingRequested: (() -> Void)?
     @MainActor public var onStopRecordingRequested: (() -> Void)?
@@ -185,7 +185,7 @@ public final class AppGroupCoordinator: @unchecked Sendable {
         sharedDefaults = userDefaults
     }
 
-    nonisolated deinit {
+    deinit {
         removeNotificationObservers()
     }
 
@@ -833,7 +833,7 @@ public final class AppGroupCoordinator: @unchecked Sendable {
 
     // MARK: - Darwin Notifications (Real-time Communication)
 
-    nonisolated private func setupNotificationObservers() {
+    private func setupNotificationObservers() {
         guard let center = notificationCenter else { return }
 
         CFNotificationCenterAddObserver(
@@ -1098,12 +1098,12 @@ public final class AppGroupCoordinator: @unchecked Sendable {
         )
     }
 
-    nonisolated private func removeNotificationObservers() {
+    private func removeNotificationObservers() {
         guard let center = notificationCenter else { return }
         CFNotificationCenterRemoveEveryObserver(center, Unmanaged.passUnretained(self).toOpaque())
     }
 
-    nonisolated private func postDarwinNotification(_ name: String) {
+    private func postDarwinNotification(_ name: String) {
         guard let center = notificationCenter else { return }
         CFNotificationCenterPostNotification(
             center,
@@ -1116,56 +1116,56 @@ public final class AppGroupCoordinator: @unchecked Sendable {
 
     // MARK: - Notification Handlers
 
-    nonisolated private func handleStartRecordingNotification() {
+    private func handleStartRecordingNotification() {
         Task { @MainActor in
             onStartRecordingRequested?()
         }
     }
 
-    nonisolated private func handleStopRecordingNotification() {
+    private func handleStopRecordingNotification() {
         Task { @MainActor in
             onStopRecordingRequested?()
         }
     }
 
-    nonisolated private func handleCancelRecordingNotification() {
+    private func handleCancelRecordingNotification() {
         Task { @MainActor in
             onCancelRecordingRequested?()
         }
     }
 
-    nonisolated private func handlePauseRecordingNotification() {
+    private func handlePauseRecordingNotification() {
         Task { @MainActor in
             onPauseRecordingRequested?()
         }
     }
 
-    nonisolated private func handleResumeRecordingNotification() {
+    private func handleResumeRecordingNotification() {
         Task { @MainActor in
             onResumeRecordingRequested?()
         }
     }
 
-    nonisolated private func handleTranscriptionTranscribingNotification() {
+    private func handleTranscriptionTranscribingNotification() {
         Task { @MainActor in
             onTranscriptionTranscribing?()
         }
     }
 
-    nonisolated private func handleTranscriptionEnhancingNotification() {
+    private func handleTranscriptionEnhancingNotification() {
         Task { @MainActor in
             onTranscriptionEnhancing?()
         }
     }
 
-    nonisolated private func handleTranscriptionCompletedNotification() {
+    private func handleTranscriptionCompletedNotification() {
         Task { @MainActor in
             let text = getAndConsumeTranscribedText() ?? ""
             onTranscriptionCompleted?(text)
         }
     }
 
-    nonisolated private func handleTranscriptionErrorNotification() {
+    private func handleTranscriptionErrorNotification() {
         Task { @MainActor in
             let message = getAndConsumeTranscriptionErrorMessage() ?? ""
             onTranscriptionError?()
@@ -1175,51 +1175,51 @@ public final class AppGroupCoordinator: @unchecked Sendable {
         }
     }
 
-    nonisolated private func handleTranscriptionCancelledNotification() {
+    private func handleTranscriptionCancelledNotification() {
         Task { @MainActor in
             onTranscriptionCancelled?()
         }
     }
 
-    nonisolated private func handleAudioLevelUpdatedNotification() {
+    private func handleAudioLevelUpdatedNotification() {
         Task { @MainActor in
             let level = currentAudioLevel
             onAudioLevelUpdated?(level)
         }
     }
 
-    nonisolated private func handleRecordingStateChangedNotification() {
+    private func handleRecordingStateChangedNotification() {
         Task { @MainActor in
             let recording = isRecording
             onRecordingStateChanged?(recording)
         }
     }
 
-    nonisolated private func handleKeyboardSessionActivatedNotification() {
+    private func handleKeyboardSessionActivatedNotification() {
         Task { @MainActor in
             onKeyboardSessionActivated?()
         }
     }
 
-    nonisolated private func handleKeyboardSessionExpiredNotification() {
+    private func handleKeyboardSessionExpiredNotification() {
         Task { @MainActor in
             onKeyboardSessionExpired?()
         }
     }
 
-    nonisolated private func handleStartRecordingFromControlNotification() {
+    private func handleStartRecordingFromControlNotification() {
         Task { @MainActor in
             onStartRecordingFromControl?()
         }
     }
 
-    nonisolated private func handleTerminateSessionFromLiveActivityNotification() {
+    private func handleTerminateSessionFromLiveActivityNotification() {
         Task { @MainActor in
             onTerminateSessionFromLiveActivity?()
         }
     }
 
-    nonisolated private func handleVivaModeChangedNotification() {
+    private func handleVivaModeChangedNotification() {
         Task { @MainActor in
             onVivaModeChanged?()
         }
@@ -1227,13 +1227,13 @@ public final class AppGroupCoordinator: @unchecked Sendable {
 
     // Text processing (keyboard rewrite)
 
-    nonisolated private func handleTextProcessingRequestedNotification() {
+    private func handleTextProcessingRequestedNotification() {
         Task { @MainActor in
             onTextProcessingRequested?()
         }
     }
 
-    nonisolated private func handleTextProcessingCompletedNotification() {
+    private func handleTextProcessingCompletedNotification() {
         Task { @MainActor in
             // Only consume the result if a callback is set — prevents the main app
             // from racing with the keyboard extension and deleting the result first.
@@ -1243,7 +1243,7 @@ public final class AppGroupCoordinator: @unchecked Sendable {
         }
     }
 
-    nonisolated private func handleTextProcessingErrorNotification() {
+    private func handleTextProcessingErrorNotification() {
         Task { @MainActor in
             guard let callback = onTextProcessingError else { return }
             let message = getAndConsumeTextProcessingError() ?? "Text processing failed"

--- a/VivaDicta/Services/AIEnhance/ExaWebSearchTool.swift
+++ b/VivaDicta/Services/AIEnhance/ExaWebSearchTool.swift
@@ -142,7 +142,7 @@ nonisolated enum ExaSearchClient: Sendable {
     /// URL session used for Exa search requests. Override only from tests.
     nonisolated(unsafe) static var networkService: any NetworkService = DefaultNetworkService(category: "AppClient")
 
-    nonisolated static func search(query: String, apiKey: String) async throws -> [ExaResult] {
+    static func search(query: String, apiKey: String) async throws -> [ExaResult] {
         guard let url = URL(string: "https://api.exa.ai/search") else {
             throw ExaError.invalidURL
         }
@@ -174,11 +174,11 @@ nonisolated enum ExaSearchClient: Sendable {
 
 @available(iOS 26, *)
 nonisolated enum ExaAPIClient: Sendable {
-    nonisolated static func search(query: String, apiKey: String) async throws -> [ExaResult] {
+    static func search(query: String, apiKey: String) async throws -> [ExaResult] {
         try await ExaSearchClient.search(query: query, apiKey: apiKey)
     }
 
-    nonisolated static func formatResults(query: String, results: [ExaResult]) -> GeneratedContent {
+    static func formatResults(query: String, results: [ExaResult]) -> GeneratedContent {
         if results.isEmpty {
             return GeneratedContent(properties: [
                 "status": "empty",
@@ -203,7 +203,7 @@ nonisolated enum ExaAPIClient: Sendable {
         ])
     }
 
-    nonisolated static func formatError(_ message: String) -> GeneratedContent {
+    static func formatError(_ message: String) -> GeneratedContent {
         GeneratedContent(properties: [
             "status": "error",
             "summary": message

--- a/VivaDicta/Services/AudioPrewarmManager.swift
+++ b/VivaDicta/Services/AudioPrewarmManager.swift
@@ -368,7 +368,7 @@ nonisolated private final class AudioCaptureContext: @unchecked Sendable {
     private var _audioFile: AVAudioFile?
     private var _currentAudioLevel: Float = 0.0
 
-    nonisolated init() {}
+    init() {}
 
     var isCapturing: Bool {
         get {
@@ -402,7 +402,7 @@ nonisolated private final class AudioCaptureContext: @unchecked Sendable {
         return _currentAudioLevel
     }
 
-    nonisolated func writeBufferIfCapturing(_ buffer: AVAudioPCMBuffer, updateLevel: @escaping (Float) -> Void) {
+    func writeBufferIfCapturing(_ buffer: AVAudioPCMBuffer, updateLevel: @escaping (Float) -> Void) {
         // Calculate audio level from PCM buffer
         let level = calculateAudioLevel(from: buffer)
 

--- a/VivaDicta/Services/LiveTranslation/LiveTranslationAudio.swift
+++ b/VivaDicta/Services/LiveTranslation/LiveTranslationAudio.swift
@@ -314,7 +314,7 @@ nonisolated private final class PlaybackBufferQueue: @unchecked Sendable {
     private let lowWaterMark: TimeInterval = 0.05
 
     /// Returns `true` if the caller should resume playback.
-    nonisolated func didQueueBuffer(duration: TimeInterval) -> Bool {
+    func didQueueBuffer(duration: TimeInterval) -> Bool {
         lock.lock()
         defer { lock.unlock() }
         queuedDuration += duration
@@ -328,7 +328,7 @@ nonisolated private final class PlaybackBufferQueue: @unchecked Sendable {
     }
 
     /// Returns `true` if the caller should pause playback (queue starved).
-    nonisolated func didCompleteBuffer(duration: TimeInterval) -> Bool {
+    func didCompleteBuffer(duration: TimeInterval) -> Bool {
         lock.lock()
         defer { lock.unlock() }
         queuedDuration -= duration
@@ -343,13 +343,13 @@ nonisolated private final class PlaybackBufferQueue: @unchecked Sendable {
 
     /// Allows kick-starting playback the very first time without crossing the
     /// refill threshold (so the listener doesn't wait too long for first audio).
-    nonisolated func canStartFresh() -> Bool {
+    func canStartFresh() -> Bool {
         lock.lock()
         defer { lock.unlock() }
         return !hasEverStarted && queuedDuration > 0
     }
 
-    nonisolated func reset() {
+    func reset() {
         lock.lock()
         defer { lock.unlock() }
         queuedDuration = 0
@@ -375,7 +375,7 @@ nonisolated private final class AudioTeardownContext: @unchecked Sendable {
     private let deactivateSession: Bool
     private let logger: Logger
 
-    nonisolated init(
+    init(
         engine: AVAudioEngine,
         playerNode: AVAudioPlayerNode,
         removeTap: Bool,
@@ -389,7 +389,7 @@ nonisolated private final class AudioTeardownContext: @unchecked Sendable {
         self.logger = logger
     }
 
-    nonisolated func perform() {
+    func perform() {
         logger.logInfo("Audio teardown: stopping player node")
         playerNode.stop()
 
@@ -435,13 +435,13 @@ nonisolated private final class TapInstaller: @unchecked Sendable {
     private let captureFormat: AVAudioFormat
     private let continuation: AsyncStream<Data>.Continuation
 
-    nonisolated init(converter: AVAudioConverter, captureFormat: AVAudioFormat, continuation: AsyncStream<Data>.Continuation) {
+    init(converter: AVAudioConverter, captureFormat: AVAudioFormat, continuation: AsyncStream<Data>.Continuation) {
         self.converter = converter
         self.captureFormat = captureFormat
         self.continuation = continuation
     }
 
-    nonisolated func process(_ buffer: AVAudioPCMBuffer) {
+    func process(_ buffer: AVAudioPCMBuffer) {
         let sourceFormat = buffer.format
         let ratio = captureFormat.sampleRate / sourceFormat.sampleRate
         let estimatedFrames = Double(buffer.frameLength) * ratio


### PR DESCRIPTION
## Summary

Removes **41 redundant `nonisolated` keywords**. The local SPM modules use the language-default (nonisolated) actor isolation; the app target is `@MainActor`-by-default (`SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`). A `nonisolated` keyword only does work when the enclosing context would otherwise be isolated - on a declaration that is *already* nonisolated it is pure noise (almost always carried over verbatim when code was extracted into modules).

### Removed (all on already-nonisolated declarations)

| File | Count | Why redundant |
|---|---|---|
| `AppGroup/AppGroupCoordinator.swift` | 27 | plain class in a nonisolated-default module - its methods, enums, `deinit`, and stored property were already nonisolated |
| `LiveTranslation/LiveTranslationAudio.swift` | 8 | members nested inside `nonisolated` helper classes (`PlaybackBufferQueue`, `AudioTeardownContext`, `TapInstaller`) |
| `AIEnhance/ExaWebSearchTool.swift` | 4 | `static func`s nested inside `nonisolated` enums (`ExaSearchClient`, `ExaAPIClient`) |
| `AudioPrewarmManager.swift` | 2 | members nested inside the `nonisolated AudioCaptureContext` class |

### Deliberately kept (load-bearing)

- **Type-level `nonisolated`** in the MainActor-default app target (`nonisolated struct ExaResult`, `nonisolated final class BackgroundTaskQueue`, the audio helper classes) - these opt the whole type out of the MainActor default.
- **File-scope `nonisolated` functions** (`installInputTapNonisolated`, `installLiveTranslationInputTap`) - global functions inherit the target's MainActor default too.
- **`nonisolated(unsafe)`** static state (AIProviders, DesignSystem, Exa's `networkService`) - a separate feature for mutable global state, unrelated to isolation defaults.
- **`@MainActor`/`actor` opt-outs** in `AudioRecording` (`@MainActor` class satisfying the nonisolated `AVAudioRecorderDelegate`) and `TranscriptionKit` (`actor`) - the type declares its own isolation, so the keyword is the required escape.

## Testing

- `xcodebuild ... -scheme VivaDicta -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max,OS=26.4' build` -> **BUILD SUCCEEDED**

## Notes

No behavior change. Every removed keyword was on a declaration that was already nonisolated, so isolation semantics are identical - this is noise reduction only.