### PR TITLE
Seam RecordViewModel for testability (AppGroupBridge) + construct it in a test

### DIFF
--- a/VivaDicta/Services/AppGroupBridge.swift
+++ b/VivaDicta/Services/AppGroupBridge.swift
@@ -1,0 +1,37 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import CoreGraphics
+import Foundation
+import AppGroup
+
+/// The app-group coordination surface ``RecordViewModel`` depends on - publishing
+/// recording/transcription state to the keyboard extension and receiving its
+/// control callbacks. ``AppGroupCoordinator`` is the production conformance;
+/// tests inject a mock so the view model can be constructed and its recording
+/// flow exercised without touching the process-global singleton.
+@MainActor
+protocol AppGroupBridge: AnyObject {
+    // Keyboard -> app control callbacks (set during setup).
+    var onStartRecordingRequested: (() -> Void)? { get set }
+    var onStopRecordingRequested: (() -> Void)? { get set }
+    var onCancelRecordingRequested: (() -> Void)? { get set }
+    var onPauseRecordingRequested: (() -> Void)? { get set }
+    var onResumeRecordingRequested: (() -> Void)? { get set }
+    var onStartRecordingFromControl: (() -> Void)? { get set }
+    var onVivaModeChanged: (() -> Void)? { get set }
+    var onTextProcessingRequested: (() -> Void)? { get set }
+
+    // App -> keyboard state + results.
+    func updateRecordingState(_ isRecording: Bool)
+    func updateAudioLevel(_ level: CGFloat)
+    func updateTranscriptionStatus(_ status: AppGroupCoordinator.TranscriptionStatus)
+    func updateTranscriptionError(_ message: String)
+    func shareTranscribedText(_ text: String)
+    func setPendingObsidianHandoff(url: URL, clipboardText: String)
+    func shareTextProcessingResult(_ text: String)
+    func shareTextProcessingError(_ message: String)
+    func refreshKeyboardSessionExpiry(timeoutSeconds: Int)
+    func getAndConsumePendingTextProcessing() -> (text: String, modeName: String, presetId: String?)?
+}
+
+extension AppGroupCoordinator: AppGroupBridge {}

--- a/VivaDicta/Views/RecordViewModel.swift
+++ b/VivaDicta/Views/RecordViewModel.swift
@@ -1031,11 +1031,9 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
                 self.logger.logInfo("📱 Starting recording from keyboard request")
 
                 // Reload the selected VivaMode from extension before starting
-                self.appState?.aiService.reloadSelectedModeFromExtension()
+                self.aiService.reloadSelectedModeFromExtension()
                 // Update TranscriptionManager with the reloaded mode
-                if let selectedMode = self.appState?.aiService.selectedMode {
-                    self.appState?.transcriptionManager.setCurrentMode(selectedMode)
-                }
+                self.transcriptionManager.setCurrentMode(self.aiService.selectedMode)
 
                 self.startCaptureAudio(sourceTag: SourceTag.keyboard)
             }
@@ -1049,11 +1047,9 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
                 self.logger.logInfo("📱 Stopping recording from keyboard request")
 
                 // Reload the selected VivaMode from extension before transcription
-                self.appState?.aiService.reloadSelectedModeFromExtension()
+                self.aiService.reloadSelectedModeFromExtension()
                 // Update TranscriptionManager with the reloaded mode
-                if let selectedMode = self.appState?.aiService.selectedMode {
-                    self.appState?.transcriptionManager.setCurrentMode(selectedMode)
-                }
+                self.transcriptionManager.setCurrentMode(self.aiService.selectedMode)
 
                 self.stopCaptureAudio(modelContext: modelContext)
             }
@@ -1114,7 +1110,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
             guard let self = self else { return }
 
             self.logger.logInfo("📱 VivaMode changed from keyboard extension")
-            self.appState?.aiService.reloadSelectedModeFromExtension()
+            self.aiService.reloadSelectedModeFromExtension()
         }
 
         // Handle text processing request from keyboard (rewrite feature)

--- a/VivaDicta/Views/RecordViewModel.swift
+++ b/VivaDicta/Views/RecordViewModel.swift
@@ -86,7 +86,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
     private let audioRecordingService: AudioRecordingService
     private let audioFileService: AudioFileService
     private let prewarmManager: any AudioPrewarmer
-    private let appGroupCoordinator: any AppGroupBridge
+    private let appGroupBridge: any AppGroupBridge
     private let logger = Logger(category: .recordViewModel)
 
     var animationTimer: Timer?
@@ -114,7 +114,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
         audioRecordingService: AudioRecordingService = DefaultAudioRecordingService(),
         audioFileService: AudioFileService = DefaultAudioFileService(),
         prewarmManager: any AudioPrewarmer = AudioPrewarmManager.shared,
