### PR TITLE
Add CoreML (ANE) on-device LLM + fix keyboard on-device AI crash/hang

### DIFF
--- a/Modules/AICore/Sources/AICore/AIProvider.swift
+++ b/Modules/AICore/Sources/AICore/AIProvider.swift
@@ -625,11 +625,49 @@ public enum AIProvider: String, CaseIterable, Identifiable, Codable, Sendable {
         case .customOpenAI:
             return [] // Model is configured by user
         case .local:
-            // Gemma (LiteRT) + MLX models; AIService picks the runtime by id.
+            // On-device models; AIService picks the runtime by id (see
+            // `localRuntime(forModelID:)`):
+            //   gemma-4-*   -> LiteRT (Metal GPU, foreground-only)
+            //   *-coreml    -> CoreML (Apple Neural Engine, works backgrounded)
+            //   *-mlx       -> MLX    (Metal GPU, foreground-only)
             return ["gemma-4-E2B", "gemma-4-E4B",
+                    "qwen3.5-2b-coreml", "qwen3.5-0.8b-coreml",
                     "qwen3.5-4b-mlx", "qwen3.5-2b-mlx", "qwen3.5-0.8b-mlx", "phi-4-mini-mlx",
                     "llama-3.2-1b-mlx", "llama-3.2-3b-mlx", "ministral-3b-mlx", "falcon3-3b-mlx", "granite-3.3-2b-mlx"]
         }
+    }
+}
+
+// MARK: - On-device runtime classification
+
+public extension AIProvider {
+    /// The on-device runtime backing a `.local` model id.
+    enum LocalRuntime: Sendable {
+        /// LiteRT-LM (Gemma) - runs on the Metal GPU.
+        case liteRT
+        /// MLX - runs on the Metal GPU.
+        case mlx
+        /// CoreML-LLM - runs on the Apple Neural Engine (ANE).
+        case coreML
+
+        /// Whether the runtime executes on the ANE rather than the Metal GPU.
+        /// GPU runtimes cannot run while the app is backgrounded (iOS blocks GPU
+        /// command-buffer submission), so only ANE runtimes work from the keyboard.
+        public var runsOnNeuralEngine: Bool { self == .coreML }
+    }
+
+    /// Classifies a `.local` model id by its backing runtime. The id suffix is the
+    /// discriminator (`-coreml`, `-mlx`); Gemma ids (`gemma-4-*`) default to LiteRT.
+    static func localRuntime(forModelID id: String) -> LocalRuntime {
+        if id.hasSuffix("-coreml") { return .coreML }
+        if id.hasSuffix("-mlx") { return .mlx }
+        return .liteRT
+    }
+
+    /// True when a `.local` model runs on the ANE and therefore works while the
+    /// app is backgrounded (e.g. driven from the keyboard).
+    static func localModelRunsOnNeuralEngine(_ id: String) -> Bool {
+        localRuntime(forModelID: id).runsOnNeuralEngine
     }
 }
 

