### PR TITLE
Test coverage: cloud transcription, AI clients, OAuth, networking streaming

### DIFF
--- a/Modules/AIProviders/Tests/AIProvidersTests/CopilotAPIClientTests.swift
+++ b/Modules/AIProviders/Tests/AIProvidersTests/CopilotAPIClientTests.swift
@@ -1,0 +1,216 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import Networking
+import NetworkingMocks
+import OAuth
+import Testing
+@testable import AIProviders
+import AICore
+
+/// Tests cover `CopilotAPIClient`'s non-streaming surface: `enhance`
+/// (both the Anthropic-routed `claude-` branch and the OpenAI-routed
+/// default branch, the request shape, success parsing, and the status
+/// handling the client does itself), and `fetchModels` (parsing the
+/// `data[].id` list and the fallback behaviour on garbage/failed
+/// responses).
+///
+/// `CopilotAPIClient` is a `public enum` with a `nonisolated(unsafe)
+/// static var networkService`, i.e. shared mutable state. The suite is
+/// `.serialized` so tests never race on it, and every test sets
+/// `CopilotAPIClient.networkService` at the top before exercising.
+///
+/// The streaming paths (`enhanceStreaming` and helpers) route through
+/// `networkService.bytes(for:)`, which `MockNetworkService` cannot stub
+/// (`URLSession.AsyncBytes` has no public initializer), so they are not
+/// covered here.
+@Suite("CopilotAPIClient", .serialized, .tags(.networking))
+struct CopilotAPIClientTests {
+
+    private func makeHTTPResponse(_ code: Int) -> HTTPURLResponse {
+        let url = URL(string: "\(CopilotAPIClient.baseURL)/chat/completions")!
+        return HTTPURLResponse(url: url, statusCode: code, httpVersion: nil, headerFields: nil)!
+    }
+
+    // MARK: - enhance success (OpenAI branch)
+
+    @Test func enhanceReturnsTrimmedContentForOpenAIModel() async throws {
+        let networkService = MockNetworkService()
+        CopilotAPIClient.networkService = networkService
+        let body = Data(#"{"choices":[{"message":{"content":"  enhanced output  "}}]}"#.utf8)
+        networkService.stubSendResponse = .success((body, makeHTTPResponse(200)))
+
+        let result = try await CopilotAPIClient.enhance(
+            text: "rewrite this",
+            systemPrompt: "you are a helper",
+            model: "gpt-4o",
+            copilotToken: "copilot-token"
+        )
+
+        #expect(result == "enhanced output")
+    }
+
+    // MARK: - enhance success (Anthropic branch)
+
+    @Test func enhanceReturnsTrimmedContentForClaudeModel() async throws {
+        let networkService = MockNetworkService()
+        CopilotAPIClient.networkService = networkService
+        // Copilot returns OpenAI-style choices even for Claude models.
+        let body = Data(#"{"choices":[{"message":{"content":"claude reply"}}]}"#.utf8)
+        networkService.stubSendResponse = .success((body, makeHTTPResponse(200)))
+
+        let result = try await CopilotAPIClient.enhance(
+            text: "rewrite this",
+            systemPrompt: "you are a helper",
+            model: "claude-sonnet-4-5",
+            copilotToken: "copilot-token"
+        )
+
+        #expect(result == "claude reply")
+    }
+
+    // MARK: - enhance request shape
+
+    @Test func enhanceTargetsChatCompletionsEndpointWithAuthAndChatHeaders() async throws {
+        let networkService = MockNetworkService()
+        CopilotAPIClient.networkService = networkService
+        let body = Data(#"{"choices":[{"message":{"content":"ok"}}]}"#.utf8)
+        networkService.stubSendResponse = .success((body, makeHTTPResponse(200)))
+
+        _ = try await CopilotAPIClient.enhance(
+            text: "u",
+            systemPrompt: "s",
+            model: "gpt-4o",
+            copilotToken: "copilot-token"
+        )
+
+        let request = try #require(networkService.capturedRequest)
+        #expect(request.url?.absoluteString == "\(CopilotAPIClient.baseURL)/chat/completions")
+        #expect(request.httpMethod == "POST")
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer copilot-token")
+        #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/json")
+        // A representative static chat header is forwarded.
+        #expect(request.value(forHTTPHeaderField: "Copilot-Integration-Id") == "vscode-chat")
+    }
+
+    @Test func enhanceSendsModelAndMessagesBody() async throws {
+        let networkService = MockNetworkService()
+        CopilotAPIClient.networkService = networkService
+        let body = Data(#"{"choices":[{"message":{"content":"ok"}}]}"#.utf8)
+        networkService.stubSendResponse = .success((body, makeHTTPResponse(200)))
+
+        _ = try await CopilotAPIClient.enhance(
+            text: "rewrite this",
+            systemPrompt: "you are helpful",
+            model: "gpt-4o",
+            copilotToken: "copilot-token"
+        )
+
+        let httpBody = try #require(networkService.capturedRequest?.httpBody)
+        let json = try #require(try JSONSerialization.jsonObject(with: httpBody) as? [String: Any])
+        #expect(json["model"] as? String == "gpt-4o")
+        let messages = try #require(json["messages"] as? [[String: String]])
+        #expect(messages == [
+            ["role": "system", "content": "you are helpful"],
+            ["role": "user", "content": "rewrite this"]
+        ])
+    }
+
+    // MARK: - enhance status handling
+
+    @Test func enhanceMaps429ToRateLimitCustomError() async throws {
+        let networkService = MockNetworkService()
+        CopilotAPIClient.networkService = networkService
+        networkService.stubSendResponse = .success((Data(), makeHTTPResponse(429)))
+
+        let error = try await #require(throws: EnhancementError.self) {
+            _ = try await CopilotAPIClient.enhance(
+                text: "u",
+                systemPrompt: "s",
+                model: "gpt-4o",
+                copilotToken: "copilot-token"
+            )
+        }
+        guard case let .customError(message) = error else {
+            Issue.record("Expected .customError, got \(error)")
+            return
+        }
+        #expect(message.localizedStandardContains("rate limit"))
+    }
+
+    @Test func enhanceThrowsCopilotOAuthErrorOnOtherNon2xx() async throws {
+        let networkService = MockNetworkService()
+        CopilotAPIClient.networkService = networkService
+        let body = Data(#"{"error":"unauthorized"}"#.utf8)
+        networkService.stubSendResponse = .success((body, makeHTTPResponse(401)))
+
+        let error = try await #require(throws: CopilotOAuthError.self) {
+            _ = try await CopilotAPIClient.enhance(
+                text: "u",
+                systemPrompt: "s",
+                model: "gpt-4o",
+                copilotToken: "copilot-token"
+            )
+        }
+        guard case let .tokenExchangeFailed(message) = error else {
+            Issue.record("Expected .tokenExchangeFailed, got \(error)")
+            return
+        }
+        #expect(message.hasPrefix("HTTP 401"))
+    }
+
+    // MARK: - fetchModels
+
+    @Test func fetchModelsReturnsSortedFilteredIDs() async {
+        let networkService = MockNetworkService()
+        CopilotAPIClient.networkService = networkService
+        let body = Data(#"""
+        {"data":[
+            {"id":"gpt-4o"},
+            {"id":"claude-sonnet-4-5"},
+            {"id":"text-embedding-3-small"},
+            {"id":"some-inference-model"}
+        ]}
+        """#.utf8)
+        networkService.stubSendResponse = .success((body, makeHTTPResponse(200)))
+
+        let models = await CopilotAPIClient.fetchModels(copilotToken: "copilot-token")
+
+        // Embedding and inference models are filtered out; the rest are sorted.
+        #expect(models == ["claude-sonnet-4-5", "gpt-4o"])
+    }
+
+    @Test func fetchModelsTargetsModelsEndpointWithAuth() async throws {
+        let networkService = MockNetworkService()
+        CopilotAPIClient.networkService = networkService
+        let body = Data(#"{"data":[{"id":"gpt-4o"}]}"#.utf8)
+        networkService.stubSendResponse = .success((body, makeHTTPResponse(200)))
+
+        _ = await CopilotAPIClient.fetchModels(copilotToken: "copilot-token")
+
+        let request = try #require(networkService.capturedRequest)
+        #expect(request.url?.absoluteString == "\(CopilotAPIClient.baseURL)/models")
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer copilot-token")
+    }
+
+    @Test func fetchModelsFallsBackToDefaultModelOnGarbageResponse() async {
+        let networkService = MockNetworkService()
+        CopilotAPIClient.networkService = networkService
+        let body = Data(#"{"unexpected":"shape"}"#.utf8)
+        networkService.stubSendResponse = .success((body, makeHTTPResponse(200)))
+
+        let models = await CopilotAPIClient.fetchModels(copilotToken: "copilot-token")
+
+        #expect(models == [CopilotAPIClient.defaultModel])
+    }
+
+    @Test func fetchModelsFallsBackToDefaultModelOnTransportError() async {
+        let networkService = MockNetworkService()
+        CopilotAPIClient.networkService = networkService
+        networkService.stubSendResponse = .failure(URLError(.notConnectedToInternet))
+
+        let models = await CopilotAPIClient.fetchModels(copilotToken: "copilot-token")
+
+        #expect(models == [CopilotAPIClient.defaultModel])
+    }
+}

--- a/Modules/AIProviders/Tests/AIProvidersTests/GeminiAPIClientTests.swift
+++ b/Modules/AIProviders/Tests/AIProvidersTests/GeminiAPIClientTests.swift
@@ -1,0 +1,304 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import Networking
+import NetworkingMocks
+import os
+import Testing
+import AIProviders
+import AICore
+import OAuth
+
+/// Tests cover `GeminiAPIClient.enhance` (the non-streaming Cloud Code
+/// Assist path that uses `networkService.send`): the outgoing request
+/// shape (endpoint, POST method, `Authorization: Bearer` OAuth header,
+/// Cloud Code Assist body), success parsing for both the wrapped
+/// (`response.candidates`) and raw (`candidates`) shapes, and the
+/// status-code / malformed-body error mapping.
+///
+/// `enhance` passes `Set<Int>.acceptAny` as the acceptable status codes,
+/// so `MockNetworkService.validateStatus` never throws on a non-2xx
+/// response - the client inspects `httpResponse.statusCode` itself, which
+/// is exactly the behavior these tests exercise.
+///
+/// The streaming paths (`enhanceStreaming`, `chatStreaming`, and `chat`
+/// which delegates to `chatStreaming`) all call `networkService.bytes(for:)`,
+/// which `MockNetworkService` cannot stub (it throws `StubNotSetError`), so
+/// they are intentionally not covered here.
+@Suite("GeminiAPIClient", .tags(.networking))
+struct GeminiAPIClientTests {
+
+    private let endpoint = "https://cloudcode-pa.googleapis.com/v1internal:generateContent"
+
+    private func makeHTTPResponse(_ code: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: URL(string: endpoint)!,
+            statusCode: code,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+    }
+
+    /// Builds a Cloud Code Assist success body wrapping the standard Gemini
+    /// `candidates -> content -> parts -> text` response under `response`.
+    private func wrappedSuccessBody(text: String) -> Data {
+        Data(#"""
+        {"response":{"candidates":[{"content":{"parts":[{"text":"\#(text)"}]}}]}}
+        """#.utf8)
+    }
+
+    // MARK: - enhance success
+
+    @Test func enhanceReturnsTrimmedTextFromWrappedResponse() async throws {
+        let networkService = MockNetworkService()
+        networkService.stubSendResponse = .success(
+            (wrappedSuccessBody(text: "  enhanced output  "), makeHTTPResponse(200))
+        )
+
+        let result = try await GeminiAPIClient.enhance(
+            text: "raw",
+            systemPrompt: "system",
+            model: "gemini-3.5-flash",
+            accessToken: "ya29.token",
+            projectId: nil,
+            networkService: networkService
+        )
+
+        // Leading/trailing whitespace is trimmed.
+        #expect(result == "enhanced output")
+    }
+
+    @Test func enhanceParsesUnwrappedCandidatesShape() async throws {
+        // Some responses arrive without the Cloud Code Assist `response`
+        // wrapper; the client falls back to reading `candidates` at the top
+        // level.
+        let networkService = MockNetworkService()
+        let body = Data(#"{"candidates":[{"content":{"parts":[{"text":"top level"}]}}]}"#.utf8)
+        networkService.stubSendResponse = .success((body, makeHTTPResponse(200)))
+
+        let result = try await GeminiAPIClient.enhance(
+            text: "raw",
+            systemPrompt: "system",
+            model: "gemini-3.5-flash",
+            accessToken: "ya29.token",
+            projectId: nil,
+            networkService: networkService
+        )
+
+        #expect(result == "top level")
+    }
+
+    // MARK: - request shape
+
+    @Test func enhanceTargetsCloudCodeAssistEndpointWithPost() async throws {
+        let networkService = MockNetworkService()
+        networkService.stubSendResponse = .success(
+            (wrappedSuccessBody(text: "ok"), makeHTTPResponse(200))
+        )
+
+        _ = try await GeminiAPIClient.enhance(
+            text: "raw",
+            systemPrompt: "system",
+            model: "gemini-3.5-flash",
+            accessToken: "ya29.token",
+            projectId: nil,
+            networkService: networkService
+        )
+
+        let request = try #require(networkService.capturedRequest)
+        #expect(request.url?.absoluteString == endpoint)
+        #expect(request.httpMethod == "POST")
+    }
+
+    @Test func enhanceSendsOAuthBearerAuthorizationHeader() async throws {
+        let networkService = MockNetworkService()
+        networkService.stubSendResponse = .success(
+            (wrappedSuccessBody(text: "ok"), makeHTTPResponse(200))
+        )
+
+        _ = try await GeminiAPIClient.enhance(
+            text: "raw",
+            systemPrompt: "system",
+            model: "gemini-3.5-flash",
+            accessToken: "ya29.token",
+            projectId: nil,
+            networkService: networkService
+        )
+
+        let request = try #require(networkService.capturedRequest)
+        // The OAuth access token is transmitted as a Bearer Authorization
+        // header (not as an `x-goog-api-key` header or `?key=` query param).
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer ya29.token")
+        #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/json")
+    }
+
+    @Test func enhanceSendsCloudCodeAssistBodyWithPromptAndContents() async throws {
+        let networkService = MockNetworkService()
+        networkService.stubSendResponse = .success(
+            (wrappedSuccessBody(text: "ok"), makeHTTPResponse(200))
+        )
+
+        _ = try await GeminiAPIClient.enhance(
+            text: "rewrite this",
+            systemPrompt: "you are a helper",
+            model: "gemini-2.5-pro",
+            accessToken: "ya29.token",
+            projectId: "proj-123",
+            networkService: networkService
+        )
+
+        let httpBody = try #require(networkService.capturedRequest?.httpBody)
+        let json = try #require(try JSONSerialization.jsonObject(with: httpBody) as? [String: Any])
+        #expect(json["model"] as? String == "gemini-2.5-pro")
+        #expect(json["userAgent"] as? String == "vivadicta")
+        // projectId, when present, is carried at the top level of the body.
+        #expect(json["project"] as? String == "proj-123")
+
+        let nestedRequest = try #require(json["request"] as? [String: Any])
+
+        // The user text becomes the first content part.
+        let contents = try #require(nestedRequest["contents"] as? [[String: Any]])
+        let firstContent = try #require(contents.first)
+        #expect(firstContent["role"] as? String == "user")
+        let contentParts = try #require(firstContent["parts"] as? [[String: Any]])
+        #expect(contentParts.first?["text"] as? String == "rewrite this")
+
+        // The system prompt becomes the systemInstruction part.
+        let systemInstruction = try #require(nestedRequest["systemInstruction"] as? [String: Any])
+        let systemParts = try #require(systemInstruction["parts"] as? [[String: Any]])
+        #expect(systemParts.first?["text"] as? String == "you are a helper")
+    }
+
+    @Test func enhanceOmitsProjectWhenProjectIdNil() async throws {
+        let networkService = MockNetworkService()
+        networkService.stubSendResponse = .success(
+            (wrappedSuccessBody(text: "ok"), makeHTTPResponse(200))
+        )
+
+        _ = try await GeminiAPIClient.enhance(
+            text: "raw",
+            systemPrompt: "system",
+            model: "gemini-3.5-flash",
+            accessToken: "ya29.token",
+            projectId: nil,
+            networkService: networkService
+        )
+
+        let httpBody = try #require(networkService.capturedRequest?.httpBody)
+        let json = try #require(try JSONSerialization.jsonObject(with: httpBody) as? [String: Any])
+        #expect(json["project"] == nil)
+    }
+
+    // MARK: - status-code error mapping
+
+    @Test func enhanceThrowsTokenExchangeFailedOnNon2xx() async throws {
+        let networkService = MockNetworkService()
+        let body = Data(#"{"error":"unauthorized"}"#.utf8)
+        networkService.stubSendResponse = .success((body, makeHTTPResponse(401)))
+
+        let error = try await #require(throws: OAuthError.self) {
+            _ = try await GeminiAPIClient.enhance(
+                text: "raw",
+                systemPrompt: "system",
+                model: "gemini-3.5-flash",
+                accessToken: "ya29.token",
+                projectId: nil,
+                networkService: networkService
+            )
+        }
+        guard case let .tokenExchangeFailed(reason) = error else {
+            Issue.record("Expected .tokenExchangeFailed, got \(error)")
+            return
+        }
+        #expect(reason.hasPrefix("HTTP 401"))
+    }
+
+    @Test func enhanceMaps429WithoutErrorMessageToRateLimitExceeded() async throws {
+        let networkService = MockNetworkService()
+        // A 429 body with no parseable `error.message` falls through to the
+        // generic rate-limit error.
+        networkService.stubSendResponse = .success((Data(), makeHTTPResponse(429)))
+
+        let error = try await #require(throws: EnhancementError.self) {
+            _ = try await GeminiAPIClient.enhance(
+                text: "raw",
+                systemPrompt: "system",
+                model: "gemini-3.5-flash",
+                accessToken: "ya29.token",
+                projectId: nil,
+                networkService: networkService
+            )
+        }
+        guard case .rateLimitExceeded = error else {
+            Issue.record("Expected .rateLimitExceeded, got \(error)")
+            return
+        }
+    }
+
+    @Test func enhanceMaps429WithErrorMessageToCustomError() async throws {
+        let networkService = MockNetworkService()
+        let body = Data(#"{"error":{"message":"quota exceeded for project"}}"#.utf8)
+        networkService.stubSendResponse = .success((body, makeHTTPResponse(429)))
+
+        let error = try await #require(throws: EnhancementError.self) {
+            _ = try await GeminiAPIClient.enhance(
+                text: "raw",
+                systemPrompt: "system",
+                model: "gemini-3.5-flash",
+                accessToken: "ya29.token",
+                projectId: nil,
+                networkService: networkService
+            )
+        }
+        guard case let .customError(message) = error else {
+            Issue.record("Expected .customError, got \(error)")
+            return
+        }
+        #expect(message.contains("quota exceeded for project"))
+    }
+
+    // MARK: - malformed success body
+
+    @Test func enhanceThrowsInvalidResponseOnUndecodableBody() async throws {
+        let networkService = MockNetworkService()
+        // A 200 with a non-JSON body cannot be parsed.
+        networkService.stubSendResponse = .success((Data("not json".utf8), makeHTTPResponse(200)))
+
+        let error = try await #require(throws: OAuthError.self) {
+            _ = try await GeminiAPIClient.enhance(
+                text: "raw",
+                systemPrompt: "system",
+                model: "gemini-3.5-flash",
+                accessToken: "ya29.token",
+                projectId: nil,
+                networkService: networkService
+            )
+        }
+        guard case .invalidResponse = error else {
+            Issue.record("Expected .invalidResponse, got \(error)")
+            return
+        }
+    }
+
+    @Test func enhanceThrowsInvalidResponseOnEmptyCandidates() async throws {
+        let networkService = MockNetworkService()
+        // Valid JSON but with no candidates to extract text from.
+        let body = Data(#"{"response":{"candidates":[]}}"#.utf8)
+        networkService.stubSendResponse = .success((body, makeHTTPResponse(200)))
+
+        let error = try await #require(throws: OAuthError.self) {
+            _ = try await GeminiAPIClient.enhance(
+                text: "raw",
+                systemPrompt: "system",
+                model: "gemini-3.5-flash",
+                accessToken: "ya29.token",
+                projectId: nil,
+                networkService: networkService
+            )
+        }
+        guard case .invalidResponse = error else {
+            Issue.record("Expected .invalidResponse, got \(error)")
+            return
+        }
+    }
+}

--- a/Modules/CloudTranscription/Sources/CloudTranscription/GeminiTranscriptionService.swift
+++ b/Modules/CloudTranscription/Sources/CloudTranscription/GeminiTranscriptionService.swift
@@ -149,19 +149,22 @@ public struct GeminiTranscriptionService: TranscriptionService, Sendable {
         let data: String
     }
 
-    private struct GeminiResponse: Codable {
+    // Response types are `internal` (not `private`) so consumer tests can
+    // construct a decoded `GeminiResponse` to stub `NetworkService.sendJSON`,
+    // which returns an already-decoded value rather than raw `Data`.
+    struct GeminiResponse: Codable {
         let candidates: [GeminiCandidate]
     }
 
-    private struct GeminiCandidate: Codable {
+    struct GeminiCandidate: Codable {
         let content: GeminiResponseContent
     }
 
-    private struct GeminiResponseContent: Codable {
+    struct GeminiResponseContent: Codable {
         let parts: [GeminiResponsePart]
     }
 
-    private struct GeminiResponsePart: Codable {
+    struct GeminiResponsePart: Codable {
         let text: String
     }
 }

--- a/Modules/CloudTranscription/Tests/CloudTranscriptionTests/AssemblyAITranscriptionServiceTests.swift
+++ b/Modules/CloudTranscription/Tests/CloudTranscriptionTests/AssemblyAITranscriptionServiceTests.swift
@@ -1,0 +1,367 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import Networking
+import NetworkingMocks
+import Testing
+@testable import CloudTranscription
+import TranscriptionCore
+
+/// Tests exercise `AssemblyAITranscriptionService` end-to-end with a stubbed
+/// `MockNetworkService`. AssemblyAI uses a three-stage **upload -> create ->
+/// poll** job flow: the audio is uploaded to `/v2/upload`, a transcript job is
+/// created via `/v2/transcript`, then the job is polled at
+/// `/v2/transcript/{id}` until it reports `completed`. The `create` and `poll`
+/// stages share `send(_:)`, so the suite drives them via
+/// `MockNetworkService.stubSendResponses` (a FIFO queue).
+///
+/// Verifies the happy path, the endpoint/header/body shape of each stage, the
+/// language / diarization / vocabulary branches, and the error paths (missing
+/// key, upload failure, undecodable create, poll `error`). Every poll response
+/// here resolves on the first iteration (`completed`/`error`), so no test waits
+/// on the real poll interval.
+@Suite(.tags(.networking))
+struct AssemblyAITranscriptionServiceTests {
+
+    // MARK: - Test Helpers
+
+    private func makeAudioFile() throws -> URL {
+        let url = URL.temporaryDirectory.appending(path: "\(UUID().uuidString).wav")
+        try Data([0x52, 0x49, 0x46, 0x46]).write(to: url) // "RIFF"
+        return url
+    }
+
+    private func httpResponse(_ statusCode: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: URL(string: "https://api.assemblyai.com/v2/transcript")!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/json"]
+        )!
+    }
+
+    private func jsonData(_ object: [String: Any]) throws -> Data {
+        try JSONSerialization.data(withJSONObject: object)
+    }
+
+    private func makeService(
+        networkService: MockNetworkService,
+        apiKey: String = "aai-test-key",
+        modelName: String = "universal-3-pro",
+        language: String = "auto",
+        vocabulary: [String] = [],
+        isSpeakerDiarizationEnabled: Bool = false
+    ) -> AssemblyAITranscriptionService {
+        AssemblyAITranscriptionService(
+            config: .init(
+                apiKey: apiKey,
+                modelName: modelName,
+                language: language,
+                vocabulary: vocabulary,
+                isSpeakerDiarizationEnabled: isSpeakerDiarizationEnabled
+            ),
+            networkService: networkService
+        )
+    }
+
+    /// Stubs a successful upload -> create -> poll(completed) sequence.
+    /// `transcript` is the transcript `text`; pass `utterances` to exercise the
+    /// speaker-diarization branch.
+    private func stubHappyFlow(
+        on networkService: MockNetworkService,
+        transcript: String = "hello world",
+        utterances: [[String: Any]]? = nil
+    ) throws {
+        networkService.stubUploadResponse = .success((
+            try jsonData(["upload_url": "https://cdn.assemblyai.com/upload/abc"]),
+            httpResponse(200)
+        ))
+        var pollCompleted: [String: Any] = [
+            "status": "completed",
+            "text": transcript
+        ]
+        if let utterances {
+            pollCompleted["utterances"] = utterances
+        }
+        networkService.stubSendResponses = [
+            .success((try jsonData(["id": "transcript-1"]), httpResponse(200))),   // create
+            .success((try jsonData(pollCompleted), httpResponse(200)))             // poll -> completed
+        ]
+    }
+
+    // MARK: - Happy path
+
+    @Test func successReturnsTranscribedText() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService, transcript: "assemblyai hello")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        let result = try await sut.transcribe(audioURL: audio)
+
+        #expect(result.text == "assemblyai hello")
+        #expect(result.isSpeakerAttributed == false)
+        #expect(networkService.uploadCallCount == 1)
+        #expect(networkService.sendCallCount == 2) // create + one poll
+    }
+
+    @Test func speakerDiarizationReturnsAttributedText() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(
+            on: networkService,
+            transcript: "ignored when utterances present",
+            utterances: [
+                ["text": "hi there", "speaker": "A"],
+                ["text": "hello back", "speaker": "B"]
+            ]
+        )
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, isSpeakerDiarizationEnabled: true)
+
+        let result = try await sut.transcribe(audioURL: audio)
+
+        #expect(result.isSpeakerAttributed == true)
+        #expect(result.text.contains("hi there"))
+        #expect(result.text.contains("hello back"))
+    }
+
+    // MARK: - Request shape (sequence / endpoints / headers)
+
+    @Test func requestSequenceTargetsUploadCreatePollEndpoints() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService)
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        #expect(networkService.capturedRequests.count == 3)
+        let upload = networkService.capturedRequests[0]
+        let create = networkService.capturedRequests[1]
+        let poll = networkService.capturedRequests[2]
+        #expect(upload.url?.absoluteString == "https://api.assemblyai.com/v2/upload")
+        #expect(upload.httpMethod == "POST")
+        #expect(create.url?.absoluteString == "https://api.assemblyai.com/v2/transcript")
+        #expect(create.httpMethod == "POST")
+        #expect(poll.url?.absoluteString == "https://api.assemblyai.com/v2/transcript/transcript-1")
+        #expect(poll.httpMethod == "GET")
+    }
+
+    @Test func everyRequestSendsRawAuthorizationKey() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService)
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, apiKey: "aai-abc123")
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        for request in networkService.capturedRequests {
+            // AssemblyAI uses the raw key (no "Bearer" prefix).
+            #expect(request.value(forHTTPHeaderField: "Authorization") == "aai-abc123")
+        }
+    }
+
+    @Test func uploadSendsOctetStreamContentType() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService)
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        #expect(networkService.capturedRequests[0].value(forHTTPHeaderField: "Content-Type") == "application/octet-stream")
+    }
+
+    @Test func createSendsJSONContentType() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService)
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        #expect(networkService.capturedRequests[1].value(forHTTPHeaderField: "Content-Type") == "application/json")
+    }
+
+    // MARK: - Create body (audio_url / models / language / diarization / vocabulary)
+
+    private func createBody(_ networkService: MockNetworkService) throws -> [String: Any] {
+        let body = try #require(networkService.capturedRequests[1].httpBody)
+        return try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+    }
+
+    @Test func createBodyCarriesUploadedAudioUrlAndDefaultModels() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService)
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, modelName: "universal-3-pro")
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let body = try createBody(networkService)
+        #expect(body["audio_url"] as? String == "https://cdn.assemblyai.com/upload/abc")
+        #expect(body["speech_models"] as? [String] == ["universal-3-pro", "universal-2"])
+    }
+
+    @Test func createBodyUsesSpecifiedModelWhenNotDefault() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService)
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, modelName: "universal-2")
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        #expect(try createBody(networkService)["speech_models"] as? [String] == ["universal-2"])
+    }
+
+    @Test func createBodyEnablesLanguageDetectionWhenAuto() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService)
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, language: "auto")
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let body = try createBody(networkService)
+        #expect(body["language_detection"] as? Bool == true)
+        #expect(body["language_code"] == nil)
+    }
+
+    @Test func createBodyPinsLanguageCodeWhenSpecified() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService)
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, language: "fr")
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let body = try createBody(networkService)
+        #expect(body["language_code"] as? String == "fr")
+        #expect(body["language_detection"] == nil)
+    }
+
+    @Test func createBodyEnablesSpeakerLabelsWhenDiarizationOn() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService)
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, isSpeakerDiarizationEnabled: true)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        #expect(try createBody(networkService)["speaker_labels"] as? Bool == true)
+    }
+
+    @Test func createBodyOmitsSpeakerLabelsWhenDiarizationOff() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService)
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, isSpeakerDiarizationEnabled: false)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        #expect(try createBody(networkService)["speaker_labels"] == nil)
+    }
+
+    @Test func createBodyIncludesVocabularyWhenProvided() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService)
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, vocabulary: ["SwiftUI", "Kubernetes"])
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        #expect(try createBody(networkService)["keyterms_prompt"] as? [String] == ["SwiftUI", "Kubernetes"])
+    }
+
+    @Test func createBodyOmitsVocabularyWhenEmpty() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService)
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, vocabulary: [])
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        #expect(try createBody(networkService)["keyterms_prompt"] == nil)
+    }
+
+    // MARK: - Validation / error paths
+
+    @Test func missingAPIKeyThrowsBeforeAnyRequest() async throws {
+        let networkService = MockNetworkService()
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, apiKey: "")
+
+        await #expect(throws: CloudTranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: audio)
+        }
+        #expect(networkService.uploadCallCount == 0)
+        #expect(networkService.sendCallCount == 0)
+    }
+
+    @Test func uploadStageNonSuccessStatusThrowsApiRequestFailed() async throws {
+        let networkService = MockNetworkService()
+        networkService.stubUploadResponse = .success((
+            Data(#"{"error":"bad key"}"#.utf8),
+            httpResponse(401)
+        ))
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        let error = try await #require(throws: CloudTranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: audio)
+        }
+        guard case let .apiRequestFailed(statusCode, message) = error else {
+            Issue.record("expected apiRequestFailed, got \(error)")
+            return
+        }
+        #expect(statusCode == 401)
+        #expect(message.contains("bad key"))
+        #expect(networkService.sendCallCount == 0, "create/poll must not run after upload fails")
+    }
+
+    @Test func undecodableCreateResponseThrowsNoTranscriptionReturned() async throws {
+        let networkService = MockNetworkService()
+        networkService.stubUploadResponse = .success((
+            try jsonData(["upload_url": "https://cdn.assemblyai.com/upload/abc"]),
+            httpResponse(200)
+        ))
+        networkService.stubSendResponses = [
+            .success((Data(#"{"unexpected":true}"#.utf8), httpResponse(200))) // create: no "id"
+        ]
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        let error = try await #require(throws: CloudTranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: audio)
+        }
+        guard case .noTranscriptionReturned = error else {
+            Issue.record("expected noTranscriptionReturned, got \(error)")
+            return
+        }
+        #expect(networkService.sendCallCount == 1, "poll must not run when create can't be decoded")
+    }
+
+    @Test func pollStatusErrorThrowsApiRequestFailed() async throws {
+        let networkService = MockNetworkService()
+        networkService.stubUploadResponse = .success((
+            try jsonData(["upload_url": "https://cdn.assemblyai.com/upload/abc"]),
+            httpResponse(200)
+        ))
+        networkService.stubSendResponses = [
+            .success((try jsonData(["id": "transcript-1"]), httpResponse(200))),                          // create
+            .success((try jsonData(["status": "error", "error": "unsupported language"]), httpResponse(200))) // poll -> error
+        ]
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        let error = try await #require(throws: CloudTranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: audio)
+        }
+        guard case let .apiRequestFailed(statusCode, message) = error else {
+            Issue.record("expected apiRequestFailed, got \(error)")
+            return
+        }
+        #expect(statusCode == -1)
+        #expect(message.contains("unsupported language"))
+    }
+}

--- a/Modules/CloudTranscription/Tests/CloudTranscriptionTests/CartesiaTranscriptionServiceTests.swift
+++ b/Modules/CloudTranscription/Tests/CloudTranscriptionTests/CartesiaTranscriptionServiceTests.swift
@@ -1,0 +1,201 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import Networking
+import NetworkingMocks
+import Testing
+@testable import CloudTranscription
+import TranscriptionCore
+
+/// Tests exercise `CartesiaTranscriptionService` end-to-end with a stubbed
+/// `MockNetworkService`. Verifies request shape (URL, method, headers,
+/// multipart body) and response handling (success, non-2xx, undecodable JSON).
+///
+/// Mirrors the structure of `OpenAITranscriptionServiceTests`. Retry-path
+/// tests are intentionally skipped here - retry semantics belong on
+/// `NetworkRetry`'s own tests.
+@Suite(.tags(.networking))
+struct CartesiaTranscriptionServiceTests {
+
+    // MARK: - Test Helpers
+
+    private func makeAudioFile() throws -> URL {
+        let url = URL.temporaryDirectory.appending(path: "\(UUID().uuidString).wav")
+        try Data([0x52, 0x49, 0x46, 0x46]).write(to: url) // "RIFF"
+        return url
+    }
+
+    private func makeHTTPResponse(_ statusCode: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: URL(string: "https://api.cartesia.ai/stt")!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/json"]
+        )!
+    }
+
+    private func stubSuccess(on networkService: MockNetworkService, text: String) {
+        let body = Data(#"{"text":"\#(text)"}"#.utf8)
+        networkService.stubUploadResponse = .success((body, makeHTTPResponse(200)))
+    }
+
+    private func makeService(
+        networkService: MockNetworkService,
+        apiKey: String = "csk-test-key",
+        modelName: String = "ink-whisper",
+        language: String = "en"
+    ) -> CartesiaTranscriptionService {
+        CartesiaTranscriptionService(
+            config: .init(
+                apiKey: apiKey,
+                modelName: modelName,
+                language: language
+            ),
+            networkService: networkService
+        )
+    }
+
+    // MARK: - Success path
+
+    @Test func successReturnsTranscribedText() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "cartesia hello")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        let result = try await sut.transcribe(audioURL: audio)
+
+        #expect(result.text == "cartesia hello")
+        #expect(result.isSpeakerAttributed == false)
+        #expect(networkService.uploadCallCount == 1)
+    }
+
+    // MARK: - Request shape
+
+    @Test func requestTargetsCartesiaSTTEndpoint() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let req = try #require(networkService.capturedRequest)
+        #expect(req.url?.absoluteString == "https://api.cartesia.ai/stt")
+        #expect(req.httpMethod == "POST")
+    }
+
+    @Test func requestSendsBearerAuthorizationHeader() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, apiKey: "csk-abc123")
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let req = try #require(networkService.capturedRequest)
+        #expect(req.value(forHTTPHeaderField: "Authorization") == "Bearer csk-abc123")
+    }
+
+    @Test func requestSendsCartesiaVersionHeader() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let req = try #require(networkService.capturedRequest)
+        #expect(req.value(forHTTPHeaderField: "Cartesia-Version") == CartesiaTranscriptionService.cartesiaVersion)
+    }
+
+    @Test func requestSendsMultipartContentTypeWithBoundary() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let req = try #require(networkService.capturedRequest)
+        let contentType = try #require(req.value(forHTTPHeaderField: "Content-Type"))
+        #expect(contentType.hasPrefix("multipart/form-data; boundary=Boundary-"))
+    }
+
+    @Test func bodyContainsModelAndLanguageFields() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, modelName: "ink-whisper", language: "fr")
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let body = try #require(networkService.capturedBody)
+        let bodyString = try #require(String(data: body, encoding: .utf8))
+        // Regex form ensures each value immediately follows its multipart field
+        // header, so a misordered body can't pass by coincidence.
+        #expect(bodyString.range(of: "name=\"model\"\\s*\\r\\n\\r\\nink-whisper", options: .regularExpression) != nil)
+        #expect(bodyString.range(of: "name=\"language\"\\s*\\r\\n\\r\\nfr", options: .regularExpression) != nil)
+    }
+
+    // MARK: - Validation / short-circuit
+
+    @Test func missingAPIKeyThrowsBeforeMakingRequest() async throws {
+        let networkService = MockNetworkService()
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, apiKey: "")
+
+        await #expect(throws: CloudTranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: audio)
+        }
+        #expect(networkService.uploadCallCount == 0, "no network call should be made when API key is empty")
+    }
+
+    @Test func missingAudioFileThrowsAudioFileNotFound() async {
+        let networkService = MockNetworkService()
+        let audio = URL.temporaryDirectory.appending(path: "definitely-not-a-real-file-\(UUID()).wav")
+        let sut = makeService(networkService: networkService)
+
+        await #expect(throws: CloudTranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: audio)
+        }
+    }
+
+    // MARK: - Response handling
+
+    @Test func nonSuccessStatusThrowsApiRequestFailed() async throws {
+        // 401 is not retried (only 429 + 5xx are), so this throws immediately.
+        let networkService = MockNetworkService()
+        networkService.stubUploadResponse = .success((
+            Data(#"{"error":"invalid key"}"#.utf8),
+            makeHTTPResponse(401)
+        ))
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        let error = try await #require(throws: CloudTranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: audio)
+        }
+        guard case let .apiRequestFailed(statusCode, message) = error else {
+            Issue.record("expected CloudTranscriptionError.apiRequestFailed, got \(error)")
+            return
+        }
+        #expect(statusCode == 401)
+        #expect(message.contains("invalid key"))
+    }
+
+    @Test func undecodableJSONOn200ThrowsNoTranscriptionReturned() async throws {
+        let networkService = MockNetworkService()
+        networkService.stubUploadResponse = .success((Data("not json".utf8), makeHTTPResponse(200)))
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        let error = try await #require(throws: CloudTranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: audio)
+        }
+        guard case .noTranscriptionReturned = error else {
+            Issue.record("expected noTranscriptionReturned, got \(error)")
+            return
+        }
+    }
+}

--- a/Modules/CloudTranscription/Tests/CloudTranscriptionTests/CohereTranscriptionServiceTests.swift
+++ b/Modules/CloudTranscription/Tests/CloudTranscriptionTests/CohereTranscriptionServiceTests.swift
@@ -1,0 +1,188 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import Networking
+import NetworkingMocks
+import Testing
+@testable import CloudTranscription
+import TranscriptionCore
+
+/// Tests exercise `CohereTranscriptionService` end-to-end with a stubbed
+/// `MockNetworkService`. Verifies request shape (URL, method, headers,
+/// multipart body) and response handling (success, non-2xx, undecodable JSON).
+///
+/// Mirrors the structure of `OpenAITranscriptionServiceTests`. Unlike OpenAI/Groq,
+/// Cohere always sends a `language` field (the caller normalizes "auto" to a
+/// supported default before constructing the config), so there's no
+/// omit-language path to test here. Retry-path tests are intentionally skipped -
+/// retry semantics belong on `NetworkRetry`'s own tests.
+@Suite(.tags(.networking))
+struct CohereTranscriptionServiceTests {
+
+    // MARK: - Test Helpers
+
+    private func makeAudioFile() throws -> URL {
+        let url = URL.temporaryDirectory.appending(path: "\(UUID().uuidString).wav")
+        try Data([0x52, 0x49, 0x46, 0x46]).write(to: url) // "RIFF"
+        return url
+    }
+
+    private func makeHTTPResponse(_ statusCode: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: URL(string: "https://api.cohere.com/v2/audio/transcriptions")!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/json"]
+        )!
+    }
+
+    private func stubSuccess(on networkService: MockNetworkService, text: String) {
+        let body = Data(#"{"text":"\#(text)"}"#.utf8)
+        networkService.stubUploadResponse = .success((body, makeHTTPResponse(200)))
+    }
+
+    private func makeService(
+        networkService: MockNetworkService,
+        apiKey: String = "co-test-key",
+        modelName: String = "diarize-v1",
+        language: String = "en"
+    ) -> CohereTranscriptionService {
+        CohereTranscriptionService(
+            config: .init(apiKey: apiKey, modelName: modelName, language: language),
+            networkService: networkService
+        )
+    }
+
+    // MARK: - Success path
+
+    @Test func successReturnsTranscribedText() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "cohere hello")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        let result = try await sut.transcribe(audioURL: audio)
+
+        #expect(result.text == "cohere hello")
+        #expect(result.isSpeakerAttributed == false)
+        #expect(networkService.uploadCallCount == 1)
+    }
+
+    // MARK: - Request shape
+
+    @Test func requestTargetsCohereTranscriptionsEndpoint() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let req = try #require(networkService.capturedRequest)
+        #expect(req.url?.absoluteString == "https://api.cohere.com/v2/audio/transcriptions")
+        #expect(req.httpMethod == "POST")
+    }
+
+    @Test func requestSendsBearerAuthorizationHeader() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, apiKey: "co-abc123")
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let req = try #require(networkService.capturedRequest)
+        #expect(req.value(forHTTPHeaderField: "Authorization") == "Bearer co-abc123")
+    }
+
+    @Test func requestSendsMultipartContentTypeWithBoundary() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let req = try #require(networkService.capturedRequest)
+        let contentType = try #require(req.value(forHTTPHeaderField: "Content-Type"))
+        #expect(contentType.hasPrefix("multipart/form-data; boundary=Boundary-"))
+    }
+
+    @Test func bodyContainsModelLanguageAndTemperatureFields() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, modelName: "diarize-v1", language: "fr")
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let body = try #require(networkService.capturedBody)
+        let bodyString = try #require(String(data: body, encoding: .utf8))
+        // Regex form (rather than separate `contains` checks) ensures each
+        // value immediately follows its multipart field header, so a
+        // misordered body can't pass by coincidence.
+        #expect(bodyString.range(of: "name=\"model\"\\s*\\r\\n\\r\\ndiarize-v1", options: .regularExpression) != nil)
+        #expect(bodyString.range(of: "name=\"language\"\\s*\\r\\n\\r\\nfr", options: .regularExpression) != nil)
+        #expect(bodyString.range(of: "name=\"temperature\"\\s*\\r\\n\\r\\n0", options: .regularExpression) != nil)
+    }
+
+    // MARK: - Validation / short-circuit
+
+    @Test func missingAPIKeyThrowsBeforeMakingRequest() async throws {
+        let networkService = MockNetworkService()
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, apiKey: "")
+
+        await #expect(throws: CloudTranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: audio)
+        }
+        #expect(networkService.uploadCallCount == 0, "no network call should be made when API key is empty")
+    }
+
+    @Test func missingAudioFileThrowsAudioFileNotFound() async {
+        let networkService = MockNetworkService()
+        let audio = URL.temporaryDirectory.appending(path: "definitely-not-a-real-file-\(UUID()).wav")
+        let sut = makeService(networkService: networkService)
+
+        await #expect(throws: CloudTranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: audio)
+        }
+    }
+
+    // MARK: - Response handling
+
+    @Test func nonSuccessStatusThrowsApiRequestFailed() async throws {
+        let networkService = MockNetworkService()
+        networkService.stubUploadResponse = .success((
+            Data(#"{"error":"invalid key"}"#.utf8),
+            makeHTTPResponse(401)
+        ))
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        let error = try await #require(throws: CloudTranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: audio)
+        }
+        guard case let .apiRequestFailed(statusCode, message) = error else {
+            Issue.record("expected CloudTranscriptionError.apiRequestFailed, got \(error)")
+            return
+        }
+        #expect(statusCode == 401)
+        #expect(message.contains("invalid key"))
+    }
+
+    @Test func undecodableJSONOn200ThrowsNoTranscriptionReturned() async throws {
+        let networkService = MockNetworkService()
+        networkService.stubUploadResponse = .success((Data("not json".utf8), makeHTTPResponse(200)))
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        let error = try await #require(throws: CloudTranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: audio)
+        }
+        guard case .noTranscriptionReturned = error else {
+            Issue.record("expected noTranscriptionReturned, got \(error)")
+            return
+        }
+    }
+}

--- a/Modules/CloudTranscription/Tests/CloudTranscriptionTests/CustomTranscriptionServiceTests.swift
+++ b/Modules/CloudTranscription/Tests/CloudTranscriptionTests/CustomTranscriptionServiceTests.swift
@@ -1,0 +1,227 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import Networking
+import NetworkingMocks
+import Testing
+@testable import CloudTranscription
+import TranscriptionCore
+
+/// Tests exercise `CustomTranscriptionService` end-to-end with a stubbed
+/// `MockNetworkService`. Verifies request shape (URL, method, headers,
+/// multipart body) and response handling (success, non-2xx, undecodable
+/// JSON).
+///
+/// Unlike the fixed-provider services, this service builds its endpoint from
+/// `config.apiEndpoint`, so the endpoint assertions match whatever base URL
+/// the test config supplies. The API key is optional - the service simply
+/// omits the `Authorization` header when no key is present, so there is no
+/// "missing API key throws" short-circuit to cover here.
+///
+/// Mirrors the structure of `OpenAITranscriptionServiceTests`. Retry-path
+/// tests are intentionally skipped here - retry semantics belong on
+/// `NetworkRetry`'s own tests.
+@Suite(.tags(.networking))
+struct CustomTranscriptionServiceTests {
+
+    // MARK: - Test Helpers
+
+    private static let endpoint = "https://example.com/v1/audio/transcriptions"
+
+    private func makeAudioFile() throws -> URL {
+        let url = URL.temporaryDirectory.appending(path: "\(UUID().uuidString).wav")
+        try Data([0x52, 0x49, 0x46, 0x46]).write(to: url) // "RIFF"
+        return url
+    }
+
+    private func makeHTTPResponse(_ statusCode: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: URL(string: Self.endpoint)!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/json"]
+        )!
+    }
+
+    private func stubSuccess(on networkService: MockNetworkService, text: String) {
+        let body = Data(#"{"text":"\#(text)","language":"en","duration":0.5}"#.utf8)
+        networkService.stubUploadResponse = .success((body, makeHTTPResponse(200)))
+    }
+
+    private func makeService(
+        networkService: MockNetworkService,
+        apiEndpoint: String = endpoint,
+        apiKey: String? = "custom-test-key",
+        modelName: String = "whisper-1",
+        language: String = "auto"
+    ) -> CustomTranscriptionService {
+        CustomTranscriptionService(
+            config: .init(
+                apiEndpoint: apiEndpoint,
+                apiKey: apiKey,
+                modelName: modelName,
+                language: language
+            ),
+            networkService: networkService
+        )
+    }
+
+    // MARK: - Success path
+
+    @Test func successReturnsTranscribedText() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "custom hello")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        let result = try await sut.transcribe(audioURL: audio)
+
+        #expect(result.text == "custom hello")
+        #expect(result.isSpeakerAttributed == false)
+        #expect(networkService.uploadCallCount == 1)
+    }
+
+    // MARK: - Request shape
+
+    @Test func requestTargetsConfiguredEndpoint() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let customEndpoint = "https://my-host.internal/transcribe"
+        let sut = makeService(networkService: networkService, apiEndpoint: customEndpoint)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let req = try #require(networkService.capturedRequest)
+        #expect(req.url?.absoluteString == customEndpoint)
+        #expect(req.httpMethod == "POST")
+    }
+
+    @Test func requestSendsBearerAuthorizationHeader() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, apiKey: "custom-abc123")
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let req = try #require(networkService.capturedRequest)
+        #expect(req.value(forHTTPHeaderField: "Authorization") == "Bearer custom-abc123")
+    }
+
+    @Test func requestOmitsAuthorizationHeaderWhenNoAPIKey() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, apiKey: nil)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let req = try #require(networkService.capturedRequest)
+        #expect(req.value(forHTTPHeaderField: "Authorization") == nil)
+        #expect(networkService.uploadCallCount == 1)
+    }
+
+    @Test func requestSendsMultipartContentTypeWithBoundary() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let req = try #require(networkService.capturedRequest)
+        let contentType = try #require(req.value(forHTTPHeaderField: "Content-Type"))
+        #expect(contentType.hasPrefix("multipart/form-data; boundary=Boundary-"))
+    }
+
+    @Test func bodyContainsModelAndResponseFormatFields() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, modelName: "custom-stt-v2")
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let body = try #require(networkService.capturedBody)
+        let bodyString = try #require(String(data: body, encoding: .utf8))
+        #expect(bodyString.range(of: "name=\"model\"\\s*\\r\\n\\r\\ncustom-stt-v2", options: .regularExpression) != nil)
+        #expect(bodyString.range(of: "name=\"response_format\"\\s*\\r\\n\\r\\njson", options: .regularExpression) != nil)
+        #expect(bodyString.range(of: "name=\"temperature\"\\s*\\r\\n\\r\\n0", options: .regularExpression) != nil)
+    }
+
+    @Test func bodyIncludesLanguageFieldWhenNotAuto() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, language: "de")
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let body = try #require(networkService.capturedBody)
+        let bodyString = try #require(String(data: body, encoding: .utf8))
+        #expect(bodyString.range(of: "name=\"language\"\\s*\\r\\n\\r\\nde", options: .regularExpression) != nil)
+    }
+
+    @Test func bodyOmitsLanguageFieldWhenAuto() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, language: "auto")
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let body = try #require(networkService.capturedBody)
+        let bodyString = try #require(String(data: body, encoding: .utf8))
+        #expect(bodyString.contains("name=\"language\"") == false)
+    }
+
+    // MARK: - Validation / short-circuit
+
+    @Test func missingAudioFileThrowsAudioFileNotFound() async {
+        let networkService = MockNetworkService()
+        let audio = URL.temporaryDirectory.appending(path: "definitely-not-a-real-file-\(UUID()).wav")
+        let sut = makeService(networkService: networkService)
+
+        await #expect(throws: CloudTranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: audio)
+        }
+    }
+
+    // MARK: - Response handling
+
+    @Test func nonSuccessStatusThrowsApiRequestFailed() async throws {
+        let networkService = MockNetworkService()
+        networkService.stubUploadResponse = .success((
+            Data(#"{"error":"invalid key"}"#.utf8),
+            makeHTTPResponse(401)
+        ))
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        let error = try await #require(throws: CloudTranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: audio)
+        }
+        guard case let .apiRequestFailed(statusCode, message) = error else {
+            Issue.record("expected CloudTranscriptionError.apiRequestFailed, got \(error)")
+            return
+        }
+        #expect(statusCode == 401)
+        #expect(message.contains("invalid key"))
+    }
+
+    @Test func undecodableJSONOn200ThrowsNoTranscriptionReturned() async throws {
+        let networkService = MockNetworkService()
+        networkService.stubUploadResponse = .success((Data("not json".utf8), makeHTTPResponse(200)))
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        let error = try await #require(throws: CloudTranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: audio)
+        }
+        guard case .noTranscriptionReturned = error else {
+            Issue.record("expected noTranscriptionReturned, got \(error)")
+            return
+        }
+    }
+}

--- a/Modules/CloudTranscription/Tests/CloudTranscriptionTests/DeepgramTranscriptionServiceTests.swift
+++ b/Modules/CloudTranscription/Tests/CloudTranscriptionTests/DeepgramTranscriptionServiceTests.swift
@@ -1,0 +1,314 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import Networking
+import NetworkingMocks
+import Testing
+@testable import CloudTranscription
+import TranscriptionCore
+
+/// Tests exercise `DeepgramTranscriptionService` end-to-end with a stubbed
+/// `MockNetworkService`. Unlike the OpenAI/Groq services, Deepgram sends the
+/// raw audio bytes as the request body (not multipart) and carries its options
+/// in URL query parameters, so the assertions check the URL path + query items
+/// and the raw body rather than a multipart payload.
+///
+/// Verifies request shape (URL, method, headers, query, raw body) and response
+/// handling (success, non-2xx, undecodable JSON). Retry-path tests are
+/// intentionally skipped here - retry semantics belong on `NetworkRetry`'s own
+/// tests.
+///
+/// Each test creates a fresh `MockNetworkService`, so there's no shared mutable
+/// state and the suite is safe to run in parallel with other suites.
+@Suite(.tags(.networking))
+struct DeepgramTranscriptionServiceTests {
+
+    // MARK: - Test Helpers
+
+    /// Writes a small payload to a unique temp URL and returns it. The bytes
+    /// don't need to be valid audio - `DeepgramTranscriptionService` just
+    /// forwards them as the raw request body.
+    private func makeAudioFile() throws -> URL {
+        let url = URL.temporaryDirectory.appending(path: "\(UUID().uuidString).wav")
+        try Data([0x52, 0x49, 0x46, 0x46]).write(to: url) // "RIFF"
+        return url
+    }
+
+    private func makeHTTPResponse(_ statusCode: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: URL(string: "https://api.deepgram.com/v1/listen")!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/json"]
+        )!
+    }
+
+    private func stubSuccess(on networkService: MockNetworkService, text: String) {
+        let body = Data(#"{"results":{"channels":[{"alternatives":[{"transcript":"\#(text)","confidence":0.99}]}]}}"#.utf8)
+        networkService.stubUploadResponse = .success((body, makeHTTPResponse(200)))
+    }
+
+    /// Resolves the captured request's URL into `URLComponents`, so individual
+    /// query items can be checked without depending on query-item order.
+    private func components(of request: URLRequest) throws -> URLComponents {
+        let url = try #require(request.url)
+        return try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+    }
+
+    private func makeService(
+        networkService: MockNetworkService,
+        apiKey: String = "dg-test-key",
+        modelName: String = "nova-3",
+        language: String = "auto",
+        vocabulary: [String] = [],
+        isSpeakerDiarizationEnabled: Bool = false
+    ) -> DeepgramTranscriptionService {
+        DeepgramTranscriptionService(
+            config: .init(
+                apiKey: apiKey,
+                modelName: modelName,
+                language: language,
+                vocabulary: vocabulary,
+                isSpeakerDiarizationEnabled: isSpeakerDiarizationEnabled
+            ),
+            networkService: networkService
+        )
+    }
+
+    // MARK: - Success path
+
+    @Test func successReturnsTranscribedText() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "deepgram hello")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        let result = try await sut.transcribe(audioURL: audio)
+
+        #expect(result.text == "deepgram hello")
+        #expect(result.isSpeakerAttributed == false)
+        #expect(networkService.uploadCallCount == 1)
+    }
+
+    // MARK: - Request shape
+
+    @Test func requestTargetsDeepgramListenEndpoint() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let req = try #require(networkService.capturedRequest)
+        let comps = try components(of: req)
+        #expect(comps.host == "api.deepgram.com")
+        #expect(comps.path == "/v1/listen")
+        #expect(req.httpMethod == "POST")
+    }
+
+    @Test func requestSetsModelQueryParameter() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, modelName: "nova-2")
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let req = try #require(networkService.capturedRequest)
+        let items = try components(of: req).queryItems ?? []
+        #expect(items.contains(URLQueryItem(name: "model", value: "nova-2")))
+        #expect(items.contains(URLQueryItem(name: "smart_format", value: "true")))
+        #expect(items.contains(URLQueryItem(name: "punctuate", value: "true")))
+        #expect(items.contains(URLQueryItem(name: "paragraphs", value: "true")))
+    }
+
+    @Test func requestSendsTokenAuthorizationHeader() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, apiKey: "dg-abc123")
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let req = try #require(networkService.capturedRequest)
+        #expect(req.value(forHTTPHeaderField: "Authorization") == "Token dg-abc123")
+    }
+
+    @Test func requestSendsRawAudioBytesAsBody() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let body = try #require(networkService.capturedBody)
+        // Deepgram forwards the file's bytes verbatim, not a multipart payload.
+        #expect(body == Data([0x52, 0x49, 0x46, 0x46]))
+    }
+
+    @Test func requestIncludesLanguageQueryWhenNotAuto() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, language: "en")
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let req = try #require(networkService.capturedRequest)
+        let items = try components(of: req).queryItems ?? []
+        #expect(items.contains(URLQueryItem(name: "language", value: "en")))
+    }
+
+    @Test func requestOmitsLanguageQueryWhenAuto() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, language: "auto")
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let req = try #require(networkService.capturedRequest)
+        let items = try components(of: req).queryItems ?? []
+        #expect(items.contains { $0.name == "language" } == false)
+    }
+
+    // MARK: - Diarization
+
+    @Test func requestOmitsDiarizationQueriesWhenDisabled() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, isSpeakerDiarizationEnabled: false)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let req = try #require(networkService.capturedRequest)
+        let items = try components(of: req).queryItems ?? []
+        #expect(items.contains { $0.name == "diarize" } == false)
+        #expect(items.contains { $0.name == "utterances" } == false)
+    }
+
+    @Test func requestIncludesDiarizationQueriesWhenEnabled() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, isSpeakerDiarizationEnabled: true)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let req = try #require(networkService.capturedRequest)
+        let items = try components(of: req).queryItems ?? []
+        #expect(items.contains(URLQueryItem(name: "diarize", value: "true")))
+        #expect(items.contains(URLQueryItem(name: "utterances", value: "true")))
+    }
+
+    // MARK: - Vocabulary
+
+    @Test func requestOmitsKeytermQueriesWhenVocabularyIsEmpty() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, modelName: "nova-3", vocabulary: [])
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let req = try #require(networkService.capturedRequest)
+        let items = try components(of: req).queryItems ?? []
+        #expect(items.contains { $0.name == "keyterm" } == false)
+        #expect(items.contains { $0.name == "keywords" } == false)
+    }
+
+    @Test func requestUsesKeytermForNova3Vocabulary() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, modelName: "nova-3", vocabulary: ["SwiftUI", "Kubernetes"])
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let req = try #require(networkService.capturedRequest)
+        let items = try components(of: req).queryItems ?? []
+        let keyterms = items.filter { $0.name == "keyterm" }.compactMap(\.value)
+        #expect(keyterms.contains("SwiftUI"))
+        #expect(keyterms.contains("Kubernetes"))
+        #expect(items.contains { $0.name == "keywords" } == false)
+    }
+
+    @Test func requestUsesKeywordsForNonNova3Vocabulary() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, modelName: "nova-2", vocabulary: ["SwiftUI"])
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let req = try #require(networkService.capturedRequest)
+        let items = try components(of: req).queryItems ?? []
+        let keywords = items.filter { $0.name == "keywords" }.compactMap(\.value)
+        #expect(keywords.contains("SwiftUI"))
+        #expect(items.contains { $0.name == "keyterm" } == false)
+    }
+
+    // MARK: - Validation / short-circuit
+
+    @Test func missingAPIKeyThrowsBeforeMakingRequest() async throws {
+        let networkService = MockNetworkService()
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, apiKey: "")
+
+        await #expect(throws: CloudTranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: audio)
+        }
+        #expect(networkService.uploadCallCount == 0, "no network call should be made when API key is empty")
+    }
+
+    @Test func missingAudioFileThrowsAudioFileNotFound() async {
+        let networkService = MockNetworkService()
+        let audio = URL.temporaryDirectory.appending(path: "definitely-not-a-real-file-\(UUID()).wav")
+        let sut = makeService(networkService: networkService)
+
+        await #expect(throws: CloudTranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: audio)
+        }
+    }
+
+    // MARK: - Response handling
+
+    @Test func nonSuccessStatusThrowsApiRequestFailed() async throws {
+        // 401 is not retried (only 429 + 5xx are), so this throws immediately.
+        let networkService = MockNetworkService()
+        networkService.stubUploadResponse = .success((
+            Data(#"{"err_msg":"invalid key"}"#.utf8),
+            makeHTTPResponse(401)
+        ))
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        let error = try await #require(throws: CloudTranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: audio)
+        }
+        guard case let .apiRequestFailed(statusCode, message) = error else {
+            Issue.record("expected CloudTranscriptionError.apiRequestFailed, got \(error)")
+            return
+        }
+        #expect(statusCode == 401)
+        #expect(message.contains("invalid key"))
+    }
+
+    @Test func undecodableJSONOn200ThrowsNoTranscriptionReturned() async throws {
+        let networkService = MockNetworkService()
+        networkService.stubUploadResponse = .success((Data("not json".utf8), makeHTTPResponse(200)))
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        let error = try await #require(throws: CloudTranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: audio)
+        }
+        guard case .noTranscriptionReturned = error else {
+            Issue.record("expected noTranscriptionReturned, got \(error)")
+            return
+        }
+    }
+}

--- a/Modules/CloudTranscription/Tests/CloudTranscriptionTests/GeminiTranscriptionServiceTests.swift
+++ b/Modules/CloudTranscription/Tests/CloudTranscriptionTests/GeminiTranscriptionServiceTests.swift
@@ -1,0 +1,266 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import Networking
+import NetworkingMocks
+import Testing
+@testable import CloudTranscription
+import TranscriptionCore
+
+/// Tests exercise `GeminiTranscriptionService` end-to-end with a stubbed
+/// `MockNetworkService`. Verifies request shape (URL, method, `x-goog-api-key`
+/// header, inlined-base64 JSON body) and response handling (success, non-2xx,
+/// undecodable JSON).
+///
+/// Unlike the OpenAI/Groq services - which `upload` raw `Data` and decode it
+/// themselves - Gemini calls `NetworkService.sendJSON`, so the mock is stubbed
+/// via `stubSendJSONResponse` with an already-decoded `GeminiResponse`. Error
+/// paths are stubbed as `.failure(NetworkError...)` so the service's
+/// `asTranscriptionError()` mapping is what's exercised.
+///
+/// Retry-path tests are intentionally skipped here - retry semantics belong on
+/// `NetworkRetry`'s own tests.
+@Suite(.tags(.networking))
+struct GeminiTranscriptionServiceTests {
+
+    // MARK: - Test Helpers
+
+    /// Writes a tiny RIFF payload to a unique temp URL. The bytes don't need to
+    /// be valid audio - the service just base64-encodes whatever it reads.
+    private func makeAudioFile() throws -> URL {
+        let url = URL.temporaryDirectory.appending(path: "\(UUID().uuidString).wav")
+        try Data([0x52, 0x49, 0x46, 0x46]).write(to: url) // "RIFF"
+        return url
+    }
+
+    private func makeHTTPResponse(_ statusCode: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: URL(string: "https://generativelanguage.googleapis.com/v1beta/models/gemini:generateContent")!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/json"]
+        )!
+    }
+
+    /// Decodes the documented Gemini `generateContent` response shape into the
+    /// concrete `GeminiResponse` the mock returns from `sendJSON`. Decoding from
+    /// real JSON (rather than a hand-built value) keeps the stub anchored to the
+    /// wire format the service expects.
+    private func makeGeminiResponse(text: String) throws -> GeminiTranscriptionService.GeminiResponse {
+        let json = Data(#"{"candidates":[{"content":{"parts":[{"text":"\#(text)"}]}}]}"#.utf8)
+        return try JSONDecoder().decode(GeminiTranscriptionService.GeminiResponse.self, from: json)
+    }
+
+    private func stubSuccess(on networkService: MockNetworkService, text: String) throws {
+        let response = try makeGeminiResponse(text: text)
+        networkService.stubSendJSONResponse = .success(response)
+    }
+
+    private func makeService(
+        networkService: MockNetworkService,
+        apiKey: String = "gemini-test-key",
+        modelName: String = "gemini-2.0-flash"
+    ) -> GeminiTranscriptionService {
+        GeminiTranscriptionService(
+            config: .init(apiKey: apiKey, modelName: modelName),
+            networkService: networkService
+        )
+    }
+
+    // MARK: - Success path
+
+    @Test func successReturnsTranscribedText() async throws {
+        let networkService = MockNetworkService()
+        try stubSuccess(on: networkService, text: "gemini hello")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        let result = try await sut.transcribe(audioURL: audio)
+
+        #expect(result.text == "gemini hello")
+        #expect(result.isSpeakerAttributed == false)
+        #expect(networkService.sendJSONCallCount == 1)
+    }
+
+    @Test func successTrimsSurroundingWhitespace() async throws {
+        let networkService = MockNetworkService()
+        // Leading/trailing whitespace the service trims with
+        // `.whitespacesAndNewlines`.
+        try stubSuccess(on: networkService, text: "  spaced out  ")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        let result = try await sut.transcribe(audioURL: audio)
+
+        #expect(result.text == "spaced out")
+    }
+
+    // MARK: - Request shape
+
+    @Test func requestTargetsGeminiGenerateContentEndpoint() async throws {
+        let networkService = MockNetworkService()
+        try stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, modelName: "gemini-2.0-flash")
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let req = try #require(networkService.capturedRequest)
+        #expect(
+            req.url?.absoluteString
+                == "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent"
+        )
+        #expect(req.url?.host == "generativelanguage.googleapis.com")
+        #expect(req.url?.path == "/v1beta/models/gemini-2.0-flash:generateContent")
+        #expect(req.httpMethod == "POST")
+    }
+
+    // MARK: - Auth (header, not query param)
+
+    @Test func requestSendsApiKeyInGoogleHeader() async throws {
+        let networkService = MockNetworkService()
+        try stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, apiKey: "gemini-abc123")
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let req = try #require(networkService.capturedRequest)
+        #expect(req.value(forHTTPHeaderField: "x-goog-api-key") == "gemini-abc123")
+        // Gemini puts the key in a header, never on the URL.
+        let components = URLComponents(url: try #require(req.url), resolvingAgainstBaseURL: false)
+        #expect(components?.queryItems == nil)
+        #expect(req.value(forHTTPHeaderField: "Authorization") == nil)
+    }
+
+    @Test func requestSendsJSONContentType() async throws {
+        let networkService = MockNetworkService()
+        try stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let req = try #require(networkService.capturedRequest)
+        #expect(req.value(forHTTPHeaderField: "Content-Type") == "application/json")
+    }
+
+    // MARK: - Body
+
+    @Test func bodyInlinesBase64AudioWithMimeTypeAndPrompt() async throws {
+        let networkService = MockNetworkService()
+        try stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let req = try #require(networkService.capturedRequest)
+        let body = try #require(req.httpBody)
+        let object = try #require(
+            try JSONSerialization.jsonObject(with: body) as? [String: Any]
+        )
+        let contents = try #require(object["contents"] as? [[String: Any]])
+        let parts = try #require(contents.first?["parts"] as? [[String: Any]])
+
+        // Text part carries the transcription instruction.
+        let textValues = parts.compactMap { $0["text"] as? String }
+        #expect(textValues.contains { $0.contains("transcribe this audio file") })
+
+        // Audio part inlines the base64-encoded "RIFF" bytes + a MIME type.
+        let inlineData = try #require(
+            parts.compactMap { $0["inlineData"] as? [String: Any] }.first
+        )
+        #expect((inlineData["data"] as? String) == Data([0x52, 0x49, 0x46, 0x46]).base64EncodedString())
+        #expect((inlineData["mimeType"] as? String)?.isEmpty == false)
+    }
+
+    // MARK: - Validation / short-circuit
+
+    @Test func missingAPIKeyThrowsBeforeMakingRequest() async throws {
+        let networkService = MockNetworkService()
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, apiKey: "")
+
+        await #expect(throws: CloudTranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: audio)
+        }
+        #expect(networkService.sendJSONCallCount == 0, "no network call should be made when API key is empty")
+    }
+
+    @Test func missingAudioFileThrowsAudioFileNotFound() async {
+        let networkService = MockNetworkService()
+        let audio = URL.temporaryDirectory.appending(path: "definitely-not-a-real-file-\(UUID()).wav")
+        let sut = makeService(networkService: networkService)
+
+        await #expect(throws: CloudTranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: audio)
+        }
+    }
+
+    // MARK: - Response handling
+
+    @Test func nonSuccessStatusThrowsApiRequestFailed() async throws {
+        // The mock's `sendJSON` doesn't validate status itself, so the
+        // production `NetworkError.unacceptableStatus` is stubbed directly to
+        // exercise the service's `asTranscriptionError()` mapping.
+        let networkService = MockNetworkService()
+        networkService.stubSendJSONResponse = .failure(
+            NetworkError.unacceptableStatus(code: 401, body: Data(#"{"error":"invalid key"}"#.utf8))
+        )
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        let error = try await #require(throws: CloudTranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: audio)
+        }
+        guard case let .apiRequestFailed(statusCode, message) = error else {
+            Issue.record("expected CloudTranscriptionError.apiRequestFailed, got \(error)")
+            return
+        }
+        #expect(statusCode == 401)
+        #expect(message.contains("invalid key"))
+    }
+
+    @Test func undecodableJSONThrowsNoTranscriptionReturned() async throws {
+        // Production `sendJSON` surfaces a decode failure as
+        // `NetworkError.decodingFailed`, which the service maps to
+        // `noTranscriptionReturned`.
+        struct DummyDecodeError: Error {}
+        let networkService = MockNetworkService()
+        networkService.stubSendJSONResponse = .failure(
+            NetworkError.decodingFailed(DummyDecodeError())
+        )
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        let error = try await #require(throws: CloudTranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: audio)
+        }
+        guard case .noTranscriptionReturned = error else {
+            Issue.record("expected noTranscriptionReturned, got \(error)")
+            return
+        }
+    }
+
+    @Test func emptyCandidatesThrowsNoTranscriptionReturned() async throws {
+        // A 200 that decodes but carries no candidates -> the service's own
+        // guard throws `noTranscriptionReturned`.
+        let networkService = MockNetworkService()
+        let emptyResponse = try JSONDecoder().decode(
+            GeminiTranscriptionService.GeminiResponse.self,
+            from: Data(#"{"candidates":[]}"#.utf8)
+        )
+        networkService.stubSendJSONResponse = .success(emptyResponse)
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        let error = try await #require(throws: CloudTranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: audio)
+        }
+        guard case .noTranscriptionReturned = error else {
+            Issue.record("expected noTranscriptionReturned, got \(error)")
+            return
+        }
+    }
+}

--- a/Modules/CloudTranscription/Tests/CloudTranscriptionTests/GladiaTranscriptionServiceTests.swift
+++ b/Modules/CloudTranscription/Tests/CloudTranscriptionTests/GladiaTranscriptionServiceTests.swift
@@ -1,0 +1,333 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import Networking
+import NetworkingMocks
+import Testing
+@testable import CloudTranscription
+import TranscriptionCore
+
+/// Tests exercise `GladiaTranscriptionService` end-to-end with a stubbed
+/// `MockNetworkService`. Gladia uses a three-stage **upload -> create -> poll**
+/// job flow, so the `create` and `poll` stages share `send(_:)` - the suite
+/// drives them via `MockNetworkService.stubSendResponses` (a FIFO queue).
+///
+/// Verifies the happy path, the endpoint/header/body shape of each stage, the
+/// `language_config` / vocabulary branches, speaker diarization, and the error
+/// paths (missing key, upload failure, undecodable create, poll `error`). Every
+/// poll response here resolves on the first iteration (`done`/`error`), so no
+/// test waits on the real poll interval.
+@Suite(.tags(.networking))
+struct GladiaTranscriptionServiceTests {
+
+    // MARK: - Test Helpers
+
+    private func makeAudioFile() throws -> URL {
+        let url = URL.temporaryDirectory.appending(path: "\(UUID().uuidString).wav")
+        try Data([0x52, 0x49, 0x46, 0x46]).write(to: url) // "RIFF"
+        return url
+    }
+
+    private func httpResponse(_ statusCode: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: URL(string: "https://api.gladia.io/v2/pre-recorded")!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/json"]
+        )!
+    }
+
+    private func jsonData(_ object: [String: Any]) throws -> Data {
+        try JSONSerialization.data(withJSONObject: object)
+    }
+
+    private func makeService(
+        networkService: MockNetworkService,
+        apiKey: String = "gld-test-key",
+        language: String = "auto",
+        vocabulary: [String] = [],
+        isSpeakerDiarizationEnabled: Bool = false,
+        translationTargetLanguage: String = ""
+    ) -> GladiaTranscriptionService {
+        GladiaTranscriptionService(
+            config: .init(
+                apiKey: apiKey,
+                language: language,
+                vocabulary: vocabulary,
+                isSpeakerDiarizationEnabled: isSpeakerDiarizationEnabled,
+                translationTargetLanguage: translationTargetLanguage
+            ),
+            networkService: networkService
+        )
+    }
+
+    /// Stubs a successful upload -> create -> poll(done) sequence.
+    /// `transcript` is the `full_transcript`; pass `utterances` to exercise the
+    /// speaker-diarization branch.
+    private func stubHappyFlow(
+        on networkService: MockNetworkService,
+        transcript: String = "hello world",
+        utterances: [[String: Any]]? = nil
+    ) throws {
+        networkService.stubUploadResponse = .success((
+            try jsonData(["audio_url": "https://api.gladia.io/files/abc"]),
+            httpResponse(200)
+        ))
+        var transcription: [String: Any] = ["full_transcript": transcript]
+        if let utterances {
+            transcription["utterances"] = utterances
+        }
+        let pollDone: [String: Any] = [
+            "id": "job-1",
+            "status": "done",
+            "result": ["transcription": transcription]
+        ]
+        networkService.stubSendResponses = [
+            .success((try jsonData(["id": "job-1"]), httpResponse(200))),       // create
+            .success((try jsonData(pollDone), httpResponse(200)))               // poll -> done
+        ]
+    }
+
+    // MARK: - Happy path
+
+    @Test func successReturnsTranscribedText() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService, transcript: "gladia hello")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        let result = try await sut.transcribe(audioURL: audio)
+
+        #expect(result.text == "gladia hello")
+        #expect(result.isSpeakerAttributed == false)
+        #expect(networkService.uploadCallCount == 1)
+        #expect(networkService.sendCallCount == 2) // create + one poll
+    }
+
+    @Test func speakerDiarizationReturnsAttributedText() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(
+            on: networkService,
+            transcript: "ignored when utterances present",
+            utterances: [
+                ["text": "hi there", "speaker": 0],
+                ["text": "hello back", "speaker": 1]
+            ]
+        )
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, isSpeakerDiarizationEnabled: true)
+
+        let result = try await sut.transcribe(audioURL: audio)
+
+        #expect(result.isSpeakerAttributed == true)
+        #expect(result.text.contains("hi there"))
+        #expect(result.text.contains("hello back"))
+    }
+
+    // MARK: - Request shape (sequence / endpoints / headers)
+
+    @Test func requestSequenceTargetsUploadCreatePollEndpoints() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService)
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        #expect(networkService.capturedRequests.count == 3)
+        let upload = networkService.capturedRequests[0]
+        let create = networkService.capturedRequests[1]
+        let poll = networkService.capturedRequests[2]
+        #expect(upload.url?.absoluteString == "https://api.gladia.io/v2/upload")
+        #expect(upload.httpMethod == "POST")
+        #expect(create.url?.absoluteString == "https://api.gladia.io/v2/pre-recorded")
+        #expect(create.httpMethod == "POST")
+        #expect(poll.url?.absoluteString == "https://api.gladia.io/v2/pre-recorded/job-1")
+        #expect(poll.httpMethod == "GET")
+    }
+
+    @Test func everyRequestSendsGladiaKeyHeader() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService)
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, apiKey: "gld-abc123")
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        for request in networkService.capturedRequests {
+            #expect(request.value(forHTTPHeaderField: "x-gladia-key") == "gld-abc123")
+        }
+    }
+
+    @Test func uploadSendsMultipartContentTypeWithBoundary() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService)
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let contentType = try #require(networkService.capturedRequests[0].value(forHTTPHeaderField: "Content-Type"))
+        #expect(contentType.hasPrefix("multipart/form-data; boundary=Boundary-"))
+    }
+
+    @Test func createSendsJSONContentType() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService)
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        #expect(networkService.capturedRequests[1].value(forHTTPHeaderField: "Content-Type") == "application/json")
+    }
+
+    // MARK: - Create body (language_config / vocabulary / diarization)
+
+    private func createBody(_ networkService: MockNetworkService) throws -> [String: Any] {
+        let body = try #require(networkService.capturedRequests[1].httpBody)
+        return try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+    }
+
+    @Test func createBodyUsesCodeSwitchingWhenLanguageAuto() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService)
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, language: "auto")
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let langConfig = try #require(try createBody(networkService)["language_config"] as? [String: Any])
+        #expect(langConfig["code_switching"] as? Bool == true)
+        #expect((langConfig["languages"] as? [String])?.isEmpty == true)
+    }
+
+    @Test func createBodyPinsLanguageWhenSpecified() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService)
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, language: "fr")
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let langConfig = try #require(try createBody(networkService)["language_config"] as? [String: Any])
+        #expect(langConfig["languages"] as? [String] == ["fr"])
+        #expect(langConfig["code_switching"] as? Bool == false)
+    }
+
+    @Test func createBodyEnablesDiarizationFlag() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService)
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, isSpeakerDiarizationEnabled: true)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        #expect(try createBody(networkService)["diarization"] as? Bool == true)
+    }
+
+    @Test func createBodyIncludesVocabularyWhenProvided() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService)
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, vocabulary: ["SwiftUI", "Kubernetes"])
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let body = try createBody(networkService)
+        #expect(body["custom_vocabulary"] as? Bool == true)
+        let vocabConfig = try #require(body["custom_vocabulary_config"] as? [String: Any])
+        #expect(vocabConfig["vocabulary"] as? [String] == ["SwiftUI", "Kubernetes"])
+    }
+
+    @Test func createBodyOmitsVocabularyWhenEmpty() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService)
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, vocabulary: [])
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        #expect(try createBody(networkService)["custom_vocabulary"] == nil)
+    }
+
+    // MARK: - Validation / error paths
+
+    @Test func missingAPIKeyThrowsBeforeAnyRequest() async throws {
+        let networkService = MockNetworkService()
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, apiKey: "")
+
+        await #expect(throws: CloudTranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: audio)
+        }
+        #expect(networkService.uploadCallCount == 0)
+        #expect(networkService.sendCallCount == 0)
+    }
+
+    @Test func uploadStageNonSuccessStatusThrowsApiRequestFailed() async throws {
+        let networkService = MockNetworkService()
+        networkService.stubUploadResponse = .success((
+            Data(#"{"error":"bad key"}"#.utf8),
+            httpResponse(401)
+        ))
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        let error = try await #require(throws: CloudTranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: audio)
+        }
+        guard case let .apiRequestFailed(statusCode, message) = error else {
+            Issue.record("expected apiRequestFailed, got \(error)")
+            return
+        }
+        #expect(statusCode == 401)
+        #expect(message.contains("bad key"))
+        #expect(networkService.sendCallCount == 0, "create/poll must not run after upload fails")
+    }
+
+    @Test func undecodableCreateResponseThrowsNoTranscriptionReturned() async throws {
+        let networkService = MockNetworkService()
+        networkService.stubUploadResponse = .success((
+            try jsonData(["audio_url": "https://api.gladia.io/files/abc"]),
+            httpResponse(200)
+        ))
+        networkService.stubSendResponses = [
+            .success((Data(#"{"unexpected":true}"#.utf8), httpResponse(200))) // no "id"
+        ]
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        let error = try await #require(throws: CloudTranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: audio)
+        }
+        guard case .noTranscriptionReturned = error else {
+            Issue.record("expected noTranscriptionReturned, got \(error)")
+            return
+        }
+        #expect(networkService.sendCallCount == 1, "poll must not run when create can't be decoded")
+    }
+
+    @Test func pollStatusErrorThrowsApiRequestFailed() async throws {
+        let networkService = MockNetworkService()
+        networkService.stubUploadResponse = .success((
+            try jsonData(["audio_url": "https://api.gladia.io/files/abc"]),
+            httpResponse(200)
+        ))
+        networkService.stubSendResponses = [
+            .success((try jsonData(["id": "job-1"]), httpResponse(200))),                  // create
+            .success((try jsonData(["status": "error", "error_code": 42]), httpResponse(200))) // poll -> error
+        ]
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        let error = try await #require(throws: CloudTranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: audio)
+        }
+        guard case let .apiRequestFailed(statusCode, _) = error else {
+            Issue.record("expected apiRequestFailed, got \(error)")
+            return
+        }
+        #expect(statusCode == 42)
+    }
+}

--- a/Modules/CloudTranscription/Tests/CloudTranscriptionTests/MistralTranscriptionServiceTests.swift
+++ b/Modules/CloudTranscription/Tests/CloudTranscriptionTests/MistralTranscriptionServiceTests.swift
@@ -1,0 +1,262 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import Networking
+import NetworkingMocks
+import Testing
+@testable import CloudTranscription
+import TranscriptionCore
+
+/// Tests exercise `MistralTranscriptionService` end-to-end with a stubbed
+/// `MockNetworkService`. Verifies request shape (URL, method, headers,
+/// multipart body) and response handling (success, non-2xx, undecodable
+/// JSON), plus the Mistral-specific diarization path.
+///
+/// Mirrors the structure of `OpenAITranscriptionServiceTests`. Retry-path
+/// tests are intentionally skipped here - retry semantics belong on
+/// `NetworkRetry`'s own tests.
+@Suite(.tags(.networking))
+struct MistralTranscriptionServiceTests {
+
+    // MARK: - Test Helpers
+
+    private func makeAudioFile() throws -> URL {
+        let url = URL.temporaryDirectory.appending(path: "\(UUID().uuidString).wav")
+        try Data([0x52, 0x49, 0x46, 0x46]).write(to: url) // "RIFF"
+        return url
+    }
+
+    private func makeHTTPResponse(_ statusCode: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: URL(string: "https://api.mistral.ai/v1/audio/transcriptions")!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/json"]
+        )!
+    }
+
+    private func stubSuccess(on networkService: MockNetworkService, text: String) {
+        let body = Data(#"{"text":"\#(text)","language":"en","duration":0.5}"#.utf8)
+        networkService.stubUploadResponse = .success((body, makeHTTPResponse(200)))
+    }
+
+    private func makeService(
+        networkService: MockNetworkService,
+        apiKey: String = "mst-test-key",
+        modelName: String = "voxtral-mini-latest",
+        language: String = "auto",
+        isSpeakerDiarizationEnabled: Bool = false
+    ) -> MistralTranscriptionService {
+        MistralTranscriptionService(
+            config: .init(
+                apiKey: apiKey,
+                modelName: modelName,
+                language: language,
+                isSpeakerDiarizationEnabled: isSpeakerDiarizationEnabled
+            ),
+            networkService: networkService
+        )
+    }
+
+    // MARK: - Success path
+
+    @Test func successReturnsTranscribedText() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "mistral hello")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        let result = try await sut.transcribe(audioURL: audio)
+
+        #expect(result.text == "mistral hello")
+        #expect(result.isSpeakerAttributed == false)
+        #expect(networkService.uploadCallCount == 1)
+    }
+
+    // MARK: - Request shape
+
+    @Test func requestTargetsMistralTranscriptionsEndpoint() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let req = try #require(networkService.capturedRequest)
+        #expect(req.url?.absoluteString == "https://api.mistral.ai/v1/audio/transcriptions")
+        #expect(req.httpMethod == "POST")
+    }
+
+    @Test func requestSendsBearerAuthorizationHeader() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, apiKey: "mst-abc123")
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let req = try #require(networkService.capturedRequest)
+        #expect(req.value(forHTTPHeaderField: "Authorization") == "Bearer mst-abc123")
+    }
+
+    @Test func requestSendsMultipartContentTypeWithBoundary() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let req = try #require(networkService.capturedRequest)
+        let contentType = try #require(req.value(forHTTPHeaderField: "Content-Type"))
+        #expect(contentType.hasPrefix("multipart/form-data; boundary=Boundary-"))
+    }
+
+    @Test func bodyContainsModelField() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, modelName: "voxtral-mini-latest")
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let body = try #require(networkService.capturedBody)
+        let bodyString = try #require(String(data: body, encoding: .utf8))
+        // Regex form (rather than separate `contains` checks) ensures the
+        // value immediately follows its multipart field header, so a
+        // misordered body can't pass by coincidence.
+        #expect(bodyString.range(of: "name=\"model\"\\s*\\r\\n\\r\\nvoxtral-mini-latest", options: .regularExpression) != nil)
+    }
+
+    @Test func bodyIncludesLanguageFieldWhenNotAuto() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, language: "fr")
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let body = try #require(networkService.capturedBody)
+        let bodyString = try #require(String(data: body, encoding: .utf8))
+        #expect(bodyString.range(of: "name=\"language\"\\s*\\r\\n\\r\\nfr", options: .regularExpression) != nil)
+    }
+
+    @Test func bodyOmitsLanguageFieldWhenAuto() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, language: "auto")
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let body = try #require(networkService.capturedBody)
+        let bodyString = try #require(String(data: body, encoding: .utf8))
+        #expect(bodyString.contains("name=\"language\"") == false)
+    }
+
+    // MARK: - Diarization (Mistral-specific)
+
+    @Test func bodyOmitsDiarizeFieldWhenDiarizationDisabled() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, isSpeakerDiarizationEnabled: false)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let body = try #require(networkService.capturedBody)
+        let bodyString = try #require(String(data: body, encoding: .utf8))
+        #expect(bodyString.contains("name=\"diarize\"") == false)
+        #expect(bodyString.contains("name=\"timestamp_granularities\"") == false)
+    }
+
+    @Test func bodyIncludesDiarizeFieldsWhenDiarizationEnabled() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, isSpeakerDiarizationEnabled: true)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let body = try #require(networkService.capturedBody)
+        let bodyString = try #require(String(data: body, encoding: .utf8))
+        #expect(bodyString.range(of: "name=\"diarize\"\\s*\\r\\n\\r\\ntrue", options: .regularExpression) != nil)
+        #expect(bodyString.range(of: "name=\"timestamp_granularities\"\\s*\\r\\n\\r\\nsegment", options: .regularExpression) != nil)
+    }
+
+    @Test func bodyOmitsLanguageFieldWhenDiarizationEnabledEvenIfLanguageSet() async throws {
+        // Mistral diarization requires automatic language detection, so an
+        // explicit language is dropped when diarization is on.
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, language: "fr", isSpeakerDiarizationEnabled: true)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let body = try #require(networkService.capturedBody)
+        let bodyString = try #require(String(data: body, encoding: .utf8))
+        #expect(bodyString.contains("name=\"language\"") == false)
+    }
+
+    // MARK: - Validation / short-circuit
+
+    @Test func missingAPIKeyThrowsBeforeMakingRequest() async throws {
+        let networkService = MockNetworkService()
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, apiKey: "")
+
+        await #expect(throws: CloudTranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: audio)
+        }
+        #expect(networkService.uploadCallCount == 0, "no network call should be made when API key is empty")
+    }
+
+    @Test func missingAudioFileThrowsAudioFileNotFound() async {
+        let networkService = MockNetworkService()
+        let audio = URL.temporaryDirectory.appending(path: "definitely-not-a-real-file-\(UUID()).wav")
+        let sut = makeService(networkService: networkService)
+
+        await #expect(throws: CloudTranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: audio)
+        }
+    }
+
+    // MARK: - Response handling
+
+    @Test func nonSuccessStatusThrowsApiRequestFailed() async throws {
+        let networkService = MockNetworkService()
+        networkService.stubUploadResponse = .success((
+            Data(#"{"error":"invalid key"}"#.utf8),
+            makeHTTPResponse(401)
+        ))
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        let error = try await #require(throws: CloudTranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: audio)
+        }
+        guard case let .apiRequestFailed(statusCode, message) = error else {
+            Issue.record("expected CloudTranscriptionError.apiRequestFailed, got \(error)")
+            return
+        }
+        #expect(statusCode == 401)
+        #expect(message.contains("invalid key"))
+    }
+
+    @Test func undecodableJSONOn200ThrowsNoTranscriptionReturned() async throws {
+        let networkService = MockNetworkService()
+        networkService.stubUploadResponse = .success((Data("not json".utf8), makeHTTPResponse(200)))
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        let error = try await #require(throws: CloudTranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: audio)
+        }
+        guard case .noTranscriptionReturned = error else {
+            Issue.record("expected noTranscriptionReturned, got \(error)")
+            return
+        }
+    }
+}

--- a/Modules/CloudTranscription/Tests/CloudTranscriptionTests/SonioxTranscriptionServiceTests.swift
+++ b/Modules/CloudTranscription/Tests/CloudTranscriptionTests/SonioxTranscriptionServiceTests.swift
@@ -1,0 +1,283 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import Networking
+import NetworkingMocks
+import Testing
+@testable import CloudTranscription
+import TranscriptionCore
+
+/// Tests exercise `SonioxTranscriptionService` end-to-end with a stubbed
+/// `MockNetworkService`. Soniox uses a four-stage **upload -> create -> poll ->
+/// fetch-transcript** job flow; `create`, `poll`, and `fetch` all share
+/// `send(_:)`, so the suite drives them via `MockNetworkService.stubSendResponses`
+/// (a FIFO queue). Every poll response resolves on the first iteration, so no
+/// test waits on the real poll interval.
+@Suite(.tags(.networking))
+struct SonioxTranscriptionServiceTests {
+
+    // MARK: - Test Helpers
+
+    private func makeAudioFile() throws -> URL {
+        let url = URL.temporaryDirectory.appending(path: "\(UUID().uuidString).wav")
+        try Data([0x52, 0x49, 0x46, 0x46]).write(to: url) // "RIFF"
+        return url
+    }
+
+    private func httpResponse(_ statusCode: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: URL(string: "https://api.soniox.com/v1/transcriptions")!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/json"]
+        )!
+    }
+
+    private func jsonData(_ object: [String: Any]) throws -> Data {
+        try JSONSerialization.data(withJSONObject: object)
+    }
+
+    private func makeService(
+        networkService: MockNetworkService,
+        apiKey: String = "snx-test-key",
+        modelName: String = "stt-async-preview",
+        language: String = "auto",
+        vocabulary: [String] = [],
+        isSpeakerDiarizationEnabled: Bool = false,
+        translationTargetLanguage: String = ""
+    ) -> SonioxTranscriptionService {
+        SonioxTranscriptionService(
+            config: .init(
+                apiKey: apiKey,
+                modelName: modelName,
+                language: language,
+                vocabulary: vocabulary,
+                isSpeakerDiarizationEnabled: isSpeakerDiarizationEnabled,
+                translationTargetLanguage: translationTargetLanguage
+            ),
+            networkService: networkService
+        )
+    }
+
+    /// Stubs upload -> create -> poll(completed) -> fetch(transcript).
+    private func stubHappyFlow(
+        on networkService: MockNetworkService,
+        transcript: String = "hello world",
+        tokens: [[String: Any]]? = nil
+    ) throws {
+        networkService.stubUploadResponse = .success((
+            try jsonData(["id": "file-1"]),
+            httpResponse(200)
+        ))
+        var transcriptResponse: [String: Any] = ["text": transcript]
+        if let tokens {
+            transcriptResponse["tokens"] = tokens
+        }
+        networkService.stubSendResponses = [
+            .success((try jsonData(["id": "tr-1"]), httpResponse(200))),               // create
+            .success((try jsonData(["status": "completed"]), httpResponse(200))),       // poll -> completed
+            .success((try jsonData(transcriptResponse), httpResponse(200)))             // fetch transcript
+        ]
+    }
+
+    // MARK: - Happy path
+
+    @Test func successReturnsTranscribedText() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService, transcript: "soniox hello")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        let result = try await sut.transcribe(audioURL: audio)
+
+        #expect(result.text == "soniox hello")
+        #expect(result.isSpeakerAttributed == false)
+        #expect(networkService.uploadCallCount == 1)
+        #expect(networkService.sendCallCount == 3) // create + poll + fetch
+    }
+
+    @Test func speakerDiarizationReturnsAttributedText() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(
+            on: networkService,
+            transcript: "ignored when tokens present",
+            tokens: [
+                ["text": "hi there", "speaker": "1"],
+                ["text": " hello back", "speaker": "2"]
+            ]
+        )
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, isSpeakerDiarizationEnabled: true)
+
+        let result = try await sut.transcribe(audioURL: audio)
+
+        #expect(result.isSpeakerAttributed == true)
+        #expect(result.text.contains("hi there"))
+        #expect(result.text.contains("hello back"))
+    }
+
+    // MARK: - Request shape
+
+    @Test func requestSequenceTargetsFilesCreatePollFetchEndpoints() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService)
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        #expect(networkService.capturedRequests.count == 4)
+        let r = networkService.capturedRequests
+        #expect(r[0].url?.absoluteString == "https://api.soniox.com/v1/files")
+        #expect(r[0].httpMethod == "POST")
+        #expect(r[1].url?.absoluteString == "https://api.soniox.com/v1/transcriptions")
+        #expect(r[1].httpMethod == "POST")
+        #expect(r[2].url?.absoluteString == "https://api.soniox.com/v1/transcriptions/tr-1")
+        #expect(r[2].httpMethod == "GET")
+        #expect(r[3].url?.absoluteString == "https://api.soniox.com/v1/transcriptions/tr-1/transcript")
+        #expect(r[3].httpMethod == "GET")
+    }
+
+    @Test func everyRequestSendsBearerAuthorization() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService)
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, apiKey: "snx-abc123")
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        for request in networkService.capturedRequests {
+            #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer snx-abc123")
+        }
+    }
+
+    // MARK: - Create body
+
+    private func createBody(_ networkService: MockNetworkService) throws -> [String: Any] {
+        let body = try #require(networkService.capturedRequests[1].httpBody)
+        return try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+    }
+
+    @Test func createBodyCarriesFileIdModelAndFlags() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService)
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, modelName: "stt-async-preview", isSpeakerDiarizationEnabled: true)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let body = try createBody(networkService)
+        #expect(body["file_id"] as? String == "file-1")
+        #expect(body["model"] as? String == "stt-async-preview")
+        #expect(body["enable_speaker_diarization"] as? Bool == true)
+        #expect(body["enable_language_identification"] as? Bool == true)
+    }
+
+    @Test func createBodyIncludesLanguageHintsWhenSpecified() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService)
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, language: "fr")
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let body = try createBody(networkService)
+        #expect(body["language_hints"] as? [String] == ["fr"])
+        #expect(body["language_hints_strict"] as? Bool == true)
+    }
+
+    @Test func createBodyOmitsLanguageHintsWhenAuto() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService)
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, language: "auto")
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        #expect(try createBody(networkService)["language_hints"] == nil)
+    }
+
+    @Test func createBodyIncludesVocabularyContextWhenProvided() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService)
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, vocabulary: ["SwiftUI", "Kubernetes"])
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let context = try #require(try createBody(networkService)["context"] as? [String: Any])
+        #expect(context["terms"] as? [String] == ["SwiftUI", "Kubernetes"])
+    }
+
+    // MARK: - Error paths
+
+    @Test func missingAPIKeyThrowsBeforeAnyRequest() async throws {
+        let networkService = MockNetworkService()
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, apiKey: "")
+
+        await #expect(throws: CloudTranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: audio)
+        }
+        #expect(networkService.uploadCallCount == 0)
+        #expect(networkService.sendCallCount == 0)
+    }
+
+    @Test func uploadStageNonSuccessStatusThrowsApiRequestFailed() async throws {
+        let networkService = MockNetworkService()
+        networkService.stubUploadResponse = .success((
+            Data(#"{"error":"bad key"}"#.utf8),
+            httpResponse(401)
+        ))
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        let error = try await #require(throws: CloudTranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: audio)
+        }
+        guard case let .apiRequestFailed(statusCode, _) = error else {
+            Issue.record("expected apiRequestFailed, got \(error)")
+            return
+        }
+        #expect(statusCode == 401)
+        #expect(networkService.sendCallCount == 0)
+    }
+
+    @Test func pollStatusFailedThrowsApiRequestFailed() async throws {
+        let networkService = MockNetworkService()
+        networkService.stubUploadResponse = .success((try jsonData(["id": "file-1"]), httpResponse(200)))
+        networkService.stubSendResponses = [
+            .success((try jsonData(["id": "tr-1"]), httpResponse(200))),           // create
+            .success((try jsonData(["status": "failed"]), httpResponse(200)))       // poll -> failed
+        ]
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        let error = try await #require(throws: CloudTranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: audio)
+        }
+        guard case let .apiRequestFailed(statusCode, _) = error else {
+            Issue.record("expected apiRequestFailed, got \(error)")
+            return
+        }
+        #expect(statusCode == 500)
+    }
+
+    @Test func undecodableCreateResponseThrowsNoTranscriptionReturned() async throws {
+        let networkService = MockNetworkService()
+        networkService.stubUploadResponse = .success((try jsonData(["id": "file-1"]), httpResponse(200)))
+        networkService.stubSendResponses = [
+            .success((Data(#"{"unexpected":true}"#.utf8), httpResponse(200))) // create: no "id"
+        ]
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        let error = try await #require(throws: CloudTranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: audio)
+        }
+        guard case .noTranscriptionReturned = error else {
+            Issue.record("expected noTranscriptionReturned, got \(error)")
+            return
+        }
+    }
+}

--- a/Modules/CloudTranscription/Tests/CloudTranscriptionTests/SpeechmaticsTranscriptionServiceTests.swift
+++ b/Modules/CloudTranscription/Tests/CloudTranscriptionTests/SpeechmaticsTranscriptionServiceTests.swift
@@ -1,0 +1,282 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import Networking
+import NetworkingMocks
+import Testing
+@testable import CloudTranscription
+import TranscriptionCore
+
+/// Tests exercise `SpeechmaticsTranscriptionService` end-to-end with a stubbed
+/// `MockNetworkService`. Speechmatics uses an **upload(create-job) -> poll ->
+/// fetch-transcript** flow. The job config travels inside the multipart upload
+/// body (a `config` part), so config-shape assertions inspect
+/// `MockNetworkService.capturedBody`; the `poll` and `fetch` stages share
+/// `send(_:)` and are driven via `stubSendResponses`. Every poll response
+/// resolves on the first iteration, so no test waits on the real poll interval.
+@Suite(.tags(.networking))
+struct SpeechmaticsTranscriptionServiceTests {
+
+    // MARK: - Test Helpers
+
+    private func makeAudioFile() throws -> URL {
+        let url = URL.temporaryDirectory.appending(path: "\(UUID().uuidString).wav")
+        try Data([0x52, 0x49, 0x46, 0x46]).write(to: url) // "RIFF"
+        return url
+    }
+
+    private func httpResponse(_ statusCode: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: URL(string: "https://asr.api.speechmatics.com/v2/jobs")!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/json"]
+        )!
+    }
+
+    private func jsonData(_ object: [String: Any]) throws -> Data {
+        try JSONSerialization.data(withJSONObject: object)
+    }
+
+    private func makeService(
+        networkService: MockNetworkService,
+        apiKey: String = "smx-test-key",
+        language: String = "auto",
+        vocabulary: [String] = [],
+        isSpeakerDiarizationEnabled: Bool = false,
+        translationTargetLanguage: String = ""
+    ) -> SpeechmaticsTranscriptionService {
+        SpeechmaticsTranscriptionService(
+            config: .init(
+                apiKey: apiKey,
+                language: language,
+                vocabulary: vocabulary,
+                isSpeakerDiarizationEnabled: isSpeakerDiarizationEnabled,
+                translationTargetLanguage: translationTargetLanguage
+            ),
+            networkService: networkService
+        )
+    }
+
+    /// `results` are json-v2 transcript items; defaults to a two-word transcript.
+    private func stubHappyFlow(
+        on networkService: MockNetworkService,
+        results: [[String: Any]] = [
+            ["type": "word", "alternatives": [["content": "hello"]]],
+            ["type": "word", "alternatives": [["content": "world"]]]
+        ]
+    ) throws {
+        networkService.stubUploadResponse = .success((
+            try jsonData(["id": "job-1"]),
+            httpResponse(200)
+        ))
+        networkService.stubSendResponses = [
+            .success((try jsonData(["job": ["id": "job-1", "status": "done"]]), httpResponse(200))), // poll -> done
+            .success((try jsonData(["results": results]), httpResponse(200)))                        // fetch transcript
+        ]
+    }
+
+    /// The createJob config JSON lives inside the multipart upload body.
+    private func uploadBodyString(_ networkService: MockNetworkService) throws -> String {
+        let body = try #require(networkService.capturedBody)
+        return try #require(String(data: body, encoding: .utf8))
+    }
+
+    // MARK: - Happy path
+
+    @Test func successReturnsTranscribedText() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService)
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        let result = try await sut.transcribe(audioURL: audio)
+
+        #expect(result.text == "hello world")
+        #expect(result.isSpeakerAttributed == false)
+        #expect(networkService.uploadCallCount == 1)
+        #expect(networkService.sendCallCount == 2) // poll + fetch
+    }
+
+    @Test func punctuationAttachesToPreviousWordWithoutSpace() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService, results: [
+            ["type": "word", "alternatives": [["content": "hello"]]],
+            ["type": "punctuation", "attaches_to": "previous", "alternatives": [["content": "."]]]
+        ])
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        let result = try await sut.transcribe(audioURL: audio)
+
+        #expect(result.text == "hello.")
+    }
+
+    @Test func speakerDiarizationReturnsAttributedText() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService, results: [
+            ["type": "word", "alternatives": [["content": "hi", "speaker": "S1"]]],
+            ["type": "word", "alternatives": [["content": "bye", "speaker": "S2"]]]
+        ])
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, isSpeakerDiarizationEnabled: true)
+
+        let result = try await sut.transcribe(audioURL: audio)
+
+        #expect(result.isSpeakerAttributed == true)
+        #expect(result.text.contains("hi"))
+        #expect(result.text.contains("bye"))
+    }
+
+    // MARK: - Request shape
+
+    @Test func requestSequenceTargetsJobsCreatePollFetchEndpoints() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService)
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        #expect(networkService.capturedRequests.count == 3)
+        let r = networkService.capturedRequests
+        #expect(r[0].url?.absoluteString == "https://asr.api.speechmatics.com/v2/jobs")
+        #expect(r[0].httpMethod == "POST")
+        #expect(r[1].url?.absoluteString == "https://asr.api.speechmatics.com/v2/jobs/job-1")
+        #expect(r[1].httpMethod == "GET")
+        #expect(r[2].url?.absoluteString == "https://asr.api.speechmatics.com/v2/jobs/job-1/transcript?format=json-v2")
+        #expect(r[2].httpMethod == "GET")
+    }
+
+    @Test func everyRequestSendsBearerAuthorization() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService)
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, apiKey: "smx-abc123")
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        for request in networkService.capturedRequests {
+            #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer smx-abc123")
+        }
+    }
+
+    // MARK: - Config body (inside the multipart upload)
+
+    @Test func configBodyMapsZhToCmn() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService)
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, language: "zh")
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        #expect(try uploadBodyString(networkService).contains("\"language\":\"cmn\""))
+    }
+
+    @Test func configBodyPassesNonMandarinLanguageThrough() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService)
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, language: "de")
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        #expect(try uploadBodyString(networkService).contains("\"language\":\"de\""))
+    }
+
+    @Test func configBodyEnablesSpeakerDiarization() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService)
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, isSpeakerDiarizationEnabled: true)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        #expect(try uploadBodyString(networkService).contains("\"diarization\":\"speaker\""))
+    }
+
+    @Test func configBodyIncludesAdditionalVocabWhenProvided() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService)
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, vocabulary: ["SwiftUI"])
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let body = try uploadBodyString(networkService)
+        #expect(body.contains("additional_vocab"))
+        #expect(body.contains("\"content\":\"SwiftUI\""))
+    }
+
+    // MARK: - Error paths
+
+    @Test func missingAPIKeyThrowsBeforeAnyRequest() async throws {
+        let networkService = MockNetworkService()
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, apiKey: "")
+
+        await #expect(throws: CloudTranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: audio)
+        }
+        #expect(networkService.uploadCallCount == 0)
+        #expect(networkService.sendCallCount == 0)
+    }
+
+    @Test func createJobNonSuccessStatusThrowsApiRequestFailed() async throws {
+        let networkService = MockNetworkService()
+        networkService.stubUploadResponse = .success((
+            Data(#"{"error":"bad key"}"#.utf8),
+            httpResponse(401)
+        ))
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        let error = try await #require(throws: CloudTranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: audio)
+        }
+        guard case let .apiRequestFailed(statusCode, _) = error else {
+            Issue.record("expected apiRequestFailed, got \(error)")
+            return
+        }
+        #expect(statusCode == 401)
+        #expect(networkService.sendCallCount == 0)
+    }
+
+    @Test func pollRejectedStatusThrowsApiRequestFailed() async throws {
+        let networkService = MockNetworkService()
+        networkService.stubUploadResponse = .success((try jsonData(["id": "job-1"]), httpResponse(200)))
+        networkService.stubSendResponses = [
+            .success((try jsonData(["job": ["id": "job-1", "status": "rejected"]]), httpResponse(200)))
+        ]
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        let error = try await #require(throws: CloudTranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: audio)
+        }
+        guard case let .apiRequestFailed(statusCode, _) = error else {
+            Issue.record("expected apiRequestFailed, got \(error)")
+            return
+        }
+        #expect(statusCode == 422)
+    }
+
+    @Test func undecodableCreateResponseThrowsNoTranscriptionReturned() async throws {
+        let networkService = MockNetworkService()
+        networkService.stubUploadResponse = .success((
+            Data(#"{"unexpected":true}"#.utf8), // no "id"
+            httpResponse(200)
+        ))
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        let error = try await #require(throws: CloudTranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: audio)
+        }
+        guard case .noTranscriptionReturned = error else {
+            Issue.record("expected noTranscriptionReturned, got \(error)")
+            return
+        }
+    }
+}

--- a/Modules/Networking/Sources/NetworkingMocks/MockNetworkService.swift
+++ b/Modules/Networking/Sources/NetworkingMocks/MockNetworkService.swift
@@ -32,6 +32,12 @@ public final class MockNetworkService: NetworkService, @unchecked Sendable {
     // MARK: - send
 
     public var stubSendResponse: Result<(Data, HTTPURLResponse), Error>?
+    /// Optional FIFO queue of `send` responses, consumed one per call in the
+    /// order added. When non-empty it takes precedence over ``stubSendResponse``
+    /// - use it for multi-call flows (e.g. job APIs that `create` then `poll`)
+    /// that need a different response per call. Falls back to
+    /// ``stubSendResponse`` once the queue is exhausted.
+    public var stubSendResponses: [Result<(Data, HTTPURLResponse), Error>] = []
     public var didSend: (() -> Void)?
     public private(set) var sendCallCount = 0
 
@@ -81,7 +87,12 @@ public final class MockNetworkService: NetworkService, @unchecked Sendable {
         capturedRequest = request
         capturedRequests.append(request)
         capturedAcceptableStatusCodes = acceptableStatusCodes
-        let (data, response): (Data, HTTPURLResponse) = try stubSendResponse.evaluate()
+        let (data, response): (Data, HTTPURLResponse)
+        if stubSendResponses.isEmpty {
+            (data, response) = try stubSendResponse.evaluate()
+        } else {
+            (data, response) = try stubSendResponses.removeFirst().get()
+        }
         try validateStatus(response, body: data, acceptable: acceptableStatusCodes)
         return (data, response)
     }

--- a/Modules/Networking/Tests/NetworkingTests/DefaultNetworkServiceBytesTests.swift
+++ b/Modules/Networking/Tests/NetworkingTests/DefaultNetworkServiceBytesTests.swift
@@ -1,0 +1,107 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import Testing
+@testable import Networking
+
+/// Tests the `bytes(for:)` streaming path of `DefaultNetworkService` against a
+/// real `URLSession` driven by ``URLProtocolStub``.
+///
+/// This is the one seam `MockNetworkService` cannot reach: `URLSession.AsyncBytes`
+/// has no public initializer, so the streaming success path and the non-2xx
+/// "drain the body into an error" path can only be exercised by intercepting a
+/// real session. Serialized because `URLProtocolStub` holds a process-global stub.
+@Suite(.serialized)
+struct DefaultNetworkServiceBytesTests {
+
+    private func makeSUT() -> DefaultNetworkService {
+        DefaultNetworkService(session: URLProtocolStub.makeSession(), category: "BytesTests")
+    }
+
+    private func httpResponse(_ statusCode: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: URL(string: "https://example.com/stream")!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+    }
+
+    private func streamRequest() -> URLRequest {
+        URLRequest(url: URL(string: "https://example.com/stream")!)
+    }
+
+    private func drain(_ bytes: URLSession.AsyncBytes) async throws -> Data {
+        var received = Data()
+        for try await byte in bytes {
+            received.append(byte)
+        }
+        return received
+    }
+
+    @Test func successReturnsResponseAndStreamsBody() async throws {
+        let body = Data("hello stream".utf8)
+        URLProtocolStub.stub(data: body, response: httpResponse(200))
+        defer { URLProtocolStub.reset() }
+        let sut = makeSUT()
+
+        let (bytes, http) = try await sut.bytes(for: streamRequest())
+
+        #expect(http.statusCode == 200)
+        let received = try await drain(bytes)
+        #expect(received == body)
+    }
+
+    @Test func nonSuccessStatusDrainsBodyAndThrowsUnacceptableStatus() async throws {
+        let errorBody = Data("stream error detail".utf8)
+        URLProtocolStub.stub(data: errorBody, response: httpResponse(500))
+        defer { URLProtocolStub.reset() }
+        let sut = makeSUT()
+
+        let error = try await #require(throws: NetworkError.self) {
+            _ = try await sut.bytes(for: streamRequest())
+        }
+        guard case let .unacceptableStatus(code, body) = error else {
+            Issue.record("expected NetworkError.unacceptableStatus, got \(error)")
+            return
+        }
+        #expect(code == 500)
+        #expect(String(data: body, encoding: .utf8) == "stream error detail")
+    }
+
+    @Test func acceptableStatusOverrideLetsNonDefaultStatusStream() async throws {
+        // 404 is normally unacceptable; passing it in acceptableStatusCodes must
+        // let the stream through instead of throwing.
+        let body = Data("custom-accept".utf8)
+        URLProtocolStub.stub(data: body, response: httpResponse(404))
+        defer { URLProtocolStub.reset() }
+        let sut = makeSUT()
+
+        let (bytes, http) = try await sut.bytes(for: streamRequest(), acceptableStatusCodes: [404])
+
+        #expect(http.statusCode == 404)
+        let received = try await drain(bytes)
+        #expect(received == body)
+    }
+
+    @Test func nonHTTPResponseThrowsInvalidResponse() async throws {
+        // A non-HTTP URLResponse must surface as NetworkError.invalidResponse.
+        let response = URLResponse(
+            url: URL(string: "https://example.com/stream")!,
+            mimeType: nil,
+            expectedContentLength: 0,
+            textEncodingName: nil
+        )
+        URLProtocolStub.stub(data: Data(), response: response)
+        defer { URLProtocolStub.reset() }
+        let sut = makeSUT()
+
+        let error = try await #require(throws: NetworkError.self) {
+            _ = try await sut.bytes(for: streamRequest())
+        }
+        guard case .invalidResponse = error else {
+            Issue.record("expected NetworkError.invalidResponse, got \(error)")
+            return
+        }
+    }
+}

--- a/Modules/Networking/Tests/NetworkingTests/URLProtocolStub.swift
+++ b/Modules/Networking/Tests/NetworkingTests/URLProtocolStub.swift
@@ -1,0 +1,58 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+
+/// A `URLProtocol` that intercepts requests issued through a real `URLSession`
+/// and returns a canned response / body / error - the "don't mock a type you do
+/// not own; intercept it" technique. Register it on an ephemeral
+/// `URLSessionConfiguration` (see ``makeSession()``) so a real `URLSession`
+/// exercises the actual loading path without touching the network.
+///
+/// The stub is process-global, so drive it from a `.serialized` suite and
+/// `reset()` after each test.
+final class URLProtocolStub: URLProtocol {
+    struct Stub {
+        let data: Data?
+        let response: URLResponse?
+        let error: Error?
+    }
+
+    nonisolated(unsafe) static var stub: Stub?
+
+    static func stub(data: Data?, response: URLResponse?, error: Error? = nil) {
+        stub = Stub(data: data, response: response, error: error)
+    }
+
+    static func reset() {
+        stub = nil
+    }
+
+    /// A real `URLSession` wired to this stub via an ephemeral configuration.
+    static func makeSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [URLProtocolStub.self]
+        return URLSession(configuration: configuration)
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        // Response first so `URLSession.bytes(for:)` can return its headers,
+        // then the body bytes the AsyncBytes stream yields, then completion.
+        if let response = Self.stub?.response {
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        }
+        if let data = Self.stub?.data {
+            client?.urlProtocol(self, didLoad: data)
+        }
+        if let error = Self.stub?.error {
+            client?.urlProtocol(self, didFailWithError: error)
+        } else {
+            client?.urlProtocolDidFinishLoading(self)
+        }
+    }
+
+    override func stopLoading() {}
+}

--- a/Modules/OAuth/Tests/OAuthTests/DefaultOAuthManagerTests.swift
+++ b/Modules/OAuth/Tests/OAuthTests/DefaultOAuthManagerTests.swift
@@ -1,0 +1,189 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Testing
+import Foundation
+@testable import OAuth
+import OAuthMocks
+import KeychainMocks
+import NetworkingMocks
+import TestUtilities
+
+/// Exercises the constructor-injected seams of `DefaultOAuthManager` - the
+/// keychain credential store and the network-backed token-refresh path.
+///
+/// `signIn(provider:)` is intentionally NOT covered: it launches a real
+/// `ASWebAuthenticationSession` browser auth flow, which cannot run under a
+/// unit test.
+@MainActor
+struct DefaultOAuthManagerTests {
+
+    private let keychain: MockKeychainService
+    private let network: MockNetworkService
+    private let provider: MockOAuthProvider
+    private let sut: DefaultOAuthManager
+
+    init() {
+        self.keychain = MockKeychainService()
+        self.network = MockNetworkService()
+        self.provider = MockOAuthProvider(keychainKey: "test.oauth.credential")
+        self.sut = DefaultOAuthManager(keychain: keychain, networkService: network)
+        // The refresh path calls `provider.postAuthSetup` (via `try?`); stub it
+        // benignly so its unset-stub guard does not record a spurious issue.
+        self.provider.stubPostAuthSetupResponse = .success(nil)
+    }
+
+    // MARK: - isSignedIn
+
+    @Test func isSignedInReturnsFalseWhenKeychainEmpty() {
+        #expect(sut.isSignedIn(provider: provider) == false)
+    }
+
+    @Test func isSignedInReturnsTrueWhenCredentialStored() throws {
+        try seedCredential(makeCredential())
+
+        #expect(sut.isSignedIn(provider: provider))
+    }
+
+    // MARK: - accountEmail
+
+    @Test func accountEmailReturnsNilWhenKeychainEmpty() {
+        #expect(sut.accountEmail(for: provider) == nil)
+    }
+
+    @Test func accountEmailReturnsStoredEmail() throws {
+        try seedCredential(makeCredential(accountEmail: "user@example.com"))
+
+        #expect(sut.accountEmail(for: provider) == "user@example.com")
+    }
+
+    // MARK: - Credential persistence round-trip
+
+    @Test func storedCredentialIsReadBackByIsSignedInAndAccountEmail() throws {
+        try seedCredential(makeCredential(accountEmail: "round@trip.com"))
+
+        #expect(sut.isSignedIn(provider: provider))
+        #expect(sut.accountEmail(for: provider) == "round@trip.com")
+    }
+
+    // MARK: - signOut
+
+    @Test func signOutRemovesCredentialAndCallsKeychainDelete() throws {
+        try seedCredential(makeCredential())
+        #expect(sut.isSignedIn(provider: provider))
+
+        sut.signOut(provider: provider)
+
+        #expect(sut.isSignedIn(provider: provider) == false)
+        #expect(keychain.deleteCallCount >= 1)
+        #expect(keychain.getData(forKey: provider.keychainKey, syncable: false) == nil)
+    }
+
+    // MARK: - validAccessToken
+
+    @Test func validAccessTokenReturnsStoredTokenWhenStillValid() async throws {
+        try seedCredential(
+            makeCredential(
+                accessToken: "valid-token",
+                expiresAt: Date().addingTimeInterval(3600),
+                accountId: "acct-77"
+            )
+        )
+
+        let result = try await sut.validAccessToken(for: provider)
+
+        #expect(result.token == "valid-token")
+        #expect(result.accountId == "acct-77")
+        // A still-valid token must not trigger a refresh network call.
+        #expect(network.sendCallCount == 0)
+    }
+
+    @Test func validAccessTokenRefreshesExpiredCredentialViaNetwork() async throws {
+        // Seed an expired credential. It keeps a non-empty refresh token so
+        // `loadCredential` does not discard it as unrefreshable.
+        try seedCredential(
+            makeCredential(
+                accessToken: "stale-token",
+                refreshToken: "refresh-token",
+                expiresAt: Date().addingTimeInterval(-60)
+            )
+        )
+
+        // `tokenRequest` decodes access_token / refresh_token / expires_in
+        // from the JSON body via JSONSerialization.
+        let body = Data(
+            #"{"access_token":"fresh-token","refresh_token":"new-refresh","expires_in":3600}"#.utf8
+        )
+        network.stubSendResponse = .success((body, makeHTTPResponse(200)))
+
+        let result = try await sut.validAccessToken(for: provider)
+
+        #expect(result.token == "fresh-token")
+        #expect(network.sendCallCount == 1)
+    }
+
+    @Test func validAccessTokenPersistsRefreshedCredential() async throws {
+        try seedCredential(
+            makeCredential(
+                accessToken: "stale-token",
+                refreshToken: "refresh-token",
+                expiresAt: Date().addingTimeInterval(-60)
+            )
+        )
+
+        let body = Data(
+            #"{"access_token":"fresh-token","refresh_token":"new-refresh","expires_in":3600}"#.utf8
+        )
+        network.stubSendResponse = .success((body, makeHTTPResponse(200)))
+
+        _ = try await sut.validAccessToken(for: provider)
+
+        // The refreshed credential is written back to the keychain and decodes
+        // to the new access token.
+        let persisted = try #require(keychain.getData(forKey: provider.keychainKey, syncable: false))
+        let decoded = try JSONDecoder().decode(OAuthCredential.self, from: persisted)
+        #expect(decoded.accessToken == "fresh-token")
+    }
+
+    @Test func validAccessTokenThrowsWhenNoCredential() async {
+        await #expect(throws: OAuthError.self) {
+            _ = try await sut.validAccessToken(for: provider)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func makeCredential(
+        accessToken: String = "access",
+        refreshToken: String = "refresh",
+        expiresAt: Date = Date().addingTimeInterval(3600),
+        accountId: String? = "acct-1",
+        accountEmail: String? = "user@example.com",
+        projectId: String? = nil
+    ) -> OAuthCredential {
+        OAuthCredential(
+            accessToken: accessToken,
+            refreshToken: refreshToken,
+            expiresAt: expiresAt,
+            accountId: accountId,
+            accountEmail: accountEmail,
+            projectId: projectId
+        )
+    }
+
+    /// Encodes the credential the same way `DefaultOAuthManager.saveCredential`
+    /// does (JSONEncoder under `provider.keychainKey`) so `loadCredential` reads
+    /// it back.
+    private func seedCredential(_ credential: OAuthCredential) throws {
+        let encoded = try JSONEncoder().encode(credential)
+        keychain.save(data: encoded, forKey: provider.keychainKey, syncable: false)
+    }
+
+    private func makeHTTPResponse(_ statusCode: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: URL(string: "https://example.com/token")!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/json"]
+        )!
+    }
+}


### PR DESCRIPTION
## Summary

Tier A of the test-coverage effort: unit tests for previously-untested logic across four SPM modules. The focus is logic that was at or near 0% but is cleanly testable through an injected network/keychain seam. Streaming paths (`URLSession.AsyncBytes`) and the OAuth browser flow are intentionally left out - they are not unit-testable - except the one streaming seam reachable via `URLProtocolStub`.

## What's covered

**CloudTranscription (10 services, module services 43% -> 86%)**
- Job-flow services (upload -> create -> poll): Gladia, Soniox, Speechmatics, AssemblyAI.
- Single-request services: Cartesia, Cohere, Custom, Deepgram, Gemini, Mistral.
- Each suite: happy path, request endpoint/method/auth header, request body fields (language, vocabulary, diarization), and error paths (missing key, upload failure, undecodable response, poll error).

**AIProviders (non-streaming only)**
- `GeminiAPIClient` `enhance` (0 -> 22%); `CopilotAPIClient` `enhance` + `fetchModels` (28 -> 42%).
- The `bytes(for:)` streaming paths are not covered: `URLSession.AsyncBytes` cannot be stubbed.

**OAuth**
- `DefaultOAuthManager` (10 -> 38%): token refresh over the network, credential persistence, `isSignedIn` / `accountEmail` / `signOut` / `validAccessToken`. `signIn` is skipped (real browser auth session).

**Networking**
- `DefaultNetworkService.bytes(for:)` (file 63 -> 91%) via a new `URLProtocolStub` against a real `URLSession` - the streaming success path, the non-2xx drain-into-error path, an `acceptableStatusCodes` override, and the non-HTTP `invalidResponse` case. This is the one seam `MockNetworkService` cannot reach.

## Supporting changes

- `MockNetworkService`: added `stubSendResponses`, a backward-compatible FIFO queue so multi-call job flows (create + poll + fetch) can stub a distinct response per call. Falls back to the existing single `stubSendResponse`.
- `GeminiTranscriptionService`: relaxed the nested response decode structs from `private` to `internal` (documented) so the `sendJSON` success path can be stubbed with a decoded value. Module-scoped, no public API change.

## Testing

All affected module suites pass via `swift test --enable-code-coverage`:
- CloudTranscription: 190 tests
- AIProviders: 92 tests
- OAuth: 25 tests
- Networking: 27 tests

Coverage figures above are from `llvm-cov report` on each module.