### PR TITLE
Fix memory-pressure handler crash from implicit MainActor isolation

### DIFF
--- a/VivaDicta/Services/AIEnhance/OnDeviceModelMemory.swift
+++ b/VivaDicta/Services/AIEnhance/OnDeviceModelMemory.swift
@@ -27,7 +27,10 @@ import os
 import AICore
 import LocalLLM
 
-final class OnDeviceModelMemory: @unchecked Sendable {
+// nonisolated: the memory-pressure handler fires on a utility queue; without
+// this the class inherits the project-default @MainActor isolation and the
+// handler's runtime isolation check aborts the process (3.7.1 crash).
+nonisolated final class OnDeviceModelMemory: @unchecked Sendable {
     static let shared = OnDeviceModelMemory()
 
     private let logger = Logger(subsystem: "com.antonnovoselov.VivaDicta", category: "OnDeviceModelMemory")


### PR DESCRIPTION
## Summary

Fixes the top crash in 3.7.1 (Crashlytics issue `5c6c4687`): `_dispatch_assert_queue_fail` inside `closure #1 in OnDeviceModelMemory.startMemoryPressureMonitor()` on the `com.apple.root.utility-qos` queue.

### Root cause

- The app target builds with `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` (Swift 6.2), so the unannotated `OnDeviceModelMemory` class was implicitly `@MainActor` (`@unchecked Sendable` does not opt it out).
- The closure passed to `DispatchSourceMemoryPressure.setEventHandler` was formed in that MainActor context. Since the parameter is a plain non-`@Sendable` block, the closure inherited MainActor isolation and the compiler emitted a dynamic isolation check at closure entry (SE-0423).
- The dispatch source is scheduled on `.global(qos: .utility)`, so on every real kernel memory-pressure event the entry check ran `dispatch_assert_queue(main)` on the utility queue and aborted the process - before the handler body executed. The feature meant to free on-device LLMs under memory pressure instead crashed the app exactly when pressure hit.
- The monitor is armed unconditionally at launch (`AppDelegate`), so every 3.7.1 user is exposed, not just local-LLM users; local-LLM and large local-transcription users are the most likely to provoke the pressure event.
- It escaped testing because the simulator's "Simulate Memory Warning" posts the UIKit notification but does not fire `DispatchSourceMemoryPressure`.

### Fix

Mark the class `nonisolated`. It is a thread-safe singleton by design: `Logger` is Sendable, all three model managers (`LiteRTModelManager`, `CoreMLQwenModelManager`, `LocalMLXModelManager`) are actors reached via `await`, and `memoryPressureSource` is only written in `init`. With the class nonisolated, the handler closure no longer inherits MainActor isolation and no runtime check is emitted. Call sites are unaffected.

## Testing

- `xcodebuild` Debug build for iOS Simulator: succeeds, 0 errors.
- The crash itself is not reproducible on demand (requires a real kernel memory-pressure event on device); the fix removes the compiler-inserted isolation assertion that was the direct cause.

## Notes

- Candidate for a 3.7.2 hotfix release.