### PR TITLE
Add Whisper language detection scores to Transcription Detail

### DIFF
--- a/Modules/LocalTranscription/Sources/LocalTranscription/WhisperKitTranscriptionService.swift
+++ b/Modules/LocalTranscription/Sources/LocalTranscription/WhisperKitTranscriptionService.swift
@@ -82,14 +82,27 @@ public final class WhisperKitTranscriptionService: @unchecked Sendable {
                 .joined(separator: " ")
                 .trimmingCharacters(in: .whitespacesAndNewlines)
 
+            let languageProbabilities = await detectLanguageProbabilities(
+                whisperKit: whisperKit,
+                audioURL: audioURL,
+                options: options
+            )
+
             if options.isSpeakerDiarizationEnabled,
                let diarizedResult = await makeSpeakerAttributedResult(from: result, audioURL: audioURL) {
                 logger.logNotice("✅ WhisperKit diarization completed successfully")
-                return diarizedResult
+                return TranscriptionServiceResult(
+                    text: diarizedResult.text,
+                    isSpeakerAttributed: diarizedResult.isSpeakerAttributed,
+                    languageProbabilities: languageProbabilities
+                )
             }
 
             logger.logNotice("✅ WhisperKit transcription completed, model kept in memory")
-            return .plain(transcribedText)
+            return TranscriptionServiceResult(
+                text: transcribedText,
+                languageProbabilities: languageProbabilities
+            )
         } catch {
             logger.logError("❌ WhisperKit transcription failed: \(error.localizedDescription)")
             throw TranscriptionError.transcriptionFailed
@@ -135,6 +148,28 @@ public final class WhisperKitTranscriptionService: @unchecked Sendable {
     public var currentModelState: ModelState { modelState }
 
     // MARK: - Private
+
+    /// Runs Whisper's language-identification pass and returns the full
+    /// probability distribution over language tokens, or `nil` when the pass
+    /// is skipped (explicit language selected) or fails. Detection is
+    /// best-effort: a failure here must never fail the transcription itself.
+    private func detectLanguageProbabilities(
+        whisperKit: WhisperKit,
+        audioURL: URL,
+        options: Options
+    ) async -> [String: Double]? {
+        guard options.language == "auto" else { return nil }
+
+        do {
+            let detection = try await whisperKit.detectLanguage(audioPath: audioURL.path)
+            let probabilities = detection.langProbs.mapValues { Double($0) }
+            logger.logNotice("🌐 Language detection: \(detection.language) (\(probabilities.count) languages scored)")
+            return probabilities
+        } catch {
+            logger.logError("⚠️ Language detection failed: \(error.localizedDescription)")
+            return nil
+        }
+    }
 
     private func loadModel(modelName: String) async throws {
         if currentModelName == modelName && modelState == .loaded {

--- a/Modules/TranscriptionCore/Sources/TranscriptionCore/TranscriptionServiceResult.swift
+++ b/Modules/TranscriptionCore/Sources/TranscriptionCore/TranscriptionServiceResult.swift
@@ -5,10 +5,21 @@ import Foundation
 public struct TranscriptionServiceResult: Sendable {
     public let text: String
     public let isSpeakerAttributed: Bool
+    /// Whisper language-identification probabilities keyed by language code
+    /// (e.g. `["en": 0.72, "ru": 0.21]`). Populated only by the local
+    /// WhisperKit backend when transcribing with automatic language
+    /// detection; `nil` for cloud/Parakeet backends, which expose no such
+    /// distribution.
+    public let languageProbabilities: [String: Double]?
 
-    public init(text: String, isSpeakerAttributed: Bool = false) {
+    public init(
+        text: String,
+        isSpeakerAttributed: Bool = false,
+        languageProbabilities: [String: Double]? = nil
+    ) {
         self.text = text
         self.isSpeakerAttributed = isSpeakerAttributed
+        self.languageProbabilities = languageProbabilities
     }
 
     public static func plain(_ text: String) -> Self {

--- a/Modules/TranscriptionCore/Tests/TranscriptionCoreTests/TranscriptionCoreTests.swift
+++ b/Modules/TranscriptionCore/Tests/TranscriptionCoreTests/TranscriptionCoreTests.swift
@@ -16,6 +16,20 @@ struct TranscriptionServiceResultTests {
         #expect(result.text == "Alice: hi")
         #expect(result.isSpeakerAttributed == true)
     }
+
+    @Test func helpersDefaultToNilLanguageProbabilities() {
+        #expect(TranscriptionServiceResult.plain("hello").languageProbabilities == nil)
+        #expect(TranscriptionServiceResult.speakerAttributed("Alice: hi").languageProbabilities == nil)
+    }
+
+    @Test func carriesLanguageProbabilities() {
+        let result = TranscriptionServiceResult(
+            text: "hello",
+            languageProbabilities: ["en": 0.7, "ru": 0.2]
+        )
+        #expect(result.languageProbabilities == ["en": 0.7, "ru": 0.2])
+        #expect(result.isSpeakerAttributed == false)
+    }
 }
 
 struct TranscriptionProgressInfoTests {

--- a/VivaDicta/AppState.swift
+++ b/VivaDicta/AppState.swift
@@ -240,7 +240,7 @@ class AppState {
     /// - Returns: The transcribed text.
     /// - Throws: Any error from the underlying transcription service.
     func transcribe(audioURL: URL) async throws -> String {
-        return try await transcriptionManager.transcribe(audioURL: audioURL)
+        return try await transcriptionManager.transcribe(audioURL: audioURL).text
     }
     
     

--- a/VivaDicta/Models/Transcription.swift
+++ b/VivaDicta/Models/Transcription.swift
@@ -95,6 +95,11 @@ class Transcription {
     /// Source that created this transcription (app, keyboard, shareExtension, actionExtension, macApp).
     var sourceTag: String?
 
+    /// Whisper language-identification probabilities keyed by language code
+    /// (e.g. `["en": 0.72, "ru": 0.21]`). Only set for local WhisperKit
+    /// transcriptions made with automatic language detection.
+    var languageProbabilities: [String: Double]?
+
     /// AI-generated text variations (Summary, Action Points, Professional, etc.).
     @Relationship(deleteRule: .cascade)
     var variations: [TranscriptionVariation]? = []
@@ -129,6 +134,7 @@ class Transcription {
     ///   - promptName: Name of the enhancement prompt.
     ///   - transcriptionDuration: Time taken to transcribe.
     ///   - enhancementDuration: Time taken to enhance.
+    ///   - languageProbabilities: Whisper language-identification scores, if available.
     init(text: String,
          enhancedText: String? = nil,
          audioDuration: TimeInterval,
@@ -141,7 +147,8 @@ class Transcription {
          transcriptionDuration: TimeInterval? = nil,
          enhancementDuration: TimeInterval? = nil,
          powerModeId: String? = nil,
-         sourceTag: String? = nil) {
+         sourceTag: String? = nil,
+         languageProbabilities: [String: Double]? = nil) {
         self.text = text
         self.enhancedText = enhancedText
         self.timestamp = Date()
@@ -156,6 +163,7 @@ class Transcription {
         self.enhancementDuration = enhancementDuration
         self.powerModeId = powerModeId
         self.sourceTag = sourceTag
+        self.languageProbabilities = languageProbabilities
     }
 
     /// Appends new raw transcription text to the original note body.

--- a/VivaDicta/Services/Transcription/Transcriber.swift
+++ b/VivaDicta/Services/Transcription/Transcriber.swift
@@ -25,6 +25,7 @@ protocol Transcriber {
     func getCurrentTranscriptionModel() -> (any TranscriptionModel)?
 
     /// Transcribe `audioURL` under the current mode, apply the post-processing
-    /// pipeline, and return the final text.
-    func transcribe(audioURL: URL, progressHandler: TranscriptionProgressHandler?) async throws -> String
+    /// pipeline, and return the final text plus backend metadata (e.g.
+    /// language-identification scores from local WhisperKit).
+    func transcribe(audioURL: URL, progressHandler: TranscriptionProgressHandler?) async throws -> TranscriptionServiceResult
 }

--- a/VivaDicta/Services/Transcription/TranscriptionManager.swift
+++ b/VivaDicta/Services/Transcription/TranscriptionManager.swift
@@ -146,11 +146,13 @@ class TranscriptionManager: Transcriber {
 
     /// Transcribes audio using the current mode's model via `TranscriptionEngine`,
     /// then applies the app's post-processing pipeline (filter, text formatter,
-    /// replacements, trailing-period strip).
+    /// replacements, trailing-period strip). The returned result carries the
+    /// processed text plus backend metadata (speaker attribution, WhisperKit
+    /// language-identification scores).
     public func transcribe(
         audioURL: URL,
         progressHandler: TranscriptionProgressHandler? = nil
-    ) async throws -> String {
+    ) async throws -> TranscriptionServiceResult {
         guard let model = getCurrentTranscriptionModel() else {
             throw TranscriptionError.transcriptionFailed
         }
@@ -194,7 +196,11 @@ class TranscriptionManager: Transcriber {
             outputLength: result.count
         ))
 
-        return result
+        return TranscriptionServiceResult(
+            text: result,
+            isSpeakerAttributed: transcriptionResult.isSpeakerAttributed,
+            languageProbabilities: transcriptionResult.languageProbabilities
+        )
     }
 
     /// Resolves the language of the transcription *output* for post-processing.

--- a/VivaDicta/Services/WatchAudioProcessor.swift
+++ b/VivaDicta/Services/WatchAudioProcessor.swift
@@ -68,7 +68,8 @@ final class WatchAudioProcessor {
 
             // Transcribe
             let transcriptionStart = Date()
-            let transcribedText = try await transcriptionManager.transcribe(audioURL: audioURL, progressHandler: nil)
+            let transcriptionResult = try await transcriptionManager.transcribe(audioURL: audioURL, progressHandler: nil)
+            let transcribedText = transcriptionResult.text
             let transcriptionDuration = Date().timeIntervalSince(transcriptionStart)
 
             // Validate
@@ -114,7 +115,8 @@ final class WatchAudioProcessor {
                 transcriptionDuration: transcriptionDuration,
                 enhancementDuration: enhancementDuration,
                 powerModeId: aiService.selectedMode.id.uuidString,
-                sourceTag: sourceTag
+                sourceTag: sourceTag,
+                languageProbabilities: transcriptionResult.languageProbabilities
             )
 
             transcription.timestamp = recordingTimestamp

--- a/VivaDicta/Views/LanguageScoresView.swift
+++ b/VivaDicta/Views/LanguageScoresView.swift
@@ -1,0 +1,109 @@
+//
+//  LanguageScoresView.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.07.19
+//
+
+import SwiftUI
+
+/// A single language's identification score, ready for display.
+///
+/// Wraps one entry of the Whisper language-probability distribution with a
+/// human-readable name and pre-formatted percentage. Kept as a plain value
+/// type so sorting/formatting is unit-testable without SwiftUI.
+struct LanguageScore: Identifiable, Equatable {
+    /// Whisper language code (e.g. "en", "ru").
+    let code: String
+    /// Probability in `0...1`.
+    let probability: Double
+
+    var id: String { code }
+
+    /// Localized display name for the language, falling back to the raw code
+    /// when the locale can't resolve it (Whisper includes a few exotic codes).
+    var displayName: String {
+        Locale.current.localizedString(forLanguageCode: code) ?? code
+    }
+
+    /// Probability formatted as a percentage with one fractional digit,
+    /// e.g. `"72.4%"`.
+    var formattedPercent: String {
+        probability.formatted(.percent.precision(.fractionLength(1)))
+    }
+
+    /// Converts a raw probability dictionary into scores sorted by
+    /// probability descending; ties break alphabetically by code so the
+    /// ordering is stable.
+    static func sorted(from probabilities: [String: Double]) -> [LanguageScore] {
+        probabilities
+            .map { LanguageScore(code: $0.key, probability: $0.value) }
+            .sorted {
+                if $0.probability != $1.probability {
+                    return $0.probability > $1.probability
+                }
+                return $0.code < $1.code
+            }
+    }
+}
+
+/// Bottom sheet listing Whisper's language-identification scores for a
+/// transcription, ordered by probability. Shown from the Transcription Detail
+/// screen for local WhisperKit transcriptions made with auto language
+/// detection.
+struct LanguageScoresView: View {
+    let probabilities: [String: Double]
+
+    private var scores: [LanguageScore] {
+        LanguageScore.sorted(from: probabilities)
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    ForEach(scores) { score in
+                        scoreRow(score)
+                    }
+                } footer: {
+                    Text("How confidently Whisper identified each language from the audio. A high score for a non-spoken language usually reflects the speaker's accent.")
+                }
+            }
+            .navigationTitle("Language Scores")
+            .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+
+    private func scoreRow(_ score: LanguageScore) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text(score.displayName)
+                    .font(.subheadline)
+
+                Text(score.code)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Spacer()
+
+                Text(score.formattedPercent)
+                    .font(.subheadline.monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }
+
+            ProgressView(value: score.probability)
+                .tint(.accentColor)
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+#Preview {
+    LanguageScoresView(probabilities: [
+        "en": 0.61,
+        "ru": 0.29,
+        "uk": 0.04,
+        "pl": 0.02,
+        "de": 0.01,
+    ])
+}

--- a/VivaDicta/Views/RecordViewModel.swift
+++ b/VivaDicta/Views/RecordViewModel.swift
@@ -34,6 +34,7 @@ private struct PendingTranscriptionData {
     let transcriptionDuration: TimeInterval
     let modelContext: ModelContext
     let sourceTag: String?
+    let languageProbabilities: [String: Double]?
 }
 
 /// View model managing audio recording, transcription, and enhancement workflow.
@@ -431,7 +432,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
                 try Task.checkCancellation()
 
                 let transcriptionStart = Date()
-                let transcribedText = try await transcriptionManager.transcribe(
+                let transcriptionResult = try await transcriptionManager.transcribe(
                     audioURL: audioURLToTranscribe,
                     progressHandler: { progress in
                         await MainActor.run {
@@ -439,6 +440,7 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
                         }
                     }
                 )
+                let transcribedText = transcriptionResult.text
                 let transcriptionDuration = Date().timeIntervalSince(transcriptionStart)
 
                 // Check for cancellation after transcription
@@ -484,7 +486,8 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
                         transcriptionProviderName: transcriptionManager.currentMode.transcriptionProvider.displayName,
                         transcriptionDuration: transcriptionDuration,
                         modelContext: modelContext,
-                        sourceTag: resolvedSourceTag
+                        sourceTag: resolvedSourceTag,
+                        languageProbabilities: transcriptionResult.languageProbabilities
                     )
 
                     // Update state to show enhancing animation
@@ -546,7 +549,8 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
                         audioDuration: audioDuration,
                         transcriptionDuration: transcriptionDuration,
                         modelContext: modelContext,
-                        sourceTag: resolvedSourceTag
+                        sourceTag: resolvedSourceTag,
+                        languageProbabilities: transcriptionResult.languageProbabilities
                     )
                     textToShare = enhancedText ?? transcribedText
 
@@ -713,7 +717,8 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
                     transcriptionDuration: pending.transcriptionDuration,
                     enhancementDuration: nil,
                     powerModeId: aiService.selectedMode.id.uuidString,
-                    sourceTag: pending.sourceTag
+                    sourceTag: pending.sourceTag,
+                    languageProbabilities: pending.languageProbabilities
                 )
 
                 pending.modelContext.insert(transcription)
@@ -842,7 +847,8 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
         audioDuration: Double,
         transcriptionDuration: TimeInterval?,
         modelContext: ModelContext,
-        sourceTag: String?
+        sourceTag: String?,
+        languageProbabilities: [String: Double]? = nil
     ) throws -> Transcription {
         let transcription = Transcription(
             text: transcribedText,
@@ -857,7 +863,8 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
             transcriptionDuration: transcriptionDuration,
             enhancementDuration: enhancementDur,
             powerModeId: aiService.selectedMode.id.uuidString,
-            sourceTag: sourceTag
+            sourceTag: sourceTag,
+            languageProbabilities: languageProbabilities
         )
 
         modelContext.insert(transcription)

--- a/VivaDicta/Views/TranscriptionDetailView.swift
+++ b/VivaDicta/Views/TranscriptionDetailView.swift
@@ -37,6 +37,7 @@ struct TranscriptionDetailView: View {
     @State private var showPresetPicker: Bool = false
     @State private var showExtractedRemindersSheet: Bool = false
     @State private var showMetaInfo: Bool = false
+    @State private var showLanguageScores: Bool = false
     @State private var showConfigureAI: Bool = false
     @State private var showConfigureChat: Bool = false
     @State private var generatingPresetId: String?
@@ -459,6 +460,10 @@ struct TranscriptionDetailView: View {
             )
             .presentationDetents([.medium])
         }
+        .sheet(isPresented: $showLanguageScores) {
+            LanguageScoresView(probabilities: transcription.languageProbabilities ?? [:])
+                .presentationDetents([.medium, .large])
+        }
         .sheet(isPresented: $showPresetPicker) {
             PresetPickerSheet(
                 presetManager: appState.presetManager,
@@ -546,6 +551,11 @@ struct TranscriptionDetailView: View {
             }
             ToolbarItem(placement: .primaryAction) {
                 HStack(spacing: 8) {
+                    if transcription.languageProbabilities?.isEmpty == false {
+                        Button("Language Scores", systemImage: "globe") {
+                            showLanguageScores = true
+                        }
+                    }
                     Button("Info", systemImage: "info.circle") {
                         showMetaInfo = true
                     }
@@ -1088,13 +1098,14 @@ struct TranscriptionDetailView: View {
 
             do {
                 let transcriptionStart = Date()
-                let newText = try await appState.transcriptionManager.transcribe(audioURL: audioURL)
+                let result = try await appState.transcriptionManager.transcribe(audioURL: audioURL)
                 let transcriptionDuration = Date().timeIntervalSince(transcriptionStart)
 
-                transcription.text = newText
+                transcription.text = result.text
                 transcription.transcriptionModelName = appState.transcriptionManager.getCurrentTranscriptionModel()?.displayName
                 transcription.transcriptionProviderName = appState.transcriptionManager.currentMode.transcriptionProvider.displayName
                 transcription.transcriptionDuration = transcriptionDuration
+                transcription.languageProbabilities = result.languageProbabilities
 
                 // Update Spotlight index (AppState method is @concurrent - runs off MainActor)
                 let entity = transcription.entity

--- a/VivaDictaTests/Acceptance/RecordEnhanceStoreAcceptanceTests.swift
+++ b/VivaDictaTests/Acceptance/RecordEnhanceStoreAcceptanceTests.swift
@@ -44,8 +44,8 @@ struct RecordEnhanceStoreAcceptanceTests {
         }
         func setCurrentMode(_ mode: VivaMode) { currentMode = mode }
         func getCurrentTranscriptionModel() -> (any TranscriptionModel)? { nil }
-        func transcribe(audioURL: URL, progressHandler: TranscriptionProgressHandler?) async throws -> String {
-            stubbedText
+        func transcribe(audioURL: URL, progressHandler: TranscriptionProgressHandler?) async throws -> TranscriptionServiceResult {
+            .plain(stubbedText)
         }
     }
 

--- a/VivaDictaTests/LanguageScoreTests.swift
+++ b/VivaDictaTests/LanguageScoreTests.swift
@@ -1,0 +1,31 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Testing
+@testable import VivaDicta
+
+struct LanguageScoreTests {
+
+    @Test func sortsByProbabilityDescending() {
+        let scores = LanguageScore.sorted(from: ["ru": 0.29, "en": 0.61, "uk": 0.04])
+        #expect(scores.map(\.code) == ["en", "ru", "uk"])
+    }
+
+    @Test func breaksTiesAlphabetically() {
+        let scores = LanguageScore.sorted(from: ["pl": 0.02, "de": 0.02, "uk": 0.02])
+        #expect(scores.map(\.code) == ["de", "pl", "uk"])
+    }
+
+    @Test func emptyInputProducesEmptyOutput() {
+        #expect(LanguageScore.sorted(from: [:]).isEmpty)
+    }
+
+    @Test func fallsBackToRawCodeForUnknownLanguage() {
+        let score = LanguageScore(code: "zz-unknown", probability: 0.5)
+        #expect(score.displayName.isEmpty == false)
+    }
+
+    @Test func formatsPercentWithOneFractionDigit() {
+        let score = LanguageScore(code: "en", probability: 0.6149)
+        #expect(score.formattedPercent.contains("61"))
+    }
+}

--- a/VivaDictaTests/Mocks/MockTranscriber.swift
+++ b/VivaDictaTests/Mocks/MockTranscriber.swift
@@ -11,6 +11,7 @@ import TranscriptionCore
 final class MockTranscriber: Transcriber {
     var currentMode: VivaMode
     var stubbedText: String
+    var stubbedLanguageProbabilities: [String: Double]?
     private(set) var setCurrentModeCalls: [VivaMode] = []
     private(set) var transcribeCallCount = 0
 
@@ -26,8 +27,11 @@ final class MockTranscriber: Transcriber {
 
     func getCurrentTranscriptionModel() -> (any TranscriptionModel)? { nil }
 
-    func transcribe(audioURL: URL, progressHandler: TranscriptionProgressHandler?) async throws -> String {
+    func transcribe(audioURL: URL, progressHandler: TranscriptionProgressHandler?) async throws -> TranscriptionServiceResult {
         transcribeCallCount += 1
-        return stubbedText
+        return TranscriptionServiceResult(
+            text: stubbedText,
+            languageProbabilities: stubbedLanguageProbabilities
+        )
     }
 }


### PR DESCRIPTION
## What

Surfaces WhisperKit's full language-identification distribution (the ~99-language softmax Whisper computes before decoding) for locally-transcribed notes, and shows it in a bottom sheet on the Transcription Detail screen.

- New **globe toolbar button** on Transcription Detail (visible only when scores exist) opens a sheet listing all languages sorted by score: localized name, code, percentage, progress bar (`.presentationDetents([.medium, .large])`).
- Scores are captured only for **local WhisperKit transcriptions with language = auto** - the language-ID pass is a cheap extra forward call to `WhisperKit.detectLanguage(audioPath:)` after the transcription succeeds. A detection failure is logged and never fails the transcription.

## Implementation notes

- `TranscriptionCore.TranscriptionServiceResult` gains optional `languageProbabilities: [String: Double]` (source-compatible: defaulted init param, `.plain`/`.speakerAttributed` unchanged).
- `Transcriber` protocol + `TranscriptionManager.transcribe` now return `TranscriptionServiceResult` instead of a bare `String`, so backend metadata survives the post-processing pipeline. Call sites updated: `RecordViewModel` (incl. pending-save path), `WatchAudioProcessor` (watch notes also get scores), `AppState` wrapper (still returns `String`), retranscribe flow in `TranscriptionDetailView` (refreshes scores).
- SwiftData: new optional `languageProbabilities` attribute on `Transcription` - lightweight migration, CloudKit-compatible (optional Codable attribute). Older notes simply show no button.
- **Parakeet and all 14 cloud providers intentionally excluded**: FluidAudio's `ASRResult` exposes only text + confidence (language-code exposure is still an open FR, FluidInference/FluidAudio#303), and no cloud API returns a full language distribution (AssemblyAI/ElevenLabs return a single winning-language confidence at most).
- New `LanguageScore` value type keeps sorting/formatting testable; unit tests added for it and for the `TranscriptionServiceResult` field. Mock transcribers updated.

## Verification needed

Authored on a Linux box without Xcode - **no local build/test run was possible**. Please verify in CI or locally:
- `xcodebuild` for the app + watch targets
- VivaDictaTests (`LanguageScoreTests`, `RecordViewModelTests`, acceptance) and TranscriptionCore package tests
- A quick manual run: local WhisperKit model, language = auto → record → globe button on the detail screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)