### PR TITLE
Extract Analytics into an SPM module (Analytics + AnalyticsMocks)

### DIFF
--- a/Modules/Analytics/.gitignore
+++ b/Modules/Analytics/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Modules/Analytics/Package.swift
+++ b/Modules/Analytics/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         ),
         .testTarget(
             name: "AnalyticsTests",
-            dependencies: ["Analytics"]
+            dependencies: ["Analytics", "AnalyticsMocks"]
         ),
     ],
     swiftLanguageModes: [.v6]

--- a/Modules/Analytics/Package.swift
+++ b/Modules/Analytics/Package.swift
@@ -1,0 +1,29 @@
+// swift-tools-version: 6.2
+
+import PackageDescription
+
+let package = Package(
+    name: "Analytics",
+    platforms: [
+        .iOS(.v18),
+        .macOS(.v14),
+    ],
+    products: [
+        .library(name: "Analytics", targets: ["Analytics"]),
+        .library(name: "AnalyticsMocks", targets: ["AnalyticsMocks"]),
+    ],
+    targets: [
+        .target(
+            name: "Analytics"
+        ),
+        .target(
+            name: "AnalyticsMocks",
+            dependencies: ["Analytics"]
+        ),
+        .testTarget(
+            name: "AnalyticsTests",
+            dependencies: ["Analytics"]
+        ),
+    ],
+    swiftLanguageModes: [.v6]
+)

--- a/Modules/Analytics/Sources/Analytics/AnalyticsService.swift
+++ b/Modules/Analytics/Sources/Analytics/AnalyticsService.swift
@@ -14,9 +14,9 @@ import Foundation
 /// 2. Map it in `name` and `parameters`.
 /// 3. Track it via the injected `analytics` (or `DefaultAnalyticsService.live`):
 ///    `analytics.track(.yourEvent(...))`.