-        appGroupCoordinator: any AppGroupBridge = AppGroupCoordinator.shared
+        appGroupBridge: any AppGroupBridge = AppGroupCoordinator.shared
     ) {
         self.appState = appState
         self.transcriptionManager = transcriptionManager ?? appState.transcriptionManager
@@ -123,7 +123,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
         self.audioRecordingService = audioRecordingService
         self.audioFileService = audioFileService
         self.prewarmManager = prewarmManager
-        self.appGroupCoordinator = appGroupCoordinator
+        self.appGroupBridge = appGroupBridge
         super.init()
         self.audioRecordingService.onDidFinishUnsuccessfully = { [weak self] in
             guard let self else { return }
@@ -155,7 +155,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
     var recordingState: RecordingState = .idle {
         didSet {
             logger.logInfo("📱 Recording state changed: \(String(describing: self.recordingState))")
-            // Recording state is shared with keyboard extension via appGroupCoordinator.updateRecordingState()
+            // Recording state is shared with keyboard extension via appGroupBridge.updateRecordingState()
             // which is called in startCaptureAudio(), stopCaptureAudio(), and cancelTranscribe()
         }
     }
@@ -224,7 +224,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
                 HapticManager.mediumImpact()
 
                 // Notify keyboard that recording has started
-                appGroupCoordinator.updateRecordingState(true)
+                appGroupBridge.updateRecordingState(true)
 
                 do {
                     // Use prewarm manager's AVAudioEngine for recording
@@ -239,7 +239,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
                             guard let self = self else { return }
                             let level = Double(self.prewarmManager.currentAudioLevel)
                             self.audioPower = level
-                            self.appGroupCoordinator.updateAudioLevel(level)
+                            self.appGroupBridge.updateAudioLevel(level)
                         }
                     })
 
@@ -269,7 +269,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
                 HapticManager.mediumImpact()
 
                 // Notify keyboard that recording has started (even in normal mode)
-                appGroupCoordinator.updateRecordingState(true)
+                appGroupBridge.updateRecordingState(true)
 
                 do {
                     let settings: [String : Any] = [
@@ -292,7 +292,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
                             let rawPower = Double(self.audioRecordingService.currentAudioPower)
                             let power = min(1, max(0, 1 - abs(rawPower / 50)))
                             self.audioPower = power
-                            self.appGroupCoordinator.updateAudioLevel(power)
+                            self.appGroupBridge.updateAudioLevel(power)
                         }
                     })
 
@@ -328,7 +328,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
                 resetValues()
 
                 // Notify keyboard that recording has stopped
-                appGroupCoordinator.updateRecordingState(false)
+                appGroupBridge.updateRecordingState(false)
 
                 let finalURL = FileManager.appDirectory(for: .audio).appendingPathComponent("\(UUID().uuidString).wav")
                 do {
@@ -348,7 +348,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
             resetValues()
 
             // Notify keyboard that recording has stopped
-            appGroupCoordinator.updateRecordingState(false)
+            appGroupBridge.updateRecordingState(false)
 
             let finalURL = FileManager.appDirectory(for: .audio).appendingPathComponent("\(UUID().uuidString).wav")
             do {
@@ -387,7 +387,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
                 self.transcriptionProgress = nil
 
                 // Notify keyboard that transcription has started
-                appGroupCoordinator.updateTranscriptionStatus(.transcribing)
+                appGroupBridge.updateTranscriptionStatus(.transcribing)
 
                 var audioURLToTranscribe = recordURL
 
@@ -455,8 +455,8 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
                     resetValues()
                     aiService.clearCapturedClipboard()
                     recordingState = .idle
-                    appGroupCoordinator.updateRecordingState(false)
-                    appGroupCoordinator.updateTranscriptionStatus(.idle)
+                    appGroupBridge.updateRecordingState(false)
+                    appGroupBridge.updateTranscriptionStatus(.idle)
                     return
                 }
 
@@ -493,7 +493,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
                     HapticManager.lightImpact()
 
                     // Notify keyboard that AI processing has started
-                    appGroupCoordinator.updateTranscriptionStatus(.enhancing)
+                    appGroupBridge.updateTranscriptionStatus(.enhancing)
 
                     do {
                         let (enhanced, enhancementDuration, prompt) = try await aiService.enhance(transcribedText)
@@ -579,7 +579,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
                     mode: aiService.selectedMode
                 )
 
-                appGroupCoordinator.shareTranscribedText(textToShare)
+                appGroupBridge.shareTranscribedText(textToShare)
 
                 // Cache for keyboard "Recent Notes" feature
                 RecentNotesCache.addNote(
@@ -609,7 +609,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
                 resetValues()
 
                 // Notify keyboard of error
-                appGroupCoordinator.updateTranscriptionError("Transcription failed: \(error.localizedDescription)")
+                appGroupBridge.updateTranscriptionError("Transcription failed: \(error.localizedDescription)")
 
                 // Reschedule session timeout even on error
                 self.prewarmManager.rescheduleSessionTimeout()
@@ -631,7 +631,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
                 if let audioPlayer = self?.audioPlayer {
                     let power = min(1, max(0, 1 - abs(Double(audioPlayer.averagePower(forChannel: 0)) / 160) ))
                     self?.audioPower = power
-                    self?.appGroupCoordinator.updateAudioLevel(power)
+                    self?.appGroupBridge.updateAudioLevel(power)
                 }
             }
         })
@@ -658,8 +658,8 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
         recordingState = .idle
 
         // Notify keyboard that recording was canceled
-        appGroupCoordinator.updateRecordingState(false)
-        appGroupCoordinator.updateTranscriptionStatus(.idle)
+        appGroupBridge.updateRecordingState(false)
+        appGroupBridge.updateTranscriptionStatus(.idle)
 
         // Reschedule session timeout after cancellation
         prewarmManager.rescheduleSessionTimeout()
@@ -695,8 +695,8 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
                     logger.logInfo("📱 Pending transcription contains no meaningful content, skipping save")
                     resetValues()
                     recordingState = .idle
-                    appGroupCoordinator.updateRecordingState(false)
-                    appGroupCoordinator.updateTranscriptionStatus(.idle)
+                    appGroupBridge.updateRecordingState(false)
+                    appGroupBridge.updateTranscriptionStatus(.idle)
                     return
                 }
 
