### PR TITLE
Refresh AI chat model lineup across seven providers

### DIFF
--- a/Modules/AICore/Sources/AICore/AIProvider.swift
+++ b/Modules/AICore/Sources/AICore/AIProvider.swift
@@ -378,21 +378,25 @@ public enum AIProvider: String, CaseIterable, Identifiable, Codable, Sendable {
         case .apple:
             return "foundation-model"
         case .cerebras:
-            return "llama3.1-8b"
+            // llama3.1-8b was retired from Cerebras' public catalog; gpt-oss-120b
+            // is their only production model.
+            return "gpt-oss-120b"
         case .groq:
             return "openai/gpt-oss-120b"
         case .gemini:
             return "gemini-3.5-flash"
         case .anthropic:
-            return "claude-sonnet-4-6"
+            return "claude-sonnet-5"
         case .openAI:
-            return "gpt-5.5"
+            return "gpt-5.6-terra"
         case .grok:
-            return "grok-4.20-beta"
+            // grok-4.5 is the newest flagship but is not yet available in the EU;
+            // grok-4.3 works everywhere.
+            return "grok-4.3"
         case .zai:
-            return "glm-5"
+            return "glm-5.2"
         case .kimi:
-            return "kimi-k2.5"
+            return "kimi-k2.6"
         case .minimax:
             return "MiniMax-M3"
         case .elevenLabs:
@@ -481,6 +485,28 @@ public enum AIProvider: String, CaseIterable, Identifiable, Codable, Sendable {
         }
     }
 