--- a/Modules/AICore/Sources/AICore/EnhancementError.swift
+++ b/Modules/AICore/Sources/AICore/EnhancementError.swift
@@ -8,6 +8,10 @@ public enum EnhancementError: LocalizedError, Sendable {
     case networkError
     case serverError
     case rateLimitExceeded
+    /// On-device LLMs (Gemma/LiteRT, MLX) run on the Metal GPU in-process, which
+    /// iOS forbids while the app is backgrounded. Surfaced when on-device AI is
+    /// requested from the keyboard (the main app does the work in the background).
+    case onDeviceLLMRequiresForeground
     case customError(String)
 
     public var errorDescription: String? {
@@ -24,6 +28,8 @@ public enum EnhancementError: LocalizedError, Sendable {
             return "Server error occurred"
         case .rateLimitExceeded:
             return "Rate limit exceeded"
+        case .onDeviceLLMRequiresForeground:
+            return "On-device AI needs the app open"
         case .customError(let message):
             return message
         }
@@ -43,6 +49,8 @@ public enum EnhancementError: LocalizedError, Sendable {
             return "The AI provider's server is temporarily unavailable. Please wait a few minutes and try again."
         case .rateLimitExceeded:
             return "You've exceeded the rate limit for the AI service. Please wait a moment before trying again, or upgrade your API plan."
+        case .onDeviceLLMRequiresForeground:
+            return "On-device AI models run on the GPU, which iOS only allows while VivaDicta is open. Open the app to use this model, or pick a cloud model or Apple Foundation Model for keyboard use."
         case .customError(let message):
             return "An error occurred: \(message)"
         }

--- a/Modules/LocalLLM/Package.swift
+++ b/Modules/LocalLLM/Package.swift
@@ -17,6 +17,14 @@ let package = Package(
         // framework is firewalled into this module instead of linked directly
         // by the app target (mirrors how LocalTranscription owns WhisperKit).
         .package(url: "https://github.com/n0an/swift-litert-lm.git", branch: "main"),
+        // On-device LLM runtime that runs on the Apple Neural Engine (ANE), not
+        // the Metal GPU. Because it never submits GPU command buffers, it can run
+        // while the app is backgrounded (e.g. driven from the keyboard) - unlike
+        // the GPU-bound LiteRT/MLX runtimes. Defaults to `.cpuAndNeuralEngine`.
+        .package(url: "https://github.com/john-rocky/CoreML-LLM", from: "1.9.0"),
+        // Tokenizer for the CoreML Qwen path (CoreMLLLM's Qwen3.5 generator takes
+        // token ids, so we tokenize/detokenize here, like its example).
+        .package(url: "https://github.com/huggingface/swift-transformers", from: "1.0.0"),
     ],
     targets: [
         .target(
@@ -24,6 +32,8 @@ let package = Package(
             dependencies: [
                 .product(name: "AICore", package: "AICore"),
                 .product(name: "LiteRTFoundation", package: "swift-litert-lm"),
+                .product(name: "CoreMLLLM", package: "CoreML-LLM"),
+                .product(name: "Tokenizers", package: "swift-transformers"),
             ]
         ),
         .target(
@@ -34,5 +44,12 @@ let package = Package(
             name: "LocalLLMTests",
             dependencies: ["LocalLLM", "LocalLLMMocks"]
         ),
-    ]
+    ],
+    // Swift 5 language mode: this module wraps concurrency-unfriendly native LLM
+    // runtimes (CoreML-LLM's non-Sendable @Observable generators with nonisolated
+    // async methods + a token callback). Building the module in v5 absorbs that
+    // here; its public API (LiteRTGemmaVariant, CoreMLQwenVariant, the engine
+    // protocols, etc.) is still declared Sendable, so the strict-v6 app consumes
+    // it safely.
+    swiftLanguageModes: [.v5]
 )

--- a/Modules/LocalLLM/Sources/LocalLLM/CoreMLQwenModelManager.swift
+++ b/Modules/LocalLLM/Sources/LocalLLM/CoreMLQwenModelManager.swift
@@ -181,7 +181,9 @@ public actor CoreMLQwenModelManager: CoreMLQwenEngine {
     }
 
     /// Stream a completion for `prompt`. Yields text deltas. Requires a prior load.
-    func stream(prompt: String) async throws -> AsyncStream<String> {
+    /// Throwing so a mid-generation failure propagates (via the provider) to
+    /// AIService's error path - never surfaced as enhanced text - matching LiteRT.
+    func stream(prompt: String) async throws -> AsyncThrowingStream<String, Error> {
         #if canImport(CoreMLLLM)
         guard let gen = generator, let tok = tokenizer else { throw CoreMLQwenError.notLoaded }
         guard !isGenerating else { throw CoreMLQwenError.busy }
@@ -198,7 +200,7 @@ public actor CoreMLQwenModelManager: CoreMLQwenEngine {
             throw CoreMLQwenError.promptTooLong
         }
 
-        return AsyncStream { continuation in
+        return AsyncThrowingStream { continuation in
             Task {
                 var accum: [Int] = []
                 var emitted = ""
@@ -224,10 +226,12 @@ public actor CoreMLQwenModelManager: CoreMLQwenEngine {
                             }
                         }
                     )
+                    continuation.finish()
                 } catch {
-                    continuation.yield("[Error: \(error.localizedDescription)]")
+                    // Propagate the failure instead of yielding it as text, so the
+                    // provider/AIService treat it as an error (not an enhancement).
+                    continuation.finish(throwing: error)
                 }
-                continuation.finish()
                 await self.endGeneration()
             }
         }

--- a/Modules/LocalLLM/Sources/LocalLLM/CoreMLQwenModelManager.swift
+++ b/Modules/LocalLLM/Sources/LocalLLM/CoreMLQwenModelManager.swift
@@ -1,0 +1,307 @@
+//
+//  CoreMLQwenModelManager.swift
+//  LocalLLM
+//
+//  Created by Anton Novoselov on 2026.06.27
+//
+//  Owns the on-device Qwen3.5 model (CoreML-LLM) - the CoreML counterpart to
+//  LiteRTModelManager / LocalMLXModelManager. Unlike those two, CoreML-LLM runs
+//  inference on the Apple Neural Engine (ANE), NOT the Metal GPU. iOS forbids GPU
+//  command-buffer submission from a backgrounded app (that is why LiteRT/MLX
+//  hang/crash when driven from the keyboard), but ANE work is permitted in the
+//  background - so this runtime is the one on-device LLM that works from the
+//  keyboard. We pin `.cpuAndNeuralEngine` explicitly so it can never fall back to
+//  the GPU and lose that property.
+//
+//  Qwen3.5 uses the low-level `Qwen35MLKVGenerator` (token-ids in/out), so this
+//  also owns the tokenizer (swift-transformers) and the download (CoreML-LLM's
+//  `ModelDownloader`, whose built-in ModelInfo already points at the
+//  `mlboydaisuke/*` HuggingFace repos).
+//
+//  CoreMLLLM's generator + tokenizer are non-Sendable @Observable classes with
+//  nonisolated async methods; the module's Swift 5 language mode absorbs that,
+//  and this manager's public surface (variant + engine protocol) stays Sendable.
+//
+
+import Foundation
+import os
+
+#if canImport(CoreMLLLM)
+@preconcurrency import CoreMLLLM
+@preconcurrency import Tokenizers
+import CoreML
+#endif
+
+/// The on-device Qwen variants the app can run via CoreML (ANE). Raw values match
+/// the CoreML entries in `AIProvider.local`'s model identifiers - suffixed
+/// `-coreml` to disambiguate from the MLX Qwen models (`qwen3.5-2b-mlx`).
+public nonisolated enum CoreMLQwenVariant: String, CaseIterable, Sendable {
+    case qwen2B = "qwen3.5-2b-coreml"
+    case qwen08B = "qwen3.5-0.8b-coreml"
+
+    public init(modelID: String) {
+        self = CoreMLQwenVariant(rawValue: modelID) ?? .qwen2B
+    }
+
+    public var displayName: String {
+        switch self {
+        case .qwen2B: "Qwen3.5 2B"
+        case .qwen08B: "Qwen3.5 0.8B"
+        }
+    }
+
+    /// Short description for the settings cards. Emphasizes the keyboard-friendly
+    /// ANE story (the reason to pick CoreML over the faster GPU runtimes).
+    public var subtitle: String {
+        switch self {
+        case .qwen2B: "Runs on the Neural Engine, so it also works from the keyboard. Higher quality, very low memory. Slower than GPU models."
+        case .qwen08B: "Runs on the Neural Engine, so it also works from the keyboard. Smallest and fastest to download; lower quality than 2B."
+        }
+    }
+
+    /// Approximate download size, shown before downloading.
+    public var approxDownloadDescription: String {
+        switch self {
+        case .qwen2B: "~2.8 GB"
+        case .qwen08B: "~1.2 GB"
+        }
+    }
+
+    /// HuggingFace tokenizer repo (fetched at runtime by swift-transformers).
+    var tokenizerId: String {
+        switch self {
+        case .qwen2B: "Qwen/Qwen3.5-2B"
+        case .qwen08B: "Qwen/Qwen3.5-0.8B"
+        }
+    }
+
+    #if canImport(CoreMLLLM)
+    /// CoreML-LLM's built-in ModelInfo (its `downloadURL` already points at the
+    /// `mlboydaisuke/qwen3.5-*-CoreML` HuggingFace repos).
+    var modelInfo: ModelDownloader.ModelInfo {
+        switch self {
+        case .qwen2B: .qwen35_2b
+        case .qwen08B: .qwen35_08b
+        }
+    }
+    #endif
+
+    /// Whether the model is downloaded (synchronous, for the picker/cards filter).
+    public var isDownloaded: Bool {
+        #if canImport(CoreMLLLM)
+        ModelDownloader.shared.isDownloaded(modelInfo)
+        #else
+        false
+        #endif
+    }
+
+    /// 2B is the recommended pick - both run comfortably on the ANE (~200 MB),
+    /// so prefer the higher-quality one.
+    public var isRecommendedForThisDevice: Bool { self == .qwen2B }
+}
+
+/// Model-lifecycle surface the Qwen settings view model depends on (parallel to
+/// `LocalModelEngine` for Gemma). Seamed so the view model can be unit-tested
+/// against a mock instead of the real downloader/ANE runtime.
+public protocol CoreMLQwenEngine: Sendable {
+    func ensureLoaded(variant: CoreMLQwenVariant, onDownloadProgress: (@Sendable (Double) -> Void)?) async throws
+    func isDownloaded(_ variant: CoreMLQwenVariant) async -> Bool
+    func downloadedBytes(_ variant: CoreMLQwenVariant) async -> Int64
+    func deleteModel(_ variant: CoreMLQwenVariant) async throws
+}
+
+public actor CoreMLQwenModelManager: CoreMLQwenEngine {
+    public static let shared = CoreMLQwenModelManager()
+
+    private let logger = Logger(subsystem: "com.antonnovoselov.VivaDicta", category: "CoreMLQwen")
+
+    #if canImport(CoreMLLLM)
+    private let downloader = ModelDownloader.shared
+    private var generator: Qwen35MLKVGenerator?
+    private var tokenizer: (any Tokenizer)?
+    #endif
+
+    private(set) var loadedVariant: CoreMLQwenVariant?
+    private var isGenerating = false
+    private var isLoading = false
+
+    private init() {}
+
+    /// Download (first launch only) + load the requested variant. Download-allowed
+    /// path - call only from the Settings download action; generation uses
+    /// `loadForGeneration`, which never downloads.
+    public func ensureLoaded(variant: CoreMLQwenVariant = .qwen2B, onDownloadProgress: (@Sendable (Double) -> Void)? = nil) async throws {
+        #if canImport(CoreMLLLM)
+        if generator != nil, loadedVariant == variant { return }
+        guard !isLoading, !isGenerating else { throw CoreMLQwenError.busy }
+        isLoading = true
+        defer { isLoading = false }
+        generator = nil
+        tokenizer = nil
+        loadedVariant = nil
+
+        let info = variant.modelInfo
+        let folder: URL
+        if downloader.isDownloaded(info), let url = downloader.localModelURL(for: info) {
+            // load() wants the folder CONTAINING the chunks subdir; localModelURL
+            // points one level in (matches CoreML-LLM's own example).
+            folder = url.deletingLastPathComponent()
+        } else {
+            // The card shows an indeterminate "Downloading..." (multi-file model
+            // progress is non-linear and reads as stuck), so 0 -> 1 is enough.
+            onDownloadProgress?(0)
+            let url = try await downloader.download(info)
+            onDownloadProgress?(1)
+            folder = url.deletingLastPathComponent()
+        }
+
+        let tok = try await AutoTokenizer.from(pretrained: variant.tokenizerId)
+        let cfg: Qwen35MLKVGenerator.Config = variant == .qwen08B ? .default0_8B : .default2B
+        let gen = Qwen35MLKVGenerator(cfg: cfg)
+        gen.setModelFolder(folder)
+        // Pin the ANE: never the GPU, so generation keeps working while the app is
+        // backgrounded (e.g. driven from the keyboard).
+        gen.setComputeUnits(.cpuAndNeuralEngine)
+        try await gen.load()
+
+        generator = gen
+        tokenizer = tok
+        loadedVariant = variant
+        logger.info("CoreML Qwen \(variant.rawValue, privacy: .public) ready (ANE)")
+        #else
+        throw CoreMLQwenError.unavailable
+        #endif
+    }
+
+    /// Load an already-downloaded variant for generation - throws `.notDownloaded`
+    /// if absent, so processing never silently kicks off a multi-GB download.
+    func loadForGeneration(variant: CoreMLQwenVariant) async throws {
+        guard variant.isDownloaded else { throw CoreMLQwenError.notDownloaded }
+        try await ensureLoaded(variant: variant)
+    }
+
+    /// Stream a completion for `prompt`. Yields text deltas. Requires a prior load.
+    func stream(prompt: String) async throws -> AsyncStream<String> {
+        #if canImport(CoreMLLLM)
+        guard let gen = generator, let tok = tokenizer else { throw CoreMLQwenError.notLoaded }
+        guard !isGenerating else { throw CoreMLQwenError.busy }
+        isGenerating = true
+
+        let chat: [[String: any Sendable]] = [["role": "user", "content": prompt]]
+        let templated = try? tok.applyChatTemplate(messages: chat)
+        let inputIds = (templated ?? tok.encode(text: prompt)).map { Int32($0) }
+        var eos: Set<Int32> = [248044, 248045, 248046]
+        if let e = tok.eosTokenId { eos.insert(Int32(e)) }
+        let maxNew = min(2048 - inputIds.count - 1, 1024)
+        guard maxNew >= 1 else {
+            isGenerating = false
+            throw CoreMLQwenError.promptTooLong
+        }
+
+        return AsyncStream { continuation in
+            Task {
+                var accum: [Int] = []
+                var emitted = ""
+                do {
+                    _ = try await gen.generate(
+                        inputIds: inputIds,
+                        maxNewTokens: maxNew,
+                        temperature: 0.0,
+                        topK: 40,
+                        topP: 1.0,
+                        repetitionPenalty: 1.1,
+                        eosTokenIds: eos,
+                        onToken: { tokenId in
+                            if eos.contains(tokenId) { return }
+                            accum.append(Int(tokenId))
+                            var current = tok.decode(tokens: accum)
+                            // Drop a trailing replacement char from a partial
+                            // multi-byte token until the next token completes it.
+                            while current.hasSuffix("\u{FFFD}") { current = String(current.dropLast()) }
+                            if current.count > emitted.count, current.hasPrefix(emitted) {
+                                continuation.yield(String(current.dropFirst(emitted.count)))
+                                emitted = current
+                            }
+                        }
+                    )
+                } catch {
+                    continuation.yield("[Error: \(error.localizedDescription)]")
+                }
+                continuation.finish()
+                await self.endGeneration()
+            }
+        }
+        #else
+        throw CoreMLQwenError.unavailable
+        #endif
+    }
+
+    private func endGeneration() {
+        isGenerating = false
+    }
+
+    /// Free the model (e.g. on memory pressure). The next load reloads from the
+    /// on-disk cache (no re-download).
+    public func unload() {
+        #if canImport(CoreMLLLM)
+        generator = nil
+        tokenizer = nil
+        #endif
+        loadedVariant = nil
+        isLoading = false
+        logger.info("CoreML Qwen model unloaded")
+    }
+
+    public func isDownloaded(_ variant: CoreMLQwenVariant) -> Bool {
+        variant.isDownloaded
+    }
+
+    public func downloadedBytes(_ variant: CoreMLQwenVariant) -> Int64 {
+        #if canImport(CoreMLLLM)
+        guard let url = downloader.localModelURL(for: variant.modelInfo) else { return 0 }
+        let folder = url.deletingLastPathComponent()
+        return Self.directorySize(folder)
+        #else
+        return 0
+        #endif
+    }
+
+    public func deleteModel(_ variant: CoreMLQwenVariant) throws {
+        guard !isGenerating else { throw CoreMLQwenError.busy }
+        if loadedVariant == variant { unload() }
+        #if canImport(CoreMLLLM)
+        try downloader.delete(variant.modelInfo)
+        logger.info("CoreML Qwen \(variant.rawValue, privacy: .public) deleted")
+        #endif
+    }
+
+    /// Recursive byte size of a downloaded model folder.
+    private static func directorySize(_ url: URL) -> Int64 {
+        let fm = FileManager.default
+        guard let e = fm.enumerator(at: url, includingPropertiesForKeys: [.fileSizeKey, .isRegularFileKey]) else { return 0 }
+        var total: Int64 = 0
+        for case let f as URL in e {
+            let v = try? f.resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey])
+            if v?.isRegularFile == true { total += Int64(v?.fileSize ?? 0) }
+        }
+        return total
+    }
+}
+
+public enum CoreMLQwenError: LocalizedError {
+    case unavailable
+    case notLoaded
+    case notDownloaded
+    case busy
+    case promptTooLong
+
+    public var errorDescription: String? {
+        switch self {
+        case .unavailable: "On-device Qwen (CoreML) is not available in this build."
+        case .notLoaded: "The on-device Qwen model has not been loaded yet."
+        case .notDownloaded: "Download the on-device Qwen model in AI Providers settings before using it."
+        case .busy: "The on-device Qwen model is already processing another request. Try again in a moment."
+        case .promptTooLong: "The text is too long for Qwen's 2048-token context."
+        }
+    }
+}

