### PR TITLE
Introduce AnalyticsService protocol seam (Default + Mock), inject into ChatViewModel

### DIFF
--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -929,7 +929,7 @@ class AIService {
         let duration = Date().timeIntervalSince(startTime)
         Task { await AIVariationsDiscoveryTip.variationGeneratedEvent.donate() }
 
-        DefaultAnalyticsService().track(.variationGenerated(
+        DefaultAnalyticsService.live.track(.variationGenerated(
             presetId: preset.isBuiltIn ? preset.id : "custom",
             isBuiltInPreset: preset.isBuiltIn,
             provider: mode.aiProvider?.rawValue ?? "unknown",

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -929,7 +929,7 @@ class AIService {
         let duration = Date().timeIntervalSince(startTime)
         Task { await AIVariationsDiscoveryTip.variationGeneratedEvent.donate() }
 
-        AnalyticsService.track(.variationGenerated(
+        DefaultAnalyticsService().track(.variationGenerated(
             presetId: preset.isBuiltIn ? preset.id : "custom",
             isBuiltInPreset: preset.isBuiltIn,
             provider: mode.aiProvider?.rawValue ?? "unknown",

--- a/VivaDicta/Services/Analytics/AnalyticsService.swift
+++ b/VivaDicta/Services/Analytics/AnalyticsService.swift
@@ -13,7 +13,8 @@ import Presets
 /// Adding a new event:
 /// 1. Add a case here with the parameters you want to attach.
 /// 2. Map it in `name` and `parameters`.
-/// 3. Call `AnalyticsService.track(.yourEvent(...))` from the relevant call site.
+/// 3. Track it via the injected `analytics` (or `DefaultAnalyticsService.live`):
+///    `analytics.track(.yourEvent(...))`.
 enum AnalyticsEvent {
 
     enum ChatType: String {

--- a/VivaDicta/Services/Analytics/AnalyticsService.swift
+++ b/VivaDicta/Services/Analytics/AnalyticsService.swift
@@ -6,8 +6,6 @@
 //
 
 import Foundation
-import FirebaseAnalytics
-import os
 import Presets
 
 /// Strongly-typed catalog of every analytics event the app reports.
@@ -284,30 +282,12 @@ extension AnalyticsEvent {
     }
 }
 
-/// Single chokepoint for reporting analytics events. Wraps Firebase Analytics
-/// behind a typed API so call sites can't typo event names or drift in
-/// parameter keys.
+/// Reports analytics events through one typed chokepoint, so call sites can't
+/// typo event names or drift in parameter keys. `track` is safe to call from any
+/// context.
 ///
-/// `Analytics.logEvent` is thread-safe; `track` can be called from any context.
-enum AnalyticsService {
-    nonisolated private static let logger = Logger(category: .analytics)
-
-    nonisolated static func track(_ event: AnalyticsEvent) {
-        let name = event.name
-
-        var merged = event.parameters ?? [:]
-        if event.attachesDeviceConditions {
-            // Event-specific keys win on the (unexpected) collision.
-            merged.merge(DeviceConditions.parameters) { current, _ in current }
-        }
-        let params: [String: Any]? = merged.isEmpty ? nil : merged
-
-        Analytics.logEvent(name, parameters: params)
-
-        if let params {
-            logger.logDebug("📊 \(name) \(params)")
-        } else {
-            logger.logDebug("📊 \(name)")
-        }
-    }
+/// Production wires `DefaultAnalyticsService` (Firebase); tests wire
+/// `MockAnalyticsService` to assert which events fired.
+protocol AnalyticsService: Sendable {
+    func track(_ event: AnalyticsEvent)
 }

--- a/VivaDicta/Services/Analytics/DefaultAnalyticsService.swift
+++ b/VivaDicta/Services/Analytics/DefaultAnalyticsService.swift
@@ -10,6 +10,10 @@ import os
 /// Stateless and `Sendable`, so `track` can be called from any context (matching
 /// Firebase's thread-safety) - the same guarantee the previous static facade gave.
 struct DefaultAnalyticsService: AnalyticsService {
+    /// Shared production instance - one symbol to inject as the default and to
+    /// grep when these call sites move to constructor injection / the module.
+    nonisolated static let live = DefaultAnalyticsService()
+
     nonisolated private static let logger = Logger(category: .analytics)
 
     nonisolated func track(_ event: AnalyticsEvent) {

--- a/VivaDicta/Services/Analytics/DefaultAnalyticsService.swift
+++ b/VivaDicta/Services/Analytics/DefaultAnalyticsService.swift
@@ -1,0 +1,33 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import FirebaseAnalytics
+import os
+
+/// Firebase-backed `AnalyticsService`. Wraps `Analytics.logEvent`, merging in
+/// device-condition parameters for events that opt in.
+///
+/// Stateless and `Sendable`, so `track` can be called from any context (matching
+/// Firebase's thread-safety) - the same guarantee the previous static facade gave.
+struct DefaultAnalyticsService: AnalyticsService {
+    nonisolated private static let logger = Logger(category: .analytics)
+
+    nonisolated func track(_ event: AnalyticsEvent) {
+        let name = event.name
+
+        var merged = event.parameters ?? [:]
+        if event.attachesDeviceConditions {
+            // Event-specific keys win on the (unexpected) collision.
+            merged.merge(DeviceConditions.parameters) { current, _ in current }
+        }
+        let params: [String: Any]? = merged.isEmpty ? nil : merged
+
+        Analytics.logEvent(name, parameters: params)
+
+        if let params {
+            Self.logger.logDebug("📊 \(name) \(params)")
+        } else {
+            Self.logger.logDebug("📊 \(name)")
+        }
+    }
+}

--- a/VivaDicta/Services/Analytics/PerformanceMonitoringService.swift
+++ b/VivaDicta/Services/Analytics/PerformanceMonitoringService.swift
@@ -66,10 +66,10 @@ final class PerformanceMonitoringService: NSObject, MXMetricManagerSubscriber, @
         for payload in payloads {
             for hang in payload.hangDiagnostics ?? [] {
                 let seconds = hang.hangDuration.converted(to: .seconds).value
-                AnalyticsService.track(.appHangDiagnostic(hangSeconds: seconds))
+                DefaultAnalyticsService().track(.appHangDiagnostic(hangSeconds: seconds))
             }
             for cpu in payload.cpuExceptionDiagnostics ?? [] {
-                AnalyticsService.track(.appCPUExceptionDiagnostic(
+                DefaultAnalyticsService().track(.appCPUExceptionDiagnostic(
                     cpuSeconds: cpu.totalCPUTime.converted(to: .seconds).value,
                     sampledSeconds: cpu.totalSampledTime.converted(to: .seconds).value
                 ))
@@ -82,13 +82,13 @@ final class PerformanceMonitoringService: NSObject, MXMetricManagerSubscriber, @
     nonisolated private func reportLaunchTime(_ payload: MXMetricPayload) {
         guard let launch = payload.applicationLaunchMetrics,
               let stats = weightedAverageMs(launch.histogrammedTimeToFirstDraw) else { return }
-        AnalyticsService.track(.appLaunchMetric(averageMs: stats.averageMs, sampleCount: stats.count))
+        DefaultAnalyticsService().track(.appLaunchMetric(averageMs: stats.averageMs, sampleCount: stats.count))
     }
 
     nonisolated private func reportHangTime(_ payload: MXMetricPayload) {
         guard let responsiveness = payload.applicationResponsivenessMetrics,
               let stats = weightedAverageMs(responsiveness.histogrammedApplicationHangTime) else { return }
-        AnalyticsService.track(.appHangMetric(averageMs: stats.averageMs, sampleCount: stats.count))
+        DefaultAnalyticsService().track(.appHangMetric(averageMs: stats.averageMs, sampleCount: stats.count))
     }
 
     nonisolated private func reportMemory(_ payload: MXMetricPayload) {
@@ -98,7 +98,7 @@ final class PerformanceMonitoringService: NSObject, MXMetricManagerSubscriber, @
         // and the Jetsam limit, both of which are MiB-based.
         let peakMB = Int(memory.peakMemoryUsage.converted(to: .bytes).value) / (1024 * 1024)
         let suspendedMB = Int(memory.averageSuspendedMemory.averageMeasurement.converted(to: .bytes).value) / (1024 * 1024)
-        AnalyticsService.track(.appMemoryMetric(peakMB: peakMB, averageSuspendedMB: suspendedMB))
+        DefaultAnalyticsService().track(.appMemoryMetric(peakMB: peakMB, averageSuspendedMB: suspendedMB))
     }
 
     /// Collapses a duration histogram into a single bucket-weighted average (in

--- a/VivaDicta/Services/Analytics/PerformanceMonitoringService.swift
+++ b/VivaDicta/Services/Analytics/PerformanceMonitoringService.swift
@@ -50,8 +50,8 @@ final class PerformanceMonitoringService: NSObject, MXMetricManagerSubscriber, @
     // `@MainActor` method runs a runtime executor precondition on entry. MetricKit
     // calls subscribers synchronously on its own background queue, so on iOS 26
     // (trapping variant) that precondition crashes before the body runs. The bodies
-    // only read the payload and call the `nonisolated` `AnalyticsService.track`, so
-    // running off the main actor is safe. The helpers below are `nonisolated` for
+    // only read the payload and call the `nonisolated` `DefaultAnalyticsService.live.track`,
+    // so running off the main actor is safe. The helpers below are `nonisolated` for
     // the same reason (they're reached only from here).
 
     nonisolated func didReceive(_ payloads: [MXMetricPayload]) {
@@ -66,10 +66,10 @@ final class PerformanceMonitoringService: NSObject, MXMetricManagerSubscriber, @
         for payload in payloads {
             for hang in payload.hangDiagnostics ?? [] {
                 let seconds = hang.hangDuration.converted(to: .seconds).value
-                DefaultAnalyticsService().track(.appHangDiagnostic(hangSeconds: seconds))
+                DefaultAnalyticsService.live.track(.appHangDiagnostic(hangSeconds: seconds))
             }
             for cpu in payload.cpuExceptionDiagnostics ?? [] {
-                DefaultAnalyticsService().track(.appCPUExceptionDiagnostic(
+                DefaultAnalyticsService.live.track(.appCPUExceptionDiagnostic(
                     cpuSeconds: cpu.totalCPUTime.converted(to: .seconds).value,
                     sampledSeconds: cpu.totalSampledTime.converted(to: .seconds).value
                 ))
@@ -82,13 +82,13 @@ final class PerformanceMonitoringService: NSObject, MXMetricManagerSubscriber, @
     nonisolated private func reportLaunchTime(_ payload: MXMetricPayload) {
         guard let launch = payload.applicationLaunchMetrics,
               let stats = weightedAverageMs(launch.histogrammedTimeToFirstDraw) else { return }
-        DefaultAnalyticsService().track(.appLaunchMetric(averageMs: stats.averageMs, sampleCount: stats.count))
+        DefaultAnalyticsService.live.track(.appLaunchMetric(averageMs: stats.averageMs, sampleCount: stats.count))
     }
 
     nonisolated private func reportHangTime(_ payload: MXMetricPayload) {
         guard let responsiveness = payload.applicationResponsivenessMetrics,
               let stats = weightedAverageMs(responsiveness.histogrammedApplicationHangTime) else { return }
-        DefaultAnalyticsService().track(.appHangMetric(averageMs: stats.averageMs, sampleCount: stats.count))
+        DefaultAnalyticsService.live.track(.appHangMetric(averageMs: stats.averageMs, sampleCount: stats.count))
     }
 
     nonisolated private func reportMemory(_ payload: MXMetricPayload) {
@@ -98,7 +98,7 @@ final class PerformanceMonitoringService: NSObject, MXMetricManagerSubscriber, @
         // and the Jetsam limit, both of which are MiB-based.
         let peakMB = Int(memory.peakMemoryUsage.converted(to: .bytes).value) / (1024 * 1024)
         let suspendedMB = Int(memory.averageSuspendedMemory.averageMeasurement.converted(to: .bytes).value) / (1024 * 1024)
-        DefaultAnalyticsService().track(.appMemoryMetric(peakMB: peakMB, averageSuspendedMB: suspendedMB))
+        DefaultAnalyticsService.live.track(.appMemoryMetric(peakMB: peakMB, averageSuspendedMB: suspendedMB))
     }
 
     /// Collapses a duration histogram into a single bucket-weighted average (in

--- a/VivaDicta/Services/LiveTranslation/LiveTranslationService.swift
+++ b/VivaDicta/Services/LiveTranslation/LiveTranslationService.swift
@@ -147,7 +147,7 @@ final class LiveTranslationService {
         if status == .starting {
             status = .running
             sessionStartedAt = Date()
-            AnalyticsService.track(.liveTranslationStarted(
+            DefaultAnalyticsService().track(.liveTranslationStarted(
                 sourceLanguage: config.sourceLanguage.rawValue,
                 targetLanguage: config.targetLanguage.rawValue,
                 ttsEnabled: config.ttsEnabled,
@@ -185,7 +185,7 @@ final class LiveTranslationService {
         status = .idle
 
         if wasRunning, let startedAt = sessionStartedAt {
-            AnalyticsService.track(.liveTranslationStopped(
+            DefaultAnalyticsService().track(.liveTranslationStopped(
                 durationSeconds: Date().timeIntervalSince(startedAt),
                 originalTokenCount: originalTokens.count,
                 translatedTokenCount: translatedTokens.count,
@@ -463,7 +463,7 @@ final class LiveTranslationService {
         await teardown()
         status = .failed(message)
         sessionStartedAt = nil
-        AnalyticsService.track(.liveTranslationFailed(reason: category))
+        DefaultAnalyticsService().track(.liveTranslationFailed(reason: category))
     }
 
     private func isFailed(_ status: LiveTranslationStatus) -> Bool {

--- a/VivaDicta/Services/LiveTranslation/LiveTranslationService.swift
+++ b/VivaDicta/Services/LiveTranslation/LiveTranslationService.swift
@@ -147,7 +147,7 @@ final class LiveTranslationService {
         if status == .starting {
             status = .running
             sessionStartedAt = Date()
-            DefaultAnalyticsService().track(.liveTranslationStarted(
+            DefaultAnalyticsService.live.track(.liveTranslationStarted(
                 sourceLanguage: config.sourceLanguage.rawValue,
                 targetLanguage: config.targetLanguage.rawValue,
                 ttsEnabled: config.ttsEnabled,
@@ -185,7 +185,7 @@ final class LiveTranslationService {
         status = .idle
 
         if wasRunning, let startedAt = sessionStartedAt {
-            DefaultAnalyticsService().track(.liveTranslationStopped(
+            DefaultAnalyticsService.live.track(.liveTranslationStopped(
                 durationSeconds: Date().timeIntervalSince(startedAt),
                 originalTokenCount: originalTokens.count,
                 translatedTokenCount: translatedTokens.count,
@@ -463,7 +463,7 @@ final class LiveTranslationService {
         await teardown()
         status = .failed(message)
         sessionStartedAt = nil
-        DefaultAnalyticsService().track(.liveTranslationFailed(reason: category))
+        DefaultAnalyticsService.live.track(.liveTranslationFailed(reason: category))
     }
 
     private func isFailed(_ status: LiveTranslationStatus) -> Bool {

--- a/VivaDicta/Services/ModelDownloadManager.swift
+++ b/VivaDicta/Services/ModelDownloadManager.swift
@@ -233,7 +233,7 @@ class ModelDownloadManager {
             downloadStatuses[model.name] = .downloaded
             logger.logNotice("✅ Successfully downloaded \(model.displayName)")
 
-            AnalyticsService.track(.modelDownloaded(name: model.displayName, type: "parakeet"))
+            DefaultAnalyticsService().track(.modelDownloaded(name: model.displayName, type: "parakeet"))
 
             try? await Task.sleep(for: .seconds(0.5))
 
@@ -330,7 +330,7 @@ class ModelDownloadManager {
             logger.logNotice("✅ Successfully downloaded and prepared \(displayName)")
             logger.logNotice("⏱️ Preparation time: prewarm: \(phaseState.prewarmDuration.formatted(.number.precision(.fractionLength(2))))s, load: \(phaseState.loadDuration.formatted(.number.precision(.fractionLength(2))))s")
 
-            AnalyticsService.track(.modelDownloaded(name: displayName, type: "whisperkit"))
+            DefaultAnalyticsService().track(.modelDownloaded(name: displayName, type: "whisperkit"))
 
             try? await Task.sleep(for: .seconds(0.5))
 

--- a/VivaDicta/Services/ModelDownloadManager.swift
+++ b/VivaDicta/Services/ModelDownloadManager.swift
@@ -233,7 +233,7 @@ class ModelDownloadManager {
             downloadStatuses[model.name] = .downloaded
             logger.logNotice("✅ Successfully downloaded \(model.displayName)")
 
-            DefaultAnalyticsService().track(.modelDownloaded(name: model.displayName, type: "parakeet"))
+            DefaultAnalyticsService.live.track(.modelDownloaded(name: model.displayName, type: "parakeet"))
 
             try? await Task.sleep(for: .seconds(0.5))
 
@@ -330,7 +330,7 @@ class ModelDownloadManager {
             logger.logNotice("✅ Successfully downloaded and prepared \(displayName)")
             logger.logNotice("⏱️ Preparation time: prewarm: \(phaseState.prewarmDuration.formatted(.number.precision(.fractionLength(2))))s, load: \(phaseState.loadDuration.formatted(.number.precision(.fractionLength(2))))s")
 
-            DefaultAnalyticsService().track(.modelDownloaded(name: displayName, type: "whisperkit"))
+            DefaultAnalyticsService.live.track(.modelDownloaded(name: displayName, type: "whisperkit"))
 
             try? await Task.sleep(for: .seconds(0.5))
 

--- a/VivaDicta/Services/PhoneWatchConnectivityService.swift
+++ b/VivaDicta/Services/PhoneWatchConnectivityService.swift
@@ -169,7 +169,7 @@ extension PhoneWatchConnectivityService: WCSessionDelegate {
             try FileManager.default.moveItem(at: sourceURL, to: destURL)
             logger.logInfo("Received watch audio: \(destURL.lastPathComponent)")
 
-            AnalyticsService.track(.watchRecordingReceived(
+            DefaultAnalyticsService().track(.watchRecordingReceived(
                 durationSeconds: duration,
                 hasModeId: modeId != nil
             ))

--- a/VivaDicta/Services/PhoneWatchConnectivityService.swift
+++ b/VivaDicta/Services/PhoneWatchConnectivityService.swift
@@ -169,7 +169,7 @@ extension PhoneWatchConnectivityService: WCSessionDelegate {
             try FileManager.default.moveItem(at: sourceURL, to: destURL)
             logger.logInfo("Received watch audio: \(destURL.lastPathComponent)")
 
-            DefaultAnalyticsService().track(.watchRecordingReceived(
+            DefaultAnalyticsService.live.track(.watchRecordingReceived(
                 durationSeconds: duration,
                 hasModeId: modeId != nil
             ))

--- a/VivaDicta/Services/RAG/RAGIndexingService.swift
+++ b/VivaDicta/Services/RAG/RAGIndexingService.swift
@@ -377,7 +377,7 @@ final class RAGIndexingService {
             let totalChunks = try await _documentCount()
             logger.logInfo("Indexing complete: \(indexed) indexed, \(skipped) skipped, \(orphanedIds.count) orphans removed, \(totalChunks) total chunks")
             await logIndexSnapshot(reason: "bulk-index-complete", using: logger)
-            DefaultAnalyticsService().track(.ragIndexingCompleted(
+            DefaultAnalyticsService.live.track(.ragIndexingCompleted(
                 indexedCount: indexed,
                 skippedCount: skipped,
                 totalChunks: totalChunks,
@@ -577,7 +577,7 @@ final class RAGIndexingService {
                 baseThreshold: threshold,
                 mapping: mapping
             )
-            DefaultAnalyticsService().track(.smartSearchQueryExecuted(
+            DefaultAnalyticsService.live.track(.smartSearchQueryExecuted(
                 queryLength: query.count,
                 topK: topK,
                 resultCount: 0
@@ -632,7 +632,7 @@ final class RAGIndexingService {
             await logIndexSnapshot(reason: "search-unmapped-raw-hits", using: searchLogger)
         }
         searchLogger.logInfo("Search '\(query.prefix(50))': \(finalResults.count) transcriptions matched")
-        DefaultAnalyticsService().track(.smartSearchQueryExecuted(
+        DefaultAnalyticsService.live.track(.smartSearchQueryExecuted(
             queryLength: query.count,
             topK: topK,
             resultCount: finalResults.count

--- a/VivaDicta/Services/RAG/RAGIndexingService.swift
+++ b/VivaDicta/Services/RAG/RAGIndexingService.swift
@@ -377,7 +377,7 @@ final class RAGIndexingService {
             let totalChunks = try await _documentCount()
             logger.logInfo("Indexing complete: \(indexed) indexed, \(skipped) skipped, \(orphanedIds.count) orphans removed, \(totalChunks) total chunks")
             await logIndexSnapshot(reason: "bulk-index-complete", using: logger)
-            AnalyticsService.track(.ragIndexingCompleted(
+            DefaultAnalyticsService().track(.ragIndexingCompleted(
                 indexedCount: indexed,
                 skippedCount: skipped,
                 totalChunks: totalChunks,
@@ -577,7 +577,7 @@ final class RAGIndexingService {
                 baseThreshold: threshold,
                 mapping: mapping
             )
-            AnalyticsService.track(.smartSearchQueryExecuted(
+            DefaultAnalyticsService().track(.smartSearchQueryExecuted(
                 queryLength: query.count,
                 topK: topK,
                 resultCount: 0
@@ -632,7 +632,7 @@ final class RAGIndexingService {
             await logIndexSnapshot(reason: "search-unmapped-raw-hits", using: searchLogger)
         }
         searchLogger.logInfo("Search '\(query.prefix(50))': \(finalResults.count) transcriptions matched")
-        AnalyticsService.track(.smartSearchQueryExecuted(
+        DefaultAnalyticsService().track(.smartSearchQueryExecuted(
             queryLength: query.count,
             topK: topK,
             resultCount: finalResults.count

--- a/VivaDicta/Services/Transcription/TranscriptionManager.swift
+++ b/VivaDicta/Services/Transcription/TranscriptionManager.swift
@@ -185,7 +185,7 @@ class TranscriptionManager: Transcriber {
             result = TranscriptionOutputFilter.stripTrailingPeriods(result)
         }
 
-        DefaultAnalyticsService().track(.transcriptionCompleted(
+        DefaultAnalyticsService.live.track(.transcriptionCompleted(
             engine: model.provider.rawValue,
             isOnDevice: TranscriptionModelProvider.localProviders.contains(model.provider),
             durationSeconds: Date().timeIntervalSince(startTime),

--- a/VivaDicta/Services/Transcription/TranscriptionManager.swift
+++ b/VivaDicta/Services/Transcription/TranscriptionManager.swift
@@ -185,7 +185,7 @@ class TranscriptionManager: Transcriber {
             result = TranscriptionOutputFilter.stripTrailingPeriods(result)
         }
 
-        AnalyticsService.track(.transcriptionCompleted(
+        DefaultAnalyticsService().track(.transcriptionCompleted(
             engine: model.provider.rawValue,
             isOnDevice: TranscriptionModelProvider.localProviders.contains(model.provider),
             durationSeconds: Date().timeIntervalSince(startTime),

--- a/VivaDicta/Views/Chat/ChatViewModel.swift
+++ b/VivaDicta/Views/Chat/ChatViewModel.swift
@@ -146,6 +146,7 @@ final class ChatViewModel {
     let transcription: Transcription
     private let aiService: any AIChatService
     private let modelContext: ModelContext
+    private let analytics: any AnalyticsService
     private var streamingTask: Task<Void, Never>?
     private var pendingUserMessage: ChatMessage?
     private let notesSearchToolCaptureID = UUID()
@@ -161,11 +162,12 @@ final class ChatViewModel {
 
     // MARK: - Init
 
-    init(conversation: ChatConversation, transcription: Transcription, aiService: any AIChatService, modelContext: ModelContext) {
+    init(conversation: ChatConversation, transcription: Transcription, aiService: any AIChatService, modelContext: ModelContext, analytics: any AnalyticsService = DefaultAnalyticsService()) {
         self.conversation = conversation
         self.transcription = transcription
         self.aiService = aiService
         self.modelContext = modelContext
+        self.analytics = analytics
 
         loadMessages()
         hasLoggedConversationStart = messages.contains { $0.role == "user" }
@@ -240,7 +242,7 @@ final class ChatViewModel {
 
         let turnCount = messages.filter { $0.role == "user" }.count
         if !hasLoggedConversationStart {
-            AnalyticsService.track(.chatConversationStarted(
+            analytics.track(.chatConversationStarted(
                 chatType: .singleNote,
                 provider: provider.rawValue,
                 model: model,
@@ -248,7 +250,7 @@ final class ChatViewModel {
             ))
             hasLoggedConversationStart = true
         }
-        AnalyticsService.track(.chatMessageSent(
+        analytics.track(.chatMessageSent(
             chatType: .singleNote,
             provider: provider.rawValue,
             model: model,

--- a/VivaDicta/Views/Chat/ChatViewModel.swift
+++ b/VivaDicta/Views/Chat/ChatViewModel.swift
@@ -162,7 +162,7 @@ final class ChatViewModel {
 
     // MARK: - Init
 
-    init(conversation: ChatConversation, transcription: Transcription, aiService: any AIChatService, modelContext: ModelContext, analytics: any AnalyticsService = DefaultAnalyticsService()) {
+    init(conversation: ChatConversation, transcription: Transcription, aiService: any AIChatService, modelContext: ModelContext, analytics: any AnalyticsService = DefaultAnalyticsService.live) {
         self.conversation = conversation
         self.transcription = transcription
         self.aiService = aiService

--- a/VivaDicta/Views/LiveTranslation/LiveTranslationView.swift
+++ b/VivaDicta/Views/LiveTranslation/LiveTranslationView.swift
@@ -60,7 +60,7 @@ private struct LiveTranslationSessionView: View {
             }
             .onAppear {
                 hasSonioxKey = checkSonioxKey()
-                DefaultAnalyticsService().track(.liveTranslationOpened)
+                DefaultAnalyticsService.live.track(.liveTranslationOpened)
             }
             .onReceive(NotificationCenter.default.publisher(for: AVAudioSession.routeChangeNotification)) { _ in
                 headphonesConnected = LiveTranslationAudio.isHeadphonesRouteActive
@@ -451,7 +451,7 @@ private struct LiveTranslationSessionView: View {
         do {
             try modelContext.save()
             savedSnapshot = SavedSnapshot()
-            DefaultAnalyticsService().track(.liveTranslationSavedAsNote)
+            DefaultAnalyticsService.live.track(.liveTranslationSavedAsNote)
         } catch {
             // Roll the insert out of the context so the same Transcription
             // instance isn't dangling in memory and won't auto-save next

--- a/VivaDicta/Views/LiveTranslation/LiveTranslationView.swift
+++ b/VivaDicta/Views/LiveTranslation/LiveTranslationView.swift
@@ -60,7 +60,7 @@ private struct LiveTranslationSessionView: View {
             }
             .onAppear {
                 hasSonioxKey = checkSonioxKey()
-                AnalyticsService.track(.liveTranslationOpened)
+                DefaultAnalyticsService().track(.liveTranslationOpened)
             }
             .onReceive(NotificationCenter.default.publisher(for: AVAudioSession.routeChangeNotification)) { _ in
                 headphonesConnected = LiveTranslationAudio.isHeadphonesRouteActive
@@ -451,7 +451,7 @@ private struct LiveTranslationSessionView: View {
         do {
             try modelContext.save()
             savedSnapshot = SavedSnapshot()
-            AnalyticsService.track(.liveTranslationSavedAsNote)
+            DefaultAnalyticsService().track(.liveTranslationSavedAsNote)
         } catch {
             // Roll the insert out of the context so the same Transcription
             // instance isn't dangling in memory and won't auto-save next

--- a/VivaDicta/Views/MultiNoteChat/MultiNoteChatViewModel.swift
+++ b/VivaDicta/Views/MultiNoteChat/MultiNoteChatViewModel.swift
@@ -229,7 +229,7 @@ final class MultiNoteChatViewModel {
         let chatType: AnalyticsEvent.ChatType = conversation.isAllNotes ? .allNotes : .multiNote
         let turnCount = messages.filter { $0.role == "user" }.count
         if !hasLoggedConversationStart {
-            AnalyticsService.track(.chatConversationStarted(
+            DefaultAnalyticsService().track(.chatConversationStarted(
                 chatType: chatType,
                 provider: provider.rawValue,
                 model: model,
@@ -237,7 +237,7 @@ final class MultiNoteChatViewModel {
             ))
             hasLoggedConversationStart = true
         }
-        AnalyticsService.track(.chatMessageSent(
+        DefaultAnalyticsService().track(.chatMessageSent(
             chatType: chatType,
             provider: provider.rawValue,
             model: model,

--- a/VivaDicta/Views/MultiNoteChat/MultiNoteChatViewModel.swift
+++ b/VivaDicta/Views/MultiNoteChat/MultiNoteChatViewModel.swift
@@ -229,7 +229,7 @@ final class MultiNoteChatViewModel {
         let chatType: AnalyticsEvent.ChatType = conversation.isAllNotes ? .allNotes : .multiNote
         let turnCount = messages.filter { $0.role == "user" }.count
         if !hasLoggedConversationStart {
-            DefaultAnalyticsService().track(.chatConversationStarted(
+            DefaultAnalyticsService.live.track(.chatConversationStarted(
                 chatType: chatType,
                 provider: provider.rawValue,
                 model: model,
@@ -237,7 +237,7 @@ final class MultiNoteChatViewModel {
             ))
             hasLoggedConversationStart = true
         }
-        DefaultAnalyticsService().track(.chatMessageSent(
+        DefaultAnalyticsService.live.track(.chatMessageSent(
             chatType: chatType,
             provider: provider.rawValue,
             model: model,

--- a/VivaDicta/Views/SmartSearch/SmartSearchChatViewModel.swift
+++ b/VivaDicta/Views/SmartSearch/SmartSearchChatViewModel.swift
@@ -172,7 +172,7 @@ final class SmartSearchChatViewModel {
 
         let turnCount = messages.filter { $0.role == "user" }.count
         if !hasLoggedConversationStart {
-            DefaultAnalyticsService().track(.chatConversationStarted(
+            DefaultAnalyticsService.live.track(.chatConversationStarted(
                 chatType: .smartSearch,
                 provider: provider.rawValue,
                 model: model,
@@ -180,7 +180,7 @@ final class SmartSearchChatViewModel {
             ))
             hasLoggedConversationStart = true
         }
-        DefaultAnalyticsService().track(.chatMessageSent(
+        DefaultAnalyticsService.live.track(.chatMessageSent(
             chatType: .smartSearch,
             provider: provider.rawValue,
             model: model,

--- a/VivaDicta/Views/SmartSearch/SmartSearchChatViewModel.swift
+++ b/VivaDicta/Views/SmartSearch/SmartSearchChatViewModel.swift
@@ -172,7 +172,7 @@ final class SmartSearchChatViewModel {
 
         let turnCount = messages.filter { $0.role == "user" }.count
         if !hasLoggedConversationStart {
-            AnalyticsService.track(.chatConversationStarted(
+            DefaultAnalyticsService().track(.chatConversationStarted(
                 chatType: .smartSearch,
                 provider: provider.rawValue,
                 model: model,
@@ -180,7 +180,7 @@ final class SmartSearchChatViewModel {
             ))
             hasLoggedConversationStart = true
         }
-        AnalyticsService.track(.chatMessageSent(
+        DefaultAnalyticsService().track(.chatMessageSent(
             chatType: .smartSearch,
             provider: provider.rawValue,
             model: model,

--- a/VivaDicta/VivaDictaApp.swift
+++ b/VivaDicta/VivaDictaApp.swift
@@ -286,7 +286,7 @@ struct VivaDictaApp: App {
                     if let release = WhatsNewCatalog.release(for: currentVersion) {
                         UserDefaultsStorage.appPrivate.set(release.id, forKey: UserDefaultsStorage.Keys.lastSeenWhatsNewVersion)
                     }
-                    AnalyticsService.track(.onboardingCompleted)
+                    DefaultAnalyticsService().track(.onboardingCompleted)
                 }
             }
         }
@@ -387,7 +387,7 @@ struct VivaDictaApp: App {
             if !knownNoSchemeHosts.contains(hostId) {
                 // Log unrecognized host app to Firebase Analytics
                 // This helps track which apps users are trying to use but we don't have URL schemes for yet
-                AnalyticsService.track(.unrecognizedHostApp(bundleId: hostId))
+                DefaultAnalyticsService().track(.unrecognizedHostApp(bundleId: hostId))
             }
         }
     }
@@ -427,7 +427,7 @@ struct VivaDictaApp: App {
                     let hostId = components?.queryItems?.first(where: { $0.name == "hostId" })?.value
 
                     // Log keyboard session start to Firebase Analytics
-                    AnalyticsService.track(.keyboardSessionStarted(hostBundleId: hostId))
+                    DefaultAnalyticsService().track(.keyboardSessionStarted(hostBundleId: hostId))
 
                     // Activate keyboard session to notify keyboard that hot mic is ready
                     let timeoutSeconds = AudioPrewarmManager.shared.audioSessionTimeout

--- a/VivaDicta/VivaDictaApp.swift
+++ b/VivaDicta/VivaDictaApp.swift
@@ -286,7 +286,7 @@ struct VivaDictaApp: App {
                     if let release = WhatsNewCatalog.release(for: currentVersion) {
                         UserDefaultsStorage.appPrivate.set(release.id, forKey: UserDefaultsStorage.Keys.lastSeenWhatsNewVersion)
                     }
-                    DefaultAnalyticsService().track(.onboardingCompleted)
+                    DefaultAnalyticsService.live.track(.onboardingCompleted)
                 }
             }
         }
@@ -387,7 +387,7 @@ struct VivaDictaApp: App {
             if !knownNoSchemeHosts.contains(hostId) {
                 // Log unrecognized host app to Firebase Analytics
                 // This helps track which apps users are trying to use but we don't have URL schemes for yet
-                DefaultAnalyticsService().track(.unrecognizedHostApp(bundleId: hostId))
+                DefaultAnalyticsService.live.track(.unrecognizedHostApp(bundleId: hostId))
             }
         }
     }
@@ -427,7 +427,7 @@ struct VivaDictaApp: App {
                     let hostId = components?.queryItems?.first(where: { $0.name == "hostId" })?.value
 
                     // Log keyboard session start to Firebase Analytics
-                    DefaultAnalyticsService().track(.keyboardSessionStarted(hostBundleId: hostId))
+                    DefaultAnalyticsService.live.track(.keyboardSessionStarted(hostBundleId: hostId))
 
                     // Activate keyboard session to notify keyboard that hot mic is ready
                     let timeoutSeconds = AudioPrewarmManager.shared.audioSessionTimeout

--- a/VivaDictaTests/ChatViewModelTests.swift
+++ b/VivaDictaTests/ChatViewModelTests.swift
@@ -108,5 +108,6 @@ struct ChatViewModelTests {
             await Task.yield()
             spins += 1
         }
+        #expect(!fixture.sut.isStreaming)   // drained for real, not just hit the spin cap
     }
 }

--- a/VivaDictaTests/ChatViewModelTests.swift
+++ b/VivaDictaTests/ChatViewModelTests.swift
@@ -40,9 +40,10 @@ struct ChatViewModelTests {
         let sut: ChatViewModel
         let mockAIService: MockAIChatService
         let container: ModelContainer
+        let analytics: MockAnalyticsService
     }
 
-    private func makeFixture(stubMode: VivaMode = .defaultMode) throws -> Fixture {
+    private func makeFixture(stubMode: VivaMode = .defaultMode, analytics: MockAnalyticsService = MockAnalyticsService()) throws -> Fixture {
         let container = try makeContainer()
         let conversation = ChatConversation()
         let transcription = Transcription(text: "Test note", audioDuration: 5)
@@ -56,9 +57,10 @@ struct ChatViewModelTests {
             conversation: conversation,
             transcription: transcription,
             aiService: mockAIService,
-            modelContext: container.mainContext
+            modelContext: container.mainContext,
+            analytics: analytics
         )
-        return Fixture(sut: sut, mockAIService: mockAIService, container: container)
+        return Fixture(sut: sut, mockAIService: mockAIService, container: container, analytics: analytics)
     }
 
     @Test func selectedProvider_reflectsMockSelectedMode() throws {
@@ -80,5 +82,31 @@ struct ChatViewModelTests {
             stubMode: makeMode(provider: .openAI, model: "")
         )
         #expect(fixture.sut.selectedModel == nil)
+    }
+
+    /// The capability the Analytics seam unlocks: assert which events fired by
+    /// injecting a recording `MockAnalyticsService` (impossible with the old
+    /// static facade). `sendMessage` logs conversation-started + message-sent
+    /// synchronously, before the streaming task runs.
+    @Test func sendMessage_tracksConversationStartedAndMessageSent() async throws {
+        let fixture = try makeFixture(
+            stubMode: makeMode(provider: .openAI, model: "gpt-4")
+        )
+        fixture.sut.inputText = "hello there"
+
+        fixture.sut.sendMessage()
+
+        // Events fire synchronously, before the streaming task starts.
+        #expect(fixture.analytics.trackedEventNames.contains("chat_conversation_started"))
+        #expect(fixture.analytics.trackedEventNames.contains("chat_message_sent"))
+
+        // Drain the background streaming task so it finishes while the in-memory
+        // container is still alive (otherwise it touches a reset ModelContext).
+        fixture.sut.cancelStreaming()
+        var spins = 0
+        while fixture.sut.isStreaming && spins < 1000 {
+            await Task.yield()
+            spins += 1
+        }
     }
 }

--- a/VivaDictaTests/Mocks/MockAnalyticsService.swift
+++ b/VivaDictaTests/Mocks/MockAnalyticsService.swift
@@ -1,0 +1,20 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+@testable import VivaDicta
+
+/// Records tracked events so tests can assert which analytics fired.
+///
+/// `@unchecked Sendable` with a lock because `track` is `nonisolated` and may be
+/// called from any context (mirrors `MockNetworkService`).
+final class MockAnalyticsService: AnalyticsService, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _events: [AnalyticsEvent] = []
+
+    var trackedEvents: [AnalyticsEvent] { lock.withLock { _events } }
+    var trackedEventNames: [String] { lock.withLock { _events.map(\.name) } }
+
+    nonisolated func track(_ event: AnalyticsEvent) {
+        lock.withLock { _events.append(event) }
+    }
+}


### PR DESCRIPTION
## Summary

First extraction off the test-guardrail net: turns the static `AnalyticsService` facade into an injectable protocol seam, so analytics become testable. The riskiest-looking part (a 29-call-site static API) is handled behavior-preserving, and one view model is migrated to constructor injection to prove the unlock.

### The seam
- **`AnalyticsService` is now a `Sendable` protocol** (`func track(_ event: AnalyticsEvent)`), mirroring `KeychainService`.
- **`DefaultAnalyticsService`** holds the Firebase implementation - same `Analytics.logEvent` + device-condition merge as the old static facade, just as an instance.
- **`MockAnalyticsService`** records tracked events so tests can assert which analytics fired (impossible with the old static enum).
- `AnalyticsEvent` (the pure event catalogue) is unchanged.

### Injection + the unlock
- **`ChatViewModel`** takes an injected `any AnalyticsService = DefaultAnalyticsService()`.
- New test **`sendMessage_tracksConversationStartedAndMessageSent`** injects a `MockAnalyticsService` and asserts `chat_conversation_started` + `chat_message_sent` fire (the events log synchronously, before the streaming task; the test drains that task so it doesn't outlive the in-memory container).

### Behavior-preserving migration of the rest
- The other **11 call sites** (9 services + the two other chat view models) switch from the static `AnalyticsService.track(...)` to a stateless `DefaultAnalyticsService().track(...)`. No behavior change; they can move to constructor injection later, when their own tests need it (no sweep).

## Testing
- 4 `ChatViewModel` tests (incl. the new analytics assertion) green.
- 33 regression tests green across the migrated suites: `TranscriptionManager`, `AIService` (routing), the two other chat view models, `LiveTranslation`, plus the record→enhance→store acceptance + dual-write integration guardrails (which exercise the migrated `TranscriptionManager` analytics call).
- Full app + extensions build green.

## Notes
- **Behavior-preserving.** The Firebase call, event names, and parameters are unchanged.
- **No new module yet** - this is an in-app seam. None of the 12 call-site files are compiled into the extensions, so a later physical `Analytics` SPM module move (protocol + event + mock; `DefaultAnalyticsService` stays app-side for Firebase) is low-risk.