### PR TITLE
Release 3.7.0: on-device LLM processing, OpenCode Zen/Go

### DIFF
--- a/Modules/LocalLLM/Sources/LocalLLM/LiteRTModelManager.swift
+++ b/Modules/LocalLLM/Sources/LocalLLM/LiteRTModelManager.swift
@@ -41,8 +41,8 @@ public nonisolated enum LiteRTGemmaVariant: String, CaseIterable, Sendable {
     /// Short description of what the variant is good for, for settings UI.
     public var subtitle: String {
         switch self {
-        case .e2b: "Smaller and faster. Runs on 8 GB-class devices. Broad multilingual support."
-        case .e4b: "Larger and higher quality. Best on a 12 GB-class device. Broad multilingual support."
+        case .e2b: "Google Gemma 4. Smaller and faster. Runs on 8 GB-class devices. Broad multilingual support."
+        case .e4b: "Google Gemma 4. Larger and higher quality. Best on a 12 GB-class device. Broad multilingual support."
         }
     }
 

--- a/VivaDicta.xcodeproj/project.pbxproj
+++ b/VivaDicta.xcodeproj/project.pbxproj
@@ -1402,7 +1402,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = VivaDicta/VivaDicta.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3011;
+				CURRENT_PROJECT_VERSION = 3012;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = 358V8FBM3U;
 				ENABLE_PREVIEWS = YES;
@@ -1422,7 +1422,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.6.0;
+				MARKETING_VERSION = 3.7.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.antonnovoselov.VivaDicta-beta";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1445,7 +1445,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = VivaDicta/VivaDicta.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3011;
+				CURRENT_PROJECT_VERSION = 3012;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = 358V8FBM3U;
 				ENABLE_PREVIEWS = YES;
@@ -1465,7 +1465,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.6.0;
+				MARKETING_VERSION = 3.7.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.antonnovoselov.VivaDicta;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1486,11 +1486,11 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3011;
+				CURRENT_PROJECT_VERSION = 3012;
 				DEVELOPMENT_TEAM = 358V8FBM3U;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
-				MARKETING_VERSION = 3.6.0;
+				MARKETING_VERSION = 3.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.antonnovoselov.VivaDictaTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
@@ -1512,11 +1512,11 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3011;
+				CURRENT_PROJECT_VERSION = 3012;
 				DEVELOPMENT_TEAM = 358V8FBM3U;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
-				MARKETING_VERSION = 3.6.0;
+				MARKETING_VERSION = 3.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.antonnovoselov.VivaDictaTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
@@ -1538,7 +1538,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = ShareExtension/ShareExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3011;
+				CURRENT_PROJECT_VERSION = 3012;
 				DEVELOPMENT_TEAM = 358V8FBM3U;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ShareExtension/Info.plist;
@@ -1550,7 +1550,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.6.0;
+				MARKETING_VERSION = 3.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.antonnovoselov.VivaDicta-beta.ShareExtension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1568,7 +1568,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = ShareExtension/ShareExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3011;
+				CURRENT_PROJECT_VERSION = 3012;
 				DEVELOPMENT_TEAM = 358V8FBM3U;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ShareExtension/Info.plist;
@@ -1580,7 +1580,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.6.0;
+				MARKETING_VERSION = 3.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.antonnovoselov.VivaDicta.ShareExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1598,7 +1598,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = ActionExtension/ActionExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3011;
+				CURRENT_PROJECT_VERSION = 3012;
 				DEVELOPMENT_TEAM = 358V8FBM3U;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ActionExtension/Info.plist;
@@ -1610,7 +1610,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.6.0;
+				MARKETING_VERSION = 3.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.antonnovoselov.VivaDicta-beta.ActionExtension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1628,7 +1628,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = ActionExtension/ActionExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3011;
+				CURRENT_PROJECT_VERSION = 3012;
 				DEVELOPMENT_TEAM = 358V8FBM3U;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ActionExtension/Info.plist;
@@ -1640,7 +1640,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.6.0;
+				MARKETING_VERSION = 3.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.antonnovoselov.VivaDicta.ActionExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1728,7 +1728,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = VivaDicta/VivaDicta.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3011;
+				CURRENT_PROJECT_VERSION = 3012;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = 358V8FBM3U;
 				ENABLE_PREVIEWS = YES;
@@ -1748,7 +1748,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.6.0;
+				MARKETING_VERSION = 3.7.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.antonnovoselov.VivaDicta;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1769,11 +1769,11 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3011;
+				CURRENT_PROJECT_VERSION = 3012;
 				DEVELOPMENT_TEAM = 358V8FBM3U;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
-				MARKETING_VERSION = 3.6.0;
+				MARKETING_VERSION = 3.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.antonnovoselov.VivaDictaTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
@@ -1795,7 +1795,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = VivaDictaKeyboard/VivaDictaKeyboard.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3011;
+				CURRENT_PROJECT_VERSION = 3012;
 				DEVELOPMENT_TEAM = 358V8FBM3U;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = VivaDictaKeyboard/Info.plist;
@@ -1807,7 +1807,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.6.0;
+				MARKETING_VERSION = 3.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.antonnovoselov.VivaDicta.VivaDictaKeyboard;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1828,7 +1828,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3011;
+				CURRENT_PROJECT_VERSION = 3012;
 				DEVELOPMENT_TEAM = 358V8FBM3U;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = VivaDictaWidget/Info.plist;
@@ -1840,7 +1840,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.6.0;
+				MARKETING_VERSION = 3.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.antonnovoselov.VivaDicta.VivaDictaWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1862,7 +1862,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = ShareExtension/ShareExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3011;
+				CURRENT_PROJECT_VERSION = 3012;
 				DEVELOPMENT_TEAM = 358V8FBM3U;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ShareExtension/Info.plist;
@@ -1874,7 +1874,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.6.0;
+				MARKETING_VERSION = 3.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.antonnovoselov.VivaDicta.ShareExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1892,7 +1892,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = ActionExtension/ActionExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3011;
+				CURRENT_PROJECT_VERSION = 3012;
 				DEVELOPMENT_TEAM = 358V8FBM3U;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ActionExtension/Info.plist;
@@ -1904,7 +1904,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.6.0;
+				MARKETING_VERSION = 3.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.antonnovoselov.VivaDicta.ActionExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1923,7 +1923,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = WatchAppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3011;
+				CURRENT_PROJECT_VERSION = 3012;
 				DEVELOPMENT_TEAM = 358V8FBM3U;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1936,7 +1936,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.6.0;
+				MARKETING_VERSION = 3.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.antonnovoselov.VivaDicta-beta.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -1960,7 +1960,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = WatchAppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3011;
+				CURRENT_PROJECT_VERSION = 3012;
 				DEVELOPMENT_TEAM = 358V8FBM3U;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1973,7 +1973,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.6.0;
+				MARKETING_VERSION = 3.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.antonnovoselov.VivaDicta.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -1996,7 +1996,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = WatchAppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3011;
+				CURRENT_PROJECT_VERSION = 3012;
 				DEVELOPMENT_TEAM = 358V8FBM3U;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -2009,7 +2009,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.6.0;
+				MARKETING_VERSION = 3.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.antonnovoselov.VivaDicta.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -2031,10 +2031,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3011;
+				CURRENT_PROJECT_VERSION = 3012;
 				DEVELOPMENT_TEAM = 358V8FBM3U;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 3.6.0;
+				MARKETING_VERSION = 3.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.antonnovoselov.VivaDictaWatch-Watch-AppTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -2055,10 +2055,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3011;
+				CURRENT_PROJECT_VERSION = 3012;
 				DEVELOPMENT_TEAM = 358V8FBM3U;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 3.6.0;
+				MARKETING_VERSION = 3.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.antonnovoselov.VivaDictaWatch-Watch-AppTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -2078,10 +2078,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3011;
+				CURRENT_PROJECT_VERSION = 3012;
 				DEVELOPMENT_TEAM = 358V8FBM3U;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 3.6.0;
+				MARKETING_VERSION = 3.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.antonnovoselov.VivaDictaWatch-Watch-AppTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -2102,7 +2102,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3011;
+				CURRENT_PROJECT_VERSION = 3012;
 				DEVELOPMENT_TEAM = 358V8FBM3U;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = VivaDictaWatchWidget/Info.plist;
@@ -2114,7 +2114,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 3.6.0;
+				MARKETING_VERSION = 3.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.antonnovoselov.VivaDicta-beta.watchkitapp.VivaDictaWatchWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -2136,7 +2136,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3011;
+				CURRENT_PROJECT_VERSION = 3012;
 				DEVELOPMENT_TEAM = 358V8FBM3U;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = VivaDictaWatchWidget/Info.plist;
@@ -2148,7 +2148,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 3.6.0;
+				MARKETING_VERSION = 3.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.antonnovoselov.VivaDicta.watchkitapp.VivaDictaWatchWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -2169,7 +2169,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3011;
+				CURRENT_PROJECT_VERSION = 3012;
 				DEVELOPMENT_TEAM = 358V8FBM3U;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = VivaDictaWatchWidget/Info.plist;
@@ -2181,7 +2181,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 3.6.0;
+				MARKETING_VERSION = 3.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.antonnovoselov.VivaDicta.watchkitapp.VivaDictaWatchWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -2201,7 +2201,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = VivaDictaKeyboard/VivaDictaKeyboard.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3011;
+				CURRENT_PROJECT_VERSION = 3012;
 				DEVELOPMENT_TEAM = 358V8FBM3U;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = VivaDictaKeyboard/Info.plist;
@@ -2213,7 +2213,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.6.0;
+				MARKETING_VERSION = 3.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.antonnovoselov.VivaDicta-beta.VivaDictaKeyboard";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -2233,7 +2233,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = VivaDictaKeyboard/VivaDictaKeyboard.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3011;
+				CURRENT_PROJECT_VERSION = 3012;
 				DEVELOPMENT_TEAM = 358V8FBM3U;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = VivaDictaKeyboard/Info.plist;
@@ -2245,7 +2245,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.6.0;
+				MARKETING_VERSION = 3.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.antonnovoselov.VivaDicta.VivaDictaKeyboard;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -2266,7 +2266,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3011;
+				CURRENT_PROJECT_VERSION = 3012;
 				DEVELOPMENT_TEAM = 358V8FBM3U;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = VivaDictaWidget/Info.plist;
@@ -2278,7 +2278,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.6.0;
+				MARKETING_VERSION = 3.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.antonnovoselov.VivaDicta-beta.VivaDictaWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -2301,7 +2301,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3011;
+				CURRENT_PROJECT_VERSION = 3012;
 				DEVELOPMENT_TEAM = 358V8FBM3U;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = VivaDictaWidget/Info.plist;
@@ -2313,7 +2313,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.6.0;
+				MARKETING_VERSION = 3.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.antonnovoselov.VivaDicta.VivaDictaWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/VivaDicta/Services/AIEnhance/MLX/LocalMLXModel.swift
+++ b/VivaDicta/Services/AIEnhance/MLX/LocalMLXModel.swift
@@ -48,9 +48,9 @@ nonisolated enum LocalMLXModel: String, CaseIterable, Sendable {
 
     var subtitle: String {
         switch self {
-        case .qwen35_4B: "Alibaba's Qwen3.5, larger and higher quality. Broad multilingual."
-        case .qwen35_2B: "Alibaba's Qwen3.5. Broad multilingual support."
-        case .qwen35_08B: "Tiny, fastest option. Broad languages, but lower quality."
+        case .qwen35_4B: "Qwen3.5, larger and higher quality. Broad multilingual."
+        case .qwen35_2B: "Qwen3.5. Broad multilingual support."
+        case .qwen35_08B: "Tiny Qwen3.5, fastest option. Broad languages, but lower quality."
         case .phi4Mini: "Microsoft's Phi-4 Mini. Multilingual (~20+ languages)."
         case .llama32_1B: "Meta's tiny Llama 3.2. Best in English + 7 major languages."
         case .llama32_3B: "Meta's Llama 3.2. Best in English + 7 major languages."

--- a/VivaDicta/Views/SettingsScreen/AddAPIKeyView.swift
+++ b/VivaDicta/Views/SettingsScreen/AddAPIKeyView.swift
@@ -179,13 +179,7 @@ struct AddAPIKeyView: View {
                 }
             }
 
-            if provider == .ollamaCloud {
-                OllamaCloudModelTiersView()
-            } else if provider == .opencodeZen {
-                OpencodeZenModelTiersView()
-            } else {
-                Spacer()
-            }
+            Spacer()
         }
         .animation(.easeInOut(duration: 0.2), value: clearButtonVisible)
         .onAppear {
@@ -274,151 +268,10 @@ struct AddAPIKeyView: View {
     }
 }
 
-/// Shows which Ollama Cloud models are free with the user's API key versus
-/// which require a paid Ollama subscription. Classification lives in AICore
-/// (`AIProvider.ollamaCloudFreeModels` / `ollamaCloudSubscriptionModels`).
-struct OllamaCloudModelTiersView: View {
-    private let columns = [GridItem(.adaptive(minimum: 104), spacing: 8)]
-
-    var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 20) {
-                Text("Some Ollama Cloud models are free with your API key. Others need a paid Ollama subscription - choosing one returns a \"requires a subscription\" error.")
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-
-                ProviderModelTierSection(
-                    title: "Free with your key",
-                    systemImage: "checkmark.seal.fill",
-                    tint: .green,
-                    models: AIProvider.ollamaCloudFreeModels,
-                    columns: columns
-                )
-
-                ProviderModelTierSection(
-                    title: "Requires paid subscription",
-                    systemImage: "lock.fill",
-                    tint: .orange,
-                    models: AIProvider.ollamaCloudSubscriptionModels,
-                    columns: columns
-                )
-
-                Text("The free tier also has usage limits. See ollama.com/upgrade.")
-                    .font(.caption2)
-                    .foregroundStyle(.tertiary)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, 4)
-            .padding(.top, 8)
-        }
-        .scrollIndicators(.hidden)
-    }
-}
-
-/// Shows which OpenCode Zen models are free with the user's API key versus
-/// which bill pay-as-you-go. Classification lives in AICore
-/// (`AIProvider.opencodeZenFreeModels` / `opencodeZenPaidModels`).
-struct OpencodeZenModelTiersView: View {
-    private let columns = [GridItem(.adaptive(minimum: 104), spacing: 8)]
-
-    var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 20) {
-                Text("Some OpenCode Zen models are free with your API key. The rest are pay-as-you-go - choosing one without a payment method on your workspace returns a \"No payment method\" error.")
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-
-                ProviderModelTierSection(
-                    title: "Free with your key",
-                    systemImage: "checkmark.seal.fill",
-                    tint: .green,
-                    models: AIProvider.opencodeZenFreeModels,
-                    columns: columns
-                )
-
-                ProviderModelTierSection(
-                    title: "Pay-as-you-go",
-                    systemImage: "creditcard.fill",
-                    tint: .orange,
-                    models: AIProvider.opencodeZenPaidModels,
-                    columns: columns
-                )
-
-                Text("Paid models bill per token with no markup. Free models have usage limits. See opencode.ai/zen.")
-                    .font(.caption2)
-                    .foregroundStyle(.tertiary)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, 4)
-            .padding(.top, 8)
-        }
-        .scrollIndicators(.hidden)
-    }
-}
-
-/// One labelled tier (free / paid) of provider model-name chips. Shared by the
-/// Ollama Cloud and OpenCode Zen API-key screens.
-struct ProviderModelTierSection: View {
-    let title: String
-    let systemImage: String
-    let tint: Color
-    let models: [String]
-    let columns: [GridItem]
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Label("\(title) (\(models.count))", systemImage: systemImage)
-                .font(.subheadline.weight(.semibold))
-                .foregroundStyle(tint)
-
-            LazyVGrid(columns: columns, alignment: .leading, spacing: 8) {
-                ForEach(models, id: \.self) { model in
-                    ProviderModelChip(name: model, tint: tint)
-                }
-            }
-        }
-    }
-}
-
-struct ProviderModelChip: View {
-    let name: String
-    let tint: Color
-
-    var body: some View {
-        Text(name)
-            .font(.caption.monospaced())
-            .lineLimit(1)
-            .minimumScaleFactor(0.7)
-            .padding(.vertical, 5)
-            .padding(.horizontal, 8)
-            .frame(maxWidth: .infinity)
-            .background(tint.opacity(0.12), in: .rect(cornerRadius: 8))
-            .foregroundStyle(tint)
-    }
-}
-
 #Preview {
     NavigationStack {
         AddAPIKeyView(
             provider: .openAI,
-            aiService: AIService(),
-            onSave: {_ in })
-    }
-}
-
-#Preview("Ollama Cloud tiers") {
-    NavigationStack {
-        AddAPIKeyView(
-            provider: .ollamaCloud,
-            aiService: AIService(),
-            onSave: {_ in })
-    }
-}
-
-#Preview("OpenCode Zen tiers") {
-    NavigationStack {
-        AddAPIKeyView(
-            provider: .opencodeZen,
             aiService: AIService(),
             onSave: {_ in })
     }

