### PR TITLE
Refresh cloud transcription model lineup across five providers

### DIFF
--- a/Modules/AICore/Sources/AICore/AIProvider.swift
+++ b/Modules/AICore/Sources/AICore/AIProvider.swift
@@ -404,7 +404,7 @@ public enum AIProvider: String, CaseIterable, Identifiable, Codable, Sendable {
         case .openRouter:
             return "openai/gpt-oss-120b"
         case .soniox:
-            return "stt-async-v4"
+            return "stt-async-v5"
         case .gladia:
             return "solaria-1"
         case .speechmatics:

--- a/Modules/CloudTranscription/Sources/CloudTranscription/GladiaTranscriptionService.swift
+++ b/Modules/CloudTranscription/Sources/CloudTranscription/GladiaTranscriptionService.swift
@@ -6,8 +6,9 @@ import os
 import TranscriptionCore
 
 /// Pre-configured Gladia STT client. Uses an upload + create + poll flow.
-/// `modelName` is unused by the v2 API (the endpoint always uses the default
-/// pre-recorded model), so the config omits it.
+/// The v2 API selects the speech model via the `model` field: `solaria-1`
+/// (default, 100+ languages, code-switching) or `solaria-3` (async-only,
+/// EN/FR/DE/ES/IT, exactly one language required - no code switching).
 public struct GladiaTranscriptionService: TranscriptionService, Sendable {
     private let logger = Logger(cloudTranscriptionCategory: "GladiaTranscription")
     private let apiBase = "https://api.gladia.io/v2"
@@ -16,6 +17,7 @@ public struct GladiaTranscriptionService: TranscriptionService, Sendable {
 
     public struct Config: Sendable {
         public let apiKey: String
+        public let modelName: String
         public let language: String
         public let vocabulary: [String]
         public let isSpeakerDiarizationEnabled: Bool
@@ -24,12 +26,14 @@ public struct GladiaTranscriptionService: TranscriptionService, Sendable {
 
         public init(
             apiKey: String,
+            modelName: String = "solaria-1",
             language: String = "auto",
             vocabulary: [String] = [],
             isSpeakerDiarizationEnabled: Bool = false,
             translationTargetLanguage: String = ""
         ) {
             self.apiKey = apiKey
+            self.modelName = modelName
             self.language = language
             self.vocabulary = vocabulary
             self.isSpeakerDiarizationEnabled = isSpeakerDiarizationEnabled
@@ -110,6 +114,10 @@ public struct GladiaTranscriptionService: TranscriptionService, Sendable {
             "audio_url": audioURL,
             "diarization": config.isSpeakerDiarizationEnabled
         ]
+
+        if !config.modelName.isEmpty {
+            payload["model"] = config.modelName
+        }
 
         if config.language != "auto", !config.language.isEmpty {
             payload["language_config"] = [

--- a/Modules/CloudTranscription/Sources/CloudTranscription/OpenAITranscriptionService.swift
+++ b/Modules/CloudTranscription/Sources/CloudTranscription/OpenAITranscriptionService.swift
@@ -16,13 +16,28 @@ public struct OpenAITranscriptionService: TranscriptionService, Sendable {
         public let apiKey: String
         public let modelName: String
         public let language: String
+        public let isSpeakerDiarizationEnabled: Bool
 
         /// - Parameter language: BCP-47 language tag or `"auto"` to let OpenAI detect.
-        public init(apiKey: String, modelName: String, language: String = "auto") {
+        public init(
+            apiKey: String,
+            modelName: String,
+            language: String = "auto",
+            isSpeakerDiarizationEnabled: Bool = false
+        ) {
             self.apiKey = apiKey
             self.modelName = modelName
             self.language = language
+            self.isSpeakerDiarizationEnabled = isSpeakerDiarizationEnabled
         }
+    }
+
+    /// `gpt-4o-transcribe-diarize` takes a different parameter set: it requires
+    /// `chunking_strategy` for audio over 30 seconds, returns speaker-labeled
+    /// segments via the `diarized_json` response format, and does not accept
+    /// `language`, `temperature`, or prompts.
+    private var isDiarizeModel: Bool {
+        config.modelName == "gpt-4o-transcribe-diarize"
     }
 
     private let config: Config
@@ -37,13 +52,12 @@ public struct OpenAITranscriptionService: TranscriptionService, Sendable {
     }
 
     public func transcribe(audioURL: URL) async throws -> TranscriptionServiceResult {
-        let text = try await NetworkRetry.withRetry(logger: logger) {
+        try await NetworkRetry.withRetry(logger: logger) {
             try await makeTranscriptionRequest(audioURL: audioURL)
         }
-        return .plain(text)
     }
 
-    private func makeTranscriptionRequest(audioURL: URL) async throws -> String {
+    private func makeTranscriptionRequest(audioURL: URL) async throws -> TranscriptionServiceResult {
         guard !config.apiKey.isEmpty else {
             throw CloudTranscriptionError.missingAPIKey
         }
@@ -66,12 +80,51 @@ public struct OpenAITranscriptionService: TranscriptionService, Sendable {
         }
 
         do {
+            if isDiarizeModel && config.isSpeakerDiarizationEnabled {
+                let diarized = try JSONDecoder().decode(DiarizedTranscriptionResponse.self, from: data)
+                if let diarizedText = makeSpeakerAttributedText(from: diarized.segments) {
+                    return .speakerAttributed(diarizedText)
+                }
+                return .plain(diarized.segments.map(\.text).joined(separator: " "))
+            }
             let transcriptionResponse = try JSONDecoder().decode(TranscriptionResponse.self, from: data)
-            return transcriptionResponse.text
+            return .plain(transcriptionResponse.text)
         } catch {
             logger.logError("Failed to decode OpenAI API response: \(error.localizedDescription)")
             throw CloudTranscriptionError.noTranscriptionReturned
         }
+    }
+
+    private func makeSpeakerAttributedText(from segments: [DiarizedTranscriptionResponse.Segment]) -> String? {
+        guard !segments.isEmpty else {
+            return nil
+        }
+
+        var turns: [SpeakerTurn] = []
+        var currentSpeaker: String?
+        var currentText = ""
+
+        for segment in segments {
+            if turns.isEmpty && currentText.isEmpty {
+                currentSpeaker = segment.speaker
+                currentText = segment.text
+                continue
+            }
+
+            if segment.speaker == currentSpeaker || segment.speaker == nil {
+                currentText += " " + segment.text
+            } else {
+                turns.append(SpeakerTurn(speakerID: currentSpeaker, text: currentText))
+                currentSpeaker = segment.speaker
+                currentText = segment.text
+            }
+        }
+
+        if !currentText.isEmpty {
+            turns.append(SpeakerTurn(speakerID: currentSpeaker, text: currentText))
+        }
+
+        return SpeakerDiarizationFormatter.format(turns)
     }
 
     private func createOpenAICompatibleRequestBody(audioURL: URL, boundary: String) throws -> Data {
@@ -93,22 +146,30 @@ public struct OpenAITranscriptionService: TranscriptionService, Sendable {
         body.append(config.modelName.data(using: .utf8)!)
         body.append(crlf.data(using: .utf8)!)
 
-        if config.language != "auto", !config.language.isEmpty {
+        if !isDiarizeModel, config.language != "auto", !config.language.isEmpty {
             body.append("--\(boundary)\(crlf)".data(using: .utf8)!)
             body.append("Content-Disposition: form-data; name=\"language\"\(crlf)\(crlf)".data(using: .utf8)!)
             body.append(config.language.data(using: .utf8)!)
             body.append(crlf.data(using: .utf8)!)
         }
 
+        let responseFormat = isDiarizeModel && config.isSpeakerDiarizationEnabled ? "diarized_json" : "json"
         body.append("--\(boundary)\(crlf)".data(using: .utf8)!)
         body.append("Content-Disposition: form-data; name=\"response_format\"\(crlf)\(crlf)".data(using: .utf8)!)
-        body.append("json".data(using: .utf8)!)
+        body.append(responseFormat.data(using: .utf8)!)
         body.append(crlf.data(using: .utf8)!)
 
-        body.append("--\(boundary)\(crlf)".data(using: .utf8)!)
-        body.append("Content-Disposition: form-data; name=\"temperature\"\(crlf)\(crlf)".data(using: .utf8)!)
-        body.append("0".data(using: .utf8)!)
-        body.append(crlf.data(using: .utf8)!)
+        if isDiarizeModel {
+            body.append("--\(boundary)\(crlf)".data(using: .utf8)!)
+            body.append("Content-Disposition: form-data; name=\"chunking_strategy\"\(crlf)\(crlf)".data(using: .utf8)!)
+            body.append("auto".data(using: .utf8)!)
+            body.append(crlf.data(using: .utf8)!)
+        } else {
+            body.append("--\(boundary)\(crlf)".data(using: .utf8)!)
+            body.append("Content-Disposition: form-data; name=\"temperature\"\(crlf)\(crlf)".data(using: .utf8)!)
+            body.append("0".data(using: .utf8)!)
+            body.append(crlf.data(using: .utf8)!)
+        }
         body.append("--\(boundary)--\(crlf)".data(using: .utf8)!)
 
         return body
@@ -118,5 +179,14 @@ public struct OpenAITranscriptionService: TranscriptionService, Sendable {
         let text: String
         let language: String?
         let duration: Double?
+    }
+
+    private struct DiarizedTranscriptionResponse: Decodable {
+        let segments: [Segment]
+
+        struct Segment: Decodable {
+            let text: String
+            let speaker: String?
+        }
     }
 }

--- a/Modules/CloudTranscription/Sources/CloudTranscription/SpeechmaticsTranscriptionService.swift
+++ b/Modules/CloudTranscription/Sources/CloudTranscription/SpeechmaticsTranscriptionService.swift
@@ -53,11 +53,30 @@ public struct SpeechmaticsTranscriptionService: TranscriptionService, Sendable {
         self.networkService = networkService
     }
 
+    /// Maps our internal model name to the API `model` value. The legacy
+    /// internal name predates the `model` property and means the enhanced model.
+    private var apiModel: String {
+        config.modelName.isEmpty || config.modelName == "speechmatics-batch-v2"
+            ? "enhanced"
+            : config.modelName
+    }
+
     public func transcribe(audioURL: URL) async throws -> TranscriptionServiceResult {
         guard !config.apiKey.isEmpty else {
             throw CloudTranscriptionError.missingAPIKey
         }
-        let translationTargetAPI = mapToSpeechmaticsCode(config.translationTargetLanguage)
+        // Melia-1 does not support translation (Enhanced/Standard only);
+        // Speechmatics rejects melia-1 jobs carrying a translation_config.
+        // Drop a configured target so the user still gets their transcription.
+        let translationTargetAPI: String
+        if apiModel == "melia-1" {
+            if !config.translationTargetLanguage.isEmpty {
+                logger.logInfo("Speechmatics Melia-1 does not support translation; ignoring target \(config.translationTargetLanguage)")
+            }
+            translationTargetAPI = ""
+        } else {
+            translationTargetAPI = mapToSpeechmaticsCode(config.translationTargetLanguage)
+        }
         let translationEnabled = !translationTargetAPI.isEmpty
         let languageAPI = mapToSpeechmaticsCode(config.language)
 
@@ -94,12 +113,10 @@ public struct SpeechmaticsTranscriptionService: TranscriptionService, Sendable {
         request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
 
         // `model` replaced the deprecated `operating_point` property and takes
-        // the same values plus `melia-1`. Our legacy internal name maps to the
-        // enhanced model. Melia-1 detects languages automatically and requires
-        // `language: "multi"`; a concrete user-picked language becomes a hint.
-        let model = config.modelName.isEmpty || config.modelName == "speechmatics-batch-v2"
-            ? "enhanced"
-            : config.modelName
+        // the same values plus `melia-1`. Melia-1 detects languages
+        // automatically and requires `language: "multi"`; a concrete
+        // user-picked language becomes a hint.
+        let model = apiModel
 
         var transcriptionConfig: [String: Any] = ["model": model]
         if model == "melia-1" {

--- a/Modules/CloudTranscription/Sources/CloudTranscription/SpeechmaticsTranscriptionService.swift
+++ b/Modules/CloudTranscription/Sources/CloudTranscription/SpeechmaticsTranscriptionService.swift
@@ -16,6 +16,9 @@ public struct SpeechmaticsTranscriptionService: TranscriptionService, Sendable {
 
     public struct Config: Sendable {
         public let apiKey: String
+        /// Internal model name: `speechmatics-batch-v2` (the enhanced model)
+        /// or `melia-1` (multilingual with code-switching).
+        public let modelName: String
         public let language: String
         public let vocabulary: [String]
         public let isSpeakerDiarizationEnabled: Bool
@@ -24,12 +27,14 @@ public struct SpeechmaticsTranscriptionService: TranscriptionService, Sendable {
 
         public init(
             apiKey: String,
+            modelName: String = "speechmatics-batch-v2",
             language: String = "auto",
             vocabulary: [String] = [],
             isSpeakerDiarizationEnabled: Bool = false,
             translationTargetLanguage: String = ""
         ) {
             self.apiKey = apiKey
+            self.modelName = modelName
             self.language = language
             self.vocabulary = vocabulary
             self.isSpeakerDiarizationEnabled = isSpeakerDiarizationEnabled
@@ -88,10 +93,23 @@ public struct SpeechmaticsTranscriptionService: TranscriptionService, Sendable {
         let boundary = "Boundary-\(UUID().uuidString)"
         request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
 
-        var transcriptionConfig: [String: Any] = [
-            "language": language.isEmpty ? "auto" : language,
-            "operating_point": "enhanced"
-        ]
+        // `model` replaced the deprecated `operating_point` property and takes
+        // the same values plus `melia-1`. Our legacy internal name maps to the
+        // enhanced model. Melia-1 detects languages automatically and requires
+        // `language: "multi"`; a concrete user-picked language becomes a hint.
+        let model = config.modelName.isEmpty || config.modelName == "speechmatics-batch-v2"
+            ? "enhanced"
+            : config.modelName
+
+        var transcriptionConfig: [String: Any] = ["model": model]
+        if model == "melia-1" {
+            transcriptionConfig["language"] = "multi"
+            if !language.isEmpty, language != "auto" {
+                transcriptionConfig["language_hints"] = [language]
+            }
+        } else {
+            transcriptionConfig["language"] = language.isEmpty ? "auto" : language
+        }
         if config.isSpeakerDiarizationEnabled {
             transcriptionConfig["diarization"] = "speaker"
         }

--- a/Modules/CloudTranscription/Tests/CloudTranscriptionTests/GladiaTranscriptionServiceTests.swift
+++ b/Modules/CloudTranscription/Tests/CloudTranscriptionTests/GladiaTranscriptionServiceTests.swift
@@ -44,6 +44,7 @@ struct GladiaTranscriptionServiceTests {
     private func makeService(
         networkService: MockNetworkService,
         apiKey: String = "gld-test-key",
+        modelName: String = "solaria-1",
         language: String = "auto",
         vocabulary: [String] = [],
         isSpeakerDiarizationEnabled: Bool = false,
@@ -52,6 +53,7 @@ struct GladiaTranscriptionServiceTests {
         GladiaTranscriptionService(
             config: .init(
                 apiKey: apiKey,
+                modelName: modelName,
                 language: language,
                 vocabulary: vocabulary,
                 isSpeakerDiarizationEnabled: isSpeakerDiarizationEnabled,
@@ -187,6 +189,32 @@ struct GladiaTranscriptionServiceTests {
     private func createBody(_ networkService: MockNetworkService) throws -> [String: Any] {
         let body = try #require(networkService.capturedRequests[1].httpBody)
         return try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+    }
+
+    @Test func createBodyCarriesDefaultModel() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService)
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        #expect(try createBody(networkService)["model"] as? String == "solaria-1")
+    }
+
+    @Test func createBodyCarriesSolaria3WhenSelected() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService)
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, modelName: "solaria-3", language: "de")
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let body = try createBody(networkService)
+        #expect(body["model"] as? String == "solaria-3")
+        let langConfig = try #require(body["language_config"] as? [String: Any])
+        #expect(langConfig["languages"] as? [String] == ["de"])
+        #expect(langConfig["code_switching"] as? Bool == false)
     }
 
     @Test func createBodyUsesCodeSwitchingWhenLanguageAuto() async throws {

--- a/Modules/CloudTranscription/Tests/CloudTranscriptionTests/OpenAITranscriptionServiceTests.swift
+++ b/Modules/CloudTranscription/Tests/CloudTranscriptionTests/OpenAITranscriptionServiceTests.swift
@@ -49,10 +49,16 @@ struct OpenAITranscriptionServiceTests {
         networkService: MockNetworkService,
         apiKey: String = "sk-test-key",
         modelName: String = "whisper-1",
-        language: String = "auto"
+        language: String = "auto",
+        isSpeakerDiarizationEnabled: Bool = false
     ) -> OpenAITranscriptionService {
         OpenAITranscriptionService(
-            config: .init(apiKey: apiKey, modelName: modelName, language: language),
+            config: .init(
+                apiKey: apiKey,
+                modelName: modelName,
+                language: language,
+                isSpeakerDiarizationEnabled: isSpeakerDiarizationEnabled
+            ),
             networkService: networkService
         )
     }
@@ -154,6 +160,75 @@ struct OpenAITranscriptionServiceTests {
         let body = try #require(networkService.capturedBody)
         let bodyString = try #require(String(data: body, encoding: .utf8))
         #expect(bodyString.contains("name=\"language\"") == false)
+    }
+
+    // MARK: - Diarize model (gpt-4o-transcribe-diarize)
+
+    @Test func diarizeModelBodySendsChunkingStrategyAndOmitsLanguageAndTemperature() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+
+        let sut = makeService(networkService: networkService, modelName: "gpt-4o-transcribe-diarize", language: "en")
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let body = try #require(networkService.capturedBody)
+        let bodyString = try #require(String(data: body, encoding: .utf8))
+        #expect(bodyString.range(of: "name=\"chunking_strategy\"\\s*\\r\\n\\r\\nauto", options: .regularExpression) != nil)
+        #expect(bodyString.contains("name=\"language\"") == false)
+        #expect(bodyString.contains("name=\"temperature\"") == false)
+    }
+
+    @Test func diarizeModelUsesJSONFormatWhenDiarizationOff() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "plain text result")
+        let audio = try makeAudioFile()
+
+        let sut = makeService(networkService: networkService, modelName: "gpt-4o-transcribe-diarize")
+        let result = try await sut.transcribe(audioURL: audio)
+
+        let body = try #require(networkService.capturedBody)
+        let bodyString = try #require(String(data: body, encoding: .utf8))
+        #expect(bodyString.range(of: "name=\"response_format\"\\s*\\r\\n\\r\\njson", options: .regularExpression) != nil)
+        #expect(result.text == "plain text result")
+        #expect(result.isSpeakerAttributed == false)
+    }
+
+    @Test func diarizeModelReturnsSpeakerAttributedTextWhenDiarizationOn() async throws {
+        let networkService = MockNetworkService()
+        let body = Data(#"{"segments":[{"text":"hi there","speaker":"A"},{"text":"hello back","speaker":"B"}]}"#.utf8)
+        networkService.stubUploadResponse = .success((body, makeHTTPResponse(200)))
+        let audio = try makeAudioFile()
+
+        let sut = makeService(
+            networkService: networkService,
+            modelName: "gpt-4o-transcribe-diarize",
+            isSpeakerDiarizationEnabled: true
+        )
+        let result = try await sut.transcribe(audioURL: audio)
+
+        let requestBody = try #require(networkService.capturedBody)
+        let bodyString = try #require(String(data: requestBody, encoding: .utf8))
+        #expect(bodyString.range(of: "name=\"response_format\"\\s*\\r\\n\\r\\ndiarized_json", options: .regularExpression) != nil)
+        #expect(result.isSpeakerAttributed == true)
+        #expect(result.text.contains("hi there"))
+        #expect(result.text.contains("hello back"))
+    }
+
+    @Test func diarizeModelMergesConsecutiveSegmentsOfSameSpeaker() async throws {
+        let networkService = MockNetworkService()
+        let body = Data(#"{"segments":[{"text":"one","speaker":"A"},{"text":"two","speaker":"A"},{"text":"three","speaker":"B"}]}"#.utf8)
+        networkService.stubUploadResponse = .success((body, makeHTTPResponse(200)))
+        let audio = try makeAudioFile()
+
+        let sut = makeService(
+            networkService: networkService,
+            modelName: "gpt-4o-transcribe-diarize",
+            isSpeakerDiarizationEnabled: true
+        )
+        let result = try await sut.transcribe(audioURL: audio)
+
+        #expect(result.text.contains("one two"))
     }
 
     // MARK: - Validation / short-circuit

--- a/Modules/CloudTranscription/Tests/CloudTranscriptionTests/SpeechmaticsTranscriptionServiceTests.swift
+++ b/Modules/CloudTranscription/Tests/CloudTranscriptionTests/SpeechmaticsTranscriptionServiceTests.swift
@@ -41,6 +41,7 @@ struct SpeechmaticsTranscriptionServiceTests {
     private func makeService(
         networkService: MockNetworkService,
         apiKey: String = "smx-test-key",
+        modelName: String = "speechmatics-batch-v2",
         language: String = "auto",
         vocabulary: [String] = [],
         isSpeakerDiarizationEnabled: Bool = false,
@@ -49,6 +50,7 @@ struct SpeechmaticsTranscriptionServiceTests {
         SpeechmaticsTranscriptionService(
             config: .init(
                 apiKey: apiKey,
+                modelName: modelName,
                 language: language,
                 vocabulary: vocabulary,
                 isSpeakerDiarizationEnabled: isSpeakerDiarizationEnabled,
@@ -162,6 +164,46 @@ struct SpeechmaticsTranscriptionServiceTests {
     }
 
     // MARK: - Config body (inside the multipart upload)
+
+    @Test func configBodyMapsLegacyInternalNameToEnhancedModel() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService)
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let body = try uploadBodyString(networkService)
+        #expect(body.contains("\"model\":\"enhanced\""))
+        #expect(!body.contains("operating_point"))
+    }
+
+    @Test func configBodyMelia1UsesMultiLanguageWithHint() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService)
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, modelName: "melia-1", language: "de")
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let body = try uploadBodyString(networkService)
+        #expect(body.contains("\"model\":\"melia-1\""))
+        #expect(body.contains("\"language\":\"multi\""))
+        #expect(body.contains("\"language_hints\":[\"de\"]"))
+    }
+
+    @Test func configBodyMelia1OmitsHintsWhenLanguageAuto() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService)
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, modelName: "melia-1", language: "auto")
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let body = try uploadBodyString(networkService)
+        #expect(body.contains("\"language\":\"multi\""))
+        #expect(!body.contains("language_hints"))
+    }
 
     @Test func configBodyMapsZhToCmn() async throws {
         let networkService = MockNetworkService()

--- a/Modules/CloudTranscription/Tests/CloudTranscriptionTests/SpeechmaticsTranscriptionServiceTests.swift
+++ b/Modules/CloudTranscription/Tests/CloudTranscriptionTests/SpeechmaticsTranscriptionServiceTests.swift
@@ -205,6 +205,19 @@ struct SpeechmaticsTranscriptionServiceTests {
         #expect(!body.contains("language_hints"))
     }
 
+    @Test func configBodyMelia1DropsTranslationConfig() async throws {
+        let networkService = MockNetworkService()
+        try stubHappyFlow(on: networkService)
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, modelName: "melia-1", translationTargetLanguage: "de")
+
+        let result = try await sut.transcribe(audioURL: audio)
+
+        let body = try uploadBodyString(networkService)
+        #expect(!body.contains("translation_config"))
+        #expect(result.text == "hello world")
+    }
+
     @Test func configBodyMapsZhToCmn() async throws {
         let networkService = MockNetworkService()
         try stubHappyFlow(on: networkService)

--- a/VivaDicta/Models/TranscriptionModelProvider.swift
+++ b/VivaDicta/Models/TranscriptionModelProvider.swift
@@ -116,6 +116,17 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
         }
     }
     
+    /// Cloud model slugs that providers renamed or retired. Saved mode
+    /// selections may still carry the old name; normalize before any
+    /// catalog lookup so those modes keep transcribing.
+    static let renamedCloudModels: [String: String] = [
+        "stt-async-v4": "stt-async-v5"  // Soniox retired v4 on 2026-06-30
+    ]
+
+    static func normalizedCloudModelName(_ name: String) -> String {
+        renamedCloudModels[name] ?? name
+    }
+
     var defaultCloudTranscriptionModel: String? {
         switch self {
         case .groq: "whisper-large-v3-turbo"
@@ -124,7 +135,7 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
         case .deepgram: "nova-3"
         case .elevenLabs: "scribe_v2"
         case .openAI: "gpt-4o-mini-transcribe"
-        case .soniox: "stt-async-v4"
+        case .soniox: "stt-async-v5"
         case .gladia: "solaria-1"
         case .speechmatics: "speechmatics-batch-v2"
         case .cohere: "cohere-transcribe-03-2026"
@@ -187,9 +198,21 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
             ),
 
             CloudModel(
-                name: "stt-async-v4",
-                displayName: "Soniox (stt-async-v4)",
-                description: "Soniox transcription model v4 with human-parity accuracy across 60+ languages. Powers Live Translation - super-fast real-time speech-to-speech translation, ideal for lectures and workshops.",
+                name: "whisper-large-v3",
+                displayName: "Whisper Large V3",
+                description: "Full-size Whisper on Groq's LPU - higher accuracy than Turbo and still 189x real-time speed. Free tier with generous daily limits",
+                provider: .groq,
+                speed: 0.95,
+                accuracy: 0.93,
+                cost: 0.15,  // $0.111/hr (~$0.00185/min) - same free tier as Turbo
+                supportManyLanguages: true,
+                supportedLanguages: allLanguages
+            ),
+
+            CloudModel(
+                name: "stt-async-v5",
+                displayName: "Soniox (stt-async-v5)",
+                description: "Soniox transcription model v5 with human-parity accuracy across 60+ languages, reengineered speaker separation and better handling of numbers, dates and emails. Powers Live Translation - super-fast real-time speech-to-speech translation, ideal for lectures and workshops.",
                 provider: .soniox,
                 recommended: true,
                 speed: 0.95,
@@ -213,6 +236,18 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
             ),
 
             CloudModel(
+                name: "solaria-3",
+                displayName: "Gladia Solaria-3",
+                description: "Gladia's most accurate model for real-world business audio in English, French, German, Spanish and Italian. Async only, one language per recording - pick Solaria for other languages or auto-detect.",
+                provider: .gladia,
+                speed: 0.85,
+                accuracy: 0.97,
+                cost: 0.6,
+                supportManyLanguages: true,
+                supportedLanguages: gladiaSolaria3Languages
+            ),
+
+            CloudModel(
                 name: "speechmatics-batch-v2",
                 displayName: "Speechmatics Enhanced",
                 description: "Speechmatics batch transcription with industry-leading accuracy on European languages, speaker diarization and built-in translation across 50+ languages.",
@@ -221,6 +256,18 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
                 speed: 0.7,
                 accuracy: 0.97,
                 cost: 0.7,
+                supportManyLanguages: true,
+                supportedLanguages: speechmaticsLanguages
+            ),
+
+            CloudModel(
+                name: "melia-1",
+                displayName: "Speechmatics Melia-1",
+                description: "Speechmatics' multilingual model with automatic code-switching across 56+ languages - no language selection needed. Their lowest-priced tier, in production preview for batch transcription.",
+                provider: .speechmatics,
+                speed: 0.75,
+                accuracy: 0.96,
+                cost: 0.3,
                 supportManyLanguages: true,
                 supportedLanguages: speechmaticsLanguages
             ),
@@ -467,6 +514,17 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
                 supportedLanguages: allLanguages
             ),
             CloudModel(
+                name: "gpt-4o-transcribe-diarize",
+                displayName: "GPT-4o Transcribe Diarize",
+                description: "OpenAI's speaker-aware transcription model - returns speaker-labeled transcripts for conversations and meetings. Language is always auto-detected.",
+                provider: .openAI,
+                speed: 0.7,
+                accuracy: 0.95,
+                cost: 0.9,  // ~$0.006/min, same tier as gpt-4o-transcribe
+                supportManyLanguages: true,
+                supportedLanguages: ["auto": "Auto-detect"]
+            ),
+            CloudModel(
                 name: "gpt-4o-mini-transcribe",
                 displayName: "GPT-4o Mini Transcribe",
                 description: "Cost-effective OpenAI model for high-volume transcription with good accuracy",
@@ -525,6 +583,13 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
     /// Translation targets are the same set; auto-detect is also supported.
     static let gladiaLanguages: [String: String] = allLanguages
 
+    /// Gladia Solaria-3 supports 5 European languages, exactly one per
+    /// request. No auto-detect - language must be specified.
+    static let gladiaSolaria3Languages: [String: String] = {
+        let codes: Set<String> = ["en", "fr", "de", "es", "it"]
+        return allLanguages.filter { codes.contains($0.key) }
+    }()
+
     /// Speechmatics batch supports ~50 languages plus auto-detect.
     /// Note: Speechmatics uses `cmn` for Mandarin where we use `zh`; the service
     /// rewrites the code at request time so users still see "Chinese" in the picker.
@@ -575,7 +640,7 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
         "vi": "Vietnamese",
     ]
 
-    /// Soniox stt-async-v4 supports 60 languages plus auto-detect.
+    /// Soniox stt-async-v5 supports 60 languages plus auto-detect.
     /// Translation targets are the same set.
     static let sonioxLanguages: [String: String] = {
         let codes: Set<String> = [

--- a/VivaDicta/Models/TranscriptionModelProvider.swift
+++ b/VivaDicta/Models/TranscriptionModelProvider.swift
@@ -111,7 +111,8 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
             return "Custom"
 
         default:
-            guard let model = TranscriptionModelProvider.allCloudModels.first(where: {$0.name == modelName}) else { return modelName }
+            let normalized = TranscriptionModelProvider.normalizedCloudModelName(modelName)
+            guard let model = TranscriptionModelProvider.allCloudModels.first(where: {$0.name == normalized}) else { return modelName }
             return model.displayName
         }
     }

--- a/VivaDicta/Services/Transcription/TranscriptionManager.swift
+++ b/VivaDicta/Services/Transcription/TranscriptionManager.swift
@@ -118,7 +118,7 @@ class TranscriptionManager: Transcriber {
     /// Returns the transcription model for the current mode if it's available and usable.
     public func getCurrentTranscriptionModel() -> (any TranscriptionModel)? {
         let provider = currentMode.transcriptionProvider
-        let modelName = currentMode.transcriptionModel
+        let modelName = TranscriptionModelProvider.normalizedCloudModelName(currentMode.transcriptionModel)
 
         if provider == .customTranscription && modelName == "custom" {
             return customTranscriptionSource.configuredModel
@@ -272,7 +272,12 @@ class TranscriptionManager: Transcriber {
             )
 
         case .openAI:
-            return .openAI(.init(apiKey: try requireAPIKey(model), modelName: model.name, language: selectedLanguage))
+            return .openAI(.init(
+                apiKey: try requireAPIKey(model),
+                modelName: model.name,
+                language: selectedLanguage,
+                isSpeakerDiarizationEnabled: diarizationEnabled
+            ))
 
         case .groq:
             return .groq(.init(
@@ -334,6 +339,7 @@ class TranscriptionManager: Transcriber {
         case .gladia:
             return .gladia(.init(
                 apiKey: try requireAPIKey(model),
+                modelName: model.name,
                 language: selectedLanguage,
                 vocabulary: CustomVocabulary.getTerms(),
                 isSpeakerDiarizationEnabled: diarizationEnabled,
@@ -343,6 +349,7 @@ class TranscriptionManager: Transcriber {
         case .speechmatics:
             return .speechmatics(.init(
                 apiKey: try requireAPIKey(model),
+                modelName: model.name,
                 language: selectedLanguage,
                 vocabulary: CustomVocabulary.getTerms(),
                 isSpeakerDiarizationEnabled: diarizationEnabled,


### PR DESCRIPTION
## Summary

Updates the cloud transcription catalog after a sweep of all 12 provider lineups (July 2026). One required migration and four new models:

### Soniox: stt-async-v4 -> stt-async-v5 (required)
- Soniox retired `stt-async-v4` on 2026-06-30; requests auto-route to v5 server-side, but the catalog, provider default, and AICore default now reference `stt-async-v5` directly.
- New `renamedCloudModels` map in `TranscriptionModelProvider` + `normalizedCloudModelName()` applied in `TranscriptionManager.getCurrentTranscriptionModel()`, so modes with the old v4 slug saved keep resolving instead of failing the catalog lookup.

### Gladia: Solaria-3 (new accuracy option)
- Async-only model for EN/FR/DE/ES/IT, notably more accurate on real-world business audio. Requires exactly one language, so its catalog entry excludes auto-detect.
- `GladiaTranscriptionService.Config` gains `modelName` (default `solaria-1`, unchanged behavior) and the create request now sends the `model` field. Solaria-1 keeps the recommended badge and stays the general default.

### Speechmatics: Melia-1 + API migration
- New multilingual model with automatic code-switching across 56+ languages at the lowest price tier.
- The job request migrates from the deprecated `operating_point` property to the new `model` property; the internal `speechmatics-batch-v2` name maps to `"enhanced"`. Melia-1 sends `language: "multi"` (required) and passes a user-picked language as `language_hints`.

### OpenAI: GPT-4o Transcribe Diarize
- Speaker-aware batch model that pairs with the Speaker Labels toggle. The service handles its distinct parameter set: `chunking_strategy=auto` (required for audio over 30s), no `language`/`temperature` fields, and `diarized_json` response format with speaker-turn formatting via `SpeakerDiarizationFormatter` when diarization is on. Catalog entry is auto-detect only since the model rejects a language parameter.

### Groq: Whisper Large V3
- Full-size Whisper as a higher-accuracy tier alongside Turbo (~10.3% vs ~12% WER). Catalog entry only; the service already passes model names through.

## Testing

- `swift test` in `Modules/CloudTranscription`: 200 tests, all passing.
- New tests: Gladia `model` field (default + solaria-3 with pinned language), Speechmatics enhanced/melia-1 request shapes (including no `operating_point` and hint omission on auto), OpenAI diarize request fields and diarized/plain response handling with consecutive-segment merging.
- Full app builds cleanly for iOS Simulator.

## Notes

- No breaking changes. Existing user selections are preserved; the only behavioral change for existing users is Soniox modes resolving to v5, which is the model Soniox already routes v4 requests to.
- Melia-1 is in production preview for batch on Speechmatics' side.