### PR TITLE
Add streaming, chat-VM, and keychain test coverage

### DIFF
--- a/Modules/AIProviders/Tests/AIProvidersTests/GeminiAPIClientStreamingTests.swift
+++ b/Modules/AIProviders/Tests/AIProvidersTests/GeminiAPIClientStreamingTests.swift
@@ -1,0 +1,242 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import Networking
+import Testing
+import AIProviders
+import AICore
+import OAuth
+
+/// Pure, network-free helpers on `GeminiAPIClient`. These need no session at
+/// all, so they stay outside the serialized streaming suite and run in
+/// parallel.
+@Suite("GeminiAPIClient helpers", .tags(.networking))
+struct GeminiAPIClientHelperTests {
+
+    @Test func resolveModelFallsBackToDefaultWhenEmpty() {
+        #expect(GeminiAPIClient.resolveModel("") == GeminiAPIClient.defaultModel)
+    }
+
+    @Test func resolveModelKeepsExplicitModel() {
+        #expect(GeminiAPIClient.resolveModel("gemini-2.5-pro") == "gemini-2.5-pro")
+    }
+
+    @Test func streamingTextReadsCloudCodeAssistWrappedCandidate() {
+        let event: [String: Any] = ["response": ["candidates": [["content": ["parts": [["text": "abc"]]]]]]]
+        #expect(GeminiAPIClient.streamingText(from: event) == "abc")
+    }
+
+    @Test func streamingTextReadsUnwrappedCandidate() {
+        let event: [String: Any] = ["candidates": [["content": ["parts": [["text": "xyz"]]]]]]
+        #expect(GeminiAPIClient.streamingText(from: event) == "xyz")
+    }
+
+    @Test func streamingTextJoinsMultipleParts() {
+        let event: [String: Any] = ["candidates": [["content": ["parts": [["text": "a"], ["text": "b"]]]]]]
+        #expect(GeminiAPIClient.streamingText(from: event) == "ab")
+    }
+
+    @Test func streamingTextReturnsNilWhenNoCandidates() {
+        #expect(GeminiAPIClient.streamingText(from: ["foo": "bar"]) == nil)
+    }
+
+    @Test func streamingTextReturnsNilWhenPartsEmpty() {
+        let event: [String: Any] = ["candidates": [["content": ["parts": []]]]]
+        #expect(GeminiAPIClient.streamingText(from: event) == nil)
+    }
+}
+
+/// Collects the `@MainActor`-isolated partial-response callbacks so tests can
+/// assert that streaming delivered incremental deltas, not just a final value.
+@MainActor
+final class PartialSink {
+    private(set) var values: [String] = []
+    func receive(_ value: String) { values.append(value) }
+}
+
+/// Drives `GeminiAPIClient`'s SSE streaming paths (`chatStreaming`, `chat`,
+/// `enhanceStreaming`) end-to-end against a real `URLSession` whose transport
+/// is the `StreamingURLProtocol` stub. Serialized because the stub is shared
+/// static state.
+@MainActor
+@Suite("GeminiAPIClient streaming", .tags(.networking), .serialized)
+struct GeminiAPIClientStreamingTests {
+
+    /// One Cloud Code Assist SSE event carrying `text` under the standard
+    /// `candidates -> content -> parts` shape, optionally wrapped under
+    /// `response` as the Cloud Code Assist endpoint does.
+    private func candidateEvent(_ text: String, wrapped: Bool = true) -> String {
+        let inner = "{\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"\(text)\"}]}}]}"
+        return wrapped ? "{\"response\":\(inner)}" : inner
+    }
+
+    /// Joins JSON events as `data: <json>` lines. `chatStreaming` parses each
+    /// `data:` line eagerly, so multiple deltas stream correctly here.
+    /// `enhanceStreaming` instead buffers until a blank-line delimiter (which
+    /// `AsyncBytes.lines` does not surface from back-to-back newlines), so its
+    /// test below uses a single complete event rather than multiple deltas.
+    private func sse(_ events: [String]) -> Data {
+        Data(events.map { "data: \($0)" }.joined(separator: "\n").utf8)
+    }
+
+    private func userMessages() -> [[String: String]] {
+        [["role": "user", "content": "hi"]]
+    }
+
+    // MARK: - chatStreaming
+
+    @Test func chatStreamingAggregatesSSEDeltasAndStreamsPartials() async throws {
+        StreamingURLProtocol.stub = .init(
+            statusCode: 200,
+            body: sse([candidateEvent("Hello"), candidateEvent("Hello world")])
+        )
+        let sink = PartialSink()
+
+        let result = try await GeminiAPIClient.chatStreaming(
+            systemMessage: "system",
+            messages: userMessages(),
+            model: "gemini-3.5-flash",
+            accessToken: "ya29.token",
+            projectId: nil,
+            onPartialResponse: { sink.receive($0) },
+            networkService: StreamingURLProtocol.makeNetworkService()
+        )
+
+        #expect(result.contains("Hello world"))
+        // Incremental deltas were surfaced as they arrived, not just the final.
+        #expect(sink.values.contains("Hello"))
+        #expect(sink.values.contains("Hello world"))
+    }
+
+    @Test func chatStreamingThrowsInvalidResponseWhenNoTextEventsArrive() async throws {
+        // Valid SSE framing but every event lacks extractable text.
+        StreamingURLProtocol.stub = .init(
+            statusCode: 200,
+            body: sse(["{\"response\":{\"candidates\":[]}}"])
+        )
+
+        let error = try await #require(throws: OAuthError.self) {
+            _ = try await GeminiAPIClient.chatStreaming(
+                systemMessage: "system",
+                messages: userMessages(),
+                model: "gemini-3.5-flash",
+                accessToken: "ya29.token",
+                projectId: nil,
+                onPartialResponse: { _ in },
+                networkService: StreamingURLProtocol.makeNetworkService()
+            )
+        }
+        guard case .invalidResponse = error else {
+            Issue.record("Expected .invalidResponse, got \(error)")
+            return
+        }
+    }
+
+    @Test func chatStreamingMapsServerErrorOn5xx() async throws {
+        StreamingURLProtocol.stub = .init(statusCode: 503, body: Data("upstream boom".utf8))
+
+        let error = try await #require(throws: EnhancementError.self) {
+            _ = try await GeminiAPIClient.chatStreaming(
+                systemMessage: "system",
+                messages: userMessages(),
+                model: "gemini-3.5-flash",
+                accessToken: "ya29.token",
+                projectId: nil,
+                onPartialResponse: { _ in },
+                networkService: StreamingURLProtocol.makeNetworkService()
+            )
+        }
+        guard case .serverError = error else {
+            Issue.record("Expected .serverError, got \(error)")
+            return
+        }
+    }
+
+    @Test func chatStreamingMaps429WithMessageToCustomError() async throws {
+        StreamingURLProtocol.stub = .init(
+            statusCode: 429,
+            body: Data("{\"error\":{\"message\":\"quota exceeded\"}}".utf8)
+        )
+
+        let error = try await #require(throws: EnhancementError.self) {
+            _ = try await GeminiAPIClient.chatStreaming(
+                systemMessage: "system",
+                messages: userMessages(),
+                model: "gemini-3.5-flash",
+                accessToken: "ya29.token",
+                projectId: nil,
+                onPartialResponse: { _ in },
+                networkService: StreamingURLProtocol.makeNetworkService()
+            )
+        }
+        guard case let .customError(message) = error else {
+            Issue.record("Expected .customError, got \(error)")
+            return
+        }
+        #expect(message.contains("quota exceeded"))
+    }
+
+    @Test func chatStreamingMapsAuthFailureToTokenExchangeFailed() async throws {
+        StreamingURLProtocol.stub = .init(statusCode: 401, body: Data("{\"error\":\"unauthorized\"}".utf8))
+
+        let error = try await #require(throws: OAuthError.self) {
+            _ = try await GeminiAPIClient.chatStreaming(
+                systemMessage: "system",
+                messages: userMessages(),
+                model: "gemini-3.5-flash",
+                accessToken: "ya29.token",
+                projectId: nil,
+                onPartialResponse: { _ in },
+                networkService: StreamingURLProtocol.makeNetworkService()
+            )
+        }
+        guard case let .tokenExchangeFailed(reason) = error else {
+            Issue.record("Expected .tokenExchangeFailed, got \(error)")
+            return
+        }
+        #expect(reason.hasPrefix("HTTP 401"))
+    }
+
+    // MARK: - chat (non-streaming wrapper over chatStreaming)
+
+    @Test func chatBuffersStreamingHelperAndReturnsAggregate() async throws {
+        StreamingURLProtocol.stub = .init(
+            statusCode: 200,
+            body: sse([candidateEvent("Buffered reply")])
+        )
+
+        let result = try await GeminiAPIClient.chat(
+            systemMessage: "system",
+            messages: userMessages(),
+            model: "", // exercises resolveModel's empty -> default fallback
+            accessToken: "ya29.token",
+            projectId: "proj-123",
+            networkService: StreamingURLProtocol.makeNetworkService()
+        )
+
+        #expect(result.contains("Buffered reply"))
+    }
+
+    // MARK: - enhanceStreaming
+
+    @Test func enhanceStreamingParsesEventAndReturnsFinalText() async throws {
+        StreamingURLProtocol.stub = .init(
+            statusCode: 200,
+            body: sse([candidateEvent("Refined text")])
+        )
+        let sink = PartialSink()
+
+        let result = try await GeminiAPIClient.enhanceStreaming(
+            text: "raw",
+            systemPrompt: "system",
+            model: "gemini-3.5-flash",
+            accessToken: "ya29.token",
+            projectId: nil,
+            onPartialResult: { sink.receive($0) },
+            networkService: StreamingURLProtocol.makeNetworkService()
+        )
+
+        #expect(result.contains("Refined text"))
+        #expect(sink.values.contains("Refined text"))
+    }
+}

