### PR TITLE
Test guardrails: SwiftData dual-write integration + record→enhance→store acceptance + Transcriber seam

### DIFF
--- a/VivaDicta/Services/Transcription/Transcriber.swift
+++ b/VivaDicta/Services/Transcription/Transcriber.swift
@@ -1,0 +1,30 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import TranscriptionCore
+
+/// A seam over `TranscriptionManager` so orchestrators (e.g. `WatchAudioProcessor`)
+/// depend on the *behavior* - "turn audio into text under the current mode" -
+/// rather than the concrete manager.
+///
+/// `TranscriptionManager.transcribe()` resolves a real, downloaded/keyed model
+/// *before* its injectable `engine` seam, which makes the full transcribe step
+/// untestable through the engine alone. Depending on this protocol lets a test
+/// substitute a deterministic `MockTranscriber` and drive the whole
+/// record → transcribe → enhance → store flow.
+@MainActor
+protocol Transcriber {
+    /// The mode currently driving transcription (provider, model, language).
+    var currentMode: VivaMode { get }
+
+    /// Switch the active mode.
+    func setCurrentMode(_ mode: VivaMode)
+
+    /// The resolved model for the current mode, or `nil` when unavailable
+    /// (not downloaded / no API key).
+    func getCurrentTranscriptionModel() -> (any TranscriptionModel)?
+
+    /// Transcribe `audioURL` under the current mode, apply the post-processing
+    /// pipeline, and return the final text.
+    func transcribe(audioURL: URL, progressHandler: TranscriptionProgressHandler?) async throws -> String
+}

--- a/VivaDicta/Services/Transcription/TranscriptionManager.swift
+++ b/VivaDicta/Services/Transcription/TranscriptionManager.swift
@@ -31,7 +31,7 @@ import AICore
 /// only because the manager serializes access.
 @MainActor
 @Observable