@@ -758,7 +758,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
                     )
 
                     // Share with keyboard
-                    appGroupCoordinator.shareTranscribedText(pending.text)
+                    appGroupBridge.shareTranscribedText(pending.text)
 
                     // Cache for keyboard "Recent Notes" feature
                     RecentNotesCache.addNote(
@@ -779,8 +779,8 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
             recordingState = .idle
 
             // Notify keyboard
-            appGroupCoordinator.updateRecordingState(false)
-            appGroupCoordinator.updateTranscriptionStatus(.idle)
+            appGroupBridge.updateRecordingState(false)
+            appGroupBridge.updateTranscriptionStatus(.idle)
 
             // Reschedule session timeout after cancellation
             prewarmManager.rescheduleSessionTimeout()
@@ -825,7 +825,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
         }
         if sourceTag == SourceTag.keyboard {
             logger.logInfo("📱 Obsidian: delegating to keyboard \(output.url.absoluteString)")
-            appGroupCoordinator.setPendingObsidianHandoff(url: output.url, clipboardText: output.clipboardText)
+            appGroupBridge.setPendingObsidianHandoff(url: output.url, clipboardText: output.clipboardText)
         } else {
             logger.logInfo("📱 Obsidian: opening directly \(output.url.absoluteString)")
             ClipboardManager.copyToClipboard(output.clipboardText)
@@ -1004,7 +1004,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
     func resetValues() {
         audioPower = 0
         transcriptionProgress = nil
-        appGroupCoordinator.updateAudioLevel(0)
+        appGroupBridge.updateAudioLevel(0)
 
         _ = audioRecordingService.stopRecording()
 
@@ -1026,7 +1026,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
 
     private func setupKeyboardRecordingHandlers() {
         // Handle start recording request from keyboard
-        appGroupCoordinator.onStartRecordingRequested = { [weak self] in
+        appGroupBridge.onStartRecordingRequested = { [weak self] in
             guard let self = self else { return }
 
             // Only start if prewarm session is active and not already recording
@@ -1043,7 +1043,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
         }
 
         // Handle stop recording request from keyboard
-        appGroupCoordinator.onStopRecordingRequested = { [weak self] in
+        appGroupBridge.onStopRecordingRequested = { [weak self] in
             guard let self = self else { return }
 
             if self.recordingState == .recording {
@@ -1059,7 +1059,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
         }
 
         // Handle cancel recording request from keyboard
-        appGroupCoordinator.onCancelRecordingRequested = { [weak self] in
+        appGroupBridge.onCancelRecordingRequested = { [weak self] in
             guard let self = self else { return }
 
             switch self.recordingState {
@@ -1078,7 +1078,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
         }
 
         // Handle pause recording request from keyboard
-        appGroupCoordinator.onPauseRecordingRequested = { [weak self] in
+        appGroupBridge.onPauseRecordingRequested = { [weak self] in
             guard let self = self else { return }
 
             if self.recordingState == .recording {
@@ -1088,7 +1088,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
         }
 
         // Handle resume recording request from keyboard
-        appGroupCoordinator.onResumeRecordingRequested = { [weak self] in
+        appGroupBridge.onResumeRecordingRequested = { [weak self] in
             guard let self = self else { return }
 
             if self.recordingState == .recording {
@@ -1098,7 +1098,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
         }
 
         // Handle start recording request from Control Center
-        appGroupCoordinator.onStartRecordingFromControl = { [weak self] in
+        appGroupBridge.onStartRecordingFromControl = { [weak self] in
             guard let self = self else { return }
 
             self.logger.logInfo("📱 Starting recording from Control Center request")
@@ -1109,7 +1109,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
         }
 
         // Handle VivaMode change from keyboard extension
-        appGroupCoordinator.onVivaModeChanged = { [weak self] in
+        appGroupBridge.onVivaModeChanged = { [weak self] in
             guard let self = self else { return }
 
             self.logger.logInfo("📱 VivaMode changed from keyboard extension")
@@ -1117,7 +1117,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
         }
 
         // Handle text processing request from keyboard (rewrite feature)
-        appGroupCoordinator.onTextProcessingRequested = { [weak self] in
+        appGroupBridge.onTextProcessingRequested = { [weak self] in
             guard let self = self else { return }
             self.handleKeyboardTextProcessingRequest()
         }
@@ -1126,14 +1126,17 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
     // MARK: - Keyboard Text Processing
 
     private func handleKeyboardTextProcessingRequest() {
-        guard let pending = appGroupCoordinator.getAndConsumePendingTextProcessing() else {
+        guard let pending = appGroupBridge.getAndConsumePendingTextProcessing() else {
             logger.logError("📝 Text processing requested but no pending data found")
-            appGroupCoordinator.shareTextProcessingError("No text to process")
+            appGroupBridge.shareTextProcessingError("No text to process")
             return
         }
 
-        guard let appState else {
-            appGroupCoordinator.shareTextProcessingError("App not ready")
+        // Liveness gate: a nil weak appState means the app context is gone, so
+        // there is nothing to process for. The bound value is intentionally unused -
+        // the AI work routes through the injected aiService.
+        guard appState != nil else {
+            appGroupBridge.shareTextProcessingError("App not ready")
             return
         }
 
@@ -1141,7 +1144,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
 
         // Extend session while processing (same pattern as recording flow)
         let timeoutSeconds = prewarmManager.audioSessionTimeout
-        appGroupCoordinator.refreshKeyboardSessionExpiry(timeoutSeconds: timeoutSeconds)
+        appGroupBridge.refreshKeyboardSessionExpiry(timeoutSeconds: timeoutSeconds)
 
         // Temporarily switch to the requested mode, then restore.
         // Uses the injected `aiService` (== appState.aiService) so the AI surface
@@ -1166,13 +1169,13 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
                 logger.logInfo("📝 Text processing completed, result length: \(result.count)")
                 if result.isEmpty {
                     logger.logError("📝 Text processing returned empty result")
-                    appGroupCoordinator.shareTextProcessingError("AI returned empty result")
+                    appGroupBridge.shareTextProcessingError("AI returned empty result")
                 } else {
-                    appGroupCoordinator.shareTextProcessingResult(result)
+                    appGroupBridge.shareTextProcessingResult(result)
                 }
             } catch {
                 logger.logError("📝 Text processing failed: \(error.localizedDescription)")
-                appGroupCoordinator.shareTextProcessingError(error.localizedDescription)
+                appGroupBridge.shareTextProcessingError(error.localizedDescription)
             }
         }
     }

--- a/VivaDicta/Views/RecordViewModel.swift
+++ b/VivaDicta/Views/RecordViewModel.swift
@@ -86,6 +86,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
     private let audioRecordingService: AudioRecordingService
     private let audioFileService: AudioFileService
     private let prewarmManager: any AudioPrewarmer
+    private let appGroupCoordinator: any AppGroupBridge
     private let logger = Logger(category: .recordViewModel)
 
     var animationTimer: Timer?
@@ -112,7 +113,8 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
         aiService: (any AIProcessingService)? = nil,
         audioRecordingService: AudioRecordingService = DefaultAudioRecordingService(),
         audioFileService: AudioFileService = DefaultAudioFileService(),
-        prewarmManager: any AudioPrewarmer = AudioPrewarmManager.shared
+        prewarmManager: any AudioPrewarmer = AudioPrewarmManager.shared,
+        appGroupCoordinator: any AppGroupBridge = AppGroupCoordinator.shared
     ) {
         self.appState = appState
         self.transcriptionManager = transcriptionManager ?? appState.transcriptionManager
@@ -121,6 +123,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
         self.audioRecordingService = audioRecordingService
         self.audioFileService = audioFileService
         self.prewarmManager = prewarmManager
+        self.appGroupCoordinator = appGroupCoordinator
         super.init()
         self.audioRecordingService.onDidFinishUnsuccessfully = { [weak self] in
             guard let self else { return }
@@ -152,7 +155,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
     var recordingState: RecordingState = .idle {
         didSet {
             logger.logInfo("📱 Recording state changed: \(String(describing: self.recordingState))")
-            // Recording state is shared with keyboard extension via AppGroupCoordinator.shared.updateRecordingState()
+            // Recording state is shared with keyboard extension via appGroupCoordinator.updateRecordingState()
             // which is called in startCaptureAudio(), stopCaptureAudio(), and cancelTranscribe()
         }
     }
@@ -221,7 +224,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
                 HapticManager.mediumImpact()
 
                 // Notify keyboard that recording has started
-                AppGroupCoordinator.shared.updateRecordingState(true)
+                appGroupCoordinator.updateRecordingState(true)
 
                 do {
                     // Use prewarm manager's AVAudioEngine for recording
@@ -236,7 +239,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
                             guard let self = self else { return }
                             let level = Double(self.prewarmManager.currentAudioLevel)
                             self.audioPower = level
-                            AppGroupCoordinator.shared.updateAudioLevel(level)
+                            self.appGroupCoordinator.updateAudioLevel(level)
                         }
                     })
 
@@ -266,7 +269,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
                 HapticManager.mediumImpact()
 
                 // Notify keyboard that recording has started (even in normal mode)
-                AppGroupCoordinator.shared.updateRecordingState(true)
+                appGroupCoordinator.updateRecordingState(true)
 
                 do {
                     let settings: [String : Any] = [
@@ -289,7 +292,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
                             let rawPower = Double(self.audioRecordingService.currentAudioPower)
                             let power = min(1, max(0, 1 - abs(rawPower / 50)))
                             self.audioPower = power
-                            AppGroupCoordinator.shared.updateAudioLevel(power)
+                            self.appGroupCoordinator.updateAudioLevel(power)
                         }
                     })
 
@@ -325,7 +328,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
                 resetValues()
 
                 // Notify keyboard that recording has stopped
-                AppGroupCoordinator.shared.updateRecordingState(false)
+                appGroupCoordinator.updateRecordingState(false)
 
                 let finalURL = FileManager.appDirectory(for: .audio).appendingPathComponent("\(UUID().uuidString).wav")
                 do {
@@ -345,7 +348,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
             resetValues()
 
             // Notify keyboard that recording has stopped
-            AppGroupCoordinator.shared.updateRecordingState(false)
+            appGroupCoordinator.updateRecordingState(false)
 
             let finalURL = FileManager.appDirectory(for: .audio).appendingPathComponent("\(UUID().uuidString).wav")
             do {
@@ -384,7 +387,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
                 self.transcriptionProgress = nil
 
                 // Notify keyboard that transcription has started
-                AppGroupCoordinator.shared.updateTranscriptionStatus(.transcribing)
+                appGroupCoordinator.updateTranscriptionStatus(.transcribing)
 
                 var audioURLToTranscribe = recordURL
 
@@ -452,8 +455,8 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
                     resetValues()
                     aiService.clearCapturedClipboard()
                     recordingState = .idle
-                    AppGroupCoordinator.shared.updateRecordingState(false)
-                    AppGroupCoordinator.shared.updateTranscriptionStatus(.idle)
+                    appGroupCoordinator.updateRecordingState(false)
+                    appGroupCoordinator.updateTranscriptionStatus(.idle)
                     return
                 }
 
@@ -490,7 +493,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
                     HapticManager.lightImpact()
 
                     // Notify keyboard that AI processing has started
-                    AppGroupCoordinator.shared.updateTranscriptionStatus(.enhancing)
+                    appGroupCoordinator.updateTranscriptionStatus(.enhancing)
 
                     do {
                         let (enhanced, enhancementDuration, prompt) = try await aiService.enhance(transcribedText)
@@ -576,7 +579,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
                     mode: aiService.selectedMode
                 )
 
-                AppGroupCoordinator.shared.shareTranscribedText(textToShare)
+                appGroupCoordinator.shareTranscribedText(textToShare)
 
                 // Cache for keyboard "Recent Notes" feature
                 RecentNotesCache.addNote(
@@ -606,7 +609,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
                 resetValues()
 
                 // Notify keyboard of error
-                AppGroupCoordinator.shared.updateTranscriptionError("Transcription failed: \(error.localizedDescription)")
+                appGroupCoordinator.updateTranscriptionError("Transcription failed: \(error.localizedDescription)")
 
                 // Reschedule session timeout even on error
                 self.prewarmManager.rescheduleSessionTimeout()
@@ -628,7 +631,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
                 if let audioPlayer = self?.audioPlayer {
                     let power = min(1, max(0, 1 - abs(Double(audioPlayer.averagePower(forChannel: 0)) / 160) ))
                     self?.audioPower = power
-                    AppGroupCoordinator.shared.updateAudioLevel(power)
+                    self?.appGroupCoordinator.updateAudioLevel(power)
                 }
             }
         })
@@ -655,8 +658,8 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
         recordingState = .idle
 
         // Notify keyboard that recording was canceled
-        AppGroupCoordinator.shared.updateRecordingState(false)
-        AppGroupCoordinator.shared.updateTranscriptionStatus(.idle)
+        appGroupCoordinator.updateRecordingState(false)
+        appGroupCoordinator.updateTranscriptionStatus(.idle)
 
         // Reschedule session timeout after cancellation
         prewarmManager.rescheduleSessionTimeout()
@@ -692,8 +695,8 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
                     logger.logInfo("📱 Pending transcription contains no meaningful content, skipping save")
                     resetValues()
                     recordingState = .idle
-                    AppGroupCoordinator.shared.updateRecordingState(false)
-                    AppGroupCoordinator.shared.updateTranscriptionStatus(.idle)
+                    appGroupCoordinator.updateRecordingState(false)
+                    appGroupCoordinator.updateTranscriptionStatus(.idle)
                     return
                 }
 
@@ -755,7 +758,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
                     )
 
                     // Share with keyboard
-                    AppGroupCoordinator.shared.shareTranscribedText(pending.text)
+                    appGroupCoordinator.shareTranscribedText(pending.text)
 
                     // Cache for keyboard "Recent Notes" feature
                     RecentNotesCache.addNote(
@@ -776,8 +779,8 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
             recordingState = .idle
 
             // Notify keyboard
-            AppGroupCoordinator.shared.updateRecordingState(false)
-            AppGroupCoordinator.shared.updateTranscriptionStatus(.idle)
+            appGroupCoordinator.updateRecordingState(false)
+            appGroupCoordinator.updateTranscriptionStatus(.idle)
 
             // Reschedule session timeout after cancellation
             prewarmManager.rescheduleSessionTimeout()
@@ -822,7 +825,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
         }
         if sourceTag == SourceTag.keyboard {
             logger.logInfo("📱 Obsidian: delegating to keyboard \(output.url.absoluteString)")
-            AppGroupCoordinator.shared.setPendingObsidianHandoff(url: output.url, clipboardText: output.clipboardText)
+            appGroupCoordinator.setPendingObsidianHandoff(url: output.url, clipboardText: output.clipboardText)
         } else {
             logger.logInfo("📱 Obsidian: opening directly \(output.url.absoluteString)")
             ClipboardManager.copyToClipboard(output.clipboardText)
@@ -1001,7 +1004,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
     func resetValues() {
         audioPower = 0
         transcriptionProgress = nil
-        AppGroupCoordinator.shared.updateAudioLevel(0)
+        appGroupCoordinator.updateAudioLevel(0)
 
         _ = audioRecordingService.stopRecording()
 
@@ -1023,7 +1026,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
 
     private func setupKeyboardRecordingHandlers() {
         // Handle start recording request from keyboard
-        AppGroupCoordinator.shared.onStartRecordingRequested = { [weak self] in
+        appGroupCoordinator.onStartRecordingRequested = { [weak self] in
             guard let self = self else { return }
 
             // Only start if prewarm session is active and not already recording
@@ -1040,7 +1043,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
         }
 
         // Handle stop recording request from keyboard
-        AppGroupCoordinator.shared.onStopRecordingRequested = { [weak self] in
+        appGroupCoordinator.onStopRecordingRequested = { [weak self] in
             guard let self = self else { return }
 
             if self.recordingState == .recording {
@@ -1056,7 +1059,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
         }
 
         // Handle cancel recording request from keyboard
-        AppGroupCoordinator.shared.onCancelRecordingRequested = { [weak self] in
+        appGroupCoordinator.onCancelRecordingRequested = { [weak self] in
             guard let self = self else { return }
 
             switch self.recordingState {
@@ -1075,7 +1078,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
         }
 
         // Handle pause recording request from keyboard
-        AppGroupCoordinator.shared.onPauseRecordingRequested = { [weak self] in
+        appGroupCoordinator.onPauseRecordingRequested = { [weak self] in
             guard let self = self else { return }
 
             if self.recordingState == .recording {
@@ -1085,7 +1088,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
         }
 
         // Handle resume recording request from keyboard
-        AppGroupCoordinator.shared.onResumeRecordingRequested = { [weak self] in
+        appGroupCoordinator.onResumeRecordingRequested = { [weak self] in
             guard let self = self else { return }
 
             if self.recordingState == .recording {
@@ -1095,7 +1098,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
         }
 
         // Handle start recording request from Control Center
-        AppGroupCoordinator.shared.onStartRecordingFromControl = { [weak self] in
+        appGroupCoordinator.onStartRecordingFromControl = { [weak self] in
             guard let self = self else { return }
 
             self.logger.logInfo("📱 Starting recording from Control Center request")
@@ -1106,7 +1109,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
         }
 
         // Handle VivaMode change from keyboard extension
-        AppGroupCoordinator.shared.onVivaModeChanged = { [weak self] in
+        appGroupCoordinator.onVivaModeChanged = { [weak self] in
             guard let self = self else { return }
 
             self.logger.logInfo("📱 VivaMode changed from keyboard extension")
@@ -1114,7 +1117,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
         }
 
         // Handle text processing request from keyboard (rewrite feature)
-        AppGroupCoordinator.shared.onTextProcessingRequested = { [weak self] in
+        appGroupCoordinator.onTextProcessingRequested = { [weak self] in
             guard let self = self else { return }
             self.handleKeyboardTextProcessingRequest()
         }
@@ -1123,14 +1126,14 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
     // MARK: - Keyboard Text Processing
 
     private func handleKeyboardTextProcessingRequest() {
-        guard let pending = AppGroupCoordinator.shared.getAndConsumePendingTextProcessing() else {
+        guard let pending = appGroupCoordinator.getAndConsumePendingTextProcessing() else {
             logger.logError("📝 Text processing requested but no pending data found")
-            AppGroupCoordinator.shared.shareTextProcessingError("No text to process")
+            appGroupCoordinator.shareTextProcessingError("No text to process")
             return
         }
 
         guard let appState else {
-            AppGroupCoordinator.shared.shareTextProcessingError("App not ready")
+            appGroupCoordinator.shareTextProcessingError("App not ready")
             return
         }
 
@@ -1138,7 +1141,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
 
         // Extend session while processing (same pattern as recording flow)
         let timeoutSeconds = prewarmManager.audioSessionTimeout
-        AppGroupCoordinator.shared.refreshKeyboardSessionExpiry(timeoutSeconds: timeoutSeconds)
+        appGroupCoordinator.refreshKeyboardSessionExpiry(timeoutSeconds: timeoutSeconds)
 
         // Temporarily switch to the requested mode, then restore.
         // Uses the injected `aiService` (== appState.aiService) so the AI surface
@@ -1163,13 +1166,13 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
                 logger.logInfo("📝 Text processing completed, result length: \(result.count)")
                 if result.isEmpty {
                     logger.logError("📝 Text processing returned empty result")
-                    AppGroupCoordinator.shared.shareTextProcessingError("AI returned empty result")
+                    appGroupCoordinator.shareTextProcessingError("AI returned empty result")
                 } else {
-                    AppGroupCoordinator.shared.shareTextProcessingResult(result)
+                    appGroupCoordinator.shareTextProcessingResult(result)
                 }
             } catch {
                 logger.logError("📝 Text processing failed: \(error.localizedDescription)")
-                AppGroupCoordinator.shared.shareTextProcessingError(error.localizedDescription)
+                appGroupCoordinator.shareTextProcessingError(error.localizedDescription)
             }
         }
     }

--- a/VivaDictaTests/Mocks/MockAppGroupBridge.swift
+++ b/VivaDictaTests/Mocks/MockAppGroupBridge.swift
@@ -1,0 +1,47 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import CoreGraphics
+import Foundation
+import AppGroup
+@testable import VivaDicta
+
+/// Hand-rolled mock of ``AppGroupBridge`` for `RecordViewModel` tests. Records
+/// state pushed toward the keyboard and exposes the control callbacks so tests
+/// can fire them - no process-global singleton involved.
+@MainActor
+final class MockAppGroupBridge: AppGroupBridge {
+    var onStartRecordingRequested: (() -> Void)?
+    var onStopRecordingRequested: (() -> Void)?
+    var onCancelRecordingRequested: (() -> Void)?
+    var onPauseRecordingRequested: (() -> Void)?
+    var onResumeRecordingRequested: (() -> Void)?
+    var onStartRecordingFromControl: (() -> Void)?
+    var onVivaModeChanged: (() -> Void)?
+    var onTextProcessingRequested: (() -> Void)?
+
+    private(set) var recordingStates: [Bool] = []
+    private(set) var audioLevels: [CGFloat] = []
+    private(set) var transcriptionStatuses: [AppGroupCoordinator.TranscriptionStatus] = []
+    private(set) var transcriptionErrors: [String] = []
+    private(set) var sharedTranscribedTexts: [String] = []
+    private(set) var obsidianHandoffs: [(url: URL, clipboardText: String)] = []
+    private(set) var textProcessingResults: [String] = []
+    private(set) var textProcessingErrors: [String] = []
+    private(set) var refreshKeyboardSessionExpiryCalls: [Int] = []
+    var stubPendingTextProcessing: (text: String, modeName: String, presetId: String?)?
+
+    func updateRecordingState(_ isRecording: Bool) { recordingStates.append(isRecording) }
+    func updateAudioLevel(_ level: CGFloat) { audioLevels.append(level) }
+    func updateTranscriptionStatus(_ status: AppGroupCoordinator.TranscriptionStatus) { transcriptionStatuses.append(status) }
+    func updateTranscriptionError(_ message: String) { transcriptionErrors.append(message) }
+    func shareTranscribedText(_ text: String) { sharedTranscribedTexts.append(text) }
+    func setPendingObsidianHandoff(url: URL, clipboardText: String) { obsidianHandoffs.append((url, clipboardText)) }
+    func shareTextProcessingResult(_ text: String) { textProcessingResults.append(text) }
+    func shareTextProcessingError(_ message: String) { textProcessingErrors.append(message) }
+    func refreshKeyboardSessionExpiry(timeoutSeconds: Int) { refreshKeyboardSessionExpiryCalls.append(timeoutSeconds) }
+
+    func getAndConsumePendingTextProcessing() -> (text: String, modeName: String, presetId: String?)? {
+        defer { stubPendingTextProcessing = nil }
+        return stubPendingTextProcessing
+    }
+}

--- a/VivaDictaTests/Mocks/MockTranscriber.swift
+++ b/VivaDictaTests/Mocks/MockTranscriber.swift
@@ -1,0 +1,33 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import AICore
+import TranscriptionCore
+@testable import VivaDicta
+
+/// Hand-rolled mock of ``Transcriber`` for view-model tests - returns a stubbed
+/// transcript without a downloaded/keyed model.
+@MainActor
+final class MockTranscriber: Transcriber {
+    var currentMode: VivaMode
+    var stubbedText: String
+    private(set) var setCurrentModeCalls: [VivaMode] = []
+    private(set) var transcribeCallCount = 0
+
+    init(currentMode: VivaMode = .defaultMode, stubbedText: String = "stubbed transcript") {
+        self.currentMode = currentMode
+        self.stubbedText = stubbedText
+    }
+
+    func setCurrentMode(_ mode: VivaMode) {
+        currentMode = mode
+        setCurrentModeCalls.append(mode)
+    }
+
+    func getCurrentTranscriptionModel() -> (any TranscriptionModel)? { nil }
+
+    func transcribe(audioURL: URL, progressHandler: TranscriptionProgressHandler?) async throws -> String {
+        transcribeCallCount += 1
+        return stubbedText
+    }
+}

--- a/VivaDictaTests/RecordViewModelTests.swift
+++ b/VivaDictaTests/RecordViewModelTests.swift
@@ -6,18 +6,19 @@
 //
 
 import Foundation
+import SwiftData
 import Testing
+import AICore
 @testable import VivaDicta
 
-/// `AudioRecording` was extracted into its own module so the audio-capture
-/// surface of `RecordViewModel` is now mockable via `MockAudioRecordingService` /
-/// `MockAudioFileService`. The real impls are covered by `AudioRecordingTests`.
-///
-/// A fully hermetic VM test (constructing `RecordViewModel` with mock audio
-/// services) is still blocked: `AppState.init` instantiates concrete
-/// `AIService` + `TranscriptionManager` + `PresetSyncService` (CloudKit),
-/// which leaks state across parallel test runs. The right unlock is the
-/// next planned refactor - seam `AppState` / `AIService` behind protocols.
+/// `RecordViewModel` is now constructible in a test: its AI, transcription,
+/// audio, and app-group surfaces are seamed behind protocols
+/// (`AIProcessingService` / `Transcriber` / `AudioPrewarmer` / `AppGroupBridge`),
+/// so a test injects mocks for all of them. `AppState` stays a real instance -
+/// its init boots the service graph, but that is fast and non-fatal under test
+/// (the only noise is CloudKit's "no iCloud account"), so no `AppState` seam was
+/// needed. The pure-formula tests below predate the seams; the construction test
+/// exercises the seamed VM.
 struct RecordViewModelTests {
 
     // MARK: - Audio Level Normalization (pure formula, no VM construction)
@@ -50,5 +51,35 @@ struct RecordViewModelTests {
         #expect(RecordingState.idle != RecordingState.recording)
         #expect(RecordingState.error(.avInitError) == RecordingState.error(.avInitError))
         #expect(RecordingState.error(.avInitError) != RecordingState.error(.userDenied))
+    }
+
+    // MARK: - Construction (now that AI / transcription / audio / app-group are seamed)
+
+    /// Constructs the real `RecordViewModel` with every injected dependency mocked.
+    /// `AppState` is still a real instance (its god-object init boots the service
+    /// graph), but the four seams mean the VM's own AI/transcription/audio/app-group
+    /// surfaces are mock-driven, and the keyboard handlers wire onto the injected
+    /// bridge instead of the process-global singleton.
+    @MainActor
+    @Test func constructsWithMocks_andWiresKeyboardHandlersOntoInjectedBridge() throws {
+        let container = try ModelContainer(
+            for: Transcription.self,
+            configurations: .init(isStoredInMemoryOnly: true)
+        )
+        let appGroup = MockAppGroupBridge()
+        let sut = RecordViewModel(
+            appState: AppState(),
+            modelContainer: container,
+            transcriptionManager: MockTranscriber(),
+            aiService: MockAIProcessingService(),
+            prewarmManager: MockAudioPrewarmer(),
+            appGroupCoordinator: appGroup
+        )
+
+        #expect(sut.recordingState == .idle)
+        // Proof the AppGroupBridge seam is effective: setup wired the keyboard
+        // control callbacks onto the injected mock, not AppGroupCoordinator.shared.
+        #expect(appGroup.onStartRecordingRequested != nil)
+        #expect(appGroup.onStopRecordingRequested != nil)
     }
 }

--- a/VivaDictaTests/RecordViewModelTests.swift
+++ b/VivaDictaTests/RecordViewModelTests.swift
@@ -73,7 +73,7 @@ struct RecordViewModelTests {
             transcriptionManager: MockTranscriber(),
             aiService: MockAIProcessingService(),
             prewarmManager: MockAudioPrewarmer(),
-            appGroupCoordinator: appGroup
+            appGroupBridge: appGroup
         )
 
         #expect(sut.recordingState == .idle)

--- a/scripts/coverage/coverage.sh
+++ b/scripts/coverage/coverage.sh
@@ -39,7 +39,7 @@ case "$MODE" in
     echo
     echo "=== OVERALL ==="
     xcrun xccov view --report --json "$RESULT" \
-      | python3 -c 'import json,sys; d=json.load(sys.stdin); print(f"{d[\"lineCoverage\"]*100:.2f}%  ({d[\"coveredLines\"]}/{d[\"executableLines\"]} lines)")'
+      | python3 -c "import json,sys; d=json.load(sys.stdin); print('%.2f%% (%d/%d lines)' % (d['lineCoverage']*100, d['coveredLines'], d['executableLines']))"
 
     echo
     echo "=== PER-TARGET ==="
@@ -58,7 +58,17 @@ case "$MODE" in
   module)
     MODULE="${2:?usage: coverage.sh module <Module>}"
     cd "Modules/$MODULE"
-    xcrun swift test --enable-code-coverage 2>&1 | grep -iE "Test run with|error:" || true
+    # Capture swift test's own exit status (not the pipe's) so a failing build
+    # aborts instead of silently reporting stale coverage from a prior .build.
+    log="${TMPDIR:-/tmp}/coverage-module-$$.log"
+    if ! xcrun swift test --enable-code-coverage > "$log" 2>&1; then
+      grep -iE "error:|Test run with" "$log" >&2 || true
+      echo "swift test failed for $MODULE - aborting so coverage is not reported from a stale build." >&2
+      rm -f "$log"
+      exit 1
+    fi
+    grep -iE "Test run with" "$log" || true
+    rm -f "$log"
     BIN="$(find .build -name "${MODULE}PackageTests" -type f -path '*MacOS*' | head -1)"
     PROF="$(find .build -name default.profdata | head -1)"
     if [ -z "$BIN" ] || [ -z "$PROF" ]; then


### PR DESCRIPTION
## Summary

Completes making `RecordViewModel` constructible in a test. PR #351 seamed its AI / transcription / audio surfaces; this PR seams the last hard dependency (`AppGroupCoordinator.shared`) and **proves the VM now builds in a test with every injected dependency mocked**. All changes are behavior-preserving.

The notable finding: the `AppState` god-object seam I expected to need turned out **unnecessary** - a real `AppState()` works fine under test (its init boots the service graph, but that's fast and the only noise is CloudKit's "no iCloud account"). So no large `AppState` refactor was required.

## Changes

**`AppGroupBridge` seam**
- New `AppGroupBridge` protocol covering the app-group coordination surface RecordViewModel uses: recording/transcription state + audio level pushed to the keyboard, and the 8 keyboard->app control callbacks.
- `AppGroupCoordinator` conforms via an empty extension; RecordViewModel injects it (default `.shared`) instead of touching the process-global singleton across ~40 call sites.
- `MockAppGroupBridge` records pushed state and exposes the callbacks.

**Construction test**
- A reusable `MockTranscriber`, and a test that builds the real `RecordViewModel` with all four mocks (`AIProcessingService` / `Transcriber` / `AudioPrewarmer` / `AppGroupBridge`). It asserts the VM constructs and that `setupKeyboardRecordingHandlers` wired the callbacks onto the **injected** bridge, not the singleton - proof the seam is effective. The four mocks from PR #351 are now exercised.

**PR #351 review follow-ups**
- RecordViewModel: route the 5 keyboard-handler calls through the injected `aiService`/`transcriptionManager` instead of `appState` (Claude #1), so a flow test observes them. Same instances in production.
- `coverage.sh`: fix the OVERALL line (Python escapes broke inside single quotes) and stop masking `swift test` failures in module mode (Codex P2) - capture the exit status so a failing build aborts instead of reporting stale coverage.

## Coverage

`RecordViewModel.swift` goes from ~0% to **8.1%** (the construction test now exercises its init + setup). The ~1,400 lines of record->transcribe->enhance flow logic remain uncovered - they are now *reachable* and are the next step (flow tests driving the mocks). Headline app-target coverage is essentially flat, as expected for foundational seam work.

## Testing

`xcodebuild test -only-testing:VivaDictaTests/RecordViewModelTests` passes (6 tests incl. the new construction test); the seam builds clean across all production consumers.