--- a/Modules/AIProviders/Tests/AIProvidersTests/StreamingURLProtocol.swift
+++ b/Modules/AIProviders/Tests/AIProvidersTests/StreamingURLProtocol.swift
@@ -1,0 +1,55 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import Networking
+
+/// A `URLProtocol` stub that lets tests drive a *real* `URLSession` - and thus
+/// a genuine `URLSession.AsyncBytes` stream - entirely offline. This is the
+/// only way to exercise the SSE / streaming code paths
+/// (`GeminiAPIClient.chatStreaming`, `enhanceStreaming`, etc.): `AsyncBytes`
+/// has no public initializer, so `MockNetworkService.bytes(for:)` cannot
+/// fabricate one. Instead we register this protocol on an ephemeral session
+/// configuration, hand that real session to `DefaultNetworkService`, and replay
+/// a canned HTTP status + body when the request fires.
+///
+/// Because the stub is shared static state, streaming suites that use it must
+/// be `.serialized`.
+final class StreamingURLProtocol: URLProtocol {
+
+    struct Stub {
+        var statusCode: Int
+        var body: Data
+        var headers: [String: String] = ["Content-Type": "text/event-stream"]
+    }
+
+    nonisolated(unsafe) static var stub: Stub?
+
+    /// A `DefaultNetworkService` wired to a fresh session that routes every
+    /// request through this protocol. Set ``stub`` before issuing the request.
+    static func makeNetworkService() -> DefaultNetworkService {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [StreamingURLProtocol.self]
+        return DefaultNetworkService(session: URLSession(configuration: configuration), category: "StreamingTest")
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let url = request.url, let stub = StreamingURLProtocol.stub else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        let response = HTTPURLResponse(
+            url: url,
+            statusCode: stub.statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: stub.headers
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: stub.body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}

--- a/VivaDictaTests/DefaultKeychainServiceTests.swift
+++ b/VivaDictaTests/DefaultKeychainServiceTests.swift
@@ -1,0 +1,76 @@
+//
+//  DefaultKeychainServiceTests.swift
+//  VivaDictaTests
+//
+//  Created by Anton Novoselov on 2026.06.20
+//
+
+import Foundation
+import Testing
+import Keychain
+
+/// Exercises the real `DefaultKeychainService` against the system keychain.
+///
+/// These live in the app test target (not the Keychain SPM module) on purpose:
+/// the production keychain uses `kSecUseDataProtectionKeychain`, which requires
+/// the keychain-access-group entitlement. An unsigned `swift test` host bundle
+/// lacks it (every `SecItemAdd` returns `errSecMissingEntitlement`), so the
+/// round-trip can only be verified in the simulator, hosted inside the entitled
+/// VivaDicta app.
+///
+/// Each test uses a unique `service` namespace so items never collide across
+/// tests or runs, uses `syncable: false` to keep items local, and cleans up.
+@Suite("DefaultKeychainService")
+struct DefaultKeychainServiceTests {
+
+    private func makeSUT() -> DefaultKeychainService {
+        DefaultKeychainService(service: "com.antonnovoselov.VivaDicta.tests.\(UUID().uuidString)")
+    }
+
+    @Test func savesAndReadsBackString() {
+        let sut = makeSUT()
+        defer { sut.delete(forKey: "token", syncable: false) }
+
+        #expect(sut.save("secret-value", forKey: "token", syncable: false))
+        #expect(sut.getString(forKey: "token", syncable: false) == "secret-value")
+    }
+
+    @Test func savesAndReadsBackData() {
+        let sut = makeSUT()
+        defer { sut.delete(forKey: "blob", syncable: false) }
+        let bytes = Data([0xDE, 0xAD, 0xBE, 0xEF])
+
+        #expect(sut.save(data: bytes, forKey: "blob", syncable: false))
+        #expect(sut.getData(forKey: "blob", syncable: false) == bytes)
+    }
+
+    @Test func overwritesExistingValueForSameKey() {
+        let sut = makeSUT()
+        defer { sut.delete(forKey: "token", syncable: false) }
+
+        #expect(sut.save("first", forKey: "token", syncable: false))
+        #expect(sut.save("second", forKey: "token", syncable: false))
+        // save() deletes any prior item first, so the latest value wins.
+        #expect(sut.getString(forKey: "token", syncable: false) == "second")
+    }
+
+    @Test func getStringReturnsNilForMissingKey() {
+        let sut = makeSUT()
+        #expect(sut.getString(forKey: "absent", syncable: false) == nil)
+        #expect(sut.getData(forKey: "absent", syncable: false) == nil)
+    }
+
+    @Test func deleteRemovesStoredValue() {
+        let sut = makeSUT()
+        #expect(sut.save("temp", forKey: "token", syncable: false))
+
+        #expect(sut.delete(forKey: "token", syncable: false))
+        #expect(sut.getString(forKey: "token", syncable: false) == nil)
+    }
+
+    @Test func deleteOfMissingKeyIsTreatedAsSuccess() {
+        let sut = makeSUT()
+        // errSecItemNotFound is mapped to success so callers can delete blindly.
+        #expect(sut.delete(forKey: "never-saved", syncable: false))
+    }
+}

--- a/VivaDictaTests/MultiNoteChatViewModelTests.swift
+++ b/VivaDictaTests/MultiNoteChatViewModelTests.swift
@@ -188,6 +188,10 @@ struct MultiNoteChatViewModelTests {
     @Test func sendMessage_cloudHappyPath_streamsAndPersistsAssistant() async throws {
         // Skip the implicit cloud cross-note tool so the send stays hermetic
         // (it otherwise consults the global RAG feature flag + tool runtime).
+        // Restore the shared UserDefaults flag so the parallel suite stays
+        // order-independent.
+        let previousSmartSearch = SmartSearchFeature.isEnabled
+        defer { SmartSearchFeature.isEnabled = previousSmartSearch }
         SmartSearchFeature.isEnabled = false
         let fixture = try makeFixture(stubMode: cloudMode())
         fixture.mockAIService.stubMakeChatStreamingRequestPartials = ["Here", "Here is", "Here is the answer."]
@@ -209,6 +213,8 @@ struct MultiNoteChatViewModelTests {
     /// A failing cloud request is caught: the user turn is kept and an error
     /// assistant message is appended rather than the flow crashing.
     @Test func sendMessage_whenCloudRequestFails_appendsErrorAssistantMessage() async throws {
+        let previousSmartSearch = SmartSearchFeature.isEnabled
+        defer { SmartSearchFeature.isEnabled = previousSmartSearch }
         SmartSearchFeature.isEnabled = false
         let fixture = try makeFixture(stubMode: cloudMode())
         fixture.mockAIService.stubMakeChatStreamingRequestResult = .failure(TestError.boom)

--- a/VivaDictaTests/MultiNoteChatViewModelTests.swift
+++ b/VivaDictaTests/MultiNoteChatViewModelTests.swift
@@ -166,4 +166,59 @@ struct MultiNoteChatViewModelTests {
 
         #expect(fixture.sut.messages.isEmpty)
     }
+
+    // MARK: - sendMessage happy / error flows
+
+    private enum TestError: Error { case boom }
+
+    /// Spins the cooperative pool until the fire-and-forget streaming task
+    /// settles. The mock has no real latency, so this converges immediately;
+    /// the spin cap only guards against a hang.
+    private func drainStreaming(_ sut: MultiNoteChatViewModel) async {
+        var spins = 0
+        while sut.isStreaming && spins < 5_000 {
+            await Task.yield()
+            spins += 1
+        }
+    }
+
+    /// The fat path with no cross-note/web search armed: the VM streams a cloud
+    /// reply through the injected `AIChatService` and persists both the user
+    /// turn and the assistant turn.
+    @Test func sendMessage_cloudHappyPath_streamsAndPersistsAssistant() async throws {
+        // Skip the implicit cloud cross-note tool so the send stays hermetic
+        // (it otherwise consults the global RAG feature flag + tool runtime).
+        SmartSearchFeature.isEnabled = false
+        let fixture = try makeFixture(stubMode: cloudMode())
+        fixture.mockAIService.stubMakeChatStreamingRequestPartials = ["Here", "Here is", "Here is the answer."]
+        fixture.mockAIService.stubMakeChatStreamingRequestResult = .success("Here is the answer.")
+        fixture.sut.inputText = "summarize my notes"
+
+        fixture.sut.sendMessage()
+        await drainStreaming(fixture.sut)
+
+        #expect(fixture.sut.isStreaming == false)
+        #expect(fixture.mockAIService.makeChatStreamingRequestCallCount == 1)
+        #expect(fixture.sut.messages.count == 2)
+        #expect(fixture.sut.messages.last?.role == "assistant")
+        #expect(fixture.sut.messages.last?.content == "Here is the answer.")
+        #expect(fixture.sut.messages.last?.isError == false)
+        #expect(fixture.sut.errorMessage == nil)
+    }
+
+    /// A failing cloud request is caught: the user turn is kept and an error
+    /// assistant message is appended rather than the flow crashing.
+    @Test func sendMessage_whenCloudRequestFails_appendsErrorAssistantMessage() async throws {
+        SmartSearchFeature.isEnabled = false
+        let fixture = try makeFixture(stubMode: cloudMode())
+        fixture.mockAIService.stubMakeChatStreamingRequestResult = .failure(TestError.boom)
+        fixture.sut.inputText = "summarize my notes"
+
+        fixture.sut.sendMessage()
+        await drainStreaming(fixture.sut)
+
+        #expect(fixture.mockAIService.makeChatStreamingRequestCallCount == 1)
+        #expect(fixture.sut.isStreaming == false)
+        #expect(fixture.sut.messages.last?.isError == true)
+    }
 }

--- a/VivaDictaTests/SmartSearchChatViewModelTests.swift
+++ b/VivaDictaTests/SmartSearchChatViewModelTests.swift
@@ -23,7 +23,7 @@ struct SmartSearchChatViewModelTests {
     private func makeContainer() throws -> ModelContainer {
         let config = ModelConfiguration(isStoredInMemoryOnly: true)
         return try ModelContainer(
-            for: SmartSearchConversation.self, ChatMessage.self,
+            for: SmartSearchConversation.self, ChatMessage.self, Transcription.self,
             configurations: config
         )
     }
@@ -170,5 +170,89 @@ struct SmartSearchChatViewModelTests {
         fixture.sut.clearChat()
 
         #expect(fixture.sut.messages.isEmpty)
+    }
+
+    // MARK: - sendMessage happy / no-evidence / error flows
+
+    private enum TestError: Error { case boom }
+
+    /// Spins the cooperative pool until the fire-and-forget streaming task
+    /// settles. The mock has no real latency, so this converges immediately;
+    /// the spin cap only guards against a hang.
+    private func drainStreaming(_ sut: SmartSearchChatViewModel) async {
+        var spins = 0
+        while sut.isStreaming && spins < 5_000 {
+            await Task.yield()
+            spins += 1
+        }
+    }
+
+    private func ragHit(_ transcriptionId: UUID, _ chunk: String = "apples are a red fruit") -> RAGSearchResult {
+        RAGSearchResult(transcriptionId: transcriptionId, chunkText: chunk, relevanceScore: 0.9)
+    }
+
+    /// The fat path: retrieval returns a hit, so the VM assembles an augmented
+    /// prompt, streams a cloud reply through the injected `AIChatService`, and
+    /// persists both the user turn and the assistant turn with its citations.
+    @Test func sendMessage_cloudHappyPath_searchesStreamsAndPersistsAssistant() async throws {
+        let fixture = try makeFixture(stubMode: cloudMode())
+        let note = Transcription(text: "Note about apples", audioDuration: 3)
+        fixture.container.mainContext.insert(note)
+        fixture.searchService.stubResult = .success([ragHit(note.id)])
+        fixture.mockAIService.stubMakeChatStreamingRequestPartials = ["Apples", "Apples are", "Apples are a fruit."]
+        fixture.mockAIService.stubMakeChatStreamingRequestResult = .success("Apples are a fruit.")
+        fixture.sut.inputText = "tell me about apples"
+
+        fixture.sut.sendMessage()
+        await drainStreaming(fixture.sut)
+
+        #expect(fixture.sut.isStreaming == false)
+        #expect(fixture.searchService.searchCallCount == 1)
+        #expect(fixture.searchService.capturedQueries.first?.query == "tell me about apples")
+        #expect(fixture.mockAIService.makeChatStreamingRequestCallCount == 1)
+        // User turn + assistant reply are both persisted and shown.
+        #expect(fixture.sut.messages.count == 2)
+        #expect(fixture.sut.messages.last?.role == "assistant")
+        #expect(fixture.sut.messages.last?.content == "Apples are a fruit.")
+        #expect(fixture.sut.messages.last?.isError == false)
+        // The retrieved note is cited on the assistant turn.
+        #expect(fixture.sut.messages.last?.sourceTranscriptionIds == [note.id])
+        #expect(fixture.sut.errorMessage == nil)
+    }
+
+    /// Retrieval returns nothing for a grounded query, so the VM short-circuits
+    /// to a deterministic "no evidence" reply and never hits the cloud provider.
+    @Test func sendMessage_noSearchResults_returnsDeterministicNoEvidenceWithoutCloudCall() async throws {
+        let fixture = try makeFixture(stubMode: cloudMode())
+        fixture.searchService.stubResult = .success([]) // no note context
+        fixture.sut.inputText = "anything about quarterly revenue"
+
+        fixture.sut.sendMessage()
+        await drainStreaming(fixture.sut)
+
+        #expect(fixture.searchService.searchCallCount == 1)
+        #expect(fixture.mockAIService.makeChatStreamingRequestCallCount == 0) // no cloud send
+        #expect(fixture.sut.messages.last?.role == "assistant")
+        #expect(fixture.sut.messages.last?.content.localizedStandardContains("could not find") == true)
+        #expect(fixture.sut.messages.last?.isError == false)
+        #expect(fixture.sut.errorMessage == nil)
+    }
+
+    /// A failing cloud request is caught: the user turn is kept and an error
+    /// assistant message is appended rather than the flow crashing.
+    @Test func sendMessage_whenCloudRequestFails_appendsErrorAssistantMessage() async throws {
+        let fixture = try makeFixture(stubMode: cloudMode())
+        let note = Transcription(text: "Note", audioDuration: 1)
+        fixture.container.mainContext.insert(note)
+        fixture.searchService.stubResult = .success([ragHit(note.id)])
+        fixture.mockAIService.stubMakeChatStreamingRequestResult = .failure(TestError.boom)
+        fixture.sut.inputText = "tell me about apples"
+
+        fixture.sut.sendMessage()
+        await drainStreaming(fixture.sut)
+
+        #expect(fixture.mockAIService.makeChatStreamingRequestCallCount == 1)
+        #expect(fixture.sut.isStreaming == false)
+        #expect(fixture.sut.messages.last?.isError == true)
     }
 }


### PR DESCRIPTION
## Summary

Covers three previously-dark areas with behavior-level tests (no production code changes). Targets the lowest-effort, highest-yield coverage gaps.

### 1. Chat ViewModel happy paths
The SmartSearch and MultiNote chat ViewModels were already injectable (mock `AIChatService` / `NoteSearchService`), but only their guard branches were tested. Added the async send flows:
- **SmartSearch**: cloud happy path (search -> augment -> stream -> persist + cite), the deterministic no-evidence branch, and the cloud-failure branch. Added `Transcription` to the test container so retrieval resolves.
- **MultiNote**: cloud happy path and the cloud-failure branch.

### 2. AIProviders streaming
The Gemini SSE/streaming paths (~317 lines) were untestable because `bytes(for:)` returns `URLSession.AsyncBytes`, which has **no public initializer** - `MockNetworkService` can't fabricate one.

Added `StreamingURLProtocol`: a `URLProtocol` stub that drives a **real** `URLSession` (wired via `protocolClasses`) injected into `DefaultNetworkService`, producing a genuine byte stream offline with **zero production changes**. Then covered `GeminiAPIClient` `chatStreaming` / `enhanceStreaming` / `chat` aggregation and the status-code error mapping (invalid / 5xx / 429 / 401), plus the pure `streamingText` / `resolveModel` helpers.

The harness is reusable for the other providers' streaming paths (Anthropic, Copilot, OpenAICompatible).

### 3. Keychain
`DefaultKeychainService` round-trip save/get/delete tests. These live in the **app test target**, not the Keychain SPM module, because the production data-protection keychain (`kSecUseDataProtectionKeychain`) needs the keychain-access-group entitlement that an unsigned `swift test` host bundle lacks (every `SecItemAdd` returns `errSecMissingEntitlement`). The simulator app host has the entitlement, so the round-trip passes there.

## Coverage moved (canonical simulator run)

| Target / file | Before | After |
|---|---|---|
| GeminiAPIClient.swift | 22.1% | 86.7% |
| AIProviders (module) | 46.2% | 57.5% |
| SmartSearchChatViewModel | 8.3% | 58.2% |
| MultiNoteChatViewModel | 7.4% | 38.6% |
| VivaDicta.app | 7.88% | 9.42% |

## Testing

- AIProviders module: `swift test` - 106 tests pass on the macOS host.
- App test plan: full `xcodebuild test` in the iOS 26.4 simulator - **TEST SUCCEEDED**, no regressions. The new chat-VM + keychain classes (28 tests in that targeted run) pass.

## Notes

- No production code changed - tests only.
- `StreamingURLProtocol` is a reusable test harness; the other providers' streaming paths are the obvious next pull.