-public enum AnalyticsEvent {
+public enum AnalyticsEvent: Sendable {
 
-    public enum ChatType: String {
+    public enum ChatType: String, Sendable {
         case singleNote = "single_note"
         case multiNote = "multi_note"
         case allNotes = "all_notes"

--- a/Modules/Analytics/Sources/Analytics/AnalyticsService.swift
+++ b/Modules/Analytics/Sources/Analytics/AnalyticsService.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import Presets
 
 /// Strongly-typed catalog of every analytics event the app reports.
 ///
@@ -15,9 +14,9 @@ import Presets
 /// 2. Map it in `name` and `parameters`.
 /// 3. Track it via the injected `analytics` (or `DefaultAnalyticsService.live`):
 ///    `analytics.track(.yourEvent(...))`.
-enum AnalyticsEvent {
+public enum AnalyticsEvent {
 
-    enum ChatType: String {
+    public enum ChatType: String {
         case singleNote = "single_note"
         case multiNote = "multi_note"
         case allNotes = "all_notes"
@@ -125,7 +124,7 @@ extension AnalyticsEvent {
 
     /// The Firebase event name. Keep names stable - changing one breaks
     /// historical reporting in the Firebase console.
-    nonisolated var name: String {
+    public nonisolated var name: String {
         switch self {
         case .onboardingCompleted: "onboarding_completed"
         case .unrecognizedHostApp: "unrecognized_host_app"
@@ -156,7 +155,7 @@ extension AnalyticsEvent {
     /// device state is meaningful. False for the MetricKit-sourced events, whose
     /// payloads are aggregated over the past day - the device state at delivery
     /// time is unrelated to when the metrics were recorded.
-    nonisolated var attachesDeviceConditions: Bool {
+    public nonisolated var attachesDeviceConditions: Bool {
         switch self {
         case .appLaunchMetric, .appHangMetric, .appMemoryMetric,
              .appHangDiagnostic, .appCPUExceptionDiagnostic:
@@ -169,7 +168,7 @@ extension AnalyticsEvent {
     /// Parameters attached to the event. Keep keys snake_case and consistent
     /// across events (`provider`, `model`, `chat_type`, ...). Do not include
     /// raw user content - only counts, lengths, enum values, and IDs.
-    nonisolated var parameters: [String: Any]? {
+    public nonisolated var parameters: [String: Any]? {
         switch self {
         case .onboardingCompleted:
             return nil
@@ -289,6 +288,6 @@ extension AnalyticsEvent {
 ///
 /// Production wires `DefaultAnalyticsService` (Firebase); tests wire
 /// `MockAnalyticsService` to assert which events fired.
-protocol AnalyticsService: Sendable {
+public protocol AnalyticsService: Sendable {
     func track(_ event: AnalyticsEvent)
 }

--- a/Modules/Analytics/Sources/AnalyticsMocks/MockAnalyticsService.swift
+++ b/Modules/Analytics/Sources/AnalyticsMocks/MockAnalyticsService.swift
@@ -1,20 +1,21 @@
 // Copyright © 2026 Anton Novoselov. All rights reserved.
 
 import Foundation
-@testable import VivaDicta
+import Analytics
 
 /// Records tracked events so tests can assert which analytics fired.
 ///
 /// `@unchecked Sendable` with a lock because `track` is `nonisolated` and may be
 /// called from any context (mirrors `MockNetworkService`).
-final class MockAnalyticsService: AnalyticsService, @unchecked Sendable {
+public final class MockAnalyticsService: AnalyticsService, @unchecked Sendable {
+    public init() {}
     private let lock = NSLock()
     private var _events: [AnalyticsEvent] = []
 
-    var trackedEvents: [AnalyticsEvent] { lock.withLock { _events } }
-    var trackedEventNames: [String] { lock.withLock { _events.map(\.name) } }
+    public var trackedEvents: [AnalyticsEvent] { lock.withLock { _events } }
+    public var trackedEventNames: [String] { lock.withLock { _events.map(\.name) } }
 
-    nonisolated func track(_ event: AnalyticsEvent) {
+    public nonisolated func track(_ event: AnalyticsEvent) {
         lock.withLock { _events.append(event) }
     }
 }

--- a/Modules/Analytics/Tests/AnalyticsTests/AnalyticsTests.swift
+++ b/Modules/Analytics/Tests/AnalyticsTests/AnalyticsTests.swift
@@ -1,0 +1,43 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Testing
+import Analytics
+
+/// Pins the `AnalyticsEvent` -> Firebase name/parameter mapping. These names are
+/// a stable contract (changing one breaks historical reporting), so the module
+/// owns the tests that guard them.
+struct AnalyticsEventTests {
+
+    @Test func transcriptionCompleted_mapsNameParametersAndAttachesDeviceConditions() {
+        let sut: AnalyticsEvent = .transcriptionCompleted(
+            engine: "whisperKit", isOnDevice: true, durationSeconds: 1.5, outputLength: 42
+        )
+
+        #expect(sut.name == "transcription_completed")
+        #expect(sut.parameters?["engine"] as? String == "whisperKit")
+        #expect(sut.parameters?["is_on_device"] as? Bool == true)
+        #expect(sut.parameters?["output_length"] as? Int == 42)
+        #expect(sut.attachesDeviceConditions == true)   // interactive event
+    }
+
+    @Test func chatConversationStarted_omitsNoteCountWhenNil() {
+        let withCount: AnalyticsEvent = .chatConversationStarted(chatType: .multiNote, provider: "openai", model: "gpt", noteCount: 3)
+        let withoutCount: AnalyticsEvent = .chatConversationStarted(chatType: .singleNote, provider: "openai", model: "gpt", noteCount: nil)
+
+        #expect(withCount.parameters?["chat_type"] as? String == "multi_note")
+        #expect(withCount.parameters?["note_count"] as? Int == 3)
+        #expect(withoutCount.parameters?["note_count"] == nil)
+    }
+
+    @Test func metricKitEvents_doNotAttachDeviceConditions() {
+        // MetricKit payloads are aggregated over the past day, so live device
+        // state at delivery time is unrelated.
+        #expect(AnalyticsEvent.appLaunchMetric(averageMs: 100, sampleCount: 3).attachesDeviceConditions == false)
+        #expect(AnalyticsEvent.appLaunchMetric(averageMs: 100, sampleCount: 3).name == "app_launch_metric")
+    }
+
+    @Test func eventWithoutParameters_returnsNil() {
+        #expect(AnalyticsEvent.onboardingCompleted.parameters == nil)
+        #expect(AnalyticsEvent.onboardingCompleted.name == "onboarding_completed")
+    }
+}

--- a/Modules/Analytics/Tests/AnalyticsTests/AnalyticsTests.swift
+++ b/Modules/Analytics/Tests/AnalyticsTests/AnalyticsTests.swift
@@ -2,6 +2,7 @@
 
 import Testing
 import Analytics
+import AnalyticsMocks
 
 /// Pins the `AnalyticsEvent` -> Firebase name/parameter mapping. These names are
 /// a stable contract (changing one breaks historical reporting), so the module
@@ -39,5 +40,20 @@ struct AnalyticsEventTests {
     @Test func eventWithoutParameters_returnsNil() {
         #expect(AnalyticsEvent.onboardingCompleted.parameters == nil)
         #expect(AnalyticsEvent.onboardingCompleted.name == "onboarding_completed")
+    }
+}
+
+/// `AnalyticsMocks` is exercised in-module so the recording double is verified
+/// by the module that owns it, not only via the app's test target.
+struct MockAnalyticsServiceTests {
+
+    @Test func track_recordsEventsInOrder() {
+        let sut = MockAnalyticsService()
+
+        sut.track(.onboardingCompleted)
+        sut.track(.liveTranslationOpened)
+
+        #expect(sut.trackedEvents.count == 2)
+        #expect(sut.trackedEventNames == ["onboarding_completed", "live_translation_opened"])
     }
 }

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ graph BT
   TranscriptionCore[TranscriptionCore]:::core
   AICore[AICore]:::core
   AudioRecording[AudioRecording]:::core
+  Analytics[Analytics]:::core
   AppGroup[AppGroup]:::core
   DesignSystem[DesignSystem]:::core
   TestUtilities[TestUtilities]:::core
@@ -226,12 +227,13 @@ graph BT
   VivaDicta --> Presets
   VivaDicta --> AudioRecording
   VivaDicta --> AppGroup
+  VivaDicta --> Analytics
   VivaDicta --> DesignSystem
 ```
 
 | Layer | Modules |
 |-------|---------|
-| **Core** (no module deps; protocols + value types) | `Networking` · `Keychain` · `Presets` · `TranscriptionCore` · `AICore` · `AudioRecording` · `AppGroup` · `DesignSystem` |
+| **Core** (no module deps; protocols + value types) | `Networking` · `Keychain` · `Presets` · `TranscriptionCore` · `AICore` · `Analytics` · `AudioRecording` · `AppGroup` · `DesignSystem` |
 | **Adapters** (protocol + `Default` impl + `Mock`) | `OAuth` · `CloudTranscription` · `LocalTranscription` · `AIProviders` |
 | **Orchestrators** (compose adapters) | `TranscriptionKit` · `AIKit` |
 | **App** (composition root) | `VivaDicta` + keyboard / widget / share / action / watch targets |
@@ -341,6 +343,7 @@ VivaDicta/
 │   ├── TranscriptionKit/   # Cloud/local transcription routing
 │   ├── AudioRecording/     # AudioRecordingService + AudioFileService
 │   ├── Presets/            # Preset domain + management
+│   ├── Analytics/            # AnalyticsService protocol + AnalyticsEvent + AnalyticsMocks
 │   └── AppGroup · DesignSystem · TestUtilities
 ├── documentation/          # Architecture docs, references
 └── .github/workflows/      # CI: build check, Claude review, GitGuardian

--- a/VivaDicta.xcodeproj/project.pbxproj
+++ b/VivaDicta.xcodeproj/project.pbxproj
@@ -8,6 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		186C057F2FB779AA00102432 /* Keychain in Frameworks */ = {isa = PBXBuildFile; productRef = 186C057E2FB779AA00102432 /* Keychain */; };
+		616CAFAEA09DF203BD975158 /* Analytics in Frameworks */ = {isa = PBXBuildFile; productRef = FFEA7C00964E1EA320FCD72F /* Analytics */; };
+		F0D8E2E3874C477CBF276D61 /* Analytics in Frameworks */ = {isa = PBXBuildFile; productRef = 0FADDDCF6E2B224D91D572E3 /* Analytics */; };
+		1A8DED2E097CE6867571F84D /* AnalyticsMocks in Frameworks */ = {isa = PBXBuildFile; productRef = 80C6FC953001FC4053588FDB /* AnalyticsMocks */; };
 		186C05812FB779AA00102432 /* Presets in Frameworks */ = {isa = PBXBuildFile; productRef = 186C05802FB779AA00102432 /* Presets */; };
 		186C05832FB779BA00102432 /* Keychain in Frameworks */ = {isa = PBXBuildFile; productRef = 186C05822FB779BA00102432 /* Keychain */; };
 		186C05852FB779BA00102432 /* KeychainMocks in Frameworks */ = {isa = PBXBuildFile; productRef = 186C05842FB779BA00102432 /* KeychainMocks */; };
@@ -209,6 +212,7 @@
 				AICore,
 				AIKit,
 				AIProviders,
+				Analytics,
 				AppGroup,
 				AudioRecording,
 				CloudTranscription,
@@ -230,6 +234,7 @@
 				AICore,
 				AIKit,
 				AIProviders,
+				Analytics,
 				AppGroup,
 				AudioRecording,
 				CloudTranscription,
@@ -494,6 +499,7 @@
 				18F75FC02FB79A3200280269 /* CloudTranscription in Frameworks */,
 				18F7637F2FB7D5E300280269 /* LocalTranscription in Frameworks */,
 				186C057F2FB779AA00102432 /* Keychain in Frameworks */,
+				616CAFAEA09DF203BD975158 /* Analytics in Frameworks */,
 				18AABBCC0011223344556602 /* Networking in Frameworks */,
 				18E1B4AD2E8C875000BE8A11 /* KeyboardKit in Frameworks */,
 				18F75FBE2FB79A2B00280269 /* TranscriptionCore in Frameworks */,
@@ -515,6 +521,8 @@
 				18F75FC42FB79A4400280269 /* CloudTranscription in Frameworks */,
 				186C05872FB779BA00102432 /* Presets in Frameworks */,
 				186C05852FB779BA00102432 /* KeychainMocks in Frameworks */,
+				F0D8E2E3874C477CBF276D61 /* Analytics in Frameworks */,
+				1A8DED2E097CE6867571F84D /* AnalyticsMocks in Frameworks */,
 				18F75FC62FB79A4B00280269 /* CloudTranscriptionMocks in Frameworks */,
 				186C0C9E2FB782A000102432 /* OAuthMocks in Frameworks */,
 				18AABBCC0011223344556604 /* NetworkingMocks in Frameworks */,
@@ -707,6 +715,7 @@
 				18B497F12F268B2700538830 /* FirebaseCrashlytics */,
 				1879FD9F2F8C088E00952CF9 /* LumoKit */,
 				186C057E2FB779AA00102432 /* Keychain */,
+				FFEA7C00964E1EA320FCD72F /* Analytics */,
 				186C05802FB779AA00102432 /* Presets */,
 				186C0C9B2FB7829A00102432 /* OAuth */,
 				18F75FBD2FB79A2B00280269 /* TranscriptionCore */,
@@ -745,6 +754,8 @@
 			packageProductDependencies = (
 				186C05822FB779BA00102432 /* Keychain */,
 				186C05842FB779BA00102432 /* KeychainMocks */,
+				0FADDDCF6E2B224D91D572E3 /* Analytics */,
+				80C6FC953001FC4053588FDB /* AnalyticsMocks */,
 				186C05862FB779BA00102432 /* Presets */,
 				186C05882FB779BA00102432 /* PresetsMocks */,
 				186C0C9D2FB782A000102432 /* OAuthMocks */,
@@ -2429,6 +2440,18 @@
 		186C057E2FB779AA00102432 /* Keychain */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Keychain;
+		};
+		FFEA7C00964E1EA320FCD72F /* Analytics */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Analytics;
+		};
+		0FADDDCF6E2B224D91D572E3 /* Analytics */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Analytics;
+		};
+		80C6FC953001FC4053588FDB /* AnalyticsMocks */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AnalyticsMocks;
 		};
 		186C05802FB779AA00102432 /* Presets */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -6,6 +6,7 @@
 //
 
 import Keychain
+import Analytics
 import Networking
 import Presets
 import SwiftUI

--- a/VivaDicta/Services/Analytics/DefaultAnalyticsService.swift
+++ b/VivaDicta/Services/Analytics/DefaultAnalyticsService.swift
@@ -1,6 +1,7 @@
 // Copyright © 2026 Anton Novoselov. All rights reserved.
 
 import Foundation
+import Analytics
 import FirebaseAnalytics
 import os
 

--- a/VivaDicta/Services/Analytics/PerformanceMonitoringService.swift
+++ b/VivaDicta/Services/Analytics/PerformanceMonitoringService.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Analytics
 import MetricKit
 import os
 

--- a/VivaDicta/Services/LiveTranslation/LiveTranslationService.swift
+++ b/VivaDicta/Services/LiveTranslation/LiveTranslationService.swift
@@ -6,6 +6,7 @@
 //
 
 import AVFoundation
+import Analytics
 import Foundation
 import Keychain
 import os

--- a/VivaDicta/Services/ModelDownloadManager.swift
+++ b/VivaDicta/Services/ModelDownloadManager.swift
@@ -6,6 +6,7 @@
 //
 
 import LocalTranscription
+import Analytics
 import SwiftUI
 import TranscriptionCore
 import os

--- a/VivaDicta/Services/PhoneWatchConnectivityService.swift
+++ b/VivaDicta/Services/PhoneWatchConnectivityService.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import Analytics
 import WatchConnectivity
 import os
 

--- a/VivaDicta/Services/RAG/RAGIndexingService.swift
+++ b/VivaDicta/Services/RAG/RAGIndexingService.swift
@@ -6,6 +6,7 @@
 //
 
 import CryptoKit
+import Analytics
 import Foundation
 import Observation
 import SwiftData

--- a/VivaDicta/Services/Transcription/TranscriptionManager.swift
+++ b/VivaDicta/Services/Transcription/TranscriptionManager.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Analytics
 import AppGroup
 import CloudTranscription
 import LocalTranscription

--- a/VivaDicta/Views/Chat/ChatViewModel.swift
+++ b/VivaDicta/Views/Chat/ChatViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Analytics
 import FoundationModels
 import SwiftData
 import os

--- a/VivaDicta/Views/LiveTranslation/LiveTranslationView.swift
+++ b/VivaDicta/Views/LiveTranslation/LiveTranslationView.swift
@@ -6,6 +6,7 @@
 //
 
 import AVFoundation
+import Analytics
 import SwiftData
 import SwiftUI
 

--- a/VivaDicta/Views/MultiNoteChat/MultiNoteChatViewModel.swift
+++ b/VivaDicta/Views/MultiNoteChat/MultiNoteChatViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Analytics
 import FoundationModels
 import SwiftData
 import os

--- a/VivaDicta/Views/SmartSearch/SmartSearchChatViewModel.swift
+++ b/VivaDicta/Views/SmartSearch/SmartSearchChatViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Analytics
 import FoundationModels
 import SwiftData
 import TipKit

--- a/VivaDicta/VivaDictaApp.swift
+++ b/VivaDicta/VivaDictaApp.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Analytics
 import AppGroup
 import SwiftData
 import os

--- a/VivaDictaTests/ChatViewModelTests.swift
+++ b/VivaDictaTests/ChatViewModelTests.swift
@@ -6,6 +6,8 @@
 //
 
 import Foundation
+import Analytics
+import AnalyticsMocks
 import SwiftData
 import Testing
 @testable import VivaDicta

--- a/documentation/Module-Architecture.md
+++ b/documentation/Module-Architecture.md
@@ -42,6 +42,7 @@ flowchart TB
     TranscriptionCore:::core
     AICore:::core
     AudioRecording:::core
+    Analytics:::core
     AppGroup:::core
     DesignSystem:::core
     TestUtilities:::core
@@ -70,6 +71,7 @@ graph BT
   AICore[AICore]:::core
   AudioRecording[AudioRecording]:::core
   AppGroup[AppGroup]:::core
+  Analytics[Analytics]:::core
   DesignSystem[DesignSystem]:::core
   TestUtilities[TestUtilities]:::core
 
@@ -124,6 +126,7 @@ graph BT
   VivaDicta --> Presets
   VivaDicta --> AudioRecording
   VivaDicta --> AppGroup
+  VivaDicta --> Analytics
   VivaDicta --> DesignSystem
 ```
 
@@ -139,6 +142,7 @@ graph BT
 | `Presets` | core | Preset domain types + management (Regular, Summary, ...). | `PresetsMocks` |
 | `TranscriptionCore` | core | Pure protocol + value types: `TranscriptionService`, `TranscriptionServiceResult`. | n/a |
 | `AICore` | core | AI-stack API + kernel (Foundation only): `AITextProvider` protocol, `AIProvider` id enum, `EnhancementError`, `AIEnhancementOutputFilter`, `ReasoningConfig`, Apple FM sampling types. | n/a |
+| `Analytics` | core | `AnalyticsService` protocol + `AnalyticsEvent` catalogue (stable Firebase event names/params). Pure Foundation, no deps. `DefaultAnalyticsService` (Firebase) stays app-side. | `AnalyticsMocks` |
 | `AppGroup` | core | App-Group coordination keys shared between the app and extensions. | n/a |
 | `DesignSystem` | core | SwiftUI design tokens, colors, typography, shared components. | n/a |
 | `AudioRecording` | core | `AudioRecordingService` + `AudioFileService` protocols + `Default*` impls. | `MockAudioRecordingService`, `MockAudioFileService` |


### PR DESCRIPTION
## Summary

Physical SPM-module extraction of the analytics seam (the in-app seam shipped in #346). The empty `Modules/Analytics` package was created in Xcode; this PR wires it into a real module, Keychain-shaped.

### The module
- `Modules/Analytics/Package.swift` vends two products (mirrors `Keychain`):
  - **`Analytics`** - the `AnalyticsService` protocol + the `AnalyticsEvent` catalogue. Pure Foundation, **no dependencies** (dropped the unused `Presets` import).
  - **`AnalyticsMocks`** - `MockAnalyticsService` (records events for test assertions).
- `AnalyticsService.swift` and `MockAnalyticsService.swift` moved into the module (`git mv`, history preserved) and made `public`.

### App side
- **`DefaultAnalyticsService` (Firebase) stays app-side** - the Firebase dependency must not leak into the module. It imports `Analytics`.
- The ~13 app consumers + `ChatViewModelTests` import `Analytics` / `AnalyticsMocks`.
- pbxproj: linked the `Analytics` product into the app target and `Analytics` + `AnalyticsMocks` into the test target (mirrored the existing module entries; backed up + `plutil`-validated).

### Tests
- New `AnalyticsTests` (4) live in the module and pin the `AnalyticsEvent` -> Firebase name/parameter mapping (a stable contract).

### Docs
- Added `Analytics` to the Core layer + an `app -> Analytics` edge in both dependency graphs (README + `Module-Architecture.md`), plus the catalogue, layered view, layer table, and `Modules/` tree.

## Testing
- `swift test --package-path Modules/Analytics` -> `Analytics` + `AnalyticsMocks` + `AnalyticsTests` build; 4 module tests pass.
- App builds against the module; 13 `VivaDictaTests` green (ChatViewModel + TranscriptionManager + the record->enhance->store acceptance suite, which runs through the migrated analytics call).
- Full app + extensions build green.

## Notes
- **Behavior-preserving.** Event names, parameters, and the Firebase call are unchanged; this is a relocation + access-level change + linking.
- The module has zero dependencies, so it's a clean Core leaf. None of the call-site files are in the extensions, so the move didn't touch extension wiring.