### PR TITLE
Add Gemini 3.6 Flash and 3.5 Flash-Lite models

### DIFF
--- a/Modules/AICore/Sources/AICore/AIProvider.swift
+++ b/Modules/AICore/Sources/AICore/AIProvider.swift
@@ -384,7 +384,7 @@ public enum AIProvider: String, CaseIterable, Identifiable, Codable, Sendable {
         case .groq:
             return "openai/gpt-oss-120b"
         case .gemini:
-            return "gemini-3.5-flash"
+            return "gemini-3.6-flash"
         case .anthropic:
             return "claude-sonnet-5"
         case .openAI:
@@ -537,9 +537,11 @@ public enum AIProvider: String, CaseIterable, Identifiable, Codable, Sendable {
             ]
         case .gemini:
             return [
+                "gemini-3.6-flash",
                 "gemini-3.1-pro-preview",
                 "gemini-3.5-flash",
                 "gemini-3-flash-preview",
+                "gemini-3.5-flash-lite",
                 "gemini-3.1-flash-lite",
                 "gemini-2.5-pro",
                 "gemini-2.5-flash",

--- a/Modules/AICore/Sources/AICore/ReasoningConfig.swift
+++ b/Modules/AICore/Sources/AICore/ReasoningConfig.swift
@@ -18,8 +18,10 @@ public struct ReasoningConfig {
     static let geminiMinimalReasoningModels: Set<String> = [
         "gemini-2.5-pro",
         "gemini-3.1-pro-preview",
+        "gemini-3.6-flash",
         "gemini-3.5-flash",
         "gemini-3-flash-preview",
+        "gemini-3.5-flash-lite",
         "gemini-3.1-flash-lite",
         "gemini-3.1-flash-lite-preview"
     ]

--- a/Modules/AICore/Tests/AICoreTests/ReasoningConfigTests.swift
+++ b/Modules/AICore/Tests/AICoreTests/ReasoningConfigTests.swift
@@ -10,6 +10,8 @@ struct ReasoningConfigTests {
         // Gemini
         #expect(ReasoningConfig.getReasoningParameter(for: "gemini-2.5-flash") == "none")
         #expect(ReasoningConfig.getReasoningParameter(for: "gemini-2.5-pro") == "minimal")
+        #expect(ReasoningConfig.getReasoningParameter(for: "gemini-3.6-flash") == "minimal")
+        #expect(ReasoningConfig.getReasoningParameter(for: "gemini-3.5-flash-lite") == "minimal")
         // OpenAI GPT-5 series
         #expect(ReasoningConfig.getReasoningParameter(for: "gpt-5.5") == "none")
         #expect(ReasoningConfig.getReasoningParameter(for: "gpt-5-mini") == "minimal")

--- a/Modules/AIProviders/Sources/AIProviders/GeminiAPIClient.swift
+++ b/Modules/AIProviders/Sources/AIProviders/GeminiAPIClient.swift
@@ -14,15 +14,17 @@ public enum GeminiAPIClient {
 
     /// Default model for Gemini OAuth requests.
     /// Matches `AIProvider.gemini.defaultModel` so picker defaults agree across auth modes.
-    public static let defaultModel = "gemini-3.5-flash"
+    public static let defaultModel = "gemini-3.6-flash"
 
     /// Models available via Gemini OAuth (Cloud Code Assist endpoint).
     /// Kept in sync with `AIProvider.gemini.availableModels` since the Cloud Code Assist
     /// endpoint exposes the same generateContent surface as the standard API.
     public static let supportedModels: [String] = [
+        "gemini-3.6-flash",
         "gemini-3.1-pro-preview",
         "gemini-3.5-flash",
         "gemini-3-flash-preview",
+        "gemini-3.5-flash-lite",
         "gemini-3.1-flash-lite",
         "gemini-3.1-flash-lite-preview",
         "gemini-2.5-pro",

--- a/VivaDicta/Models/TranscriptionModelProvider.swift
+++ b/VivaDicta/Models/TranscriptionModelProvider.swift
@@ -132,7 +132,7 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
         switch self {
         case .groq: "whisper-large-v3-turbo"
         case .mistral: "voxtral-mini-latest"
-        case .gemini: "gemini-3.5-flash"
+        case .gemini: "gemini-3.6-flash"
         case .deepgram: "nova-3"
         case .elevenLabs: "scribe_v2"
         case .openAI: "gpt-4o-mini-transcribe"
@@ -435,13 +435,35 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
 
             // Gemini Models
             CloudModel(
+                name: "gemini-3.6-flash",
+                displayName: "Gemini 3.6 Flash",
+                description: "Google's latest fast multimodal model, successor to 3.5 Flash with better quality at lower cost.",
+                provider: .gemini,
+                speed: 0.93,
+                accuracy: 0.93,
+                cost: 0.3,  // $0.002/min - Free tier (15 RPM) + $300 Google Cloud credits for 90 days
+                supportManyLanguages: true,
+                supportedLanguages: allLanguages
+            ),
+            CloudModel(
                 name: "gemini-3.5-flash",
                 displayName: "Gemini 3.5 Flash",
-                description: "Google's latest stable fast multimodal model with strong transcription quality.",
+                description: "Google's previous-generation fast multimodal model, superseded by Gemini 3.6 Flash.",
                 provider: .gemini,
                 speed: 0.92,
                 accuracy: 0.92,
                 cost: 0.3,  // $0.002/min - Free tier (15 RPM) + $300 Google Cloud credits for 90 days
+                supportManyLanguages: true,
+                supportedLanguages: allLanguages
+            ),
+            CloudModel(
+                name: "gemini-3.5-flash-lite",
+                displayName: "Gemini 3.5 Flash Lite",
+                description: "Google's fastest 3.5-class model (350 tokens/sec) with significantly better quality than 3.1 Flash Lite.",
+                provider: .gemini,
+                speed: 0.97,
+                accuracy: 0.88,
+                cost: 0.2,  // Slightly above 3.1 Flash Lite tier - Free tier (15 RPM) + $300 Google Cloud credits for 90 days
                 supportManyLanguages: true,
                 supportedLanguages: allLanguages
             ),


### PR DESCRIPTION
## Summary

Adds the two Gemini models Google released on **2026-07-21** (user feature request via support email), and moves the Gemini default to 3.6 Flash since Google deprecated 3.5 Flash.

| Model | API ID | Notes |
|---|---|---|
| Gemini 3.6 Flash | `gemini-3.6-flash` | Successor to 3.5 Flash; \$1.50/\$7.50 per 1M in/out |
| Gemini 3.5 Flash-Lite | `gemini-3.5-flash-lite` | Fastest 3.5-class model (~460 tok/s independent benchmark); \$0.30/\$2.50 per 1M |

**Changes:**
- **AI Processing** — both models added to `AIProvider.gemini.availableModels` (API-key path) and `GeminiAPIClient.supportedModels` (OAuth path); default → `gemini-3.6-flash` on both paths
- **Transcription** — both added to the cloud model catalog in `TranscriptionModelProvider` (multimodal, audio input confirmed by Google's model cards); Gemini transcription default → `gemini-3.6-flash`
- **ReasoningConfig** — both mapped to the `"minimal"` thinking floor, consistent with other Gemini 3.x models (`"thinking": true` confirmed via live API)
- **`gemini-3.5-flash` kept** in every list so existing mode selections keep working; transcription picker description notes it's superseded by 3.6 Flash

## Testing

- Full test plan on iPhone 17 Pro Max Simulator (iOS 26.4): **891 passed, 0 failed** (4 expected failures, 1 skipped) across all 18 targets
- AICore module suite (23) and AIProviders module suite (107) pass, including 2 new `ReasoningConfig` expectations
- **Live API verification**: both IDs resolve on `generativelanguage.googleapis.com/v1beta/models` (`generateContent` + `batchGenerateContent` supported, 1M input / 64K output, thinking enabled) and both pass a `generateContent` smoke test

## Notes

- No breaking changes; nothing removed from model lists, so no `normalizedModelID` retirement-map entries needed
- Gemini 3.5 Flash Cyber (announced the same day) is intentionally excluded — limited pilot for governments/trusted partners, not in the public API