--- a/Modules/LocalLLM/Sources/LocalLLM/CoreMLQwenTextProvider.swift
+++ b/Modules/LocalLLM/Sources/LocalLLM/CoreMLQwenTextProvider.swift
@@ -50,7 +50,7 @@ public struct CoreMLQwenTextProvider: AITextProvider {
         let stream = try await CoreMLQwenModelManager.shared.stream(prompt: prompt)
 
         var full = ""
-        for await delta in stream {
+        for try await delta in stream {
             full += delta
             if let onPartialResponse {
                 let snapshot = full

--- a/Modules/LocalLLM/Sources/LocalLLM/CoreMLQwenTextProvider.swift
+++ b/Modules/LocalLLM/Sources/LocalLLM/CoreMLQwenTextProvider.swift
@@ -1,0 +1,62 @@
+//
+//  CoreMLQwenTextProvider.swift
+//  LocalLLM
+//
+//  Created by Anton Novoselov on 2026.06.27
+//
+//  `AITextProvider` backed by on-device Qwen3.5 via CoreML-LLM (ANE). Thin:
+//  defers the model lifecycle to the shared `CoreMLQwenModelManager` and maps the
+//  system + user messages into a single prompt. Output filtering is applied
+//  centrally by the caller (AIService), so this returns the raw model text.
+//
+//  Unlike the LiteRT/MLX providers, this runs on the Neural Engine, so it works
+//  while the app is backgrounded (e.g. from the keyboard).
+//
+
+import Foundation
+import AICore
+
+public struct CoreMLQwenTextProvider: AITextProvider {
+    private let variant: CoreMLQwenVariant
+
+    /// - Parameter model: the mode's selected model id (e.g. "qwen3.5-2b-coreml" /
+    ///   "qwen3.5-0.8b-coreml"); unknown ids fall back to 2B.
+    public init(model: String = CoreMLQwenVariant.qwen2B.rawValue) {
+        self.variant = CoreMLQwenVariant(modelID: model)
+    }
+
+    public func enhance(systemMessage: String, userMessage: String) async throws -> String {
+        try await run(systemMessage: systemMessage, userMessage: userMessage, onPartialResponse: nil)
+    }
+
+    public func enhanceStreaming(
+        systemMessage: String,
+        userMessage: String,
+        onPartialResponse: @escaping @MainActor (String) -> Void
+    ) async throws -> String {
+        try await run(systemMessage: systemMessage, userMessage: userMessage, onPartialResponse: onPartialResponse)
+    }
+
+    private func run(
+        systemMessage: String,
+        userMessage: String,
+        onPartialResponse: (@MainActor (String) -> Void)?
+    ) async throws -> String {
+        // loadForGeneration never downloads - throws .notDownloaded if the model
+        // isn't on disk rather than silently starting a multi-GB fetch.
+        try await CoreMLQwenModelManager.shared.loadForGeneration(variant: variant)
+
+        let prompt = systemMessage + "\n\n" + userMessage
+        let stream = try await CoreMLQwenModelManager.shared.stream(prompt: prompt)
+
+        var full = ""
+        for await delta in stream {
+            full += delta
+            if let onPartialResponse {
+                let snapshot = full
+                await MainActor.run { onPartialResponse(snapshot) }
+            }
+        }
+        return full.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/Modules/LocalLLM/Sources/LocalLLM/LiteRTModelManager.swift
+++ b/Modules/LocalLLM/Sources/LocalLLM/LiteRTModelManager.swift
@@ -139,6 +139,40 @@ public actor LiteRTModelManager: LocalModelEngine {
     /// doubles the footprint and can OOM smaller devices.
     private var isLoading = false
 
+    // MARK: Stuck-flag recovery
+    // A GPU load/generation that hangs (e.g. the app is backgrounded mid-load and
+    // the Metal command buffer is aborted) would otherwise leave `isLoading` /
+    // `isGenerating` stuck `true` forever, poisoning every later request with
+    // `.busy` ("already processing another request"). These timestamps let the
+    // next attempt detect and clear an implausibly long-held flag. A legitimate
+    // model DOWNLOAD can be slow, so it is marked and never auto-cleared.
+    private let clock = ContinuousClock()
+    private var loadStartedAt: ContinuousClock.Instant?
+    private var generationStartedAt: ContinuousClock.Instant?
+    private var isDownloadingModel = false
+    private let stuckThreshold: Duration = .seconds(120)
+
+    /// Clears a flag held longer than `stuckThreshold` - a sign the underlying GPU
+    /// op hung and its cleanup never ran. Never clears an in-flight download.
+    private func recoverFromStuckStateIfNeeded() {
+        let now = clock.now
+        if isLoading, !isDownloadingModel, let started = loadStartedAt, started.duration(to: now) > stuckThreshold {
+            logger.warning("LiteRT recovery: clearing stale isLoading (held past timeout) - dropping half-loaded model")
+            isLoading = false
+            loadStartedAt = nil
+            #if canImport(LiteRTFoundation)
+            chat = nil
+            #endif
+            loadedVariant = nil
+            state = .notLoaded
+        }
+        if isGenerating, let started = generationStartedAt, started.duration(to: now) > stuckThreshold {
+            logger.warning("LiteRT recovery: clearing stale isGenerating (held past timeout)")
+            isGenerating = false
+            generationStartedAt = nil
+        }
+    }
+
     private init() {}
 
     var isReady: Bool { state == .ready }
@@ -162,9 +196,12 @@ public actor LiteRTModelManager: LocalModelEngine {
         // devices), and never swap the model out from under a running generation.
         // Set synchronously (no await before the assignment) so the actor can't
         // interleave two callers past this guard.
+        recoverFromStuckStateIfNeeded()
         guard !isLoading, !isGenerating else { throw LiteRTModelError.busy }
+        isDownloadingModel = !variant.isDownloaded
         isLoading = true
-        defer { isLoading = false }
+        loadStartedAt = clock.now
+        defer { isLoading = false; loadStartedAt = nil; isDownloadingModel = false }
 
         // Switching variants: drop the previously-loaded model first.
         chat = nil
@@ -231,16 +268,19 @@ public actor LiteRTModelManager: LocalModelEngine {
     /// output after a few runs).
     func stream(prompt: String) async throws -> AsyncThrowingStream<String, any Error> {
         #if canImport(LiteRTFoundation)
+        recoverFromStuckStateIfNeeded()
         guard let chat else { throw LiteRTModelError.notLoaded }
         guard !isGenerating else { throw LiteRTModelError.busy }
         // Claim the generation slot synchronously (before any await) so two
         // concurrent callers can't both pass the guard during resetConversation's
         // suspension and start overlapping streams. Release it if the reset fails.
         isGenerating = true
+        generationStartedAt = clock.now
         do {
             try await chat.resetConversation()
         } catch {
             isGenerating = false
+            generationStartedAt = nil
             throw error
         }
         let base = chat.stream(prompt)
@@ -265,15 +305,18 @@ public actor LiteRTModelManager: LocalModelEngine {
 
     private func endGeneration() {
         isGenerating = false
+        generationStartedAt = nil
     }
 
     /// Free the model (e.g. on memory pressure or when backgrounded). The next
     /// `ensureLoaded()` reloads from the on-disk cache (no re-download).
-    func unload() {
+    public func unload() {
         #if canImport(LiteRTFoundation)
         chat = nil
         #endif
         loadedVariant = nil
+        loadStartedAt = nil
+        isLoading = false
         state = .notLoaded
         logger.info("LiteRT Gemma model unloaded")
     }

--- a/VivaDicta/AppDelegate.swift
+++ b/VivaDicta/AppDelegate.swift
@@ -19,6 +19,9 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         FirebaseApp.configure()
         PerformanceMonitoringService.shared.start()
         BackgroundTaskManager.registerBGTaskHandler()
+        // Arm the on-device LLM memory monitor (frees the model under pressure so
+        // we don't get jetsammed while holding a ~1-2 GB model).
+        OnDeviceModelMemory.shared.activate()
         return true
     }
 

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -11,6 +11,7 @@ import Analytics
 import Networking
 import Presets
 import SwiftUI
+import UIKit
 import AppGroup
 import TipKit
 import os
@@ -62,6 +63,7 @@ class AIService {
         case apple
         case localGemma
         case localMLX
+        case localCoreML
         case anthropic
         case copilot
         case geminiOAuth
@@ -792,10 +794,13 @@ class AIService {
             // On-device needs no API key, but the selected model must be
             // downloaded - we don't silently download during processing. A mode
             // whose model was deleted is not properly configured. The model id
-            // picks the runtime (Gemma = LiteRT, else MLX).
-            let downloaded = isLiteRTGemmaModel(mode.aiModel)
-                ? LiteRTGemmaVariant(modelID: mode.aiModel).isDownloaded
-                : LocalMLXModel(modelID: mode.aiModel).isDownloaded
+            // picks the runtime (Gemma = LiteRT, -coreml = CoreML, else MLX).
+            let downloaded: Bool
+            switch AIProvider.localRuntime(forModelID: mode.aiModel) {
+            case .coreML: downloaded = CoreMLQwenVariant(modelID: mode.aiModel).isDownloaded
+            case .liteRT: downloaded = LiteRTGemmaVariant(modelID: mode.aiModel).isDownloaded
+            case .mlx: downloaded = LocalMLXModel(modelID: mode.aiModel).isDownloaded
+            }
             guard downloaded else {
                 logger.logWarning("On-device model '\(mode.aiModel)' is not downloaded")
                 return false
@@ -944,7 +949,7 @@ class AIService {
         let startTime = Date()
         let mode = modeOverride ?? selectedMode
 
-        let (systemMessage, formattedText) = buildVariationMessages(text: text, preset: preset)
+        let (systemMessage, formattedText) = buildVariationMessages(text: text, preset: preset, compact: usesCompactPrompt(forModel: mode.aiModel))
 
         lastSystemMessageSent = systemMessage
         lastUserMessageSent = formattedText
@@ -1012,7 +1017,7 @@ class AIService {
         }
     }
 
-    private func buildVariationMessages(text: String, preset: Preset) -> (systemMessage: String, userMessage: String) {
+    private func buildVariationMessages(text: String, preset: Preset, compact: Bool = false) -> (systemMessage: String, userMessage: String) {
         var customVocabularySection = ""
         let customVocabularyWords = CustomVocabulary.getTerms()
         if !customVocabularyWords.isEmpty {
@@ -1024,7 +1029,10 @@ class AIService {
 
         let systemMessage: String
         if preset.useSystemTemplate {
-            systemMessage = PromptsTemplates.systemPrompt(with: preset.promptInstructions) + customVocabularySection + scriptSuffix
+            let template = compact
+                ? PromptsTemplates.compactSystemPrompt(with: preset.promptInstructions)
+                : PromptsTemplates.systemPrompt(with: preset.promptInstructions)
+            systemMessage = template + customVocabularySection + scriptSuffix
         } else {
             systemMessage = preset.promptInstructions + customVocabularySection + scriptSuffix
         }
@@ -1045,12 +1053,40 @@ class AIService {
         LiteRTGemmaVariant(rawValue: modelID) != nil
     }
 
+    /// Whether a model should get the lean system prompt. CoreML runs recurrent
+    /// (per-token) prefill, so time-to-first-token scales with prompt length - a
+    /// ~500-token system prompt adds tens of seconds. The lean (~120-token) prompt
+    /// cuts that. GPU runtimes (LiteRT/MLX) batch-prefill and cloud/Apple FM are
+    /// unaffected, so they keep the full prompt.
+    private func usesCompactPrompt(forModel modelID: String) -> Bool {
+        AIProvider.localRuntime(forModelID: modelID) == .coreML
+    }
+
+    /// On-device LLMs (Gemma/LiteRT, MLX) run inference on the Metal GPU
+    /// in-process. iOS forbids submitting GPU command buffers while the app is
+    /// backgrounded (`kIOGPUCommandBufferCallbackErrorBackgroundExecutionNotPermitted`):
+    /// MLX reacts by throwing an uncaught C++ exception that crashes the process,
+    /// and LiteRT hangs - neither is recoverable after the fact. This happens when
+    /// AI processing is triggered from the keyboard, because the main app runs the
+    /// work in the background on the keyboard's behalf. So we refuse before any GPU
+    /// work is submitted. Apple FM (out-of-process) and cloud providers are
+    /// unaffected and remain available from the keyboard.
+    private func ensureForegroundForOnDeviceLLM() throws {
+        guard UIApplication.shared.applicationState == .background else { return }
+        logger.logError("AI Processing - on-device LLM requested while backgrounded; refusing (GPU unavailable in background)")
+        throw EnhancementError.onDeviceLLMRequiresForeground
+    }
+
     private func resolvedStreamingRoute(for aiProvider: AIProvider, mode: VivaMode) -> StreamingRoute? {
         switch aiProvider {
         case .apple:
             return .apple
         case .local:
-            return isLiteRTGemmaModel(mode.aiModel) ? .localGemma : .localMLX
+            switch AIProvider.localRuntime(forModelID: mode.aiModel) {
+            case .coreML: return .localCoreML
+            case .liteRT: return .localGemma
+            case .mlx: return .localMLX
+            }
         case .openAI:
             if isOpenAISignedIn {
                 return .openAIOAuth
@@ -1133,7 +1169,7 @@ class AIService {
             return ""
         }
 
-        let sysMsg = systemMessage ?? getSystemMessage()
+        let sysMsg = systemMessage ?? getSystemMessage(compact: usesCompactPrompt(forModel: mode.aiModel))
         let userMsg = preFormattedUserMessage ?? formatTranscriptForLLM(text)
         lastSystemMessageSent = sysMsg
         lastUserMessageSent = userMsg
@@ -1157,16 +1193,29 @@ class AIService {
                 throw EnhancementError.notConfigured
             }
         case .localGemma:
+            try ensureForegroundForOnDeviceLLM()
             logger.logDebug("AI Processing - Using on-device Gemma (LiteRT) streaming")
+            await OnDeviceModelMemory.shared.ensureOnlyResident(.liteRT)
             let provider = LiteRTGemmaTextProvider(model: mode.aiModel)
             let result = try await provider.enhanceStreaming(systemMessage: sysMsg, userMessage: userMsg, onPartialResponse: onPartialResponse)
             return await finalizeStreamingResult(result, onPartialResponse: onPartialResponse)
         case .localMLX:
+            try ensureForegroundForOnDeviceLLM()
             logger.logDebug("AI Processing - Using on-device MLX streaming")
+            await OnDeviceModelMemory.shared.ensureOnlyResident(.mlx)
             // Per-preset temperature (extractive presets -> greedy), reusing the
             // same profile Apple FM uses.
             let temperature = AppleFoundationModelSamplingProfile.profile(for: appleFMPresetID ?? mode.presetId).temperature
             let provider = LocalMLXTextProvider(model: mode.aiModel, temperature: temperature)
+            let result = try await provider.enhanceStreaming(systemMessage: sysMsg, userMessage: userMsg, onPartialResponse: onPartialResponse)
+            return await finalizeStreamingResult(result, onPartialResponse: onPartialResponse)
+        case .localCoreML:
+            // CoreML runs on the ANE, which IS permitted in the background, so this
+            // route is intentionally NOT gated by `ensureForegroundForOnDeviceLLM()`
+            // - it is the on-device option that works from the keyboard.
+            logger.logDebug("AI Processing - Using on-device Qwen (CoreML/ANE) streaming")
+            await OnDeviceModelMemory.shared.ensureOnlyResident(.coreML)
+            let provider = CoreMLQwenTextProvider(model: mode.aiModel)
             let result = try await provider.enhanceStreaming(systemMessage: sysMsg, userMessage: userMsg, onPartialResponse: onPartialResponse)
             return await finalizeStreamingResult(result, onPartialResponse: onPartialResponse)
         case .anthropic:
@@ -1327,18 +1376,28 @@ class AIService {
         }
 
         // Handle on-device models. The model id picks the runtime:
-        // Gemma (gemma-4-*) runs on LiteRT; everything else on MLX.
+        // Gemma (gemma-4-*) -> LiteRT (GPU), *-coreml -> CoreML (ANE), else MLX (GPU).
         if aiProvider == .local {
-            let sysMsg = systemMessage ?? getSystemMessage()
+            let sysMsg = systemMessage ?? getSystemMessage(compact: usesCompactPrompt(forModel: mode.aiModel))
             let userMsg = preFormattedUserMessage ?? formatTranscriptForLLM(text)
             lastSystemMessageSent = sysMsg
             lastUserMessageSent = userMsg
             let result: String
-            if isLiteRTGemmaModel(mode.aiModel) {
+            switch AIProvider.localRuntime(forModelID: mode.aiModel) {
+            case .coreML:
+                // ANE - works backgrounded; intentionally NOT foreground-gated.
+                logger.logDebug("AI Processing - Using on-device Qwen (CoreML/ANE)")
+                await OnDeviceModelMemory.shared.ensureOnlyResident(.coreML)
+                result = try await CoreMLQwenTextProvider(model: mode.aiModel).enhance(systemMessage: sysMsg, userMessage: userMsg)
+            case .liteRT:
+                try ensureForegroundForOnDeviceLLM()
                 logger.logDebug("AI Processing - Using on-device Gemma (LiteRT)")
+                await OnDeviceModelMemory.shared.ensureOnlyResident(.liteRT)
                 result = try await LiteRTGemmaTextProvider(model: mode.aiModel).enhance(systemMessage: sysMsg, userMessage: userMsg)
-            } else {
+            case .mlx:
+                try ensureForegroundForOnDeviceLLM()
                 logger.logDebug("AI Processing - Using on-device MLX")
+                await OnDeviceModelMemory.shared.ensureOnlyResident(.mlx)
                 let temperature = AppleFoundationModelSamplingProfile.profile(for: appleFMPresetID ?? mode.presetId).temperature
                 result = try await LocalMLXTextProvider(model: mode.aiModel, temperature: temperature).enhance(systemMessage: sysMsg, userMessage: userMsg)
             }
@@ -1387,7 +1446,7 @@ class AIService {
         return ChineseScriptPreferenceStore.current.systemMessageSuffix ?? ""
     }
 
-    private func getSystemMessage() -> String {
+    private func getSystemMessage(compact: Bool = false) -> String {
         var customVocabularySection = ""
         let customVocabularyWords = CustomVocabulary.getTerms()
         if !customVocabularyWords.isEmpty {
@@ -1414,7 +1473,10 @@ class AIService {
         let contextSections = customVocabularySection + clipboardContextSection + scriptSuffix
 
         if useSystemTemplate {
-            return PromptsTemplates.systemPrompt(with: promptInstructions) + contextSections
+            let template = compact
+                ? PromptsTemplates.compactSystemPrompt(with: promptInstructions)
+                : PromptsTemplates.systemPrompt(with: promptInstructions)
+            return template + contextSections
         } else {
             // Standalone preset - use instructions directly + context
             return promptInstructions + contextSections
@@ -2101,9 +2163,11 @@ class AIService {
         // AI Providers screen instead. The model id picks the runtime to query.
         if provider == .local {
             return provider.availableModels.filter { id in
-                isLiteRTGemmaModel(id)
-                    ? LiteRTGemmaVariant(modelID: id).isDownloaded
-                    : LocalMLXModel(modelID: id).isDownloaded
+                switch AIProvider.localRuntime(forModelID: id) {
+                case .coreML: CoreMLQwenVariant(modelID: id).isDownloaded
+                case .liteRT: LiteRTGemmaVariant(modelID: id).isDownloaded
+                case .mlx: LocalMLXModel(modelID: id).isDownloaded
+                }
             }
         }
         return provider.availableModels

--- a/VivaDicta/Services/AIEnhance/MLX/LocalMLXModelManager.swift
+++ b/VivaDicta/Services/AIEnhance/MLX/LocalMLXModelManager.swift
@@ -46,6 +46,34 @@ actor LocalMLXModelManager: LocalMLXModelEngine {
     private var isLoading = false
     private var isGenerating = false
 
+    // MARK: Stuck-flag recovery
+    // A GPU load/generation that hangs (app backgrounded mid-op -> aborted Metal
+    // command buffer) would otherwise leave `isLoading`/`isGenerating` stuck and
+    // poison every later request with `.busy`. These timestamps let the next
+    // attempt clear an implausibly long-held flag. An in-flight DOWNLOAD is slow
+    // by nature, so it is marked and never auto-cleared.
+    private let clock = ContinuousClock()
+    private var loadStartedAt: ContinuousClock.Instant?
+    private var generationStartedAt: ContinuousClock.Instant?
+    private var isDownloadingModel = false
+    private let stuckThreshold: Duration = .seconds(120)
+
+    private func recoverFromStuckStateIfNeeded() {
+        let now = clock.now
+        if isLoading, !isDownloadingModel, let started = loadStartedAt, started.duration(to: now) > stuckThreshold {
+            logger.logError("🛡️ MLXManager recoverFromStuckState: clearing stale isLoading - dropping half-loaded model")
+            isLoading = false
+            loadStartedAt = nil
+            container = nil
+            loadedModel = nil
+        }
+        if isGenerating, let started = generationStartedAt, started.duration(to: now) > stuckThreshold {
+            logger.logError("🛡️ MLXManager recoverFromStuckState: clearing stale isGenerating")
+            isGenerating = false
+            generationStartedAt = nil
+        }
+    }
+
     private init() {}
 
     // MARK: - Engine
@@ -87,10 +115,12 @@ actor LocalMLXModelManager: LocalMLXModelEngine {
         userMessage: String,
         temperature: Double = 0.3
     ) async throws -> AsyncThrowingStream<String, Error> {
+        recoverFromStuckStateIfNeeded()
         try await loadForGeneration(model: model)
         guard let container else { throw LocalMLXError.notLoaded }
         guard !isGenerating else { throw LocalMLXError.busy }
         isGenerating = true // claimed synchronously before returning the stream
+        generationStartedAt = clock.now
 
         // Capture only Sendable values across the @Sendable boundary; build the
         // (non-Sendable) UserInput inside perform.
@@ -129,7 +159,22 @@ actor LocalMLXModelManager: LocalMLXModelEngine {
         }
     }
 
-    private func finishGenerating() { isGenerating = false }
+    private func finishGenerating() {
+        isGenerating = false
+        generationStartedAt = nil
+    }
+
+    /// Free the loaded model from RAM. The next generation reloads from the
+    /// on-disk cache. Used by `OnDeviceModelMemory` for single-resident
+    /// enforcement and memory-pressure/background unloading. An in-flight
+    /// generation keeps its own reference, so this won't crash it - the model
+    /// just deallocates once that generation finishes.
+    func unload() {
+        container = nil
+        loadedModel = nil
+        isLoading = false
+        logger.logInfo("Unloaded MLX model")
+    }
 
     // MARK: - Load
 
@@ -142,11 +187,14 @@ actor LocalMLXModelManager: LocalMLXModelEngine {
             progress(1)
             return
         }
+        recoverFromStuckStateIfNeeded()
         guard !isLoading, !isGenerating else { throw LocalMLXError.busy }
         if !allowDownload, !model.isDownloaded { throw LocalMLXError.notDownloaded }
 
+        isDownloadingModel = !model.isDownloaded
         isLoading = true
-        defer { isLoading = false }
+        loadStartedAt = clock.now
+        defer { isLoading = false; loadStartedAt = nil; isDownloadingModel = false }
 
         // Unload any previous model first - only one fits in memory.
         container = nil

--- a/VivaDicta/Services/AIEnhance/OnDeviceModelMemory.swift
+++ b/VivaDicta/Services/AIEnhance/OnDeviceModelMemory.swift
@@ -1,0 +1,75 @@
+//
+//  OnDeviceModelMemory.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.06.27
+//
+//  Keeps at most ONE on-device LLM resident in RAM and frees it under memory
+//  pressure / on background.
+//
+//  The three on-device runtimes each have an independent singleton manager that
+//  loads a ~1-2 GB model and never releases it on its own:
+//    - LiteRTModelManager   (Gemma, Metal GPU)
+//    - LocalMLXModelManager (MLX, Metal GPU)
+//    - CoreMLQwenModelManager (Qwen, ANE)
+//  Because they don't coordinate, using models from two runtimes in one session
+//  leaves both resident (2-3 models -> 3-5 GB), and nothing frees them under
+//  memory pressure, so iOS jetsams the app instead. This centralizes:
+//    1. single-resident: loading one runtime unloads the others;
+//    2. memory-pressure + background unload.
+//
+//  `unload()` is safe to call on a manager that is mid-generation: the in-flight
+//  task holds its own reference, so the model just deallocates once it finishes.
+//
+
+import Foundation
+import os
+import AICore
+import LocalLLM
+
+final class OnDeviceModelMemory: @unchecked Sendable {
+    static let shared = OnDeviceModelMemory()
+
+    private let logger = Logger(subsystem: "com.antonnovoselov.VivaDicta", category: "OnDeviceModelMemory")
+    private var memoryPressureSource: DispatchSourceMemoryPressure?
+
+    private init() {
+        startMemoryPressureMonitor()
+    }
+
+    /// Activate the memory-pressure monitor (call once early in app launch). The
+    /// real work happens in `init`; this just gives launch a clear hook and forces
+    /// the singleton to exist so the monitor is armed.
+    func activate() {}
+
+    /// Ensure only `runtime` may be resident: unload the other two on-device
+    /// runtimes. Call right before loading/generating with `runtime`.
+    func ensureOnlyResident(_ runtime: AIProvider.LocalRuntime) async {
+        if runtime != .liteRT { await LiteRTModelManager.shared.unload() }
+        if runtime != .coreML { await CoreMLQwenModelManager.shared.unload() }
+        if runtime != .mlx { await LocalMLXModelManager.shared.unload() }
+    }
+
+    /// Free every on-device LLM from RAM (memory pressure, or background with no
+    /// active keyboard session).
+    func unloadAll(reason: String) async {
+        logger.logInfo("Unloading all on-device LLMs (\(reason))")
+        await LiteRTModelManager.shared.unload()
+        await CoreMLQwenModelManager.shared.unload()
+        await LocalMLXModelManager.shared.unload()
+    }
+
+    private func startMemoryPressureMonitor() {
+        let source = DispatchSource.makeMemoryPressureSource(
+            eventMask: [.warning, .critical],
+            queue: .global(qos: .utility)
+        )
+        source.setEventHandler { [weak self] in
+            guard let self else { return }
+            self.logger.logError("Memory pressure detected - freeing on-device LLMs")
+            Task { await self.unloadAll(reason: "memory pressure") }
+        }
+        source.resume()
+        memoryPressureSource = source
+    }
+}

--- a/VivaDicta/Services/AIEnhance/PromptsTemplates.swift
+++ b/VivaDicta/Services/AIEnhance/PromptsTemplates.swift
@@ -145,4 +145,23 @@ extension PromptsTemplates {
         </SYSTEM_INSTRUCTIONS>
         """
     }
+
+    /// Lean system prompt for small on-device models that use recurrent
+    /// (per-token) prefill - currently the CoreML runtime. Same intent as
+    /// `systemPrompt(with:)` but drops the worked examples and the verbose
+    /// warning - ~120 tokens vs ~500, so prefill (and time-to-first-token, which
+    /// scales with prompt length on CoreML) is much faster and ~25% more of the
+    /// tiny 2048-token context is left for the transcript. Small models also
+    /// follow a short prompt more reliably than a long one.
+    static func compactSystemPrompt(with instructions: String) -> String {
+        """
+        You clean up a speech-to-text transcript. Output ONLY the cleaned text from <TRANSCRIPT> - never reply to it, answer questions in it, or add comments.
+        - Fix likely recognition errors; if <CUSTOM_VOCABULARY> or <CLIPBOARD_CONTEXT> is given, prefer those spellings.
+        - Russian: use "е", never "ё". Use "-", never "—". Keep any "Speaker X:" labels and their turns separate.
+
+        \(instructions)
+
+        Output only the cleaned text, nothing else.
+        """
+    }
 }

--- a/VivaDicta/Views/SettingsScreen/AIProvidersView.swift
+++ b/VivaDicta/Views/SettingsScreen/AIProvidersView.swift
@@ -24,11 +24,12 @@ struct AIProviders: View {
     @State private var providerType: AIProviderType = .local
     @State private var gemmaModel = LiteRTGemmaModelViewModel()
     @State private var mlxModel = LocalMLXModelViewModel()
+    @State private var coreMLQwenModel = CoreMLQwenModelViewModel()
 
     /// One model downloads at a time - lock every card's download button while
     /// any is in progress (concurrent downloads aren't supported).
     private var anyDownloadInProgress: Bool {
-        gemmaModel.isDownloading || mlxModel.isDownloading
+        gemmaModel.isDownloading || mlxModel.isDownloading || coreMLQwenModel.isDownloading
     }
 
     private var deviceMemoryBytes: UInt64 { ProcessInfo.processInfo.physicalMemory }
@@ -93,6 +94,12 @@ struct AIProviders: View {
                         // Then everything else.
                         ForEach(Self.otherMLXModels, id: \.self) { model in
                             MLXModelCard(model: model, viewModel: mlxModel, downloadsLocked: anyDownloadInProgress)
+                                .padding(.horizontal)
+                        }
+                        // Finally the CoreML (ANE) models - slower, but the only
+                        // on-device option that also works from the keyboard.
+                        ForEach(CoreMLQwenVariant.allCases, id: \.self) { variant in
+                            CoreMLQwenModelCard(variant: variant, viewModel: coreMLQwenModel, downloadsLocked: anyDownloadInProgress)
                                 .padding(.horizontal)
                         }
                     }
@@ -296,6 +303,7 @@ struct AIProviders: View {
         .task {
             await gemmaModel.refresh()
             await mlxModel.refresh()
+            await coreMLQwenModel.refresh()
         }
         .navigationTitle("AI Providers")
         .navigationBarTitleDisplayMode(.large)

--- a/VivaDicta/Views/SettingsScreen/CoreMLQwenModelView.swift
+++ b/VivaDicta/Views/SettingsScreen/CoreMLQwenModelView.swift
@@ -1,21 +1,24 @@
 //
-//  LocalMLXModelView.swift
+//  CoreMLQwenModelView.swift
 //  VivaDicta
 //
-//  Created by Anton Novoselov on 2026.06.24
+//  Created by Anton Novoselov on 2026.06.27
 //
-//  Cards for the on-device MLX models (GPU), shown inline in the AI Providers
-//  "Local" tab. One generic card type over LocalMLXModel, parallel to the
-//  LiteRT/Core ML cards (same download/cancel/delete button + badges).
+//  Cards for the on-device Qwen3.5 models that run via CoreML on the Apple Neural
+//  Engine (ANE), shown inline in the AI Providers "Local" tab. Parallel to the
+//  MLX / LiteRT cards (same download/cancel/delete button + badges). Unlike those
+//  GPU runtimes, CoreML works while the app is backgrounded, so these are the
+//  on-device models that also run from the keyboard.
 //
 
 import SwiftUI
 import Analytics
 import DesignSystem
+import LocalLLM
 
 @MainActor
 @Observable
-final class LocalMLXModelViewModel {
+final class CoreMLQwenModelViewModel {
     enum Status: Equatable {
         case checking
         case notDownloaded
@@ -25,18 +28,18 @@ final class LocalMLXModelViewModel {
         case failed(String)
     }
 
-    private(set) var status: [LocalMLXModel: Status] = [:]
-    private(set) var sizeBytes: [LocalMLXModel: Int64] = [:]
+    private(set) var status: [CoreMLQwenVariant: Status] = [:]
+    private(set) var sizeBytes: [CoreMLQwenVariant: Int64] = [:]
 
-    private var tasks: [LocalMLXModel: Task<Void, Never>] = [:]
+    private var tasks: [CoreMLQwenVariant: Task<Void, Never>] = [:]
 
-    private let engine: any LocalMLXModelEngine
+    private let engine: any CoreMLQwenEngine
 
-    init(engine: any LocalMLXModelEngine = LocalMLXModelManager.shared) {
+    init(engine: any CoreMLQwenEngine = CoreMLQwenModelManager.shared) {
         self.engine = engine
     }
 
-    func status(for model: LocalMLXModel) -> Status { status[model] ?? .checking }
+    func status(for variant: CoreMLQwenVariant) -> Status { status[variant] ?? .checking }
 
     /// True while any model is downloading/preparing - used to lock other downloads.
     var isDownloading: Bool {
@@ -45,86 +48,85 @@ final class LocalMLXModelViewModel {
         }
     }
 
-    func progress(for model: LocalMLXModel) -> Double {
-        if case .downloading(let fraction) = status(for: model) { return fraction }
+    func progress(for variant: CoreMLQwenVariant) -> Double {
+        if case .downloading(let fraction) = status(for: variant) { return fraction }
         return 1
     }
 
     func refresh() async {
-        for model in LocalMLXModel.allCases {
-            switch status[model] {
+        for variant in CoreMLQwenVariant.allCases {
+            switch status[variant] {
             case .downloading, .preparing: continue
             default: break
             }
-            let downloaded = await engine.isDownloaded(model)
-            sizeBytes[model] = await engine.downloadedBytes(model)
-            status[model] = downloaded ? .ready : .notDownloaded
+            let downloaded = await engine.isDownloaded(variant)
+            sizeBytes[variant] = await engine.downloadedBytes(variant)
+            status[variant] = downloaded ? .ready : .notDownloaded
         }
     }
 
     @discardableResult
-    func prepare(_ model: LocalMLXModel) -> Task<Void, Never> {
-        tasks[model]?.cancel()
-        status[model] = .downloading(0)
+    func prepare(_ variant: CoreMLQwenVariant) -> Task<Void, Never> {
+        tasks[variant]?.cancel()
+        status[variant] = .downloading(0)
         let task = Task { @MainActor in
-            let wasDownloaded = await engine.isDownloaded(model)
+            let wasDownloaded = await engine.isDownloaded(variant)
             do {
-                try await engine.ensureLoaded(model: model) { fraction in
+                try await engine.ensureLoaded(variant: variant) { fraction in
                     Task { @MainActor in
-                        switch self.status[model] {
+                        switch self.status[variant] {
                         case .downloading, .preparing:
-                            self.status[model] = fraction >= 1.0 ? .preparing : .downloading(fraction)
+                            self.status[variant] = fraction >= 1.0 ? .preparing : .downloading(fraction)
                         default:
                             break
                         }
                     }
                 }
-                self.status[model] = .ready
-                self.sizeBytes[model] = await engine.downloadedBytes(model)
+                self.status[variant] = .ready
+                self.sizeBytes[variant] = await engine.downloadedBytes(variant)
                 // Track only a genuine new download, not a reload of an
                 // already-downloaded model.
                 if !wasDownloaded {
-                    DefaultAnalyticsService.live.track(.modelDownloaded(name: model.rawValue, type: "mlx"))
+                    DefaultAnalyticsService.live.track(.modelDownloaded(name: variant.rawValue, type: "coreml"))
                 }
             } catch is CancellationError {
-                // Discard the partial download so it can't later read as Ready.
-                try? await engine.deleteModel(model)
-                self.status[model] = .notDownloaded
+                try? await engine.deleteModel(variant)
+                self.status[variant] = .notDownloaded
             } catch {
-                try? await engine.deleteModel(model)
+                try? await engine.deleteModel(variant)
                 if (error as? URLError)?.code == .cancelled {
-                    self.status[model] = .notDownloaded
+                    self.status[variant] = .notDownloaded
                 } else {
-                    self.status[model] = .failed(error.localizedDescription)
+                    self.status[variant] = .failed(error.localizedDescription)
                 }
             }
-            self.tasks[model] = nil
+            self.tasks[variant] = nil
         }
-        tasks[model] = task
+        tasks[variant] = task
         return task
     }
 
-    func cancel(_ model: LocalMLXModel) {
-        tasks[model]?.cancel()
-        tasks[model] = nil
-        status[model] = .notDownloaded
+    func cancel(_ variant: CoreMLQwenVariant) {
+        tasks[variant]?.cancel()
+        tasks[variant] = nil
+        status[variant] = .notDownloaded
     }
 
-    func delete(_ model: LocalMLXModel) async {
+    func delete(_ variant: CoreMLQwenVariant) async {
         do {
-            try await engine.deleteModel(model)
-            sizeBytes[model] = 0
-            status[model] = .notDownloaded
+            try await engine.deleteModel(variant)
+            sizeBytes[variant] = 0
+            status[variant] = .notDownloaded
         } catch {
-            status[model] = .failed(error.localizedDescription)
+            status[variant] = .failed(error.localizedDescription)
         }
     }
 }
 
-/// One card per on-device MLX model, shown in the AI Providers "Local" tab.
-struct MLXModelCard: View {
-    let model: LocalMLXModel
-    let viewModel: LocalMLXModelViewModel
+/// One card per on-device CoreML Qwen model, shown in the AI Providers "Local" tab.
+struct CoreMLQwenModelCard: View {
+    let variant: CoreMLQwenVariant
+    let viewModel: CoreMLQwenModelViewModel
     /// When another model is downloading, this card's download action is locked.
     var downloadsLocked: Bool = false
 
@@ -135,15 +137,15 @@ struct MLXModelCard: View {
             HStack(alignment: .top, spacing: 8) {
                 VStack(alignment: .leading, spacing: 6) {
                     HStack(spacing: 8) {
-                        icon
-                        Text(model.displayName)
+                        Image("qwen-color")
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 28, height: 28)
+                        Text(variant.displayName)
                             .font(.title3)
                             .fontWeight(.semibold)
                     }
                     statusLabel
-                    if model.isRecommendedForThisDevice {
-                        RecommendedBadge()
-                    }
                 }
 
                 Spacer()
@@ -162,11 +164,11 @@ struct MLXModelCard: View {
                 }
             }
 
-            Text(model.subtitle)
+            Text(variant.subtitle)
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
 
-            RuntimeBadge(runtime: "MLX")
+            RuntimeBadge(runtime: "CoreML · Neural Engine")
         }
         .padding(20)
         .modelCardBackground()
@@ -182,35 +184,20 @@ struct MLXModelCard: View {
         }
         .alert("Delete Model", isPresented: $showDeleteAlert) {
             Button("Delete", role: .destructive) {
-                Task { await viewModel.delete(model) }
+                Task { await viewModel.delete(variant) }
             }
             Button("Cancel", role: .cancel) { }
         } message: {
-            Text("Are you sure you want to delete \(model.displayName)? You can download it again later.")
-        }
-    }
-
-    @ViewBuilder
-    private var icon: some View {
-        if let asset = model.iconAsset {
-            Image(asset)
-                .resizable()
-                .scaledToFit()
-                .frame(width: 28, height: 28)
-        } else {
-            Image(systemName: "cpu")
-                .font(.title2)
-                .foregroundStyle(.secondary)
-                .frame(width: 28, height: 28)
+            Text("Are you sure you want to delete \(variant.displayName)? You can download it again later.")
         }
     }
 
     private var sizeText: String {
-        let bytes = viewModel.sizeBytes[model] ?? 0
-        return bytes > 0 ? bytes.formatted(.byteCount(style: .file)) : model.approxDownloadDescription
+        let bytes = viewModel.sizeBytes[variant] ?? 0
+        return bytes > 0 ? bytes.formatted(.byteCount(style: .file)) : variant.approxDownloadDescription
     }
 
-    private var status: LocalMLXModelViewModel.Status { viewModel.status(for: model) }
+    private var status: CoreMLQwenModelViewModel.Status { viewModel.status(for: variant) }
 
     private var isDownloading: Bool {
         switch status {
@@ -279,13 +266,13 @@ struct MLXModelCard: View {
             switch status {
             case .ready:
                 HapticManager.warning()
-                Task { await viewModel.delete(model) }
+                Task { await viewModel.delete(variant) }
             case .downloading, .preparing:
                 HapticManager.lightImpact()
-                viewModel.cancel(model)
+                viewModel.cancel(variant)
             case .notDownloaded, .failed, .checking:
                 HapticManager.lightImpact()
-                viewModel.prepare(model)
+                viewModel.prepare(variant)
             }
         } label: {
             // Indeterminate while downloading: the symbol is the cancel "x" (see

--- a/VivaDicta/Views/SettingsScreen/CoreMLQwenModelView.swift
+++ b/VivaDicta/Views/SettingsScreen/CoreMLQwenModelView.swift
@@ -15,6 +15,7 @@ import SwiftUI
 import Analytics
 import DesignSystem
 import LocalLLM
+import AICore
 
 @MainActor
 @Observable
@@ -72,6 +73,8 @@ final class CoreMLQwenModelViewModel {
         let task = Task { @MainActor in
             let wasDownloaded = await engine.isDownloaded(variant)
             do {
+                // A Settings download loads into RAM, so keep memory single-resident.
+                await OnDeviceModelMemory.shared.ensureOnlyResident(.coreML)
                 try await engine.ensureLoaded(variant: variant) { fraction in
                     Task { @MainActor in
                         switch self.status[variant] {

--- a/VivaDicta/Views/SettingsScreen/LiteRTGemmaModelView.swift
+++ b/VivaDicta/Views/SettingsScreen/LiteRTGemmaModelView.swift
@@ -14,6 +14,7 @@ import SwiftUI
 import Analytics
 import DesignSystem
 import LocalLLM
+import AICore
 
 @MainActor
 @Observable
@@ -78,6 +79,8 @@ final class LiteRTGemmaModelViewModel {
         let task = Task { @MainActor in
             let wasDownloaded = await engine.isDownloaded(variant)
             do {
+                // A Settings download loads into RAM, so keep memory single-resident.
+                await OnDeviceModelMemory.shared.ensureOnlyResident(.liteRT)
                 try await engine.ensureLoaded(variant: variant) { fraction in
                     Task { @MainActor in
                         // Ignore late progress callbacks after a cancel/finish.

--- a/VivaDicta/Views/SettingsScreen/LiteRTGemmaModelView.swift
+++ b/VivaDicta/Views/SettingsScreen/LiteRTGemmaModelView.swift
@@ -248,14 +248,20 @@ struct GemmaVariantCard: View {
             Label("Ready", systemImage: "checkmark.circle.fill")
                 .font(.subheadline)
                 .foregroundStyle(.green)
-        case .downloading(let fraction):
-            Text("Downloading \(fraction.formatted(.percent.precision(.fractionLength(0))))")
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
+        case .downloading:
+            HStack(spacing: 6) {
+                ProgressView().controlSize(.small)
+                Text("Downloading...")
+            }
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
         case .preparing:
-            Text("Preparing...")
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
+            HStack(spacing: 6) {
+                ProgressView().controlSize(.small)
+                Text("Preparing...")
+            }
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
         case .notDownloaded, .checking:
             Text("Not downloaded")
                 .font(.subheadline)
@@ -281,30 +287,13 @@ struct GemmaVariantCard: View {
                 model.prepare(variant)
             }
         } label: {
-            if #available(iOS 26.0, *) {
-                Image(systemName: symbolName, variableValue: isDownloading ? model.progress(for: variant) : 1)
-                    .symbolVariableValueMode(.draw)
-                    .contentTransition(.symbolEffect(.replace))
-                    .foregroundStyle(symbolColor)
-                    .font(.system(size: 30))
-            } else if isDownloading {
-                Image(systemName: "xmark")
-                    .contentTransition(.symbolEffect(.replace))
-                    .foregroundStyle(symbolColor)
-                    .font(.system(size: 16, weight: .bold))
-                    .padding(8)
-                    .background {
-                        Circle()
-                            .trim(from: 0, to: model.progress(for: variant))
-                            .stroke(.primary, lineWidth: 3)
-                            .rotationEffect(.degrees(-90))
-                    }
-            } else {
-                Image(systemName: symbolName)
-                    .contentTransition(.symbolEffect(.replace))
-                    .foregroundStyle(symbolColor)
-                    .font(.system(size: 30))
-            }
+            // Indeterminate while downloading: the symbol is the cancel "x" (see
+            // symbolName); no progress ring because multi-file model progress is
+            // non-linear and reads as stuck.
+            Image(systemName: symbolName)
+                .contentTransition(.symbolEffect(.replace))
+                .foregroundStyle(symbolColor)
+                .font(.system(size: 30))
         }
         .buttonStyle(.plain)
         .disabled(downloadsLocked && isStartDownloadState)

--- a/VivaDicta/Views/SettingsScreen/LocalMLXModelView.swift
+++ b/VivaDicta/Views/SettingsScreen/LocalMLXModelView.swift
@@ -12,6 +12,7 @@
 import SwiftUI
 import Analytics
 import DesignSystem
+import AICore
 
 @MainActor
 @Observable
@@ -69,6 +70,8 @@ final class LocalMLXModelViewModel {
         let task = Task { @MainActor in
             let wasDownloaded = await engine.isDownloaded(model)
             do {
+                // A Settings download loads into RAM, so keep memory single-resident.
+                await OnDeviceModelMemory.shared.ensureOnlyResident(.mlx)
                 try await engine.ensureLoaded(model: model) { fraction in
                     Task { @MainActor in
                         switch self.status[model] {

--- a/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
+++ b/VivaDicta/Views/SettingsScreen/ModeEditViewModel.swift
@@ -355,12 +355,16 @@ class ModeEditViewModel {
     }
 
     /// True if an on-device model id is downloaded, querying the right runtime
-    /// (Gemma ids = LiteRT, everything else = MLX).
+    /// (Gemma ids = LiteRT, `-coreml` = CoreML/ANE, everything else = MLX).
     static func isLocalModelDownloaded(_ id: String) -> Bool {
-        if LiteRTGemmaVariant(rawValue: id) != nil {
+        switch AIProvider.localRuntime(forModelID: id) {
+        case .coreML:
+            return CoreMLQwenVariant(modelID: id).isDownloaded
+        case .liteRT:
             return LiteRTGemmaVariant(modelID: id).isDownloaded
+        case .mlx:
+            return LocalMLXModel(modelID: id).isDownloaded
         }
-        return LocalMLXModel(modelID: id).isDownloaded
     }
 
     private func validateReminderExtractorModelSelection() {

--- a/VivaDicta/VivaDictaApp.swift
+++ b/VivaDicta/VivaDictaApp.swift
@@ -266,6 +266,13 @@ struct VivaDictaApp: App {
                             logger.logInfo("🎬 App became inactive")
                         case .background:
                             logger.logInfo("🎬 App went to background")
+                            // Free on-device LLMs when backgrounding normally - but
+                            // NOT during a keyboard session, where the keyboard
+                            // relies on the model staying loaded to serve requests
+                            // from the background (CoreML/ANE).
+                            if !AppGroupCoordinator.shared.isKeyboardSessionActive {
+                                Task { await OnDeviceModelMemory.shared.unloadAll(reason: "app backgrounded") }
+                            }
                             updateShortcutItems()
                             RecentNotesCache.syncFromDatabase(modelContext: modelContainer.mainContext)
                         @unknown default:

--- a/VivaDictaKeyboard/Services/KeyboardTextProcessor.swift
+++ b/VivaDictaKeyboard/Services/KeyboardTextProcessor.swift
@@ -40,6 +40,20 @@ final class KeyboardTextProcessor {
             return
         }
 
+        // GPU-backed on-device LLMs (Gemma/LiteRT, MLX) run on the Metal GPU, which
+        // iOS blocks while the app is backgrounded - and the keyboard always runs
+        // with the main app backgrounded. The doomed round-trip would otherwise
+        // hang or crash the app, so fail fast here with an actionable message.
+        // CoreML models (ANE) are exempt - they DO work backgrounded. Apple FM
+        // (out-of-process) and cloud providers also work from the keyboard.
+        if mode.aiProvider == .local, !AIProvider.localModelRunsOnNeuralEngine(mode.aiModel) {
+            logger.logInfo("📝 [TextProcessor] GPU on-device mode '\(mode.name)' unavailable from keyboard (GPU blocked in background)")
+            HapticManager.error()
+            dictationState.textProcessingPhase = .error("This on-device model runs on the GPU and needs the VivaDicta app open. Use a CoreML model, Apple Foundation Model, or a cloud model from the keyboard.")
+            autoDismissError(dictationState: dictationState)
+            return
+        }
+
         // Cancel any stale state
         cancel()
 


### PR DESCRIPTION
## Summary

On-device LLMs failed when AI processing was triggered from the **keyboard**: the keyboard delegates to the main app, which runs in the **background**, and iOS forbids Metal GPU command-buffer submission from a backgrounded app (`kIOGPUCommandBufferCallbackErrorBackgroundExecutionNotPermitted`). **MLX crashed** the process with an uncaught command-buffer error; **LiteRT/Gemma hung** in GPU kernel compile and left its load flag stuck, poisoning later requests. Transcription (ANE), Apple FM (out-of-process), and cloud were unaffected.

This PR fixes the crash/hang and adds a **CoreML runtime that runs on the Apple Neural Engine** - the one on-device LLM that works from the keyboard, since the ANE is permitted in the background.

## Changes

**Fix the GPU-in-background crash/hang**
- `AIService` refuses GPU on-device routes (LiteRT / MLX) when `applicationState == .background`, throwing an actionable error (`EnhancementError.onDeviceLLMRequiresForeground`) instead of hanging/crashing. The MLX crash is uncatchable after submission, so this prevents it.
- The keyboard pre-empts GPU on-device modes with an instant message rather than a doomed record→transcribe→fail round-trip.
- LiteRT and MLX managers self-heal a stuck load/generate flag (timestamped, 120s threshold; never clears an in-flight download).

**CoreML (ANE) on-device LLM - keyboard-capable**
- Add Qwen3.5 2B / 0.8B via `john-rocky/CoreML-LLM`, pinned to `.cpuAndNeuralEngine`. Runs on the ANE, so it works while backgrounded.
- `AIProvider.localRuntime(forModelID:)` classifies local ids by runtime (`-coreml` → ANE, `-mlx`/Gemma → GPU). CoreML is exempt from the foreground guard and keyboard pre-empt.
- **Lean system prompt for the CoreML path only** - CoreML uses recurrent (per-token) prefill, so a ~500-token system prompt added tens of seconds of time-to-first-token; the lean (~120-token) prompt cuts that. GPU runtimes batch-prefill and keep the full prompt.
- Download cards + model-picker wiring for the CoreML models (cards at the end of the Local tab, Qwen icon, "CoreML · Neural Engine" badge).

**Memory**
- Single-resident across the three runtimes: loading one unloads the others, so at most one ~1-2 GB model is in RAM.
- Free models under memory pressure (`DispatchSource`) and on background (unless a keyboard session is active), to avoid jetsam while holding a large model.

**UI**
- On-device download cards show an indeterminate "Downloading…" + spinner instead of a non-linear, stuck-looking percentage (multi-file model progress jumps then sits on the big weights file).

## Testing
- `xcodebuild` build succeeds (iPhone 17 Pro Max, iOS 26.4 simulator).
- On-device verified on a physical device: CoreML Qwen runs from the keyboard (background) and completes; MLX/LiteRT now fail fast with a clear message instead of crashing/hanging; downloads show the indeterminate state.

## Notes
- New SPM deps in `Modules/LocalLLM/Package.swift`: `CoreML-LLM` 1.9.0 + `swift-transformers`. The module is set to Swift 5 language mode (CoreML-LLM exposes non-Sendable `@Observable` generators with a token callback); its public API stays `Sendable`.
- Follow-up: Gemma 4 E2B/E4B CoreML (a different `Gemma4StatefulEngine`, separate pass).