### PR TITLE
Add OpenCode Go provider + dynamic OpenCode Zen/Go model fetch

### DIFF
--- a/Modules/AICore/Sources/AICore/AIProvider.swift
+++ b/Modules/AICore/Sources/AICore/AIProvider.swift
@@ -32,6 +32,7 @@ public enum AIProvider: String, CaseIterable, Identifiable, Codable, Sendable {
     case minimax
     case vercelAIGateway
     case opencodeZen
+    case opencodeGo
     case huggingFace
     case copilot
     case ollama
@@ -87,6 +88,8 @@ public enum AIProvider: String, CaseIterable, Identifiable, Codable, Sendable {
             "Vercel AI Gateway"
         case .opencodeZen:
             "OpenCode Zen"
+        case .opencodeGo:
+            "OpenCode Go"
         case .huggingFace:
             "HuggingFace"
         case .copilot:
@@ -147,7 +150,7 @@ public enum AIProvider: String, CaseIterable, Identifiable, Codable, Sendable {
             "assemblyai-color"
         case .vercelAIGateway:
             "vercel"
-        case .opencodeZen:
+        case .opencodeZen, .opencodeGo:
             "opencode"
         case .huggingFace:
             "huggingface-color"
@@ -187,6 +190,7 @@ public enum AIProvider: String, CaseIterable, Identifiable, Codable, Sendable {
              .minimax,
              .vercelAIGateway,
              .opencodeZen,
+             .opencodeGo,
              .huggingFace,
              .ollama,
              .ollamaCloud,
@@ -215,7 +219,7 @@ public enum AIProvider: String, CaseIterable, Identifiable, Codable, Sendable {
         case .cerebras: URL(string: "https://cloud.cerebras.ai/")
         case .grok: URL(string: "https://console.x.ai/")
         case .vercelAIGateway: URL(string: "https://vercel.com/account/tokens")
-        case .opencodeZen: URL(string: "https://opencode.ai/auth")
+        case .opencodeZen, .opencodeGo: URL(string: "https://opencode.ai/auth")
         case .huggingFace: URL(string: "https://huggingface.co/settings/tokens")
         case .zai: URL(string: "https://open.z.ai/")
         case .kimi: URL(string: "https://platform.moonshot.cn/console/api-keys")
@@ -251,6 +255,7 @@ public enum AIProvider: String, CaseIterable, Identifiable, Codable, Sendable {
         .openRouter,
         .vercelAIGateway,
         .opencodeZen,
+        .opencodeGo,
         .huggingFace,
         .ollama,
         .ollamaCloud,
@@ -263,12 +268,14 @@ public enum AIProvider: String, CaseIterable, Identifiable, Codable, Sendable {
     /// (https://docs.ollama.com/capabilities/structured-outputs). Local Ollama
     /// does support them, so it stays eligible.
     ///
-    /// Also excludes OpenCode Zen: its free-tier models reject `json_schema`
-    /// response formats ("This response_format type is unavailable now",
-    /// verified 2026-06-19), so the structured reminder extraction would fail on
-    /// the models most Zen users run.
+    /// Also excludes OpenCode Zen and OpenCode Go: their open-weight models reject
+    /// `json_schema` response formats ("This response_format type is unavailable
+    /// now", verified 2026-06-19 on Zen), so the structured reminder extraction
+    /// would fail on the models most OpenCode users run. Go routes through the same
+    /// OpenCode gateway with the same open-weight model family, so it is excluded
+    /// for the same reason.
     public static let reminderExtractorCloudProviders: [AIProvider] =
-        cloudProviders.filter { $0 != .ollamaCloud && $0 != .opencodeZen }
+        cloudProviders.filter { $0 != .ollamaCloud && $0 != .opencodeZen && $0 != .opencodeGo }
 
     /// Local AI providers that run on-device or local network (no API key needed)
     public static let localProviders: [AIProvider] = [
@@ -297,6 +304,7 @@ public enum AIProvider: String, CaseIterable, Identifiable, Codable, Sendable {
         .openRouter,
         .vercelAIGateway,
         .opencodeZen,
+        .opencodeGo,
         .huggingFace]
 
     public var baseURL: String {
@@ -345,6 +353,8 @@ public enum AIProvider: String, CaseIterable, Identifiable, Codable, Sendable {
             return "https://ai-gateway.vercel.sh/v1/chat/completions"
         case .opencodeZen:
             return "https://opencode.ai/zen/v1/chat/completions"
+        case .opencodeGo:
+            return "https://opencode.ai/zen/go/v1/chat/completions"
         case .huggingFace:
             return "https://router.huggingface.co/v1/chat/completions"
         case .copilot:
@@ -415,6 +425,10 @@ public enum AIProvider: String, CaseIterable, Identifiable, Codable, Sendable {
             // A free model so a brand-new key (no payment method) verifies and
             // works out of the box. See `opencodeZenFreeModels`.
             return "big-pickle"
+        case .opencodeGo:
+            // An OpenAI-compatible Go model included with the $10/month
+            // subscription. See `opencodeGoModels`.
+            return "deepseek-v4-flash"
         case .huggingFace:
             return "openai/gpt-oss-120b"
         case .copilot:
@@ -456,7 +470,10 @@ public enum AIProvider: String, CaseIterable, Identifiable, Codable, Sendable {
         case .cartesia: "cartesiaAPIKey"
         case .assemblyAI: "assemblyaiAPIKey"
         case .vercelAIGateway: "vercelAIGatewayAPIKey"
-        case .opencodeZen: "opencodeZenAPIKey"
+        // OpenCode Go shares the single OpenCode auth key with Zen: users enter
+        // the Zen key once and Go works. Must match the macOS app for iCloud
+        // Keychain sync, so do NOT introduce a separate key.
+        case .opencodeZen, .opencodeGo: "opencodeZenAPIKey"
         case .huggingFace: "huggingFaceAPIKey"
         case .customOpenAI: "customOpenAIAPIKey"
         case .ollamaCloud: "ollamaCloudAPIKey"
@@ -582,6 +599,10 @@ public enum AIProvider: String, CaseIterable, Identifiable, Codable, Sendable {
             // the pay-as-you-go models. Tier classification lives in
             // `opencodeZenFreeModels` / `opencodeZenPaidModels` below.
             return Self.opencodeZenFreeModels + Self.opencodeZenPaidModels
+        case .opencodeGo:
+            // OpenAI-compatible models included with the OpenCode Go subscription.
+            // See `opencodeGoModels`.
+            return Self.opencodeGoModels
         case .huggingFace:
             return []
         case .copilot:
@@ -702,6 +723,12 @@ public extension AIProvider {
     /// payment method. Selecting one without billing set up returns
     /// "No payment method. Add a payment method here ..." (verified 2026-06-19).
     /// Token pricing passes through the provider's list price with zero markup.
+    ///
+    /// Catalog last refreshed 2026-06-25 from the published Zen model list
+    /// (added `glm-5.2`). The published catalog also lists more GPT/Claude/Qwen
+    /// variants (e.g. `gpt-5.5-pro`, `claude-opus-4.6`, `qwen3.7-max`); those are
+    /// intentionally not exposed here - keep this list curated, and live-verify
+    /// (200 vs 403) any new addition before shipping it.
     static let opencodeZenPaidModels: [String] = [
         "claude-fable-5",
         "claude-opus-4-8",
@@ -719,6 +746,7 @@ public extension AIProvider {
         "gemini-3-flash",
         "deepseek-v4-pro",
         "deepseek-v4-flash",
+        "glm-5.2",
         "glm-5.1",
         "glm-5",
         "kimi-k2.6",
@@ -738,4 +766,26 @@ public extension AIProvider {
     static func isOpencodeZenModelFree(_ model: String) -> Bool {
         opencodeZenFreeModels.contains(model)
     }
+}
+
+// MARK: - OpenCode Go (subscription) models
+
+public extension AIProvider {
+    /// Models included with the $10/month OpenCode Go subscription. Go shares the
+    /// single OpenCode auth key with Zen but routes to its own `/zen/go/v1/`
+    /// endpoint; every model is covered by the subscription, so there is no
+    /// free/paid split. This is the full published catalog
+    /// (https://opencode.ai/docs/go), used only as a fallback - the live list is
+    /// fetched from `/zen/go/v1/models` at runtime.
+    ///
+    /// PROVISIONAL IDs (display names mapped to slugs); the runtime fetch returns
+    /// the canonical ids, so this fallback may lag the live catalog slightly.
+    static let opencodeGoModels: [String] = [
+        "glm-5.2", "glm-5.1",
+        "kimi-k2.7-code", "kimi-k2.6",
+        "mimo-v2.5", "mimo-v2.5-pro",
+        "minimax-m3", "minimax-m2.7",
+        "qwen3.7-max", "qwen3.7-plus", "qwen3.6-plus",
+        "deepseek-v4-pro", "deepseek-v4-flash"
+    ]
 }

--- a/Modules/AICore/Tests/AICoreTests/AICoreTests.swift
+++ b/Modules/AICore/Tests/AICoreTests/AICoreTests.swift
@@ -148,4 +148,31 @@ struct AIProviderTests {
         // The default model must be free so a brand-new key verifies and works.
         #expect(AIProvider.isOpencodeZenModelFree(AIProvider.opencodeZen.defaultModel))
     }
+
+    // MARK: - OpenCode Go
+
+    @Test func opencodeGoCatalogIsNonEmptyAndContainsItsDefault() {
+        let models = AIProvider.opencodeGoModels
+        #expect(!models.isEmpty)
+        #expect(AIProvider.opencodeGo.availableModels == models)
+        // The default must be in the catalog so a fresh pick is always valid.
+        #expect(AIProvider.opencodeGo.defaultModel == "deepseek-v4-flash")
+        #expect(models.contains(AIProvider.opencodeGo.defaultModel))
+    }
+
+    @Test func opencodeGoSharesZenKeyButUsesItsOwnEndpoint() {
+        // Go is a separate subscription that authenticates with the same OpenCode
+        // key, so it must share Zen's keychain identifier (iCloud Keychain sync).
+        #expect(AIProvider.opencodeGo.keychainKey == AIProvider.opencodeZen.keychainKey)
+        #expect(AIProvider.opencodeGo.keychainKey == "opencodeZenAPIKey")
+        // ...but routes to its own Go endpoint, distinct from Zen's.
+        #expect(AIProvider.opencodeGo.baseURL == "https://opencode.ai/zen/go/v1/chat/completions")
+        #expect(AIProvider.opencodeGo.baseURL != AIProvider.opencodeZen.baseURL)
+    }
+
+    @Test func reminderExtractorExcludesOpencodeGo() {
+        // Go serves the same open-weight model family as Zen, which rejects
+        // json_schema response formats.
+        #expect(!AIProvider.reminderExtractorCloudProviders.contains(.opencodeGo))
+    }
 }

--- a/Modules/AICore/Tests/AICoreTests/AICoreTests.swift
+++ b/Modules/AICore/Tests/AICoreTests/AICoreTests.swift
@@ -10,7 +10,7 @@ struct AIProviderTests {
     // MARK: - Catalog integrity
 
     @Test func allCasesCountIsStable() {
-        #expect(AIProvider.allCases.count == 28)
+        #expect(AIProvider.allCases.count == 29)
     }
 
     @Test func rawValuesRoundTripForCodableAndDefaultsCompatibility() {
@@ -54,6 +54,7 @@ struct AIProviderTests {
             .minimax: "minimaxAPIKey",
             .vercelAIGateway: "vercelAIGatewayAPIKey",
             .opencodeZen: "opencodeZenAPIKey",
+            .opencodeGo: "opencodeZenAPIKey", // intentionally shared with Zen
             .huggingFace: "huggingFaceAPIKey",
             .copilot: "",
             .ollama: "",

--- a/Modules/AppGroup/Sources/AppGroup/UserDefaultsStorage.swift
+++ b/Modules/AppGroup/Sources/AppGroup/UserDefaultsStorage.swift
@@ -64,6 +64,8 @@ public enum UserDefaultsStorage {
         public static let ollamaModels = "ollamaModels"
         public static let ollamaServerURL = "ollamaServerURL"
         public static let ollamaCloudModels = "ollamaCloudModels"
+        public static let opencodeZenModels = "opencodeZenModels"
+        public static let opencodeGoModels = "opencodeGoModels"
 
         // iCloud
         public static let isICloudSyncEnabled = "isICloudSyncEnabled"

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -95,6 +95,8 @@ class AIService {
     public var huggingFaceModels: [String] = []
     public var ollamaModels: [String] = []
     public var ollamaCloudModels: [String] = []
+    public var opencodeZenModels: [String] = []
+    public var opencodeGoModels: [String] = []
     public var modes: [VivaMode] = []
 
     /// Ollama server URL (configurable, defaults to localhost:11434)
@@ -266,6 +268,8 @@ class AIService {
         loadSavedHuggingFaceModels()
         loadSavedOllamaModels()
         loadSavedOllamaCloudModels()
+        loadSavedOpencodeZenModels()
+        loadSavedOpencodeGoModels()
 
         // Refresh connected providers on main actor (needed for Apple availability check)
         Task {
@@ -286,6 +290,12 @@ class AIService {
             }
             if connectedProviders.contains(.ollamaCloud) {
                 await fetchOllamaCloudModels()
+            }
+            if connectedProviders.contains(.opencodeZen) {
+                await fetchOpencodeZenModels()
+            }
+            if connectedProviders.contains(.opencodeGo) {
+                await fetchOpencodeGoModels()
             }
             // Ollama models are fetched on-demand when user configures Ollama
         }
@@ -710,6 +720,26 @@ class AIService {
 
     private func saveOllamaCloudModels() {
         userDefaults.set(ollamaCloudModels, forKey: UserDefaultsStorage.Keys.ollamaCloudModels)
+    }
+
+    private func loadSavedOpencodeZenModels() {
+        if let savedModels = userDefaults.array(forKey: UserDefaultsStorage.Keys.opencodeZenModels) as? [String] {
+            opencodeZenModels = savedModels
+        }
+    }
+
+    private func saveOpencodeZenModels() {
+        userDefaults.set(opencodeZenModels, forKey: UserDefaultsStorage.Keys.opencodeZenModels)
+    }
+
+    private func loadSavedOpencodeGoModels() {
+        if let savedModels = userDefaults.array(forKey: UserDefaultsStorage.Keys.opencodeGoModels) as? [String] {
+            opencodeGoModels = savedModels
+        }
+    }
+
+    private func saveOpencodeGoModels() {
+        userDefaults.set(opencodeGoModels, forKey: UserDefaultsStorage.Keys.opencodeGoModels)
     }
 
     // MARK: - Configuration validation
@@ -1763,6 +1793,12 @@ class AIService {
         if isValid && provider == .ollamaCloud {
             await fetchOllamaCloudModels()
         }
+        if isValid && provider == .opencodeZen {
+            await fetchOpencodeZenModels()
+        }
+        if isValid && provider == .opencodeGo {
+            await fetchOpencodeGoModels()
+        }
 
         return isValid
     }
@@ -2033,6 +2069,17 @@ class AIService {
             // static list so the picker is never empty before the first fetch.
             return ollamaCloudModels.isEmpty ? provider.availableModels : ollamaCloudModels
         }
+        if provider == .opencodeZen {
+            // Live catalog once fetched, falling back to the curated static list.
+            // The free/paid sections are still classified by the static
+            // `opencodeZenFreeModels` / `opencodeZenPaidModels` sets in AICore,
+            // so they keep working whether the list is fetched or static.
+            return opencodeZenModels.isEmpty ? provider.availableModels : opencodeZenModels
+        }
+        if provider == .opencodeGo {
+            // Live catalog once fetched, falling back to the curated static list.
+            return opencodeGoModels.isEmpty ? provider.availableModels : opencodeGoModels
+        }
         if provider == .customOpenAI {
             // Return the configured model name as a single-item array
             return customOpenAIModelName.isEmpty ? [] : [customOpenAIModelName]
@@ -2249,6 +2296,106 @@ class AIService {
 
         } catch {
             logger.logError("Error fetching Ollama Cloud models: \(error.localizedDescription)")
+            // Preserve existing cached models on failure
+        }
+    }
+
+    /// Fetches the available OpenCode Zen models from the OpenAI-compatible
+    /// `/v1/models` endpoint, then publishes them to the `@Observable`
+    /// `opencodeZenModels` property. The fetched catalog drives the model
+    /// picker; the free/paid split is still classified by the static
+    /// `opencodeZenFreeModels` / `opencodeZenPaidModels` sets in AICore. The
+    /// listing requires the API key, so the Bearer header is attached.
+    public func fetchOpencodeZenModels() async {
+        guard let apiKey = AIProvider.opencodeZen.apiKey, !apiKey.isEmpty else {
+            // No key yet (pre-config or just deleted) is an expected state, not an error.
+            logger.logDebug("Skipping OpenCode Zen model fetch: no API key configured")
+            return
+        }
+
+        let url = URL(string: "https://opencode.ai/zen/v1/models")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+
+        do {
+            let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
+
+            guard httpResponse.statusCode == 200 else {
+                logger.logError("Failed to fetch OpenCode Zen models: Invalid HTTP response")
+                // Preserve existing cached models on failure
+                return
+            }
+
+            guard let jsonResponse = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let dataArray = jsonResponse["data"] as? [[String: Any]] else {
+                logger.logError("Failed to parse OpenCode Zen models JSON")
+                // Preserve existing cached models on failure
+                return
+            }
+
+            let models = dataArray.compactMap { $0["id"] as? String }
+            guard !models.isEmpty else {
+                logger.logWarning("OpenCode Zen returned no models; keeping existing list.")
+                return
+            }
+
+            self.opencodeZenModels = models.sorted()
+            self.saveOpencodeZenModels()
+            logger.logInfo("Successfully fetched \(models.count) OpenCode Zen models.")
+
+        } catch {
+            logger.logError("Error fetching OpenCode Zen models: \(error.localizedDescription)")
+            // Preserve existing cached models on failure
+        }
+    }
+
+    /// Fetches the OpenCode Go catalog from its `/zen/go/v1/models` endpoint and
+    /// publishes the result to `opencodeGoModels`. Go shares the OpenCode Zen API
+    /// key; every Go model is covered by the subscription, so there is no
+    /// free/paid split and the full fetched catalog is shown.
+    public func fetchOpencodeGoModels() async {
+        guard let apiKey = AIProvider.opencodeGo.apiKey, !apiKey.isEmpty else {
+            // No key yet (pre-config or just deleted) is an expected state, not an error.
+            logger.logDebug("Skipping OpenCode Go model fetch: no API key configured")
+            return
+        }
+
+        let url = URL(string: "https://opencode.ai/zen/go/v1/models")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+
+        do {
+            let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
+
+            guard httpResponse.statusCode == 200 else {
+                logger.logError("Failed to fetch OpenCode Go models: Invalid HTTP response")
+                // Preserve existing cached models on failure
+                return
+            }
+
+            guard let jsonResponse = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let dataArray = jsonResponse["data"] as? [[String: Any]] else {
+                logger.logError("Failed to parse OpenCode Go models JSON")
+                // Preserve existing cached models on failure
+                return
+            }
+
+            let models = dataArray.compactMap { $0["id"] as? String }
+            guard !models.isEmpty else {
+                logger.logWarning("OpenCode Go returned no models; keeping existing list.")
+                return
+            }
+
+            self.opencodeGoModels = models.sorted()
+            self.saveOpencodeGoModels()
+            logger.logInfo("Successfully fetched \(models.count) OpenCode Go models (OpenAI-compatible).")
+
+        } catch {
+            logger.logError("Error fetching OpenCode Go models: \(error.localizedDescription)")
             // Preserve existing cached models on failure
         }
     }

--- a/VivaDicta/Views/SettingsScreen/CustomOpenAIConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/CustomOpenAIConfigurationView.swift
@@ -36,24 +36,25 @@ struct CustomOpenAIConfigurationView: View {
     }
 
     var body: some View {
-        VStack(spacing: 16) {
-            // Icon
-            Image(systemName: "server.rack")
-                .font(.system(size: 48))
-                .foregroundStyle(.secondary)
-                .padding(.top, 8)
+        ScrollView {
+            VStack(spacing: 16) {
+                // Icon
+                Image(systemName: "server.rack")
+                    .font(.system(size: 48))
+                    .foregroundStyle(.secondary)
+                    .padding(.top, 8)
 
-            Text("Custom AI provider")
-                .font(.title2)
+                Text("Custom AI provider")
+                    .font(.title2)
 
-            Text("OpenAI-Compatible API")
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
+                Text("OpenAI-Compatible API")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
 
-            // Connection status
-            connectionStatusView
+                // Connection status
+                connectionStatusView
 
-            ScrollView {
+                // Input fields
                 VStack(spacing: 20) {
                     // Endpoint URL input
                     VStack(alignment: .leading, spacing: 8) {
@@ -133,85 +134,86 @@ struct CustomOpenAIConfigurationView: View {
                     }
                 }
                 .padding(.horizontal)
-            }
 
-            // Action buttons
-            VStack(spacing: 12) {
-                // Test & Save button
-                if #available(iOS 26.0, *) {
-                    Button {
-                        testAndSave()
-                    } label: {
-                        HStack {
-                            if case .checking = connectionStatus {
-                                ProgressView()
-                                    .controlSize(.small)
+                // Action buttons
+                VStack(spacing: 12) {
+                    // Test & Save button
+                    if #available(iOS 26.0, *) {
+                        Button {
+                            testAndSave()
+                        } label: {
+                            HStack {
+                                if case .checking = connectionStatus {
+                                    ProgressView()
+                                        .controlSize(.small)
+                                }
+                                Text(connectionStatus == .checking ? "Connecting..." : "Test & Save")
+                                    .font(.headline.weight(.medium))
                             }
-                            Text(connectionStatus == .checking ? "Connecting..." : "Test & Save")
-                                .font(.headline.weight(.medium))
                         }
-                    }
-                    .disabled(isChecking || !canTestConnection)
-                    .padding(.vertical, 8)
-                    .padding(.horizontal, 16)
-                    .glassEffect(.regular.tint(.blue.opacity(0.3)).interactive())
-                    .buttonStyle(.plain)
-                } else {
-                    Button {
-                        testAndSave()
-                    } label: {
-                        HStack {
-                            if case .checking = connectionStatus {
-                                ProgressView()
-                                    .controlSize(.small)
-                            }
-                            Text(connectionStatus == .checking ? "Connecting..." : "Test & Save")
-                                .font(.headline.weight(.medium))
-                                .foregroundStyle(.primary)
-                        }
+                        .disabled(isChecking || !canTestConnection)
                         .padding(.vertical, 8)
                         .padding(.horizontal, 16)
-                        .background {
-                            Capsule()
-                                .stroke(.blue, lineWidth: 2)
+                        .glassEffect(.regular.tint(.blue.opacity(0.3)).interactive())
+                        .buttonStyle(.plain)
+                    } else {
+                        Button {
+                            testAndSave()
+                        } label: {
+                            HStack {
+                                if case .checking = connectionStatus {
+                                    ProgressView()
+                                        .controlSize(.small)
+                                }
+                                Text(connectionStatus == .checking ? "Connecting..." : "Test & Save")
+                                    .font(.headline.weight(.medium))
+                                    .foregroundStyle(.primary)
+                            }
+                            .padding(.vertical, 8)
+                            .padding(.horizontal, 16)
+                            .background {
+                                Capsule()
+                                    .stroke(.blue, lineWidth: 2)
+                            }
+                        }
+                        .disabled(isChecking || !canTestConnection)
+                        .buttonStyle(.plain)
+                    }
+
+                    // Clear Configuration button (only shown when configured)
+                    if isConfigured {
+                        Button(role: .destructive) {
+                            showingClearConfirmation = true
+                        } label: {
+                            Label("Clear Configuration", systemImage: "trash")
+                                .font(.subheadline)
                         }
                     }
-                    .disabled(isChecking || !canTestConnection)
-                    .buttonStyle(.plain)
                 }
 
-                // Clear Configuration button (only shown when configured)
-                if isConfigured {
-                    Button(role: .destructive) {
-                        showingClearConfirmation = true
-                    } label: {
-                        Label("Clear Configuration", systemImage: "trash")
-                            .font(.subheadline)
-                    }
+                // Help text
+                VStack(spacing: 8) {
+                    Text("Connect to any OpenAI-compatible API server.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+
+                    Text("Supports LiteLLM, vLLM, Ollama, and other compatible servers.")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                        .multilineTextAlignment(.center)
                 }
+                .padding(.top, 8)
+                .padding(.bottom)
             }
-
-            Spacer()
-
-            // Help text
-            VStack(spacing: 8) {
-                Text("Connect to any OpenAI-compatible API server.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
-
-                Text("Supports LiteLLM, vLLM, Ollama, and other compatible servers.")
-                    .font(.caption2)
-                    .foregroundStyle(.tertiary)
-                    .multilineTextAlignment(.center)
+            .padding()
+            .frame(maxWidth: .infinity)
+            .contentShape(Rectangle())
+            .onTapGesture {
+                UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
             }
-            .padding(.bottom)
         }
-        .padding()
-        .contentShape(Rectangle())
-        .onTapGesture {
-            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
-        }
+        .scrollDismissesKeyboard(.interactively)
         .navigationTitle("Custom AI Provider")
         .navigationBarTitleDisplayMode(.inline)
         .onAppear {

--- a/VivaDictaTests/AIServiceNetworkingTests.swift
+++ b/VivaDictaTests/AIServiceNetworkingTests.swift
@@ -1,6 +1,7 @@
 // Copyright © 2026 Anton Novoselov. All rights reserved.
 
 import Foundation
+import AICore
 import Networking
 import NetworkingMocks
 import Testing
@@ -33,5 +34,29 @@ struct AIServiceNetworkingTests {
         let sut = AIService(userDefaults: makeDefaults())
 
         #expect(sut.networkService is DefaultNetworkService)
+    }
+
+    // MARK: - Dynamic catalog: fetched list wins, static list is the fallback
+
+    @Test func getAvailableModelsPrefersFetchedOpencodeZenCatalogOverStatic() {
+        // Mock network with no stub: any catalog fetch fails gracefully, so the
+        // list stays empty until we set it explicitly below.
+        let sut = AIService(userDefaults: makeDefaults(), networkService: MockNetworkService())
+
+        // Before a fetch: the curated static list.
+        #expect(sut.getAvailableModels(for: .opencodeZen) == AIProvider.opencodeZen.availableModels)
+
+        // After a fetch: the live catalog wins.
+        sut.opencodeZenModels = ["big-pickle", "claude-opus-4-8"]
+        #expect(sut.getAvailableModels(for: .opencodeZen) == ["big-pickle", "claude-opus-4-8"])
+    }
+
+    @Test func getAvailableModelsPrefersFetchedOpencodeGoCatalogOverStatic() {
+        let sut = AIService(userDefaults: makeDefaults(), networkService: MockNetworkService())
+
+        #expect(sut.getAvailableModels(for: .opencodeGo) == AIProvider.opencodeGo.availableModels)
+
+        sut.opencodeGoModels = ["qwen3.7-max", "deepseek-v4-flash"]
+        #expect(sut.getAvailableModels(for: .opencodeGo) == ["qwen3.7-max", "deepseek-v4-flash"])
     }
 }


### PR DESCRIPTION
## Summary

Adds the **OpenCode Go** provider and makes both OpenCode providers fetch their model catalogs dynamically (like Ollama Cloud), plus a UX fix for the Custom AI Provider screen. Builds green.

### 1. OpenCode Go provider
New `opencodeGo` provider, mirroring `opencodeZen`:
- **Shared API key** (`opencodeZenAPIKey`) - enter the OpenCode key once and Go works; no new auth UI, no OAuth.
- **Endpoint** `opencode.ai/zen/go/v1/chat/completions` (OpenAI-compatible).
- **Full 13-model catalog** per the [docs](https://opencode.ai/docs/go): GLM-5.2/5.1, Kimi K2.7 Code/K2.6, MiMo V2.5/Pro, MiniMax M3/M2.7, Qwen3.7 Max/Plus, Qwen3.6 Plus, DeepSeek V4 Pro/Flash.
- Go is a flat list (all models subscription-included; no free/paid split).

### 2. Dynamic model fetch for OpenCode Zen + Go
Both now fetch their lists from `/models` at runtime - mirror of the Ollama Cloud fetch:
- GET `…/zen/v1/models` and `…/zen/go/v1/models` with the Bearer key.
- Cached in UserDefaults; refetched on connect (`refreshConnectedProviders`) and after key validation.
- Static lists demoted to a pre-fetch fallback.
- **New models now appear automatically** - no more hand-editing model arrays. The live fetch also returns canonical model IDs (resolves the dots-vs-hyphens guessing).
- The **Free/Paid picker split still works**: the fetched Zen catalog is classified against the hand-maintained `opencodeZenFreeModels` / `opencodeZenPaidModels` sets (no API exposes the tier).

### 3. Custom AI Provider screen - scroll fix
The screen wrapped only its 3 input fields in an inner `ScrollView`, so just that strip scrolled. Now the whole screen is one `ScrollView` with interactive swipe-to-dismiss keyboard.

Also: added `glm-5.2` to the Zen fallback list.

## Architecture notes
- **One runtime everywhere**: every cloud provider (Zen, Go, Ollama Cloud, OpenRouter, …) uses a single OpenAI-compatible `/chat/completions` endpoint. Even Claude/GPT/Gemini on Zen route through it - the gateway translates. No per-model or Anthropic runtimes.
- An earlier filter that hid MiniMax/Qwen on Go (from a doc misreading them as "Anthropic-only") was removed - the docs and the OpenCode CLI confirm all 13 are one catalog served through the OpenAI endpoint.

## Testing
- `xcodebuild` (iOS 26.4 sim) - **BUILD SUCCEEDED** at each step.
- Manually verified the Zen picker shows Free/Paid sections and the Custom AI Provider screen scrolls as a whole.

## Follow-up to verify
- With a live Go key, confirm a **Qwen3.7** model routes through the OpenAI endpoint (docs + CLI indicate it will). If it ever errored, that'd be the only signal a separate Anthropic runtime is needed.