### PR TITLE
Move the MLX on-device LLM runtime into the LocalLLM module

### DIFF
--- a/Modules/LocalLLM/Package.swift
+++ b/Modules/LocalLLM/Package.swift
@@ -13,10 +13,13 @@ let package = Package(
     ],
     dependencies: [
         .package(path: "../AICore"),
-        // On-device LLM runtime - owned here so the heavy, iOS-only native
-        // framework is firewalled into this module instead of linked directly
+        // On-device LLM runtimes - owned here so the heavy, iOS-only native
+        // frameworks are firewalled into this module instead of linked directly
         // by the app target (mirrors how LocalTranscription owns WhisperKit).
         .package(url: "https://github.com/n0an/swift-litert-lm.git", branch: "main"),
+        // MLX (GPU) runtime - pinned to the same revision the app target used
+        // before MLX was consolidated into this module.
+        .package(url: "https://github.com/ml-explore/mlx-swift-lm", revision: "edd42fcd947eea0b19665248acf2975a28ddf58b"),
     ],
     targets: [
         .target(
@@ -24,6 +27,8 @@ let package = Package(
             dependencies: [
                 .product(name: "AICore", package: "AICore"),
                 .product(name: "LiteRTFoundation", package: "swift-litert-lm"),
+                .product(name: "MLXLLM", package: "mlx-swift-lm"),
+                .product(name: "MLXLMCommon", package: "mlx-swift-lm"),
             ]
         ),
         .target(

--- a/Modules/LocalLLM/Sources/LocalLLM/LocalMLXModel.swift
+++ b/Modules/LocalLLM/Sources/LocalLLM/LocalMLXModel.swift
@@ -1,12 +1,12 @@
 //
 //  LocalMLXModel.swift
-//  VivaDicta
+//  LocalLLM
 //
 //  Created by Anton Novoselov on 2026.06.24
 //
-//  Catalog of on-device MLX models (GPU, via mlx-swift-lm). Unlike the LiteRT /
-//  Core ML runtimes (which live in the LocalLLM module), MLX is linked to the
-//  app target for Metal-library bundling, so its types live here.
+//  Catalog of on-device MLX models (GPU, via mlx-swift-lm). Lives in the
+//  LocalLLM module alongside the LiteRT runtime, so the heavy mlx-swift-lm /
+//  Metal framework is firewalled here instead of linked directly by the app.
 //
 //  This type is plain Swift (no MLX import) so AIService / views can reference
 //  it without pulling in MLXLLM. The manager maps `mlxRepo` -> ModelConfiguration.
@@ -16,7 +16,7 @@ import Foundation
 
 /// An on-device MLX model offered in the AI Providers "Local" tab. Current small
 /// 4-bit `mlx-community` builds suitable for iPhone (1-4B).
-nonisolated enum LocalMLXModel: String, CaseIterable, Sendable {
+public nonisolated enum LocalMLXModel: String, CaseIterable, Sendable {
     case qwen35_4B = "qwen3.5-4b-mlx"
     case qwen35_2B = "qwen3.5-2b-mlx"
     case qwen35_08B = "qwen3.5-0.8b-mlx"
@@ -28,11 +28,11 @@ nonisolated enum LocalMLXModel: String, CaseIterable, Sendable {
     case granite33_2B = "granite-3.3-2b-mlx"
 
     /// Unknown ids fall back to the recommended model.
-    init(modelID: String) {
+    public init(modelID: String) {
         self = LocalMLXModel(rawValue: modelID) ?? .qwen35_2B
     }
 
-    var displayName: String {
+    public var displayName: String {
         switch self {
         case .qwen35_4B: "Qwen3.5 4B"
         case .qwen35_2B: "Qwen3.5 2B"
@@ -46,7 +46,7 @@ nonisolated enum LocalMLXModel: String, CaseIterable, Sendable {
         }
     }
 
-    var subtitle: String {
+    public var subtitle: String {
         switch self {
         case .qwen35_4B: "Qwen3.5, larger and higher quality. Broad multilingual."
         case .qwen35_2B: "Qwen3.5. Broad multilingual support."
@@ -75,7 +75,7 @@ nonisolated enum LocalMLXModel: String, CaseIterable, Sendable {
         }
     }
 
-    var approxDownloadDescription: String {
+    public var approxDownloadDescription: String {
         switch self {
         case .qwen35_4B: "~2.3 GB"
         case .qwen35_2B: "~1.3 GB"
@@ -90,7 +90,7 @@ nonisolated enum LocalMLXModel: String, CaseIterable, Sendable {
     }
 
     /// Asset name for the card icon (nil falls back to an SF symbol).
-    var iconAsset: String? {
+    public var iconAsset: String? {
         switch self {
         case .qwen35_4B, .qwen35_2B, .qwen35_08B: "qwen-color"
         case .phi4Mini: "microsoft-color"
@@ -112,7 +112,7 @@ nonisolated enum LocalMLXModel: String, CaseIterable, Sendable {
     /// The Qwen MLX model recommended for a device with the given RAM. Only Qwen
     /// models are ever "recommended" (the badge is reserved for Qwen + Gemma):
     /// 12 GB-class -> 4B, 8 GB-class -> 2B, 6 GB-class and below -> 0.8B.
-    static func recommendedQwen(forPhysicalMemoryBytes bytes: UInt64) -> LocalMLXModel {
+    public static func recommendedQwen(forPhysicalMemoryBytes bytes: UInt64) -> LocalMLXModel {
         let ramGB = Double(bytes) / 1_073_741_824
         if ramGB >= 11 { return .qwen35_4B }
         if ramGB >= 7 { return .qwen35_2B }
@@ -120,7 +120,7 @@ nonisolated enum LocalMLXModel: String, CaseIterable, Sendable {
     }
 
     /// True only for the single Qwen recommended for this device's RAM.
-    var isRecommendedForThisDevice: Bool {
+    public var isRecommendedForThisDevice: Bool {
         self == Self.recommendedQwen(forPhysicalMemoryBytes: ProcessInfo.processInfo.physicalMemory)
     }
 
@@ -136,7 +136,7 @@ nonisolated enum LocalMLXModel: String, CaseIterable, Sendable {
     /// config AND a weights file: `config.json` is tiny and lands early, so a
     /// download cancelled/interrupted before the multi-GB `.safetensors` must not
     /// read as ready (which would let generation resume a fetch or fail late).
-    var isDownloaded: Bool {
+    public var isDownloaded: Bool {
         let fm = FileManager.default
         var isDir: ObjCBool = false
         guard fm.fileExists(atPath: cacheDirectory.path(), isDirectory: &isDir), isDir.boolValue else {
@@ -150,7 +150,7 @@ nonisolated enum LocalMLXModel: String, CaseIterable, Sendable {
     }
 
     /// On-disk size in bytes (0 when not downloaded).
-    var downloadedBytes: Int64 {
+    public var downloadedBytes: Int64 {
         let fm = FileManager.default
         guard let e = fm.enumerator(at: cacheDirectory, includingPropertiesForKeys: [.fileSizeKey]) else {
             return 0

--- a/Modules/LocalLLM/Sources/LocalLLM/LocalMLXModelManager.swift
+++ b/Modules/LocalLLM/Sources/LocalLLM/LocalMLXModelManager.swift
@@ -1,13 +1,13 @@
 //
 //  LocalMLXModelManager.swift
-//  VivaDicta
+//  LocalLLM
 //
 //  Created by Anton Novoselov on 2026.06.24
 //
 //  Lifecycle + generation for on-device MLX models, mirroring VivaDictaMac's
 //  MLXLocalModelService: LLMModelFactory.loadContainer (downloads via the
 //  default caches-backed Hub) -> ModelContainer.perform { MLXLMCommon.generate }.
-//  Lives in the app target because MLXLLM/MLXLMCommon are linked there.
+//  Lives in the LocalLLM module so MLXLLM/MLXLMCommon are firewalled here.
 //
 
 import Foundation
@@ -30,15 +30,15 @@ enum LocalMLXError: LocalizedError {
 }
 
 /// Seam for the view model (and tests) so the UI doesn't depend on the actor directly.
-protocol LocalMLXModelEngine: Sendable {
+public protocol LocalMLXModelEngine: Sendable {
     func ensureLoaded(model: LocalMLXModel, progress: @escaping @Sendable (Double) -> Void) async throws
     func isDownloaded(_ model: LocalMLXModel) async -> Bool
     func downloadedBytes(_ model: LocalMLXModel) async -> Int64
     func deleteModel(_ model: LocalMLXModel) async throws
 }
 
-actor LocalMLXModelManager: LocalMLXModelEngine {
-    static let shared = LocalMLXModelManager()
+public actor LocalMLXModelManager: LocalMLXModelEngine {
+    public static let shared = LocalMLXModelManager()
 
     private let logger = Logger(subsystem: "com.antonnovoselov.VivaDicta", category: "LocalMLX")
     private var container: ModelContainer?
@@ -50,11 +50,11 @@ actor LocalMLXModelManager: LocalMLXModelEngine {
 
     // MARK: - Engine
 
-    func isDownloaded(_ model: LocalMLXModel) -> Bool { model.isDownloaded }
-    func downloadedBytes(_ model: LocalMLXModel) -> Int64 { model.downloadedBytes }
+    public func isDownloaded(_ model: LocalMLXModel) -> Bool { model.isDownloaded }
+    public func downloadedBytes(_ model: LocalMLXModel) -> Int64 { model.downloadedBytes }
 
     /// Download (if needed) + load into memory. Used by the UI download button.
-    func ensureLoaded(model: LocalMLXModel, progress: @escaping @Sendable (Double) -> Void) async throws {
+    public func ensureLoaded(model: LocalMLXModel, progress: @escaping @Sendable (Double) -> Void) async throws {
         try await load(model: model, allowDownload: true, progress: progress)
     }
 
@@ -66,7 +66,7 @@ actor LocalMLXModelManager: LocalMLXModelEngine {
         try await load(model: model, allowDownload: false, progress: { _ in })
     }
 
-    func deleteModel(_ model: LocalMLXModel) throws {
+    public func deleteModel(_ model: LocalMLXModel) throws {
         guard !isGenerating else { throw LocalMLXError.busy }
         if loadedModel == model {
             container = nil

--- a/Modules/LocalLLM/Sources/LocalLLM/LocalMLXTextProvider.swift
+++ b/Modules/LocalLLM/Sources/LocalLLM/LocalMLXTextProvider.swift
@@ -1,6 +1,6 @@
 //
 //  LocalMLXTextProvider.swift
-//  VivaDicta
+//  LocalLLM
 //
 //  Created by Anton Novoselov on 2026.06.24
 //
@@ -13,7 +13,7 @@
 import Foundation
 import AICore
 
-struct LocalMLXTextProvider: AITextProvider {
+public struct LocalMLXTextProvider: AITextProvider {
     private let model: LocalMLXModel
     private let temperature: Double
 
@@ -22,16 +22,16 @@ struct LocalMLXTextProvider: AITextProvider {
     ///     ids fall back to the recommended model.
     ///   - temperature: per-preset sampling temperature (extractive presets pass
     ///     0 for greedy/deterministic output).
-    init(model: String, temperature: Double = 0.3) {
+    public init(model: String, temperature: Double = 0.3) {
         self.model = LocalMLXModel(modelID: model)
         self.temperature = temperature
     }
 
-    func enhance(systemMessage: String, userMessage: String) async throws -> String {
+    public func enhance(systemMessage: String, userMessage: String) async throws -> String {
         try await run(systemMessage: systemMessage, userMessage: userMessage, onPartialResponse: nil)
     }
 
-    func enhanceStreaming(
+    public func enhanceStreaming(
         systemMessage: String,
         userMessage: String,
         onPartialResponse: @escaping @MainActor (String) -> Void

--- a/Modules/LocalLLM/Tests/LocalLLMTests/LocalMLXModelTests.swift
+++ b/Modules/LocalLLM/Tests/LocalLLMTests/LocalMLXModelTests.swift
@@ -1,6 +1,6 @@
 //
 //  LocalMLXModelTests.swift
-//  VivaDictaTests
+//  LocalLLMTests
 //
 //  Created by Anton Novoselov on 2026.06.24
 //
@@ -11,7 +11,7 @@
 
 import Foundation
 import Testing
-@testable import VivaDicta
+@testable import LocalLLM
 
 struct LocalMLXModelTests {
 

--- a/VivaDicta.xcodeproj/project.pbxproj
+++ b/VivaDicta.xcodeproj/project.pbxproj
@@ -40,8 +40,6 @@
 		18C7D0922FEB07530041C086 /* LocalLLM in Frameworks */ = {isa = PBXBuildFile; productRef = 18C7D0912FEB07530041C086 /* LocalLLM */; };
 		18C7D0942FEB0BCF0041C086 /* LocalLLM in Frameworks */ = {isa = PBXBuildFile; productRef = 18C7D0932FEB0BCF0041C086 /* LocalLLM */; };
 		18C7D0962FEB0BCF0041C086 /* LocalLLMMocks in Frameworks */ = {isa = PBXBuildFile; productRef = 18C7D0952FEB0BCF0041C086 /* LocalLLMMocks */; };
-		18C7D0AC2FEBD86F0041C086 /* MLXLLM in Frameworks */ = {isa = PBXBuildFile; productRef = 18C7D0AB2FEBD86F0041C086 /* MLXLLM */; };
-		18C7D0AE2FEBD86F0041C086 /* MLXLMCommon in Frameworks */ = {isa = PBXBuildFile; productRef = 18C7D0AD2FEBD86F0041C086 /* MLXLMCommon */; };
 		18E1B4A52E8C6FF400BE8A11 /* VivaDictaKeyboard.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 18E1B49E2E8C6FF400BE8A11 /* VivaDictaKeyboard.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		18E1B4AD2E8C875000BE8A11 /* KeyboardKit in Frameworks */ = {isa = PBXBuildFile; productRef = 18E1B4AC2E8C875000BE8A11 /* KeyboardKit */; };
 		18E1B4AF2E8C875A00BE8A11 /* KeyboardKit in Frameworks */ = {isa = PBXBuildFile; productRef = 18E1B4AE2E8C875A00BE8A11 /* KeyboardKit */; };
@@ -518,13 +516,11 @@
 				18B497F22F268B2700538830 /* FirebaseCrashlytics in Frameworks */,
 				18B497F02F268B2700538830 /* FirebaseAnalytics in Frameworks */,
 				188E02572FC3BCB4007B8BC1 /* AudioRecording in Frameworks */,
-				18C7D0AC2FEBD86F0041C086 /* MLXLLM in Frameworks */,
 				18B89BC32FB875530007FA96 /* TranscriptionKit in Frameworks */,
 				18B8BEB12FB8BD7D0007FA96 /* DesignSystem in Frameworks */,
 				BFBF000000000000000000C1 /* AICore in Frameworks */,
 				18C7D0922FEB07530041C086 /* LocalLLM in Frameworks */,
 				BFBF000000000000000000D1 /* AIProviders in Frameworks */,
-				18C7D0AE2FEBD86F0041C086 /* MLXLMCommon in Frameworks */,
 				BFBF000000000000000000E1 /* AIKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -749,8 +745,6 @@
 				AEAE000000000000000000D1 /* AIProviders */,
 				AEAE000000000000000000E1 /* AIKit */,
 				18C7D0912FEB07530041C086 /* LocalLLM */,
-				18C7D0AB2FEBD86F0041C086 /* MLXLLM */,
-				18C7D0AD2FEBD86F0041C086 /* MLXLMCommon */,
 			);
 			productName = VivaDicta;
 			productReference = 181D04D72E3E55E400D357A6 /* VivaDicta.app */;
@@ -1023,7 +1017,6 @@
 				18E1B4AB2E8C875000BE8A11 /* XCRemoteSwiftPackageReference "KeyboardKit" */,
 				18B497EE2F268B2700538830 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				1879FD9E2F8C088E00952CF9 /* XCRemoteSwiftPackageReference "LumoKit" */,
-				18C7D0A82FEBD86F0041C086 /* XCRemoteSwiftPackageReference "mlx-swift-lm" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 181D04D82E3E55E400D357A6 /* Products */;
@@ -2452,14 +2445,6 @@
 				minimumVersion = 12.8.0;
 			};
 		};
-		18C7D0A82FEBD86F0041C086 /* XCRemoteSwiftPackageReference "mlx-swift-lm" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/ml-explore/mlx-swift-lm";
-			requirement = {
-				kind = revision;
-				revision = edd42fcd947eea0b19665248acf2975a28ddf58b;
-			};
-		};
 		18E1B4AB2E8C875000BE8A11 /* XCRemoteSwiftPackageReference "KeyboardKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/KeyboardKit/KeyboardKit.git";
@@ -2577,16 +2562,6 @@
 		18C7D0952FEB0BCF0041C086 /* LocalLLMMocks */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = LocalLLMMocks;
-		};
-		18C7D0AB2FEBD86F0041C086 /* MLXLLM */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 18C7D0A82FEBD86F0041C086 /* XCRemoteSwiftPackageReference "mlx-swift-lm" */;
-			productName = MLXLLM;
-		};
-		18C7D0AD2FEBD86F0041C086 /* MLXLMCommon */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 18C7D0A82FEBD86F0041C086 /* XCRemoteSwiftPackageReference "mlx-swift-lm" */;
-			productName = MLXLMCommon;
 		};
 		18E1B4AC2E8C875000BE8A11 /* KeyboardKit */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/VivaDicta/Views/SettingsScreen/LocalMLXModelView.swift
+++ b/VivaDicta/Views/SettingsScreen/LocalMLXModelView.swift
@@ -12,6 +12,7 @@
 import SwiftUI
 import Analytics
 import DesignSystem
+import LocalLLM
 
 @MainActor
 @Observable

--- a/VivaDictaTests/LocalMLXModelViewModelTests.swift
+++ b/VivaDictaTests/LocalMLXModelViewModelTests.swift
@@ -12,6 +12,7 @@
 
 import Foundation
 import Testing
+import LocalLLM
 @testable import VivaDicta
 
 @MainActor

--- a/VivaDictaTests/MockLocalMLXModelEngine.swift
+++ b/VivaDictaTests/MockLocalMLXModelEngine.swift
@@ -12,6 +12,7 @@
 //
 
 import Foundation
+import LocalLLM
 @testable import VivaDicta
 
 actor MockLocalMLXModelEngine: LocalMLXModelEngine {

--- a/documentation/Module-Architecture.md
+++ b/documentation/Module-Architecture.md
@@ -34,7 +34,7 @@ flowchart TB
     CloudTranscription:::adapter
     LocalTranscription:::adapter
     AIProviders["AIProviders — per-LLM clients + AITextProvider wraps"]:::adapter
-    LocalLLM["LocalLLM — on-device LLM (LiteRT) via LocalModelEngine"]:::adapter
+    LocalLLM["LocalLLM — on-device LLM (LiteRT + MLX) via LocalModelEngine"]:::adapter
   end
   subgraph CORE["Core (no module deps; protocols + value types)"]
     Networking:::core
@@ -95,6 +95,7 @@ graph BT
   %% External
   WhisperKit[WhisperKit / FluidAudio]:::external
   LiteRT[LiteRT-LM / LiteRTFoundation]:::external
+  MLX[MLX / mlx-swift-lm]:::external
 
   %% Adapter -> Core
   OAuth --> Keychain
@@ -107,6 +108,7 @@ graph BT
   AIProviders --> Networking
   LocalLLM --> AICore
   LocalLLM --> LiteRT
+  LocalLLM --> MLX
 
   %% Orchestrator -> Adapter + Core
   TranscriptionKit --> TranscriptionCore
@@ -160,7 +162,7 @@ graph BT
 | `CloudTranscription` | adapter | Per-provider speech-to-text services conforming to `TranscriptionService`. Depends on `TranscriptionCore` + `Networking`. | `MockTranscriptionService` |
 | `LocalTranscription` | adapter | On-device transcription (WhisperKit + Parakeet/FluidAudio). | `LocalTranscriptionMocks` |
 | `AIProviders` | adapter | Per-LLM text clients (Anthropic, OpenAI-compatible cluster, Ollama, Custom, Apple FM, OAuth clients) + thin `AITextProvider` wrappers. Depends on `AICore` + `Networking`. | (own tests) |
-| `LocalLLM` | adapter | On-device LLM text generation. `LocalModelEngine` protocol + `LiteRTModelManager` (LiteRT Gemma via swift-litert-lm) + `LiteRTGemmaTextProvider` (conforms to `AITextProvider`) + `LiteRTGemmaVariant`. The MLX runtime stays app-side (Metal-library bundling); this module owns the LiteRT engine. Depends on `AICore` + external `LiteRTFoundation`. | `LocalLLMMocks` (`MockLocalModelEngine`) |
+| `LocalLLM` | adapter | On-device LLM text generation - owns both runtimes. LiteRT: `LocalModelEngine` + `LiteRTModelManager` (Gemma via swift-litert-lm) + `LiteRTGemmaTextProvider` + `LiteRTGemmaVariant`. MLX: `LocalMLXModelEngine` + `LocalMLXModelManager` (Qwen/Phi/Llama/etc. via mlx-swift-lm) + `LocalMLXTextProvider` + `LocalMLXModel`. Both providers conform to `AITextProvider`. Depends on `AICore` + external `LiteRTFoundation` + `MLXLLM`/`MLXLMCommon`. | `LocalLLMMocks` (`MockLocalModelEngine`) |
 | `TranscriptionKit` | orchestrator | Routes a transcription request to cloud vs. local behind `TranscriptionCore`'s protocol. | `TranscriptionKitMocks` |
 | `AIKit` | orchestrator | `AIProviderRegistry` (route + model → configured `any AITextProvider`), `TextEnhancer` (cloud/CLI/OAuth routing + fallback), `CLIServerEnhancer` seam. Depends on `AICore` + `AIProviders` + `Keychain` + `OAuth` + `Networking`. | `MockCLIServerEnhancer` |
 | `VivaDicta` (app) | app | Views, SwiftData, view models, `AIService` (resolves routes + builds messages, delegates execution to `AIKit`), App Intents, extensions. | n/a |


### PR DESCRIPTION
## Summary

Consolidates both on-device LLM runtimes inside the `LocalLLM` module. The MLX glue and its `mlx-swift-lm` dependency move out of the app target into `LocalLLM`, alongside the LiteRT Gemma runtime it already owns - matching the module's documented charter (the heavy, iOS-only native framework is firewalled into the module instead of linked directly by the app, mirroring how `LocalTranscription` owns WhisperKit).

## Changes
- Moved `LocalMLXModel`, `LocalMLXModelManager`, `LocalMLXTextProvider` from `VivaDicta/Services/AIEnhance/MLX/` into `Modules/LocalLLM/Sources/LocalLLM/`, with the consumed API made `public`.
- `LocalLLM/Package.swift` now declares `mlx-swift-lm` (pinned to the same revision the app used) and links `MLXLLM` / `MLXLMCommon`.
- Removed `mlx-swift-lm` from the app target's direct dependencies; it now resolves transitively via `LocalLLM`.
- Moved `LocalMLXModelTests` into `LocalLLMTests` (it exercises internal members; already in the test plan); the app-side `MockLocalMLXModelEngine` now imports `LocalLLM`.
- Updated `documentation/Module-Architecture.md`: added the `LocalLLM -> MLX` edge + external node and rewrote the catalogue row (dropped the now-false 'MLX runtime stays app-side').

## Why
MLX was the lone on-device runtime living in the app target while LiteRT lived in `LocalLLM`. Moving it firewalls the heavy MLX/Metal framework behind the module boundary (the glue no longer recompiles on every app-code change) and makes the module consistent with its own purpose.

## Testing
- Builds clean (0 errors) for the iOS simulator.
- Confirmed `mlx-swift_Cmlx.bundle/default.metallib` is bundled into `VivaDicta.app` - mlx's Metal kernel library propagates through the module boundary, which was the original reason MLX was app-linked.
- Runtime MLX generation not yet exercised; recommend a quick check (download an MLX model and run a generation) to confirm Metal kernels load at runtime.

## Notes
No behavior change intended - pure relocation + access-level changes. The `mlx-swift-lm` revision pin is unchanged.