+    /// Chat models that providers retired or scheduled for shutdown, mapped to
+    /// their provider-recommended replacements. Saved mode selections may still
+    /// carry the old id; normalize before binding a model into a request so
+    /// those modes keep working after the provider-side shutdown.
+    public static let retiredModelReplacements: [String: String] = [
+        // Groq (qwen3-32b shut down 2026-07-17; Llama 3.x shut down 2026-08-16)
+        "qwen/qwen3-32b": "openai/gpt-oss-120b",
+        "llama-3.1-8b-instant": "openai/gpt-oss-20b",
+        "llama-3.3-70b-versatile": "openai/gpt-oss-120b",
+        // OpenAI (gpt-5.1 and gpt-4.1-nano shut down 2026-07-23)
+        "gpt-5.1": "gpt-5.5",
+        "gpt-5.2": "gpt-5.5",
+        "gpt-4.1-nano": "gpt-5.4-nano",
+        // Cerebras (llama3.1-8b removed from the public catalog)
+        "llama3.1-8b": "gpt-oss-120b"
+    ]
+
+    /// Maps a retired model id to its replacement; unknown ids pass through.
+    public static func normalizedModel(_ model: String) -> String {
+        retiredModelReplacements[model] ?? model
+    }
+
     public var availableModels: [String] {
         switch self {
         case .apple:
@@ -491,12 +517,12 @@ public enum AIProvider: String, CaseIterable, Identifiable, Codable, Sendable {
                 "zai-glm-4.7"
             ]
         case .groq:
+            // Groq retired the Llama 3.x and qwen3-32b models in mid-2026;
+            // legacy selections are mapped forward via `retiredModelReplacements`.
             return [
-                "llama-3.1-8b-instant",
-                "llama-3.3-70b-versatile",
-                "qwen/qwen3-32b",
                 "openai/gpt-oss-120b",
-                "openai/gpt-oss-20b"
+                "openai/gpt-oss-20b",
+                "qwen/qwen3.6-27b"
             ]
         case .gemini:
             return [
@@ -513,28 +539,34 @@ public enum AIProvider: String, CaseIterable, Identifiable, Codable, Sendable {
                 "claude-opus-4-8",
                 "claude-opus-4-7",
                 "claude-opus-4-6",
+                "claude-sonnet-5",
                 "claude-sonnet-4-6",
                 "claude-sonnet-4-5",
                 "claude-haiku-4-5"
             ]
         case .openAI:
+            // gpt-5.1, gpt-5.2 and gpt-4.1-nano are deprecated/shutting down;
+            // legacy selections are mapped forward via `retiredModelReplacements`.
             return [
+                "gpt-5.6-sol",
+                "gpt-5.6-terra",
+                "gpt-5.6-luna",
                 "gpt-5.5",
                 "gpt-5.4",
                 "gpt-5.4-mini",
                 "gpt-5.4-nano",
-                "gpt-5.2",
-                "gpt-5.1",
                 "gpt-5-mini",
                 "gpt-5-nano",
                 "gpt-4.1",
                 "gpt-4.1-mini",
-                "gpt-4.1-nano",
                 "gpt-4o",
                 "gpt-4o-mini"
             ]
         case .grok:
+            // grok-4.5 is xAI's newest flagship (not yet EU-available at launch,
+            // so grok-4.3 stays the default).
             return [
+                "grok-4.5",
                 "grok-4.3",
                 "grok-4.20-reasoning",
                 "grok-4.20-non-reasoning",
@@ -543,6 +575,7 @@ public enum AIProvider: String, CaseIterable, Identifiable, Codable, Sendable {
             ]
         case .zai:
             return [
+                "glm-5.2",
                 "glm-5.1",
                 "glm-5-turbo",
                 "glm-5",

--- a/Modules/AICore/Sources/AICore/AIProvider.swift
+++ b/Modules/AICore/Sources/AICore/AIProvider.swift
@@ -489,22 +489,33 @@ public enum AIProvider: String, CaseIterable, Identifiable, Codable, Sendable {
     /// their provider-recommended replacements. Saved mode selections may still
     /// carry the old id; normalize before binding a model into a request so
     /// those modes keep working after the provider-side shutdown.
-    public static let retiredModelReplacements: [String: String] = [
-        // Groq (qwen3-32b shut down 2026-07-17; Llama 3.x shut down 2026-08-16)
-        "qwen/qwen3-32b": "openai/gpt-oss-120b",
-        "llama-3.1-8b-instant": "openai/gpt-oss-20b",
-        "llama-3.3-70b-versatile": "openai/gpt-oss-120b",
-        // OpenAI (gpt-5.1 and gpt-4.1-nano shut down 2026-07-23)
-        "gpt-5.1": "gpt-5.5",
-        "gpt-5.2": "gpt-5.5",
-        "gpt-4.1-nano": "gpt-5.4-nano",
-        // Cerebras (llama3.1-8b removed from the public catalog)
-        "llama3.1-8b": "gpt-oss-120b"
+    ///
+    /// Scoped per provider so passthrough routes (custom endpoints, OpenRouter,
+    /// Ollama, ...) are never rewritten - an id retired on one provider can be
+    /// legitimately served by a user-configured endpoint.
+    public static let retiredModelReplacements: [AIProvider: [String: String]] = [
+        // qwen3-32b shut down 2026-07-17; Llama 3.x shut down 2026-08-16
+        .groq: [
+            "qwen/qwen3-32b": "openai/gpt-oss-120b",
+            "llama-3.1-8b-instant": "openai/gpt-oss-20b",
+            "llama-3.3-70b-versatile": "openai/gpt-oss-120b"
+        ],
+        // gpt-5.1 and gpt-4.1-nano shut down 2026-07-23; gpt-5.2 is deprecated
+        .openAI: [
+            "gpt-5.1": "gpt-5.5",
+            "gpt-5.2": "gpt-5.5",
+            "gpt-4.1-nano": "gpt-5.4-nano"
+        ],
+        // llama3.1-8b was removed from the public catalog
+        .cerebras: [
+            "llama3.1-8b": "gpt-oss-120b"
+        ]
     ]
 
-    /// Maps a retired model id to its replacement; unknown ids pass through.
-    public static func normalizedModel(_ model: String) -> String {
-        retiredModelReplacements[model] ?? model
+    /// Maps a retired model id on `provider` to its replacement; unknown ids
+    /// and providers without retirements pass through.
+    public static func normalizedModel(_ model: String, for provider: AIProvider) -> String {
+        retiredModelReplacements[provider]?[model] ?? model
     }
 
     public var availableModels: [String] {

--- a/Modules/AICore/Tests/AICoreTests/AICoreTests.swift
+++ b/Modules/AICore/Tests/AICoreTests/AICoreTests.swift
@@ -92,20 +92,29 @@ struct AIProviderTests {
         for provider in AIProvider.generalProviders where !provider.availableModels.isEmpty {
             let defaultModel = provider.defaultModel
             #expect(provider.availableModels.contains(defaultModel), "\(provider) default not in list")
-            #expect(AIProvider.retiredModelReplacements[defaultModel] == nil, "\(provider) default is retired")
+            #expect(AIProvider.retiredModelReplacements[provider]?[defaultModel] == nil, "\(provider) default is retired")
         }
     }
 
     @Test func retiredModelsMapToCurrentReplacements() {
-        #expect(AIProvider.normalizedModel("qwen/qwen3-32b") == "openai/gpt-oss-120b")
-        #expect(AIProvider.normalizedModel("llama-3.1-8b-instant") == "openai/gpt-oss-20b")
-        #expect(AIProvider.normalizedModel("gpt-5.1") == "gpt-5.5")
-        #expect(AIProvider.normalizedModel("llama3.1-8b") == "gpt-oss-120b")
+        #expect(AIProvider.normalizedModel("qwen/qwen3-32b", for: .groq) == "openai/gpt-oss-120b")
+        #expect(AIProvider.normalizedModel("llama-3.1-8b-instant", for: .groq) == "openai/gpt-oss-20b")
+        #expect(AIProvider.normalizedModel("gpt-5.1", for: .openAI) == "gpt-5.5")
+        #expect(AIProvider.normalizedModel("llama3.1-8b", for: .cerebras) == "gpt-oss-120b")
         // Unknown ids pass through untouched.
-        #expect(AIProvider.normalizedModel("gpt-5.6-terra") == "gpt-5.6-terra")
-        // No replacement may itself be retired (no chains).
-        for replacement in AIProvider.retiredModelReplacements.values {
-            #expect(AIProvider.retiredModelReplacements[replacement] == nil, "\(replacement) chains")
+        #expect(AIProvider.normalizedModel("gpt-5.6-terra", for: .openAI) == "gpt-5.6-terra")
+        // Retirement is provider-scoped: another provider legitimately serving
+        // the same id must not be rewritten.
+        #expect(AIProvider.normalizedModel("gpt-5.1", for: .customOpenAI) == "gpt-5.1")
+
+        for (provider, replacements) in AIProvider.retiredModelReplacements {
+            for replacement in replacements.values {
+                // No replacement may itself be retired (no chains) ...
+                #expect(replacements[replacement] == nil, "\(replacement) chains")
+                // ... and every replacement must be a live, listed model,
+                // which also catches replacement-id typos.
+                #expect(provider.availableModels.contains(replacement), "\(replacement) not listed for \(provider)")
+            }
         }
     }
 

--- a/Modules/AICore/Tests/AICoreTests/AICoreTests.swift
+++ b/Modules/AICore/Tests/AICoreTests/AICoreTests.swift
@@ -82,8 +82,31 @@ struct AIProviderTests {
 
     @Test func defaultModelsAreStable() {
         #expect(AIProvider.apple.defaultModel == "foundation-model")
-        #expect(AIProvider.anthropic.defaultModel == "claude-sonnet-4-6")
-        #expect(AIProvider.openAI.defaultModel == "gpt-5.5")
+        #expect(AIProvider.anthropic.defaultModel == "claude-sonnet-5")
+        #expect(AIProvider.openAI.defaultModel == "gpt-5.6-terra")
+    }
+
+    @Test func defaultModelsAreListedAndNotRetired() {
+        // A provider's default must be selectable in the picker and must not
+        // itself be a retired id (the Cerebras llama3.1-8b default once was).
+        for provider in AIProvider.generalProviders where !provider.availableModels.isEmpty {
+            let defaultModel = provider.defaultModel
+            #expect(provider.availableModels.contains(defaultModel), "\(provider) default not in list")
+            #expect(AIProvider.retiredModelReplacements[defaultModel] == nil, "\(provider) default is retired")
+        }
+    }
+
+    @Test func retiredModelsMapToCurrentReplacements() {
+        #expect(AIProvider.normalizedModel("qwen/qwen3-32b") == "openai/gpt-oss-120b")
+        #expect(AIProvider.normalizedModel("llama-3.1-8b-instant") == "openai/gpt-oss-20b")
+        #expect(AIProvider.normalizedModel("gpt-5.1") == "gpt-5.5")
+        #expect(AIProvider.normalizedModel("llama3.1-8b") == "gpt-oss-120b")
+        // Unknown ids pass through untouched.
+        #expect(AIProvider.normalizedModel("gpt-5.6-terra") == "gpt-5.6-terra")
+        // No replacement may itself be retired (no chains).
+        for replacement in AIProvider.retiredModelReplacements.values {
+            #expect(AIProvider.retiredModelReplacements[replacement] == nil, "\(replacement) chains")
+        }
     }
 
     // MARK: - Capability flags

--- a/Modules/AIKit/Sources/AIKit/AIProviderRegistry.swift
+++ b/Modules/AIKit/Sources/AIKit/AIProviderRegistry.swift
@@ -48,6 +48,9 @@ public struct AIProviderRegistry {
     /// when a required API key is missing, or rethrows an OAuth error when a token
     /// cannot be obtained.
     public func makeTextProvider(for route: AIProviderRoute, model: String) async throws -> any AITextProvider {
+        // Saved mode selections can outlive a provider's model lineup; map
+        // retired ids to their replacements so those modes keep working.
+        let model = AIProvider.normalizedModel(model)
         switch route {
         case .appleFoundationModel(let samplingProfile):
             if #available(iOS 26, macOS 26, *) {

--- a/Modules/AIKit/Sources/AIKit/AIProviderRegistry.swift
+++ b/Modules/AIKit/Sources/AIKit/AIProviderRegistry.swift
@@ -50,7 +50,15 @@ public struct AIProviderRegistry {
     public func makeTextProvider(for route: AIProviderRoute, model: String) async throws -> any AITextProvider {
         // Saved mode selections can outlive a provider's model lineup; map
         // retired ids to their replacements so those modes keep working.
-        let model = AIProvider.normalizedModel(model)
+        // Only routes bound to a known provider catalog are normalized -
+        // passthrough routes (custom endpoints, Ollama, OpenRouter, ...) send
+        // the user-entered id untouched.
+        let model = switch route {
+        case .anthropic: AIProvider.normalizedModel(model, for: .anthropic)
+        case .cloud(let provider): AIProvider.normalizedModel(model, for: provider)
+        case .openAIOAuth: AIProvider.normalizedModel(model, for: .openAI)
+        default: model
+        }
         switch route {
         case .appleFoundationModel(let samplingProfile):
             if #available(iOS 26, macOS 26, *) {

--- a/Modules/AIKit/Tests/AIKitTests/AIProviderRegistryTests.swift
+++ b/Modules/AIKit/Tests/AIKitTests/AIProviderRegistryTests.swift
@@ -197,4 +197,27 @@ struct AIProviderRegistryTests {
         #expect(net.capturedRequest?.value(forHTTPHeaderField: "Authorization") == "Bearer custom-token")
         #expect(net.capturedRequest?.timeoutInterval == 120)                                       // caller timeout, not the cloud baseTimeout (300)
     }
+
+    @Test func passthroughEndpointModelIsNotRewrittenByRetirementMap() async throws {
+        // A custom endpoint can legitimately serve an id retired elsewhere
+        // (e.g. a proxy exposing gpt-5.1); the registry must send it untouched.
+        let net = MockNetworkService()
+        net.stubSendResponse = .success((Data(#"{"choices":[{"message":{"content":"OK"}}]}"#.utf8), http(200)))
+        let sut = makeSUT(net: net)
+
+        let provider = try await sut.makeTextProvider(
+            for: .openAICompatibleEndpoint(
+                url: URL(string: "http://localhost:8080/v1/chat/completions")!,
+                headers: [:],
+                timeout: 120,
+                errorPrefix: "Custom"
+            ),
+            model: "gpt-5.1"
+        )
+        _ = try await provider.enhance(systemMessage: "S", userMessage: "U")
+
+        let body = try #require(net.capturedRequest?.httpBody)
+        let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        #expect(json["model"] as? String == "gpt-5.1")
+    }
 }

--- a/Modules/AIKit/Tests/AIKitTests/AIProviderRegistryTests.swift
+++ b/Modules/AIKit/Tests/AIKitTests/AIProviderRegistryTests.swift
@@ -62,7 +62,7 @@ struct AIProviderRegistryTests {
         let keychain = MockKeychainService()
         seed(keychain, "ANTHROPIC_KEY", forKey: "anthropicAPIKey") // real key name -> catches a key-name swap
         let net = MockNetworkService()
-        net.stubSendResponse = .success((Data(#"{"content":[{"text":"OK"}]}"#.utf8), http(200)))
+        net.stubSendResponse = .success((Data(#"{"content":[{"type":"text","text":"OK"}]}"#.utf8), http(200)))
         let sut = makeSUT(keychain: keychain, net: net)
 
         let provider = try await sut.makeTextProvider(for: .anthropic, model: "claude-sonnet-4-6")
@@ -86,6 +86,23 @@ struct AIProviderRegistryTests {
 
         #expect(net.capturedRequest?.url?.absoluteString == "https://api.openai.com/v1/chat/completions")
         #expect(net.capturedRequest?.value(forHTTPHeaderField: "Authorization") == "Bearer OPENAI_KEY")
+    }
+
+    @Test func retiredModelIsReplacedBeforeBindingIntoRequest() async throws {
+        // Saved modes may still carry a retired model id; the registry maps it
+        // to the provider-recommended replacement so requests keep working.
+        let keychain = MockKeychainService()
+        seed(keychain, "GROQ_KEY", forKey: "groqAPIKey")
+        let net = MockNetworkService()
+        net.stubSendResponse = .success((Data(#"{"choices":[{"message":{"content":"OK"}}]}"#.utf8), http(200)))
+        let sut = makeSUT(keychain: keychain, net: net)
+
+        let provider = try await sut.makeTextProvider(for: .cloud(.groq), model: "qwen/qwen3-32b")
+        _ = try await provider.enhance(systemMessage: "S", userMessage: "U")
+
+        let body = try #require(net.capturedRequest?.httpBody)
+        let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        #expect(json["model"] as? String == "openai/gpt-oss-120b")
     }
 
     @Test func missingAPIKeyThrowsNotConfigured() async {

--- a/Modules/AIKit/Tests/AIKitTests/TextEnhancerTests.swift
+++ b/Modules/AIKit/Tests/AIKitTests/TextEnhancerTests.swift
@@ -71,7 +71,7 @@ struct TextEnhancerTests {
         let keychain = MockKeychainService()
         _ = keychain.save("ANTHROPIC_KEY", forKey: "anthropicAPIKey")
         let net = MockNetworkService()
-        net.stubSendResponse = .success((Data(#"{"content":[{"text":"OK"}]}"#.utf8), http(200)))
+        net.stubSendResponse = .success((Data(#"{"content":[{"type":"text","text":"OK"}]}"#.utf8), http(200)))
         let sut = makeSUT(keychain: keychain, net: net)
 
         let result = try await sut.enhance(input(provider: .anthropic))
@@ -110,7 +110,7 @@ struct TextEnhancerTests {
         let keychain = MockKeychainService()
         _ = keychain.save("ANTHROPIC_KEY", forKey: "anthropicAPIKey")
         let net = MockNetworkService()
-        net.stubSendResponse = .success((Data(#"{"content":[{"text":"CLOUD_OK"}]}"#.utf8), http(200)))
+        net.stubSendResponse = .success((Data(#"{"content":[{"type":"text","text":"CLOUD_OK"}]}"#.utf8), http(200)))
         let cli = MockCLIServerEnhancer()
         cli.activeProviders = [.anthropic]
         cli.serverURL = "http://mac:4000"

--- a/Modules/AIProviders/Sources/AIProviders/AnthropicService.swift
+++ b/Modules/AIProviders/Sources/AIProviders/AnthropicService.swift
@@ -69,10 +69,13 @@ public struct AnthropicService: Sendable {
             let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
 
             if httpResponse.statusCode == 200 {
+                // Models with adaptive thinking (Sonnet 5 and newer) can emit a
+                // `thinking` block before the text block, so pick the first
+                // text block rather than assuming content[0] is text.
                 guard let jsonResponse = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                       let content = jsonResponse["content"] as? [[String: Any]],
-                      let firstContent = content.first,
-                      let enhancedText = firstContent["text"] as? String else {
+                      let textBlock = content.first(where: { ($0["type"] as? String) == "text" }),
+                      let enhancedText = textBlock["text"] as? String else {
                     logger.logError("Anthropic enhance - malformed 200 body")
                     throw EnhancementError.enhancementFailed
                 }

--- a/Modules/AIProviders/Tests/AIProvidersTests/AnthropicServiceTests.swift
+++ b/Modules/AIProviders/Tests/AIProvidersTests/AnthropicServiceTests.swift
@@ -42,7 +42,7 @@ struct AnthropicServiceTests {
     // MARK: - Request shape (non-streaming)
 
     @Test func enhanceSendsXAPIKeyHeaderNotBearer() async throws {
-        let body = Data(#"{"content":[{"text":"ok"}]}"#.utf8)
+        let body = Data(#"{"content":[{"type":"text","text":"ok"}]}"#.utf8)
         networkService.stubSendResponse = .success((body, makeHTTPResponse(200)))
 
         _ = try await sut.enhance(
@@ -60,7 +60,7 @@ struct AnthropicServiceTests {
     }
 
     @Test func enhanceSendsAnthropicMessagesBodyShape() async throws {
-        let body = Data(#"{"content":[{"text":"ok"}]}"#.utf8)
+        let body = Data(#"{"content":[{"type":"text","text":"ok"}]}"#.utf8)
         networkService.stubSendResponse = .success((body, makeHTTPResponse(200)))
 
         _ = try await sut.enhance(
@@ -95,6 +95,22 @@ struct AnthropicServiceTests {
 
         // Whitespace is trimmed and the output filter is applied.
         #expect(result == "enhanced output")
+    }
+
+    @Test func enhanceSkipsThinkingBlockBeforeTextBlock() async throws {
+        // Adaptive-thinking models (Sonnet 5+) emit a thinking block before the
+        // text block; the parser must pick the text block, not content[0].
+        let body = Data(#"{"content":[{"type":"thinking","thinking":"","signature":"sig"},{"type":"text","text":"cleaned up"}]}"#.utf8)
+        networkService.stubSendResponse = .success((body, makeHTTPResponse(200)))
+
+        let result = try await sut.enhance(
+            systemMessage: "system",
+            userMessage: "user",
+            apiKey: "sk-ant-test",
+            model: "claude-sonnet-5"
+        )
+
+        #expect(result == "cleaned up")
     }
 
     @Test func enhanceThrowsEnhancementFailedOnMalformedBody() async throws {

--- a/Modules/AIProviders/Tests/AIProvidersTests/TextProvidersTests.swift
+++ b/Modules/AIProviders/Tests/AIProvidersTests/TextProvidersTests.swift
@@ -21,7 +21,7 @@ struct TextProvidersTests {
 
     @Test func anthropicWrapperForwardsMessagesAndReturnsEnhancedText() async throws {
         let net = MockNetworkService()
-        net.stubSendResponse = .success((Data(#"{"content":[{"text":"ENHANCED"}]}"#.utf8), http(200)))
+        net.stubSendResponse = .success((Data(#"{"content":[{"type":"text","text":"ENHANCED"}]}"#.utf8), http(200)))
 
         let sut = AnthropicTextProvider(
             networkService: net, logger: logger(), baseTimeout: 30,

--- a/VivaDicta/Services/AIEnhance/AIService+Chat.swift
+++ b/VivaDicta/Services/AIEnhance/AIService+Chat.swift
@@ -826,10 +826,13 @@ extension AIService {
             throw chatHTTPError(statusCode: httpResponse.statusCode, errorString: errorString, provider: "Anthropic")
         }
 
+        // Adaptive-thinking models (Sonnet 5 and newer) can emit a `thinking`
+        // block before the text block, so pick the first text block rather
+        // than assuming content[0] is text.
         guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let content = json["content"] as? [[String: Any]],
-              let first = content.first,
-              let text = first["text"] as? String else {
+              let textBlock = content.first(where: { ($0["type"] as? String) == "text" }),
+              let text = textBlock["text"] as? String else {
             throw EnhancementError.invalidResponse
         }
 

--- a/VivaDictaTests/AIServiceEnhanceRoutingTests.swift
+++ b/VivaDictaTests/AIServiceEnhanceRoutingTests.swift
@@ -155,7 +155,7 @@ struct AIServiceEnhanceRoutingTests {
         let keychain = MockKeychainService()
         _ = keychain.save("ANTHROPIC_KEY", forKey: "anthropicAPIKey")
         let net = MockNetworkService()
-        net.stubSendResponse = .success((Data(#"{"content":[{"text":"OK"}]}"#.utf8), http(200)))
+        net.stubSendResponse = .success((Data(#"{"content":[{"type":"text","text":"OK"}]}"#.utf8), http(200)))
 
         let sut = AIService(
             userDefaults: makeDefaults(),

--- a/VivaDictaTests/Acceptance/RecordEnhanceStoreAcceptanceTests.swift
+++ b/VivaDictaTests/Acceptance/RecordEnhanceStoreAcceptanceTests.swift
@@ -103,7 +103,7 @@ struct RecordEnhanceStoreAcceptanceTests {
         let keychain = MockKeychainService()
         _ = keychain.save("ANTHROPIC_KEY", forKey: "anthropicAPIKey")
         let net = MockNetworkService()
-        net.stubSendResponse = .success((Data(#"{"content":[{"text":"Enhanced acceptance output"}]}"#.utf8), http(200)))
+        net.stubSendResponse = .success((Data(#"{"content":[{"type":"text","text":"Enhanced acceptance output"}]}"#.utf8), http(200)))
 
         let aiService = AIService(
             userDefaults: defaults,


### PR DESCRIPTION
## Summary

Updates the AI text-processing model catalog after a sweep of all providers with hardcoded lineups (July 2026). Covers urgent removals (models with shutdowns in days), new flagships, default bumps, and a safety net for saved selections. All new model IDs were verified against live provider docs before hardcoding.

### Urgent fixes
- **Cerebras**: the `defaultModel` was `llama3.1-8b`, which has been removed from Cerebras' public catalog (it was never in the picker list either). Default is now `gpt-oss-120b`, their only production model.
- **Groq**: removed `qwen/qwen3-32b` (shutdown 2026-07-17), `llama-3.1-8b-instant` and `llama-3.3-70b-versatile` (shutdown 2026-08-16); added `qwen/qwen3.6-27b`.
- **OpenAI**: removed `gpt-5.1` and `gpt-4.1-nano` (shutdown 2026-07-23) and deprecated `gpt-5.2`.

### Retired-model safety net
New `AIProvider.retiredModelReplacements` map with `normalizedModel()`, applied at the single request chokepoint (`AIProviderRegistry.makeTextProvider`). Modes whose saved selection still carries a retired id are silently upgraded to the provider-recommended replacement instead of failing once the provider shuts the model down. A test guards that no replacement is itself retired and that every provider default is listed and current.

### New models and defaults
- **Anthropic**: added `claude-sonnet-5` (new default, replacing `claude-sonnet-4-6`).
- **OpenAI**: added `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`; default moved from `gpt-5.5` to the balanced `gpt-5.6-terra`.
- **xAI**: added `grok-4.5`; default moved from the stale `grok-4.20-beta` alias to `grok-4.3` (grok-4.5 is not EU-available yet).
- **Z.AI**: added `glm-5.2` (new default). **Kimi**: default bumped `kimi-k2.5` -> `kimi-k2.6`.

### Anthropic parser fix
Claude Sonnet 5 runs adaptive thinking by default and can emit a `thinking` content block before the text block. The non-streaming parser assumed `content[0]` was text and would have failed on such responses; it now picks the first block with `type == "text"`. The streaming path already filtered by `text_delta`. Test stubs across four files were updated to the realistic `{"type":"text",...}` response shape.

## Testing

- AICore (23), AIProviders (107), and AIKit (17) module tests pass, including new tests: thinking-block skip in `AnthropicServiceTests`, retirement-map invariants in `AICoreTests` (no chained replacements, defaults never retired and always listed), and registry normalization wiring in `AIProviderRegistryTests`.
- App-level `AIServiceEnhanceRoutingTests` (10) and `RecordEnhanceStoreAcceptanceTests` (2) pass on the simulator with the updated stubs.
- Full app builds cleanly for iOS Simulator.

## Notes

- No breaking changes for users: removed picker entries are mapped forward transparently; existing explicit selections of still-live models are untouched.
- Claude Fable 5, the Ollama Cloud fallback-pin refresh, and the Gemini 2.5 removal (provider shutdown 2026-10-16) are deliberately deferred.