--- a/VivaDicta/Views/WhatsNew/WhatsNewContent.swift
+++ b/VivaDicta/Views/WhatsNew/WhatsNewContent.swift
@@ -31,6 +31,7 @@ enum WhatsNewCatalog {
     }
 
     private static let releases: [String: WhatsNewRelease] = [
+        "3.7": release_3_7,
         "3.6": release_3_6,
         "3.5": release_3_5,
         "3.4": release_3_4,
@@ -42,6 +43,38 @@ enum WhatsNewCatalog {
         "2.1": release_2_1,
         "2.2": release_2_2
     ]
+
+    private static let release_3_7 = WhatsNewRelease(
+        id: "3.7",
+        headline: "What's New in VivaDicta 3.7.0",
+        features: [
+            WhatsNewFeature(
+                icon: "cpu.fill",
+                iconColors: [.purple, .indigo],
+                title: "On-Device AI Processing",
+                description: "Process your text with AI that runs entirely on your iPhone. Download a model once, then rewrite and format offline - no API key, fully private."
+            ),
+            WhatsNewFeature(
+                icon: "arrow.down.circle.fill",
+                iconColors: [.blue, .cyan],
+                title: "Local & Cloud Tabs",
+                description: "The AI Providers screen now splits into Local and Cloud. Pick from on-device models like Gemma, Qwen, and Phi, and download what you need."
+            ),
+            WhatsNewFeature(
+                icon: "cloud.fill",
+                iconColors: [.teal, .cyan],
+                title: "OpenCode Zen & Go",
+                description: "Two new cloud AI providers. OpenCode Zen includes free models you can try with just an API key, no payment method needed."
+            ),
+            WhatsNewFeature(
+                icon: "sparkles",
+                iconColors: [.yellow, .orange],
+                title: "Quality of Life",
+                description: "Ollama Cloud now marks free vs subscription models, the custom AI provider screen scrolls fully, plus stability fixes."
+            )
+        ],
+        tagline: "AI processing, now fully on your device."
+    )
 
     private static let release_3_6 = WhatsNewRelease(
         id: "3.6",

--- a/VivaDicta/Views/WhatsNew/WhatsNewContent.swift
+++ b/VivaDicta/Views/WhatsNew/WhatsNewContent.swift
@@ -52,7 +52,7 @@ enum WhatsNewCatalog {
                 icon: "cpu.fill",
                 iconColors: [.purple, .indigo],
                 title: "On-Device LLM Processing",
-                description: "Download an on-device LLM and process your text fully offline - no API key, fully private. Now works on more devices, including many on iOS 18 without Apple Intelligence."
+                description: "Download an on-device LLM like Gemma 4 or Qwen3.5 and process your text fully offline - no API key, fully private. Now works on more devices, including many on iOS 18 without Apple Intelligence."
             ),
             WhatsNewFeature(
                 icon: "cloud.fill",

--- a/VivaDicta/Views/WhatsNew/WhatsNewContent.swift
+++ b/VivaDicta/Views/WhatsNew/WhatsNewContent.swift
@@ -51,20 +51,14 @@ enum WhatsNewCatalog {
             WhatsNewFeature(
                 icon: "cpu.fill",
                 iconColors: [.purple, .indigo],
-                title: "On-Device AI Processing",
-                description: "Process your text with AI that runs entirely on your iPhone. Download a model once, then rewrite and format offline - no API key, fully private."
-            ),
-            WhatsNewFeature(
-                icon: "arrow.down.circle.fill",
-                iconColors: [.blue, .cyan],
-                title: "Local & Cloud Tabs",
-                description: "The AI Providers screen now splits into Local and Cloud. Pick from on-device models like Gemma, Qwen, and Phi, and download what you need."
+                title: "On-Device LLM Processing",
+                description: "Download an on-device LLM and process your text fully offline - no API key, fully private. Now works on more devices, including many on iOS 18 without Apple Intelligence."
             ),
             WhatsNewFeature(
                 icon: "cloud.fill",
                 iconColors: [.teal, .cyan],
                 title: "OpenCode Zen & Go",
-                description: "Two new cloud AI providers. OpenCode Zen includes free models you can try with just an API key, no payment method needed."
+                description: "Two new cloud AI providers. OpenCode Zen includes free models you can try with just a free API key - no payment method needed."
             ),
             WhatsNewFeature(
                 icon: "sparkles",
@@ -73,7 +67,7 @@ enum WhatsNewCatalog {
                 description: "Ollama Cloud now marks free vs subscription models, the custom AI provider screen scrolls fully, plus stability fixes."
             )
         ],
-        tagline: "AI processing, now fully on your device."
+        tagline: "On-device LLM processing, now on more devices."
     )
 
     private static let release_3_6 = WhatsNewRelease(


### PR DESCRIPTION
## VivaDicta 3.7.0

### Highlights
- On-device LLM processing: run AI text enhancement fully offline by downloading a local model (Gemma 4, Qwen3.5, Phi, and more via MLX + LiteRT). Recommends Apple Foundation Model where Apple Intelligence is supported, and brings private on-device AI to devices that can't run it, including many on iOS 18.
- OpenCode Zen and OpenCode Go: two new cloud AI text providers (Zen has free models, Go is subscription), with dynamic model fetching.
- Ollama Cloud: the model picker marks free vs subscription tiers.

### Other changes
- Version bumped to 3.7.0 (build 3012) across all targets.
- New 3.7.0 What's New in-app screen.
- Removed stale model-tier chips from the API key screens; the mode edit model picker is the source of truth.

No SwiftData model changes, so no CloudKit schema deploy is required.