### PR TITLE
Add OpenCode Zen as an AI text provider with free/paid model tiers

### DIFF
--- a/Modules/AICore/Sources/AICore/AIProvider.swift
+++ b/Modules/AICore/Sources/AICore/AIProvider.swift
@@ -31,6 +31,7 @@ public enum AIProvider: String, CaseIterable, Identifiable, Codable, Sendable {
     case kimi
     case minimax
     case vercelAIGateway
+    case opencodeZen
     case huggingFace
     case copilot
     case ollama
@@ -81,6 +82,8 @@ public enum AIProvider: String, CaseIterable, Identifiable, Codable, Sendable {
             "MiniMax"
         case .vercelAIGateway:
             "Vercel AI Gateway"
+        case .opencodeZen:
+            "OpenCode Zen"
         case .huggingFace:
             "HuggingFace"
         case .copilot:
@@ -139,6 +142,8 @@ public enum AIProvider: String, CaseIterable, Identifiable, Codable, Sendable {
             "assemblyai-color"
         case .vercelAIGateway:
             "vercel"
+        case .opencodeZen:
+            "opencode"
         case .huggingFace:
             "huggingface-color"
         case .copilot:
@@ -174,6 +179,7 @@ public enum AIProvider: String, CaseIterable, Identifiable, Codable, Sendable {
              .kimi,
              .minimax,
              .vercelAIGateway,
+             .opencodeZen,
              .huggingFace,
              .ollama,
              .ollamaCloud,
@@ -201,6 +207,7 @@ public enum AIProvider: String, CaseIterable, Identifiable, Codable, Sendable {
         case .cerebras: URL(string: "https://cloud.cerebras.ai/")
         case .grok: URL(string: "https://console.x.ai/")
         case .vercelAIGateway: URL(string: "https://vercel.com/account/tokens")
+        case .opencodeZen: URL(string: "https://opencode.ai/auth")
         case .huggingFace: URL(string: "https://huggingface.co/settings/tokens")
         case .zai: URL(string: "https://open.z.ai/")
         case .kimi: URL(string: "https://platform.moonshot.cn/console/api-keys")
@@ -235,6 +242,7 @@ public enum AIProvider: String, CaseIterable, Identifiable, Codable, Sendable {
         .minimax,
         .openRouter,
         .vercelAIGateway,
+        .opencodeZen,
         .huggingFace,
         .ollama,
         .ollamaCloud,
@@ -246,7 +254,13 @@ public enum AIProvider: String, CaseIterable, Identifiable, Codable, Sendable {
     /// (`json_schema`) outputs, which Ollama Cloud does not support
     /// (https://docs.ollama.com/capabilities/structured-outputs). Local Ollama
     /// does support them, so it stays eligible.
-    public static let reminderExtractorCloudProviders: [AIProvider] = cloudProviders.filter { $0 != .ollamaCloud }
+    ///
+    /// Also excludes OpenCode Zen: its free-tier models reject `json_schema`
+    /// response formats ("This response_format type is unavailable now",
+    /// verified 2026-06-19), so the structured reminder extraction would fail on
+    /// the models most Zen users run.
+    public static let reminderExtractorCloudProviders: [AIProvider] =
+        cloudProviders.filter { $0 != .ollamaCloud && $0 != .opencodeZen }
 
     /// Local AI providers that run on-device or local network (no API key needed)
     public static let localProviders: [AIProvider] = [
@@ -272,8 +286,9 @@ public enum AIProvider: String, CaseIterable, Identifiable, Codable, Sendable {
         .minimax,
         .openRouter,
         .vercelAIGateway,
+        .opencodeZen,
         .huggingFace]
-    
+
     public var baseURL: String {
         switch self {
         case .apple:
@@ -318,6 +333,8 @@ public enum AIProvider: String, CaseIterable, Identifiable, Codable, Sendable {
             return "https://api.assemblyai.com/v2"
         case .vercelAIGateway:
             return "https://ai-gateway.vercel.sh/v1/chat/completions"
+        case .opencodeZen:
+            return "https://opencode.ai/zen/v1/chat/completions"
         case .huggingFace:
             return "https://router.huggingface.co/v1/chat/completions"
         case .copilot:
@@ -382,6 +399,10 @@ public enum AIProvider: String, CaseIterable, Identifiable, Codable, Sendable {
             // (e.g., "claude-sonnet-4-6"). Models are fetched dynamically, so this must
             // match Vercel's actual naming convention.
             return "anthropic/claude-sonnet-4.6"
+        case .opencodeZen:
+            // A free model so a brand-new key (no payment method) verifies and
+            // works out of the box. See `opencodeZenFreeModels`.
+            return "big-pickle"
         case .huggingFace:
             return "openai/gpt-oss-120b"
         case .copilot:
@@ -421,6 +442,7 @@ public enum AIProvider: String, CaseIterable, Identifiable, Codable, Sendable {
         case .cartesia: "cartesiaAPIKey"
         case .assemblyAI: "assemblyaiAPIKey"
         case .vercelAIGateway: "vercelAIGatewayAPIKey"
+        case .opencodeZen: "opencodeZenAPIKey"
         case .huggingFace: "huggingFaceAPIKey"
         case .customOpenAI: "customOpenAIAPIKey"
         case .ollamaCloud: "ollamaCloudAPIKey"
@@ -541,6 +563,11 @@ public enum AIProvider: String, CaseIterable, Identifiable, Codable, Sendable {
             return []
         case .vercelAIGateway:
             return []
+        case .opencodeZen:
+            // Curated OpenCode Zen catalog: the always-free models first, then
+            // the pay-as-you-go models. Tier classification lives in
+            // `opencodeZenFreeModels` / `opencodeZenPaidModels` below.
+            return Self.opencodeZenFreeModels + Self.opencodeZenPaidModels
         case .huggingFace:
             return []
         case .copilot:
@@ -627,5 +654,69 @@ public extension AIProvider {
     /// a stale classification never blocks a genuinely-free model.
     static func isOllamaCloudModelFree(_ model: String) -> Bool {
         !ollamaCloudSubscriptionModels.contains(model)
+    }
+}
+
+// MARK: - OpenCode Zen free / paid tiers
+
+public extension AIProvider {
+    /// OpenCode Zen models usable with the API key alone, at no cost (no payment
+    /// method required).
+    ///
+    /// Verified against the live Zen API on 2026-06-19: each model returned
+    /// HTTP 200 with `"cost": "0"` and no "No payment method" error. `big-pickle`
+    /// is Zen's promoted anonymous free model (currently routes to
+    /// deepseek-v4-flash). See https://opencode.ai/zen.
+    ///
+    /// Note: the catalog also lists `minimax-m3-free` and `qwen3.6-plus-free`,
+    /// but their free promotion has ended - both now return "Free promotion has
+    /// ended ... subscribe to OpenCode Go", so they are intentionally omitted.
+    static let opencodeZenFreeModels: [String] = [
+        "big-pickle",
+        "deepseek-v4-flash-free",
+        "nemotron-3-ultra-free",
+        "mimo-v2.5-free",
+        "north-mini-code-free"
+    ]
+
+    /// OpenCode Zen models that bill pay-as-you-go and require a workspace with a
+    /// payment method. Selecting one without billing set up returns
+    /// "No payment method. Add a payment method here ..." (verified 2026-06-19).
+    /// Token pricing passes through the provider's list price with zero markup.
+    static let opencodeZenPaidModels: [String] = [
+        "claude-fable-5",
+        "claude-opus-4-8",
+        "claude-opus-4-7",
+        "claude-sonnet-4-6",
+        "claude-sonnet-4-5",
+        "claude-haiku-4-5",
+        "gpt-5.5",
+        "gpt-5.4",
+        "gpt-5.4-mini",
+        "gpt-5.1",
+        "gpt-5-nano",
+        "gemini-3.1-pro",
+        "gemini-3.5-flash",
+        "gemini-3-flash",
+        "deepseek-v4-pro",
+        "deepseek-v4-flash",
+        "glm-5.1",
+        "glm-5",
+        "kimi-k2.6",
+        "kimi-k2.5",
+        "minimax-m2.7",
+        "minimax-m2.5",
+        "qwen3.6-plus",
+        "qwen3.5-plus",
+        "grok-build-0.1"
+    ]
+
+    /// Whether the given OpenCode Zen model is usable for free with the API key.
+    ///
+    /// Uses an explicit allowlist (unlike Ollama Cloud's deny-list): Zen's free
+    /// set is a small, fixed promotion while the paid catalog is large and
+    /// growing, so anything not explicitly free is treated as pay-as-you-go.
+    static func isOpencodeZenModelFree(_ model: String) -> Bool {
+        opencodeZenFreeModels.contains(model)
     }
 }

--- a/Modules/AICore/Tests/AICoreTests/AICoreTests.swift
+++ b/Modules/AICore/Tests/AICoreTests/AICoreTests.swift
@@ -10,7 +10,7 @@ struct AIProviderTests {
     // MARK: - Catalog integrity
 
     @Test func allCasesCountIsStable() {
-        #expect(AIProvider.allCases.count == 26)
+        #expect(AIProvider.allCases.count == 27)
     }
 
     @Test func rawValuesRoundTripForCodableAndDefaultsCompatibility() {
@@ -53,6 +53,7 @@ struct AIProviderTests {
             .kimi: "kimiAPIKey",
             .minimax: "minimaxAPIKey",
             .vercelAIGateway: "vercelAIGatewayAPIKey",
+            .opencodeZen: "opencodeZenAPIKey",
             .huggingFace: "huggingFaceAPIKey",
             .copilot: "",
             .ollama: "",
@@ -118,8 +119,31 @@ struct AIProviderTests {
         #expect(AIProvider.reminderExtractorCloudProviders.contains(.ollama))
     }
 
+    @Test func reminderExtractorExcludesOpencodeZen() {
+        // Zen's free-tier models reject json_schema response formats.
+        #expect(!AIProvider.reminderExtractorCloudProviders.contains(.opencodeZen))
+    }
+
     @Test func generalProvidersContainAppleAndOpenAI() {
         #expect(AIProvider.generalProviders.contains(.apple))
         #expect(AIProvider.generalProviders.contains(.openAI))
+    }
+
+    // MARK: - OpenCode Zen tiers
+
+    @Test func opencodeZenTiersDoNotOverlapAndCoverAvailableModels() {
+        let free = Set(AIProvider.opencodeZenFreeModels)
+        let paid = Set(AIProvider.opencodeZenPaidModels)
+        #expect(free.isDisjoint(with: paid), "a model cannot be both free and paid")
+        #expect(Set(AIProvider.opencodeZen.availableModels) == free.union(paid))
+    }
+
+    @Test func opencodeZenFreeClassificationUsesAllowlist() {
+        #expect(AIProvider.isOpencodeZenModelFree("big-pickle"))
+        #expect(!AIProvider.isOpencodeZenModelFree("claude-opus-4-8"))
+        // Unknown models are treated as paid (Zen's free set is a fixed promotion).
+        #expect(!AIProvider.isOpencodeZenModelFree("some-future-model"))
+        // The default model must be free so a brand-new key verifies and works.
+        #expect(AIProvider.isOpencodeZenModelFree(AIProvider.opencodeZen.defaultModel))
     }
 }

--- a/VivaDicta/Assets.xcassets/AIProviders/opencode.imageset/Contents.json
+++ b/VivaDicta/Assets.xcassets/AIProviders/opencode.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "filename" : "opencode.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
+  }
+}

--- a/VivaDicta/Assets.xcassets/AIProviders/opencode.imageset/opencode.svg
+++ b/VivaDicta/Assets.xcassets/AIProviders/opencode.imageset/opencode.svg
@@ -1,0 +1,1 @@
+<svg fill="currentColor" fill-rule="evenodd" height="1em" style="flex:none;line-height:1" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg"><title>opencode</title><path d="M16 6H8v12h8V6zm4 16H4V2h16v20z"></path></svg>

--- a/VivaDicta/Views/SettingsScreen/AddAPIKeyView.swift
+++ b/VivaDicta/Views/SettingsScreen/AddAPIKeyView.swift
@@ -181,6 +181,8 @@ struct AddAPIKeyView: View {
 
             if provider == .ollamaCloud {
                 OllamaCloudModelTiersView()
+            } else if provider == .opencodeZen {
+                OpencodeZenModelTiersView()
             } else {
                 Spacer()
             }
@@ -285,7 +287,7 @@ struct OllamaCloudModelTiersView: View {
                     .font(.footnote)
                     .foregroundStyle(.secondary)
 
-                OllamaModelTierSection(
+                ProviderModelTierSection(
                     title: "Free with your key",
                     systemImage: "checkmark.seal.fill",
                     tint: .green,
@@ -293,7 +295,7 @@ struct OllamaCloudModelTiersView: View {
                     columns: columns
                 )
 
-                OllamaModelTierSection(
+                ProviderModelTierSection(
                     title: "Requires paid subscription",
                     systemImage: "lock.fill",
                     tint: .orange,
@@ -313,7 +315,50 @@ struct OllamaCloudModelTiersView: View {
     }
 }
 
-struct OllamaModelTierSection: View {
+/// Shows which OpenCode Zen models are free with the user's API key versus
+/// which bill pay-as-you-go. Classification lives in AICore
+/// (`AIProvider.opencodeZenFreeModels` / `opencodeZenPaidModels`).
+struct OpencodeZenModelTiersView: View {
+    private let columns = [GridItem(.adaptive(minimum: 104), spacing: 8)]
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                Text("Some OpenCode Zen models are free with your API key. The rest are pay-as-you-go - choosing one without a payment method on your workspace returns a \"No payment method\" error.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+
+                ProviderModelTierSection(
+                    title: "Free with your key",
+                    systemImage: "checkmark.seal.fill",
+                    tint: .green,
+                    models: AIProvider.opencodeZenFreeModels,
+                    columns: columns
+                )
+
+                ProviderModelTierSection(
+                    title: "Pay-as-you-go",
+                    systemImage: "creditcard.fill",
+                    tint: .orange,
+                    models: AIProvider.opencodeZenPaidModels,
+                    columns: columns
+                )
+
+                Text("Paid models bill per token with no markup. Free models have usage limits. See opencode.ai/zen.")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 4)
+            .padding(.top, 8)
+        }
+        .scrollIndicators(.hidden)
+    }
+}
+
+/// One labelled tier (free / paid) of provider model-name chips. Shared by the
+/// Ollama Cloud and OpenCode Zen API-key screens.
+struct ProviderModelTierSection: View {
     let title: String
     let systemImage: String
     let tint: Color
@@ -328,14 +373,14 @@ struct OllamaModelTierSection: View {
 
             LazyVGrid(columns: columns, alignment: .leading, spacing: 8) {
                 ForEach(models, id: \.self) { model in
-                    OllamaModelChip(name: model, tint: tint)
+                    ProviderModelChip(name: model, tint: tint)
                 }
             }
         }
     }
 }
 
-struct OllamaModelChip: View {
+struct ProviderModelChip: View {
     let name: String
     let tint: Color
 
@@ -365,6 +410,15 @@ struct OllamaModelChip: View {
     NavigationStack {
         AddAPIKeyView(
             provider: .ollamaCloud,
+            aiService: AIService(),
+            onSave: {_ in })
+    }
+}
+
+#Preview("OpenCode Zen tiers") {
+    NavigationStack {
+        AddAPIKeyView(
+            provider: .opencodeZen,
             aiService: AIService(),
             onSave: {_ in })
     }


### PR DESCRIPTION
## Summary

Adds [OpenCode Zen](https://opencode.ai/zen) - a curated, OpenAI-compatible AI gateway - as a general-purpose text provider, and surfaces its **free vs pay-as-you-go** model tiers on the API key screen (mirroring the recent Ollama Cloud tiers work). Users can see which models work with their key before hitting a billing error.

## Changes

**`AIProvider` (AICore)**
- New `.opencodeZen` case wired through every required member: `displayName` ("OpenCode Zen"), `iconName` (`"opencode"`), `baseURL` (`https://opencode.ai/zen/v1/chat/completions`), `keychainKey` (`opencodeZenAPIKey`), `apiKeyURL`, `supportsResponseStreaming`, `cloudProviders`, and `generalProviders`.
- Requests flow through the existing generic `.cloud(provider)` Bearer-auth route - **no bespoke request handling needed**.
- `defaultModel` is a **free** model (`big-pickle`), so a brand-new key verifies and works with no payment method on the workspace.
- New `opencodeZenFreeModels` / `opencodeZenPaidModels` lists + `isOpencodeZenModelFree(_:)`. Free set uses an explicit allowlist (the free tier is a small, fixed promotion; the paid catalog is large and growing).
- **Excluded from `reminderExtractorCloudProviders`**: Zen's free-tier models reject `json_schema` response formats, which structured reminder extraction relies on (same reason Ollama Cloud is excluded).

**`AddAPIKeyView`**
- `OpencodeZenModelTiersView` shown for `.opencodeZen`.
- The chip helpers are generalized to `ProviderModelTierSection` / `ProviderModelChip` and shared with the Ollama Cloud tiers screen.

**Assets**
- `opencode` provider icon (template-rendered SVG).

## Free / paid classification (verified against the live API, 2026-06-19)

- **Free** (HTTP 200, `cost: 0`, no payment method required): `big-pickle`, `deepseek-v4-flash-free`, `nemotron-3-ultra-free`, `mimo-v2.5-free`, `north-mini-code-free`.
- **Pay-as-you-go** (returns "No payment method" until billing is added): Claude / GPT-5 / Gemini / DeepSeek-Pro / GLM / Kimi / MiniMax / Qwen / Grok families.
- **Intentionally omitted**: `minimax-m3-free` and `qwen3.6-plus-free` - their free promotion has ended ("subscribe to OpenCode Go"), so listing them as free would mislead.

## Testing

- `xcodebuild` (iPhone 17 Pro Max, iOS 26.4): **BUILD SUCCEEDED**, 0 errors.
- AICore module tests: **18/18 pass**, including updated catalog-count / keychain-contract assertions and new tier-integrity tests.
- End-to-end verified against the live Zen API with the app's exact request shape (`temperature: 0.3`, `stream: true`): the free reasoning model streams clean output, with its `reasoning_content` correctly filtered by the existing `streamingDelta` parser.

## Notes

- iOS-only for now; the macOS app's `APIKeyManager` can later reuse the same `opencodeZenAPIKey` keychain identifier for iCloud Keychain sync.