-class TranscriptionManager {
+class TranscriptionManager: Transcriber {
     private let logger = Logger(category: .transcriptionManager)
 
     private let engine: any TranscriptionEngine

--- a/VivaDicta/Services/WatchAudioProcessor.swift
+++ b/VivaDicta/Services/WatchAudioProcessor.swift
@@ -22,7 +22,7 @@ import AICore
 final class WatchAudioProcessor {
     private let logger = Logger(category: .watchConnectivity)
 
-    private let transcriptionManager: TranscriptionManager
+    private let transcriptionManager: any Transcriber
     private let aiService: AIService
     private let modelContainer: ModelContainer
 
@@ -30,7 +30,7 @@ final class WatchAudioProcessor {
     private(set) var inFlightFiles: Set<String> = []
 
 
-    init(transcriptionManager: TranscriptionManager,
+    init(transcriptionManager: any Transcriber,
          aiService: AIService,
          modelContainer: ModelContainer) {
         self.transcriptionManager = transcriptionManager
@@ -67,7 +67,7 @@ final class WatchAudioProcessor {
 
             // Transcribe
             let transcriptionStart = Date()
-            let transcribedText = try await transcriptionManager.transcribe(audioURL: audioURL)
+            let transcribedText = try await transcriptionManager.transcribe(audioURL: audioURL, progressHandler: nil)
             let transcriptionDuration = Date().timeIntervalSince(transcriptionStart)
 
             // Validate

--- a/VivaDictaTests/Acceptance/RecordEnhanceStoreAcceptanceTests.swift
+++ b/VivaDictaTests/Acceptance/RecordEnhanceStoreAcceptanceTests.swift
@@ -1,0 +1,178 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import SwiftData
+import Testing
+import AICore
+import AIKit
+import Keychain
+import KeychainMocks
+import Networking
+import NetworkingMocks
+import OAuth
+import OAuthMocks
+import Presets
+import TranscriptionCore
+@testable import VivaDicta
+
+/// Acceptance tests for the core flow **record → transcribe → enhance → store**,
+/// driven through the real headless orchestrator (`WatchAudioProcessor`) with
+/// test doubles ONLY at the system boundary: a `MockTranscriber` (the transcribe
+/// seam) and a mocked network/keychain. Everything in between is production code
+/// - the real `AIService` (route resolution + registry + message building) and
+/// the real SwiftData dual-write into an in-memory store.
+///
+/// This is the guardrail the modularization rides on: it pins the observable
+/// outcome of the whole flow (a persisted `Transcription`, with or without its
+/// enhanced `TranscriptionVariation`) so the pieces can move into modules without
+/// silently breaking the composed behavior.
+@Suite(.tags(.acceptance, .database, .networking))
+@MainActor
+struct RecordEnhanceStoreAcceptanceTests {
+
+    // MARK: - Boundary doubles
+
+    /// Stands in for `TranscriptionManager` at the `Transcriber` seam - returns
+    /// deterministic text so the test owns the "transcribed" value (the real
+    /// manager would need a downloaded/keyed model, which a test can't provide).
+    private final class MockTranscriber: Transcriber {
+        var currentMode: VivaMode
+        let stubbedText: String
+        init(currentMode: VivaMode, stubbedText: String) {
+            self.currentMode = currentMode
+            self.stubbedText = stubbedText
+        }
+        func setCurrentMode(_ mode: VivaMode) { currentMode = mode }
+        func getCurrentTranscriptionModel() -> (any TranscriptionModel)? { nil }
+        func transcribe(audioURL: URL, progressHandler: TranscriptionProgressHandler?) async throws -> String {
+            stubbedText
+        }
+    }
+
+    /// CLI server is off, so the orchestration takes the cloud path.
+    private final class StubCLIServerEnhancer: CLIServerEnhancer {
+        var serverURL: String?
+        func isCliActive(for provider: CLIServerProvider) -> Bool { false }
+        func enhance(text: String, systemPrompt: String, model: String, provider: CLIServerProvider) async throws -> String { "" }
+    }
+
+    // MARK: - Helpers
+
+    private func makeDefaults() -> UserDefaults {
+        let suiteName = "RecordEnhanceStoreAcceptanceTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+
+    private func makeMode(aiProvider: AIProvider?, aiModel: String, enhance: Bool) -> VivaMode {
+        VivaMode(
+            id: UUID(),
+            name: "Acceptance Test Mode",
+            transcriptionProvider: .whisperKit,
+            transcriptionModel: "test-whisper",
+            presetId: "regular",
+            aiProvider: aiProvider,
+            aiModel: aiModel,
+            aiEnhanceEnabled: enhance
+        )
+    }
+
+    /// A throwaway file so `audioURL.lastPathComponent` is sensible; the mock
+    /// transcriber ignores its contents and `AVURLAsset` duration resolves to 0.
+    private func makeTempAudioFile() throws -> URL {
+        let url = URL.temporaryDirectory.appendingPathComponent("acceptance-\(UUID().uuidString).m4a")
+        try Data([0x00, 0x01, 0x02]).write(to: url)
+        return url
+    }
+
+    private func http(_ code: Int) -> HTTPURLResponse {
+        HTTPURLResponse(url: URL(string: "https://example.com")!, statusCode: code, httpVersion: nil, headerFields: nil)!
+    }
+
+    // MARK: - record → transcribe → enhance → store
+
+    @Test func processedRecording_persistsTranscriptionWithEnhancedTextAndVariation() async throws {
+        let container = try TestModelContainer.makeInMemory()
+        let defaults = makeDefaults()
+
+        let mode = makeMode(aiProvider: .anthropic, aiModel: "claude-sonnet-4-6", enhance: true)
+        let transcriber = MockTranscriber(currentMode: mode, stubbedText: "this is the transcribed text")
+
+        // Enhancement boundary: mocked keychain + network return a known result.
+        let keychain = MockKeychainService()
+        _ = keychain.save("ANTHROPIC_KEY", forKey: "anthropicAPIKey")
+        let net = MockNetworkService()
+        net.stubSendResponse = .success((Data(#"{"content":[{"text":"Enhanced acceptance output"}]}"#.utf8), http(200)))
+
+        let aiService = AIService(
+            userDefaults: defaults,
+            keychain: keychain,
+            networkService: net,
+            oauthManager: MockOAuthManager(),
+            cliServerEnhancer: StubCLIServerEnhancer()
+        )
+        aiService.modes = [mode]
+        aiService.selectedMode = mode
+        aiService.connectedProviders = [.anthropic]            // satisfies isProperlyConfigured's "connected" branch
+        aiService.presetManager = PresetManager(userDefaults: defaults)
+
+        let sut = WatchAudioProcessor(
+            transcriptionManager: transcriber,
+            aiService: aiService,
+            modelContainer: container
+        )
+
+        // When: the recording is processed end to end.
+        let audioURL = try makeTempAudioFile()
+        await sut.processAudioFile(at: audioURL, sourceTag: "test-acceptance")
+
+        // Then: a Transcription with its enhanced variation is persisted.
+        let readContext = ModelContext(container)
+        let stored = try #require(try readContext.fetch(FetchDescriptor<Transcription>()).first)
+        #expect(stored.text == "this is the transcribed text")
+        #expect(stored.enhancedText == "Enhanced acceptance output")
+        #expect(stored.sourceTag == "test-acceptance")
+        #expect(stored.variations?.count == 1)
+        let variation = try #require(stored.variations?.first)
+        #expect(variation.text == "Enhanced acceptance output")
+        #expect(variation.text == stored.enhancedText)          // dual-write stays consistent
+
+        // And: the enhancement really went through the cloud path (not a stub shortcut).
+        #expect(net.capturedRequest?.url?.absoluteString == "https://api.anthropic.com/v1/messages")
+        #expect(net.capturedRequest?.value(forHTTPHeaderField: "x-api-key") == "ANTHROPIC_KEY")
+    }
+
+    @Test func processedRecording_whenEnhancementDisabled_persistsRawTranscriptionWithNoVariation() async throws {
+        let container = try TestModelContainer.makeInMemory()
+
+        let mode = makeMode(aiProvider: .anthropic, aiModel: "claude-sonnet-4-6", enhance: false)
+        let transcriber = MockTranscriber(currentMode: mode, stubbedText: "raw note, no enhancement")
+
+        let net = MockNetworkService()
+        let aiService = AIService(
+            userDefaults: makeDefaults(),
+            keychain: MockKeychainService(),
+            networkService: net,
+            oauthManager: MockOAuthManager(),
+            cliServerEnhancer: StubCLIServerEnhancer()
+        )
+        aiService.selectedMode = mode
+
+        let sut = WatchAudioProcessor(
+            transcriptionManager: transcriber,
+            aiService: aiService,
+            modelContainer: container
+        )
+
+        let audioURL = try makeTempAudioFile()
+        await sut.processAudioFile(at: audioURL, sourceTag: "test-acceptance-raw")
+
+        let readContext = ModelContext(container)
+        let stored = try #require(try readContext.fetch(FetchDescriptor<Transcription>()).first)
+        #expect(stored.text == "raw note, no enhancement")
+        #expect(stored.enhancedText == nil)
+        #expect(stored.variations?.isEmpty == true)
+        #expect(net.capturedRequest == nil)                    // enhancement skipped, no network call
+    }
+}

--- a/VivaDictaTests/Helpers/TestModelContainer.swift
+++ b/VivaDictaTests/Helpers/TestModelContainer.swift
@@ -1,0 +1,29 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import SwiftData
+@testable import VivaDicta
+
+/// Shared in-memory SwiftData container for integration / acceptance tests.
+///
+/// Mirrors the production schema declared in `VivaDictaApp.swift` so a model
+/// change is caught in ONE place instead of drifting across hand-rolled
+/// `ModelContainer(for:)` calls scattered through the suite. `isStoredInMemoryOnly`
+/// means no disk and no CloudKit - fast, isolated, and reset per test.
+///
+/// Keep the type list in sync with `VivaDictaApp.swift`'s `ModelContainer`.
+enum TestModelContainer {
+
+    /// A fresh in-memory container holding the full production schema.
+    static func makeInMemory() throws -> ModelContainer {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        return try ModelContainer(
+            for: Transcription.self, VocabularyWord.self, WordReplacement.self,
+            TranscriptionVariation.self, ExtractedReminderDraft.self,
+            CustomRewritePreset.self, RewritePreset.self, TranscriptionTag.self,
+            TranscriptionTagAssignment.self, ChatMessage.self, ChatConversation.self,
+            MultiNoteConversation.self, SmartSearchConversation.self,
+            configurations: config
+        )
+    }
+}

--- a/VivaDictaTests/Integration/TranscriptionPersistenceIntegrationTests.swift
+++ b/VivaDictaTests/Integration/TranscriptionPersistenceIntegrationTests.swift
@@ -1,0 +1,130 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import SwiftData
+import Testing
+@testable import VivaDicta
+
+/// Integration tests for the `Transcription` + `TranscriptionVariation`
+/// dual-write persistence contract, exercised against a REAL (in-memory)
+/// SwiftData store.
+///
+/// This is the riskiest surface to refactor during modularization: the record
+/// flow writes BOTH `transcription.enhancedText` and a linked
+/// `TranscriptionVariation`, and the relationship cascades on delete. Each test
+/// inserts through one `ModelContext` and re-reads through a FRESH one off the
+/// same store, so it proves the data reached the store (not just the writing
+/// context) - the Essential Developer "separate instances prove persistence"
+/// shape. These pin the contract so it can't silently change when the models or
+/// their storage move into a module.
+@Suite(.tags(.database, .integration))
+struct TranscriptionPersistenceIntegrationTests {
+
+    let container: ModelContainer
+
+    init() throws {
+        container = try TestModelContainer.makeInMemory()
+    }
+
+    // MARK: - Dual write
+
+    @Test func dualWrite_persistsEnhancedTextAndLinkedVariation() throws {
+        let writeContext = ModelContext(container)
+        let sut = Transcription(text: "raw transcript", enhancedText: "enhanced transcript", audioDuration: 12)
+        let variation = TranscriptionVariation(
+            presetId: "regular",
+            presetDisplayName: "Regular",
+            text: "enhanced transcript",
+            aiModelName: "claude-sonnet-4-6",
+            aiProviderName: "Anthropic"
+        )
+        variation.transcription = sut
+        writeContext.insert(sut)
+        writeContext.insert(variation)
+        try writeContext.save()
+
+        // Fresh context off the same store: proves it persisted, not just lived
+        // in the writing context.
+        let readContext = ModelContext(container)
+        let fetched = try readContext.fetch(FetchDescriptor<Transcription>())
+
+        #expect(fetched.count == 1)
+        let stored = try #require(fetched.first)
+        #expect(stored.text == "raw transcript")
+        #expect(stored.enhancedText == "enhanced transcript")
+        #expect(stored.variations?.count == 1)
+        #expect(stored.variations?.first?.text == "enhanced transcript")
+        #expect(stored.variations?.first?.aiProviderName == "Anthropic")
+    }
+
+    @Test func variation_inverseRelationship_pointsBackToTranscription() throws {
+        let writeContext = ModelContext(container)
+        let transcription = Transcription(text: "raw", audioDuration: 5)
+        let variation = TranscriptionVariation(presetId: "summary", text: "summary text")
+        variation.transcription = transcription
+        writeContext.insert(transcription)
+        writeContext.insert(variation)
+        try writeContext.save()
+
+        let readContext = ModelContext(container)
+        let storedVariation = try #require(try readContext.fetch(FetchDescriptor<TranscriptionVariation>()).first)
+
+        #expect(storedVariation.transcription?.text == "raw")
+    }
+
+    @Test func multipleVariations_allPersistAndLinkToOneTranscription() throws {
+        let writeContext = ModelContext(container)
+        let transcription = Transcription(text: "raw", audioDuration: 8)
+        writeContext.insert(transcription)
+        for (presetId, text) in [("regular", "regular text"), ("summary", "summary text"), ("email", "email text")] {
+            let variation = TranscriptionVariation(presetId: presetId, text: text)
+            variation.transcription = transcription
+            writeContext.insert(variation)
+        }
+        try writeContext.save()
+
+        let readContext = ModelContext(container)
+        let stored = try #require(try readContext.fetch(FetchDescriptor<Transcription>()).first)
+
+        #expect(stored.variations?.count == 3)
+        #expect(Set(stored.variations?.map(\.presetId) ?? []) == ["regular", "summary", "email"])
+    }
+
+    // MARK: - Cascade delete
+
+    @Test func deletingTranscription_cascadesToItsVariations() throws {
+        let writeContext = ModelContext(container)
+        let transcription = Transcription(text: "raw", enhancedText: "enhanced", audioDuration: 8)
+        let variation = TranscriptionVariation(presetId: "regular", text: "enhanced")
+        variation.transcription = transcription
+        writeContext.insert(transcription)
+        writeContext.insert(variation)
+        try writeContext.save()
+
+        writeContext.delete(transcription)
+        try writeContext.save()
+
+        let readContext = ModelContext(container)
+        let remainingTranscriptions = try readContext.fetch(FetchDescriptor<Transcription>())
+        let remainingVariations = try readContext.fetch(FetchDescriptor<TranscriptionVariation>())
+
+        #expect(remainingTranscriptions.isEmpty)
+        #expect(remainingVariations.isEmpty)   // .cascade removed the variation with its parent
+    }
+
+    // MARK: - Plain (un-enhanced) transcription
+
+    @Test func transcriptionWithoutEnhancement_persistsWithNoVariations() throws {
+        let writeContext = ModelContext(container)
+        let sut = Transcription(text: "just a raw note", audioDuration: 3)
+        writeContext.insert(sut)
+        try writeContext.save()
+
+        let readContext = ModelContext(container)
+        let stored = try #require(try readContext.fetch(FetchDescriptor<Transcription>()).first)
+
+        #expect(stored.text == "just a raw note")
+        #expect(stored.enhancedText == nil)
+        #expect(stored.variations?.isEmpty == true)
+    }
+}

--- a/VivaDictaTests/TestTags.swift
+++ b/VivaDictaTests/TestTags.swift
@@ -15,4 +15,13 @@ extension Tag {
     /// Marks suites that build a real SwiftData `ModelContainer`. Heavier than
     /// pure-value tests, lighter than full integration runs.
     @Tag static var database: Self
+
+    /// Marks integration suites: real collaborators (a real in-memory SwiftData
+    /// store, real file IO), happy path, asserting persistence across contexts.
+    @Tag static var integration: Self
+
+    /// Marks acceptance suites: a composed flow driven through its public seams,
+    /// with test doubles only at the system boundary (network, transcription
+    /// engine), against a real in-memory store.
+    @Tag static var acceptance: Self
 }


### PR DESCRIPTION
## Summary

Lays the **test guardrail net** under the core record → transcribe → enhance → store flow, so the upcoming modularization (module extractions, API/Impl split) can proceed behavior-preserving. Two layers of the testing pyramid that were previously missing: a labeled **integration** suite and the first **acceptance** suite.

### 1. SwiftData integration harness + dual-write contract
- `TestModelContainer.makeInMemory()` - one shared in-memory container mirroring the production 13-model schema, so a schema change is caught in one place instead of drifting across hand-rolled `ModelContainer(for:)` calls.
- `TranscriptionPersistenceIntegrationTests` - pins the `Transcription` + `TranscriptionVariation` dual-write against a real store (the riskiest surface to refactor): enhancedText + linked variation, inverse relationship, multiple variations, **cascade delete**, and the un-enhanced case. Each test inserts via one `ModelContext` and re-reads via a fresh one to prove it reached the store.
- New `.integration` / `.acceptance` test tags.

### 2. `Transcriber` seam (the gap the acceptance test surfaced)
Writing the acceptance test revealed that the flow wasn't drivable: `WatchAudioProcessor` depended on the **concrete** `TranscriptionManager`, whose injectable `engine` sits *below* model resolution (real models require `isDownloaded` / an API key), so `transcribe()` threw in tests and nothing persisted.

- New thin `@MainActor protocol Transcriber` with the members the orchestrators use (`transcribe`, `setCurrentMode`, `currentMode`, `getCurrentTranscriptionModel`).
- `TranscriptionManager` conforms unchanged (it already has them).
- `WatchAudioProcessor` depends on `any Transcriber` instead of the concrete manager.

### 3. Acceptance test
- `RecordEnhanceStoreAcceptanceTests` drives the **real** `WatchAudioProcessor` end to end with a `MockTranscriber` + mocked network/keychain and a real in-memory store:
  - enhanced path: a real Anthropic cloud request is issued and a `Transcription` with its linked variation is persisted;
  - no-enhancement path: a raw note is stored with no variation and no network call.

## Testing
- 5 integration + 2 acceptance tests, green.
- 19 `TranscriptionManager*` / integration regression tests green (confirms the `Transcriber` conformance is behavior-preserving).
- Full app + extensions build green.

## Notes
- Behavior-preserving: the only production change is an additive protocol conformance + widening one init parameter to `any Transcriber` (the single call site passes the manager, which conforms).
- `Transcriber` is an app-level testability seam today; relocating it + `TranscriptionManager` into a module is a later step.