### PR TITLE
Preserve German "um" and add filler-word removal toggle

### DIFF
--- a/Modules/AppGroup/Sources/AppGroup/UserDefaultsStorage.swift
+++ b/Modules/AppGroup/Sources/AppGroup/UserDefaultsStorage.swift
@@ -95,6 +95,7 @@ public enum UserDefaultsStorage {
         public static let isChatEnabled = "isChatEnabled"
         public static let isLiveTranslationEnabled = "isLiveTranslationEnabled"
         public static let isStripTrailingPeriodEnabled = "isStripTrailingPeriodEnabled"
+        public static let isFillerRemovalEnabled = "isFillerRemovalEnabled"
 
         /// UUID string of the mode used for AI actions in note detail when the
         /// currently selected mode has no AI processing configured. Empty = none.

--- a/Modules/TextProcessing/Sources/TextProcessing/TranscriptionOutputFilter.swift
+++ b/Modules/TextProcessing/Sources/TextProcessing/TranscriptionOutputFilter.swift
@@ -17,10 +17,14 @@ public struct TranscriptionOutputFilter {
         #"\{.*?\}"#      // {}
     ]
 
-    /// Hesitation sounds that have no real-word collisions across the supported
-    /// languages. Always stripped regardless of language.
+    /// Hesitation sounds that have no real-word collisions in any language.
+    /// Always stripped regardless of language.
+    ///
+    /// "um" is NOT universal: it's a core German preposition ("um zu", "um 10 Uhr")
+    /// and the Portuguese indefinite article ("um homem"), so it lives in the
+    /// per-language lists below instead.
     private static let universalFillers = [
-        "uh", "um", "uhm", "umm", "uhh", "uhhh",
+        "uh", "uhm", "umm", "uhh", "uhhh",
         "hmm", "hm", "mmm", "mm", "mh"
     ]
 
@@ -28,11 +32,11 @@ public struct TranscriptionOutputFilter {
     /// and are therefore only stripped when the transcript's language is known
     /// (either explicitly via the mode or detected with high confidence).
     private static let fillersByLanguage: [String: [String]] = [
-        "en": ["ah", "eh", "ehh", "ha"],
-        "ru": ["ээ", "эээ", "ээээ", "э-э", "э-э-э", "эм", "эмм", "ыы", "ыыы"],
-        "es": ["ehm", "ehmm", "eee", "eeh"],
+        "en": ["um", "ah", "eh", "ehh", "ha"],
+        "ru": ["um", "ээ", "эээ", "ээээ", "э-э", "э-э-э", "эм", "эмм", "ыы", "ыыы"],
+        "es": ["um", "ehm", "ehmm", "eee", "eeh"],
         "de": ["äh", "ähm", "ähh", "ähhh", "ähmm", "öh", "öhm"],
-        "fr": ["euh", "euhh", "euhhh", "euhm", "heu", "heuu"]
+        "fr": ["um", "euh", "euhh", "euhhh", "euhm", "heu", "heuu"]
     ]
 
     /// Returns true if the text contains meaningful content for a transcription.
@@ -54,7 +58,9 @@ public struct TranscriptionOutputFilter {
     ///   - language: ISO 639-1 code from the active mode (e.g. "en", "ru") or "auto"/nil.
     ///     When unspecified or "auto", `NLLanguageRecognizer` is used; if detection
     ///     also fails, English is the final fallback.
-    public static func filter(_ text: String, language: String? = nil) -> String {
+    ///   - removeFillers: When false, hesitation sounds are kept verbatim. Hallucination
+    ///     markers (bracketed segments, tag blocks) are stripped either way.
+    public static func filter(_ text: String, language: String? = nil, removeFillers: Bool = true) -> String {
         var filteredText = text
 
         // Remove <TAG>...</TAG> blocks
@@ -72,20 +78,25 @@ public struct TranscriptionOutputFilter {
             }
         }
 
-        // Resolve language and pick filler set.
-        let resolvedLanguage = resolveLanguage(explicit: language, text: text) ?? "en"
-        var fillers = universalFillers
-        if let extras = fillersByLanguage[resolvedLanguage] {
-            fillers.append(contentsOf: extras)
-        }
-
-        // Remove filler words
-        for fillerWord in fillers {
-            let pattern = "\\b\(NSRegularExpression.escapedPattern(for: fillerWord))\\b[,.]?"
-            if let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) {
-                let range = NSRange(filteredText.startIndex..., in: filteredText)
-                filteredText = regex.stringByReplacingMatches(in: filteredText, options: [], range: range, withTemplate: "")
+        // Resolve language, pick filler set, and remove filler words.
+        let fillerLanguage: String
+        if removeFillers {
+            let resolvedLanguage = resolveLanguage(explicit: language, text: text) ?? "en"
+            fillerLanguage = resolvedLanguage
+            var fillers = universalFillers
+            if let extras = fillersByLanguage[resolvedLanguage] {
+                fillers.append(contentsOf: extras)
             }
+
+            for fillerWord in fillers {
+                let pattern = "\\b\(NSRegularExpression.escapedPattern(for: fillerWord))\\b[,.]?"
+                if let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) {
+                    let range = NSRange(filteredText.startIndex..., in: filteredText)
+                    filteredText = regex.stringByReplacingMatches(in: filteredText, options: [], range: range, withTemplate: "")
+                }
+            }
+        } else {
+            fillerLanguage = "off"
         }
 
         // Clean whitespace while preserving intentional line breaks.
@@ -97,9 +108,9 @@ public struct TranscriptionOutputFilter {
 
         // Log results
         if filteredText != text {
-            logger.notice("📝 Output filter (\(resolvedLanguage, privacy: .public)) result: \(filteredText, privacy: .public)")
+            logger.notice("📝 Output filter (\(fillerLanguage, privacy: .public)) result: \(filteredText, privacy: .public)")
         } else {
-            logger.notice("📝 Output filter (\(resolvedLanguage, privacy: .public)) result (unchanged): \(filteredText, privacy: .public)")
+            logger.notice("📝 Output filter (\(fillerLanguage, privacy: .public)) result (unchanged): \(filteredText, privacy: .public)")
         }
 
         return filteredText

--- a/VivaDicta/Services/Transcription/TranscriptionManager.swift
+++ b/VivaDicta/Services/Transcription/TranscriptionManager.swift
@@ -172,7 +172,8 @@ class TranscriptionManager: Transcriber {
             language: Self.outputLanguage(
                 transcriptionLanguage: currentMode.transcriptionLanguage,
                 translationTargetLanguage: currentMode.translationTargetLanguage
-            )
+            ),
+            removeFillers: UserDefaults.standard.object(forKey: UserDefaultsStorage.Keys.isFillerRemovalEnabled) as? Bool ?? true
         )
 
         if currentMode.isAutoTextFormattingEnabled && transcriptionResult.isSpeakerAttributed == false {

--- a/VivaDicta/Views/SettingsScreen/AdvancedSettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/AdvancedSettingsView.swift
@@ -37,6 +37,9 @@ struct AdvancedSettingsView: View {
     @AppStorage(UserDefaultsStorage.Keys.isStripTrailingPeriodEnabled)
     private var isStripTrailingPeriodEnabled: Bool = false
 
+    @AppStorage(UserDefaultsStorage.Keys.isFillerRemovalEnabled)
+    private var isFillerRemovalEnabled: Bool = true
+
     @AppStorage(UserDefaultsStorage.Keys.defaultAIModeId)
     private var defaultAIModeId: String = ""
 
@@ -139,6 +142,16 @@ struct AdvancedSettingsView: View {
             }
 
             Section {
+                VStack(alignment: .leading, spacing: 4) {
+                    Toggle("Remove Filler Words", isOn: $isFillerRemovalEnabled)
+                        .onChange(of: isFillerRemovalEnabled) { _, _ in
+                            HapticManager.selectionChanged()
+                        }
+                    Text("Strips hesitation sounds like \"uh\", \"um\", \"ähm\" from transcripts, matched to the transcript's language. Disable to keep them verbatim. Applies to all modes.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
                 VStack(alignment: .leading, spacing: 4) {
                     Toggle("Trim Trailing Period", isOn: $isStripTrailingPeriodEnabled)
                         .onChange(of: isStripTrailingPeriodEnabled) { _, _ in

--- a/VivaDictaTests/TextProcessingFilterTests.swift
+++ b/VivaDictaTests/TextProcessingFilterTests.swift
@@ -127,12 +127,57 @@ struct TranscriptionOutputFilterTests {
     // MARK: - filter Tests — Multilingual Fillers
 
     @Test func filter_universalFillers_strippedRegardlessOfLanguage() {
-        // "uh", "um", "hmm" should be removed for any language.
-        let inputRu = "Это um важное hmm сообщение для теста."
+        // "uh", "uhm", "hmm" should be removed for any language.
+        let inputRu = "Это uhm важное hmm сообщение для теста."
         let result = TranscriptionOutputFilter.filter(inputRu, language: "ru")
 
-        #expect(result.contains("um") == false)
+        #expect(result.contains("uhm") == false)
         #expect(result.contains("hmm") == false)
+    }
+
+    @Test(arguments: ["en", "ru", "es", "fr"])
+    func filter_um_strippedForLanguagesWhereItIsNotAWord(lang: String) {
+        let result = TranscriptionOutputFilter.filter("start um end", language: lang)
+
+        #expect(result.contains("um") == false, "[\(lang)] expected \"um\" to be removed; got: \(result)")
+    }
+
+    @Test func filter_germanUm_preserved() {
+        // German "um" is a core preposition ("um zu", "um 10 Uhr"), not a filler -
+        // it must survive while genuine German fillers are stripped.
+        let input = "Wir treffen uns um 10 Uhr, ähm, um das Projekt zu besprechen."
+        let result = TranscriptionOutputFilter.filter(input, language: "de")
+
+        #expect(result.contains("um 10 Uhr"), "expected German \"um\" to be kept; got: \(result)")
+        #expect(result.contains("um das Projekt zu besprechen"), "expected German \"um\" to be kept; got: \(result)")
+        #expect(result.contains("ähm") == false, "expected \"ähm\" to be removed; got: \(result)")
+    }
+
+    @Test func filter_portugueseUm_preserved() {
+        // Portuguese "um" is the indefinite article. Portuguese has no per-language
+        // filler list, so only universal fillers apply - "um" must survive.
+        let input = "Eu vi um homem na rua."
+        let result = TranscriptionOutputFilter.filter(input, language: "pt")
+
+        #expect(result.contains("um homem"), "expected Portuguese \"um\" to be kept; got: \(result)")
+    }
+
+    // MARK: - filter Tests — Filler Removal Toggle
+
+    @Test func filter_removeFillersDisabled_keepsFillerWords() {
+        let input = "So uh I think um we should hmm go"
+        let result = TranscriptionOutputFilter.filter(input, language: "en", removeFillers: false)
+
+        #expect(result == input)
+    }
+
+    @Test func filter_removeFillersDisabled_stillStripsHallucinations() {
+        // The toggle only gates filler words - hallucination markers go either way.
+        let input = "Hello [background noise] um world"
+        let result = TranscriptionOutputFilter.filter(input, language: "en", removeFillers: false)
+
+        #expect(result.contains("[background noise]") == false)
+        #expect(result.contains("um"), "expected \"um\" to be kept with fillers off; got: \(result)")
     }
 
     @Test(arguments: [


### PR DESCRIPTION
## Summary

Fixes a user-reported issue: transcribing German speech with local models (Whisper Large Turbo, Parakeet V3) always removed the word "um" - a core German preposition ("um zu", "um 10 Uhr", "es geht um..."). The removal was not done by the models but by our own `TranscriptionOutputFilter`, which listed "um" as a universal filler stripped for every language.

### Part 1: Language-aware "um" handling

- "um" moved out of `universalFillers` into the per-language filler lists for `en`, `ru`, `es`, `fr` - languages where it is only a hesitation sound.
- German transcripts keep "um" while still stripping genuine German fillers ("äh", "ähm", "öh"...).
- Portuguese is fixed as a side effect: "um" is the Portuguese indefinite article ("um homem") and was previously stripped there too.

### Part 2: "Remove Filler Words" toggle

- New toggle in Settings -> Advanced -> Text Processing (default on), giving users full control to keep hesitation sounds verbatim in any language.
- `TranscriptionOutputFilter.filter()` gains a `removeFillers: Bool = true` parameter. When off, the filler pass (including language detection) is skipped entirely.
- Hallucination stripping (bracketed segments, tag blocks) runs regardless of the toggle - that is garbage removal, not style preference.
- New `isFillerRemovalEnabled` UserDefaults key, wired through `TranscriptionManager.transcribe()` using the same pattern as the existing `isReplacementsEnabled` gate.

## Testing

- Full `TranscriptionOutputFilterTests` suite passes on iPhone 17 Pro Max simulator: 35 tests, 0 failures.
- 8 new tests:
  - German "um zu" / "um 10 Uhr" survives while "ähm" is stripped
  - Portuguese "um homem" survives
  - Parameterized check that "um" is still stripped for en/ru/es/fr
  - Toggle off keeps fillers verbatim; hallucination brackets stripped either way
- Updated the old universal-fillers test to use "uhm" (still universal) instead of "um".

## Notes

- Behavior change beyond German/Portuguese: "um" was previously stripped for *every* language; it is now stripped only for `en`, `ru`, `es`, `fr`. For a language with no filler list (e.g. Italian, Dutch), an English "um" that spills into the transcript now survives rather than being removed. This is the intended safer tradeoff - keep a possibly-real word rather than delete it - and the toggle covers anyone who wants the old aggressive behavior off entirely.
- Auto-detect edge case: when the mode language is "auto", a very short German clip can still be misdetected as English by `NLLanguageRecognizer`, in which case "um" would be stripped. Setting the mode language explicitly to German is the reliable path.
- Pre-existing, out of scope: `"mm"` remains in the universal list and would strip a standalone "mm" in measurements like "10 mm".
- The filter runs only in the main app (`TranscriptionManager`); app extensions are unaffected.
