### PR TITLE
Add Grok subscription sign-in via OAuth device code

### DIFF
--- a/Modules/AIKit/Sources/AIKit/AIProviderRegistry.swift
+++ b/Modules/AIKit/Sources/AIKit/AIProviderRegistry.swift
@@ -57,6 +57,7 @@ public struct AIProviderRegistry {
         case .anthropic: AIProvider.normalizedModel(model, for: .anthropic)
         case .cloud(let provider): AIProvider.normalizedModel(model, for: provider)
         case .openAIOAuth: AIProvider.normalizedModel(model, for: .openAI)
+        case .grokOAuth: AIProvider.normalizedModel(model, for: .grok)
         default: model
         }
         switch route {
@@ -91,6 +92,20 @@ public struct AIProviderRegistry {
             let (token, _, projectId) = try await oauthManager.validAccessToken(for: GeminiOAuthProvider())
             return GeminiTextProvider(model: model, accessToken: token, projectId: projectId, networkService: networkService)
 
+        case .grokOAuth:
+            // The subscription token is a drop-in for the API key: same host,
+            // same OpenAI-compatible wire format, `Authorization: Bearer`.
+            let (token, _, _) = try await oauthManager.validAccessToken(for: GrokOAuthProvider())
+            guard let url = URL(string: AIProvider.grok.baseURL) else { throw EnhancementError.notConfigured }
+            return OpenAICompatibleTextProvider(
+                networkService: networkService, logger: logger,
+                url: url, modelName: model,
+                headers: ["Authorization": "Bearer \(token)"],
+                timeout: baseTimeout,
+                errorPrefix: "\(AIProvider.grok.displayName) error",
+                unauthorizedMessage: Self.grokSubscriptionRequiredMessage
+            )
+
         case .copilot:
             let token = try await copilotOAuthManager.validCopilotToken()
             return CopilotTextProvider(model: model, copilotToken: token)
@@ -103,6 +118,19 @@ public struct AIProviderRegistry {
             )
         }
     }
+
+    /// Shown when xAI accepts the subscription token but refuses inference.
+    ///
+    /// xAI runs its own allowlist on the OAuth API surface, so sign-in can
+    /// succeed while `api.x.ai` still answers 403 - reported by standard
+    /// SuperGrok and X Premium subscribers alike. A generic "unauthorized"
+    /// would read as our bug, so name the actual cause and the way out.
+    static let grokSubscriptionRequiredMessage = """
+        xAI rejected this request for your Grok subscription. xAI limits which \
+        plans can use Grok through a connected app, and a new subscription can \
+        take a while to activate. You can add an xAI API key instead, which \
+        always works.
+        """
 
     /// Reads the provider's API key from the Keychain, mirroring `AIProvider.apiKey`.
     private func requireAPIKey(for provider: AIProvider) throws -> String {

--- a/Modules/AIKit/Sources/AIKit/AIProviderRoute.swift
+++ b/Modules/AIKit/Sources/AIKit/AIProviderRoute.swift
@@ -28,6 +28,11 @@ public enum AIProviderRoute: Sendable {
     /// Gemini via OAuth (Google sign-in).
     case geminiOAuth
 
+    /// xAI Grok via OAuth (SuperGrok / X Premium subscription sign-in). Hits the
+    /// same OpenAI-compatible `api.x.ai` endpoint as `.cloud(.grok)`; only the
+    /// bearer differs - a subscription access token instead of an API key.
+    case grokOAuth
+
     /// GitHub Copilot via its device-code OAuth.
     case copilot
 

--- a/Modules/AIKit/Sources/AIKit/TextEnhancer.swift
+++ b/Modules/AIKit/Sources/AIKit/TextEnhancer.swift
@@ -115,6 +115,27 @@ public struct TextEnhancer {
             }
         }
 
+        // Grok OAuth: route xAI requests through the subscription token when
+        // signed in. No CLI server for xAI, so an API key is the only fallback.
+        if input.provider == .grok && input.isOAuthSignedIn {
+            do {
+                let provider = try await registry.makeTextProvider(for: .grokOAuth, model: input.model)
+                let result = try await provider.enhance(systemMessage: input.systemMessage, userMessage: input.userMessage)
+                return AIEnhancementOutputFilter.filter(result)
+            } catch let error as EnhancementError {
+                // Includes the 403 "subscription not entitled" message, which is
+                // actionable on its own - surface it rather than silently
+                // spending the user's API credits instead.
+                throw error
+            } catch let error as OAuthError {
+                if input.hasAPIKey {
+                    logger.logWarning("Grok OAuth failed, falling back to API key: \(error.localizedDescription)")
+                } else {
+                    throw EnhancementError.customError(error.errorDescription ?? "Grok OAuth error")
+                }
+            }
+        }
+
         // Codex CLI via Mac server: route OpenAI requests through the CLI server when enabled.
         if input.provider == .openAI && cliServerEnhancer.isCliActive(for: .codex),
            let serverURL = cliServerEnhancer.serverURL, !serverURL.isEmpty {

--- a/Modules/AIProviders/Sources/AIProviders/OpenAICompatibleService.swift
+++ b/Modules/AIProviders/Sources/AIProviders/OpenAICompatibleService.swift
@@ -117,6 +117,10 @@ public struct OpenAICompatibleService: Sendable {
     /// mapping; non-200 non-429 non-5xx maps to
     /// `.customError("HTTP <status>: <body>")`.
     ///
+    /// `unauthorizedMessage` overrides the default message on 401/403 when
+    /// provided, so callers can explain an auth or entitlement failure in terms
+    /// the user can act on.
+    ///
     /// Returns the filtered/trimmed `choices[0].message.content`. Throws
     /// `.enhancementFailed` on a malformed 200 body.
     public func enhance(
@@ -125,7 +129,8 @@ public struct OpenAICompatibleService: Sendable {
         systemMessage: String,
         userMessage: String,
         headers: [String: String],
-        timeout: TimeInterval
+        timeout: TimeInterval,
+        unauthorizedMessage: String? = nil
     ) async throws -> String {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
@@ -165,6 +170,10 @@ public struct OpenAICompatibleService: Sendable {
             } else if (500...599).contains(httpResponse.statusCode) {
                 logger.logError("OpenAI-compatible enhance - server error \(httpResponse.statusCode)")
                 throw EnhancementError.serverError
+            } else if let unauthorizedMessage, httpResponse.statusCode == 401 || httpResponse.statusCode == 403 {
+                let errorString = String(data: data, encoding: .utf8) ?? ""
+                logger.logError("OpenAI-compatible enhance - \(httpResponse.statusCode): \(errorString.prefix(500))")
+                throw EnhancementError.customError(unauthorizedMessage)
             } else {
                 let errorString = String(data: data, encoding: .utf8) ?? "Could not decode error response."
                 logger.logError("OpenAI-compatible enhance - HTTP \(httpResponse.statusCode): \(errorString.prefix(500))")
@@ -187,9 +196,10 @@ public struct OpenAICompatibleService: Sendable {
 
     /// Streaming chat-completions request via SSE. `errorPrefix` is
     /// prepended to the default error message; `notFoundMessage` /
-    /// `unauthorizedMessage` override the 404 / 401 default messages
+    /// `unauthorizedMessage` override the 404 / 401-and-403 default messages
     /// when provided (used by Ollama and Custom OpenAI to surface
-    /// model-name and auth hints).
+    /// model-name and auth hints, and by Grok OAuth to explain a missing
+    /// subscription entitlement).
     ///
     /// Calls `onPartialResponse` on the main actor as each SSE delta
     /// arrives. Returns the filtered/trimmed final text. Throws
@@ -233,10 +243,14 @@ public struct OpenAICompatibleService: Sendable {
             }
             let errorString = String(data: errorData, encoding: .utf8) ?? "Unknown error"
 
+            // 403 matters as much as 401 here: subscription-backed providers
+            // reject an authenticated-but-unentitled account with 403.
+            if let unauthorizedMessage, httpResponse.statusCode == 401 || httpResponse.statusCode == 403 {
+                logger.logError("OpenAI-compatible streaming - \(httpResponse.statusCode): \(errorString.prefix(500))")
+                throw EnhancementError.customError(unauthorizedMessage)
+            }
+
             switch httpResponse.statusCode {
-            case 401 where unauthorizedMessage != nil:
-                logger.logError("OpenAI-compatible streaming - 401: \(errorString.prefix(500))")
-                throw EnhancementError.customError(unauthorizedMessage ?? errorString)
             case 404 where notFoundMessage != nil:
                 logger.logError("OpenAI-compatible streaming - 404: \(errorString.prefix(500))")
                 throw EnhancementError.customError(notFoundMessage ?? errorString)

--- a/Modules/AIProviders/Sources/AIProviders/TextProviders.swift
+++ b/Modules/AIProviders/Sources/AIProviders/TextProviders.swift
@@ -66,7 +66,15 @@ public struct OpenAICompatibleTextProvider: AITextProvider {
     }
 
     public func enhance(systemMessage: String, userMessage: String) async throws -> String {
-        try await service.enhance(url: url, modelName: modelName, systemMessage: systemMessage, userMessage: userMessage, headers: headers, timeout: timeout)
+        try await service.enhance(
+            url: url,
+            modelName: modelName,
+            systemMessage: systemMessage,
+            userMessage: userMessage,
+            headers: headers,
+            timeout: timeout,
+            unauthorizedMessage: unauthorizedMessage
+        )
     }
 
     public func enhanceStreaming(systemMessage: String, userMessage: String, onPartialResponse: @escaping @MainActor (String) -> Void) async throws -> String {

--- a/Modules/AIProviders/Tests/AIProvidersTests/OpenAICompatibleServiceTests.swift
+++ b/Modules/AIProviders/Tests/AIProvidersTests/OpenAICompatibleServiceTests.swift
@@ -287,6 +287,55 @@ struct OpenAICompatibleServiceTests {
         #expect(message.hasPrefix("HTTP 401"))
     }
 
+    /// Subscription-backed providers answer 403 when the account authenticates
+    /// but is not entitled, so `unauthorizedMessage` has to cover 403 as well as
+    /// 401 - otherwise the caller's actionable text is swallowed by the generic
+    /// "HTTP 403: <body>" branch.
+    @Test(arguments: [401, 403])
+    func enhanceSurfacesUnauthorizedMessageForAuthFailures(_ status: Int) async throws {
+        let body = Data(#"{"error":"no active subscription"}"#.utf8)
+        networkService.stubSendResponse = .success((body, makeHTTPResponse(status)))
+
+        let error = try await #require(throws: EnhancementError.self) {
+            _ = try await sut.enhance(
+                url: URL(string: endpointURL)!,
+                modelName: "m",
+                systemMessage: "s",
+                userMessage: "u",
+                headers: [:],
+                timeout: 30,
+                unauthorizedMessage: "Add an API key instead."
+            )
+        }
+        guard case let .customError(message) = error else {
+            Issue.record("Expected .customError, got \(error)")
+            return
+        }
+        #expect(message == "Add an API key instead.")
+    }
+
+    /// Without an override the existing generic mapping must stay intact.
+    @Test func enhanceKeepsGenericMappingFor403WithoutOverride() async throws {
+        let body = Data(#"{"error":"forbidden"}"#.utf8)
+        networkService.stubSendResponse = .success((body, makeHTTPResponse(403)))
+
+        let error = try await #require(throws: EnhancementError.self) {
+            _ = try await sut.enhance(
+                url: URL(string: endpointURL)!,
+                modelName: "m",
+                systemMessage: "s",
+                userMessage: "u",
+                headers: [:],
+                timeout: 30
+            )
+        }
+        guard case let .customError(message) = error else {
+            Issue.record("Expected .customError, got \(error)")
+            return
+        }
+        #expect(message.hasPrefix("HTTP 403"))
+    }
+
     // MARK: - verifyChatCompletionsAPIKey
 
     @Test func verifyChatCompletionsAPIKeyReturnsTrueOn200() async {

--- a/Modules/OAuth/Sources/OAuth/DefaultCopilotOAuthManager.swift
+++ b/Modules/OAuth/Sources/OAuth/DefaultCopilotOAuthManager.swift
@@ -291,19 +291,28 @@ public struct DeviceCodeResponse: Sendable {
     public let deviceCode: String
     public let userCode: String
     public let verificationUri: String
+    /// Verification URI with the user code pre-filled (RFC 8628 optional field).
+    /// Preferred over ``verificationUri`` when the issuer supplies it, since it
+    /// saves the user from typing the code.
+    public let verificationUriComplete: String?
     public let interval: Int
     public let expiresIn: Int
+
+    /// The URI to open in the browser - pre-filled when available.
+    public var browserURI: String { verificationUriComplete ?? verificationUri }
 
     public init(
         deviceCode: String,
         userCode: String,
         verificationUri: String,
+        verificationUriComplete: String? = nil,
         interval: Int,
         expiresIn: Int
     ) {
         self.deviceCode = deviceCode
         self.userCode = userCode
         self.verificationUri = verificationUri
+        self.verificationUriComplete = verificationUriComplete
         self.interval = interval
         self.expiresIn = expiresIn
     }

--- a/Modules/OAuth/Sources/OAuth/DefaultOAuthManager.swift
+++ b/Modules/OAuth/Sources/OAuth/DefaultOAuthManager.swift
@@ -14,16 +14,19 @@ public final class DefaultOAuthManager: OAuthManager {
     private let logger = Logger(oauthCategory: "OAuthManager")
     private let keychain: any KeychainService
     private let networkService: any NetworkService
+    private let backgroundTaskService: (any BackgroundTaskService)?
 
     /// In-memory cache of credentials.
     private var credentials: [String: OAuthCredential] = [:]
 
     public init(
         keychain: any KeychainService,
-        networkService: any NetworkService = DefaultNetworkService(category: "OAuthManager")
+        networkService: any NetworkService = DefaultNetworkService(category: "OAuthManager"),
+        backgroundTaskService: (any BackgroundTaskService)? = nil
     ) {
         self.keychain = keychain
         self.networkService = networkService
+        self.backgroundTaskService = backgroundTaskService
     }
 
     // MARK: - Public API
@@ -152,6 +155,209 @@ public final class DefaultOAuthManager: OAuthManager {
         return (credential.accessToken, credential.accountId, credential.projectId)
     }
 
+    // MARK: - Device Code Flow (RFC 8628)
+
+    /// Requests a device code. Every field is validated before use: a malformed
+    /// or hostile payload must not reach the UI, and the verification URI is
+    /// opened in a browser so it is constrained to `https`.
+    public func startDeviceCodeFlow(provider: some OAuthProvider) async throws -> DeviceCodeResponse {
+        guard let endpoint = provider.deviceCodeURL, let url = URL(string: endpoint) else {
+            throw OAuthError.deviceCodeUnsupported(provider.providerName)
+        }
+
+        var fields = [
+            "client_id": provider.clientId,
+            "scope": provider.scopes
+        ]
+        for (key, value) in provider.deviceAuthExtraParams {
+            fields[key] = value
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Accept")
+        request.addValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.httpBody = Self.formEncoded(fields).data(using: .utf8)
+
+        let (data, httpResponse) = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny)
+
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw OAuthError.deviceCodeFailed("HTTP \(httpResponse.statusCode): invalid response")
+        }
+        guard httpResponse.statusCode == 200 else {
+            throw OAuthError.deviceCodeFailed(Self.errorDetail(json) ?? "HTTP \(httpResponse.statusCode)")
+        }
+
+        guard let deviceCode = Self.nonEmptyString(json["device_code"]),
+              let userCode = Self.nonEmptyString(json["user_code"]),
+              let rawVerificationURI = Self.nonEmptyString(json["verification_uri"]),
+              let verificationURI = Self.validatedHTTPSURI(rawVerificationURI) else {
+            throw OAuthError.deviceCodeFailed("Incomplete device authorization response")
+        }
+
+        // RFC 8628 makes `interval` optional and permits 0; fall back to the
+        // conventional 5s rather than hammering the endpoint.
+        let interval: Int = {
+            guard let raw = json["interval"] as? Int, raw > 0 else { return 5 }
+            return raw
+        }()
+
+        let expiresIn: Int = {
+            guard let raw = json["expires_in"] as? Int, raw > 0 else { return 900 }
+            return raw
+        }()
+
+        logger.logInfo("Device code issued for \(provider.providerName), expires in \(expiresIn)s")
+
+        return DeviceCodeResponse(
+            deviceCode: deviceCode,
+            userCode: userCode,
+            verificationUri: verificationURI,
+            verificationUriComplete: Self.nonEmptyString(json["verification_uri_complete"]).flatMap(Self.validatedHTTPSURI),
+            interval: interval,
+            expiresIn: expiresIn
+        )
+    }
+
+    public func pollForDeviceCodeToken(
+        provider: some OAuthProvider,
+        deviceCode: DeviceCodeResponse
+    ) async throws -> OAuthCredential {
+        var interval = max(deviceCode.interval, 1)
+        let deadline = Date().addingTimeInterval(TimeInterval(deviceCode.expiresIn))
+
+        // The user leaves for Safari to authorize, so the app backgrounds while
+        // we poll. Hold a background assertion the way the Copilot flow does.
+        let backgroundTaskId = backgroundTaskService?.beginBackgroundTask(name: "OAuthDeviceCodePoll", onExpiration: {})
+        defer {
+            if let backgroundTaskId {
+                backgroundTaskService?.endBackgroundTask(backgroundTaskId)
+            }
+        }
+
+        while Date() < deadline {
+            try await Task.sleep(for: .seconds(interval))
+
+            switch try await pollDeviceCodeOnce(provider: provider, deviceCode: deviceCode.deviceCode) {
+            case .authorized(let credential):
+                saveCredential(credential, for: provider)
+                logger.logInfo("Device-code sign-in complete for \(provider.providerName)")
+                return credential
+            case .pending:
+                continue
+            case .slowDown(let serverInterval):
+                interval = max(serverInterval ?? interval + 5, interval + 1)
+                logger.logInfo("Device-code poll throttled, backing off to \(interval)s")
+            case .denied(let reason):
+                throw OAuthError.authorizationDenied(reason)
+            case .expired:
+                throw OAuthError.deviceCodeExpired
+            }
+        }
+
+        throw OAuthError.deviceCodeExpired
+    }
+
+    private enum DeviceCodePollOutcome {
+        case authorized(OAuthCredential)
+        case pending
+        case slowDown(Int?)
+        case denied(String)
+        case expired
+    }
+
+    private func pollDeviceCodeOnce(
+        provider: some OAuthProvider,
+        deviceCode: String
+    ) async throws -> DeviceCodePollOutcome {
+        guard let url = URL(string: provider.tokenURL) else {
+            throw OAuthError.tokenExchangeFailed("Invalid token URL")
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Accept")
+        request.addValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.httpBody = Self.formEncoded([
+            "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+            "client_id": provider.clientId,
+            "device_code": deviceCode
+        ]).data(using: .utf8)
+
+        let data: Data
+        do {
+            data = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny).0
+        } catch NetworkError.transport(let underlying) where (underlying as? URLError)?.code != .cancelled {
+            // Transient failure (commonly -1005 right after backgrounding);
+            // treat as pending and retry on the next tick.
+            logger.logInfo("Device-code poll network error, retrying: \(underlying.localizedDescription)")
+            return .pending
+        }
+
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return .pending
+        }
+
+        if let error = json["error"] as? String {
+            switch error {
+            case "authorization_pending":
+                return .pending
+            case "slow_down":
+                return .slowDown(json["interval"] as? Int)
+            case "access_denied", "authorization_denied":
+                return .denied(Self.errorDetail(json) ?? "Authorization was denied")
+            case "expired_token":
+                return .expired
+            default:
+                throw OAuthError.tokenExchangeFailed(Self.errorDetail(json) ?? error)
+            }
+        }
+
+        let credential = try await buildCredential(json: json, provider: provider, existingRefreshToken: nil)
+        return .authorized(credential)
+    }
+
+    // MARK: - Request Helpers
+
+    /// Percent-encodes values against RFC 3986's *unreserved* set, so reserved
+    /// characters that carry meaning in a form body (`&`, `=`, `+`, spaces) are
+    /// escaped. `.urlQueryAllowed` would let those through intact.
+    private static let unreservedCharacters: CharacterSet = {
+        var set = CharacterSet.alphanumerics
+        set.insert(charactersIn: "-._~")
+        return set
+    }()
+
+    private static func formEncoded(_ fields: [String: String]) -> String {
+        fields.map { key, value in
+            let encoded = value.addingPercentEncoding(withAllowedCharacters: unreservedCharacters) ?? value
+            return "\(key)=\(encoded)"
+        }
+        .joined(separator: "&")
+    }
+
+    private static func nonEmptyString(_ value: Any?) -> String? {
+        guard let string = value as? String, !string.isEmpty else { return nil }
+        return string
+    }
+
+    /// Rejects anything that isn't an `https` URL. The result is handed to the
+    /// system opener, so a non-https scheme here would let a compromised or
+    /// spoofed response launch an arbitrary handler.
+    private static func validatedHTTPSURI(_ raw: String) -> String? {
+        guard let url = URL(string: raw), url.scheme?.lowercased() == "https", url.host != nil else {
+            return nil
+        }
+        return url.absoluteString
+    }
+
+    private static func errorDetail(_ json: [String: Any]) -> String? {
+        let error = json["error"] as? String
+        let description = json["error_description"] as? String
+        let detail = [error, description].compactMap { $0 }.joined(separator: ": ")
+        return detail.isEmpty ? nil : detail
+    }
+
     // MARK: - Token Exchange
 
     private func exchangeCodeForTokens(code: String, codeVerifier: String, state: String, provider: some OAuthProvider) async throws -> OAuthCredential {
@@ -253,10 +459,21 @@ public final class DefaultOAuthManager: OAuthManager {
             throw OAuthError.tokenExchangeFailed("Invalid JSON response")
         }
 
-        guard let accessToken = json["access_token"] as? String else {
+        return try await buildCredential(json: json, provider: provider, existingRefreshToken: existingRefreshToken)
+    }
+
+    /// Turns a successful token-endpoint payload into a stored-shape credential.
+    /// Shared by the redirect flow, the device-code flow, and refresh.
+    private func buildCredential(
+        json: [String: Any],
+        provider: some OAuthProvider,
+        existingRefreshToken: String?
+    ) async throws -> OAuthCredential {
+        guard let accessToken = json["access_token"] as? String, !accessToken.isEmpty else {
             throw OAuthError.tokenExchangeFailed("Missing access token in response")
         }
-        // Google's refresh endpoint omits refresh_token - fall back to existing one
+        // Google's refresh endpoint omits refresh_token, and xAI omits it when the
+        // token is not rotated - fall back to the existing one in both cases.
         let refreshToken = json["refresh_token"] as? String ?? existingRefreshToken ?? ""
 
         let expiresIn = json["expires_in"] as? TimeInterval ?? 3600

--- a/Modules/OAuth/Sources/OAuth/DefaultOAuthManager.swift
+++ b/Modules/OAuth/Sources/OAuth/DefaultOAuthManager.swift
@@ -287,7 +287,11 @@ public final class DefaultOAuthManager: OAuthManager {
         let data: Data
         do {
             data = try await networkService.send(request, acceptableStatusCodes: Set<Int>.acceptAny).0
-        } catch NetworkError.transport(let underlying) where (underlying as? URLError)?.code != .cancelled {
+        } catch NetworkError.transport(let underlying) where (underlying as? URLError)?.code == .cancelled {
+            // The user cancelled mid-request. Report it as cancellation so the
+            // caller can stay silent instead of raising a network error.
+            throw CancellationError()
+        } catch NetworkError.transport(let underlying) {
             // Transient failure (commonly -1005 right after backgrounding);
             // treat as pending and retry on the next tick.
             logger.logInfo("Device-code poll network error, retrying: \(underlying.localizedDescription)")

--- a/Modules/OAuth/Sources/OAuth/GrokOAuthProvider.swift
+++ b/Modules/OAuth/Sources/OAuth/GrokOAuthProvider.swift
@@ -1,0 +1,63 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+
+/// xAI (Grok) OAuth provider configuration.
+///
+/// Signs the user in with their **SuperGrok or X Premium subscription** instead
+/// of a metered `console.x.ai` API key. The resulting access token is a plain
+/// bearer for `https://api.x.ai/v1`, so the normal OpenAI-compatible transport
+/// is reused unchanged - the token simply takes the API key's place.
+///
+/// Uses xAI's public Grok CLI OAuth client (no client secret). The endpoints
+/// below are published at `https://auth.x.ai/.well-known/openid-configuration`.
+///
+/// Sign-in runs the **device-code** grant rather than the browser redirect:
+/// xAI validates `redirect_uri` against the values registered for this client,
+/// so the redirect flow would need a loopback listener on one specific port.
+/// Device code needs no callback at all. `authorizeURL` / `redirectURI` are
+/// still populated with the registered pair so the redirect flow stays
+/// available, but nothing in the app drives it today.
+public struct GrokOAuthProvider: OAuthProvider {
+    public let providerName = "Grok"
+    public let clientId = "b1a00492-073a-47ea-816f-4c329264a828"
+    public let authorizeURL = "https://auth.x.ai/oauth2/authorize"
+    public let tokenURL = "https://auth.x.ai/oauth2/token"
+    public let deviceCodeURL: String? = "https://auth.x.ai/oauth2/device/code"
+    public let redirectURI = "http://127.0.0.1:56121/callback"
+
+    /// `api:access` is what grants the subscription token access to
+    /// `api.x.ai`. Without it the token is scoped to Grok Build only, which
+    /// speaks a different host and wire format.
+    public let scopes = "openid profile email offline_access grok-cli:access api:access"
+
+    public let keychainKey = "grokOAuthCredential"
+
+    /// Unused - the redirect flow is not driven by the app. See the type note.
+    public let extraAuthParams: [String: String] = [:]
+
+    public let deviceAuthExtraParams: [String: String] = ["referrer": "vivadicta"]
+
+    public init() {}
+
+    public func extractAccountInfo(from claims: [String: Any]) -> (id: String?, email: String?) {
+        // Team principals carry the useful id in `principal_id`; personal
+        // accounts use the standard `sub`.
+        let id: String? = {
+            if claims["principal_type"] as? String == "Team",
+               let principalId = claims["principal_id"] as? String {
+                return principalId
+            }
+            return claims["sub"] as? String
+        }()
+
+        let email: String? = {
+            if let email = claims["email"] as? String, email.contains("@") {
+                return email
+            }
+            return claims["preferred_username"] as? String
+        }()
+
+        return (id, email)
+    }
+}

--- a/Modules/OAuth/Sources/OAuth/OAuthError.swift
+++ b/Modules/OAuth/Sources/OAuth/OAuthError.swift
@@ -11,6 +11,12 @@ public enum OAuthError: LocalizedError {
     case tokenRefreshFailed(String)
     case noCredential
     case invalidResponse
+    /// The provider does not advertise a device authorization endpoint.
+    case deviceCodeUnsupported(String)
+    /// The device-authorization request failed or returned an unusable payload.
+    case deviceCodeFailed(String)
+    /// The user did not authorize the device code before it expired.
+    case deviceCodeExpired
 
     public var errorDescription: String? {
         switch self {
@@ -28,6 +34,12 @@ public enum OAuthError: LocalizedError {
             return "Not signed in."
         case .invalidResponse:
             return "Invalid response from server."
+        case .deviceCodeUnsupported(let providerName):
+            return "\(providerName) does not support device-code sign-in."
+        case .deviceCodeFailed(let reason):
+            return "Failed to start sign-in: \(reason)"
+        case .deviceCodeExpired:
+            return "The sign-in code expired before it was authorized. Please try again."
         }
     }
 }

--- a/Modules/OAuth/Sources/OAuth/OAuthManagerProtocol.swift
+++ b/Modules/OAuth/Sources/OAuth/OAuthManagerProtocol.swift
@@ -26,4 +26,17 @@ public protocol OAuthManager {
 
     /// Returns a valid access token, refreshing if needed.
     func validAccessToken(for provider: some OAuthProvider) async throws -> (token: String, accountId: String?, projectId: String?)
+
+    /// Requests a device code (RFC 8628) for providers that advertise a
+    /// ``OAuthProvider/deviceCodeURL``. The caller shows the returned
+    /// `userCode`, opens `browserURI`, then awaits
+    /// ``pollForDeviceCodeToken(provider:deviceCode:)``.
+    ///
+    /// Throws ``OAuthError/deviceCodeUnsupported(_:)`` for redirect-only providers.
+    func startDeviceCodeFlow(provider: some OAuthProvider) async throws -> DeviceCodeResponse
+
+    /// Polls the token endpoint until the user authorizes `deviceCode`, then
+    /// stores and returns the credential. Cancelling the surrounding task
+    /// abandons the poll.
+    func pollForDeviceCodeToken(provider: some OAuthProvider, deviceCode: DeviceCodeResponse) async throws -> OAuthCredential
 }

--- a/Modules/OAuth/Sources/OAuth/OAuthProvider.swift
+++ b/Modules/OAuth/Sources/OAuth/OAuthProvider.swift
@@ -40,6 +40,15 @@ public protocol OAuthProvider: Sendable {
     /// Optional userinfo endpoint for providers whose access tokens aren't JWTs (e.g. Google).
     var userinfoURL: String? { get }
 
+    /// Device authorization endpoint (RFC 8628). Non-nil enables device-code
+    /// sign-in via ``OAuthManager/startDeviceCodeFlow(provider:)``; providers
+    /// that only support the browser redirect flow leave this `nil`.
+    var deviceCodeURL: String? { get }
+
+    /// Extra form fields sent with the device-authorization request (e.g. a
+    /// client `referrer` tag some issuers expect).
+    var deviceAuthExtraParams: [String: String] { get }
+
     /// Optional post-auth setup (e.g., project discovery). Called after token exchange.
     /// Returns a project ID if applicable.
     func postAuthSetup(accessToken: String) async throws -> String?
@@ -54,6 +63,12 @@ extension OAuthProvider {
 
     /// Default: no userinfo endpoint (use JWT claims).
     public var userinfoURL: String? { nil }
+
+    /// Default: browser redirect flow only, no device-code support.
+    public var deviceCodeURL: String? { nil }
+
+    /// Default: no extra device-authorization fields.
+    public var deviceAuthExtraParams: [String: String] { [:] }
 
     /// Default: no post-auth setup needed.
     public func postAuthSetup(accessToken: String) async throws -> String? { nil }

--- a/Modules/OAuth/Sources/OAuthMocks/MockOAuthManager.swift
+++ b/Modules/OAuth/Sources/OAuthMocks/MockOAuthManager.swift
@@ -54,6 +54,16 @@ public final class MockOAuthManager: OAuthManager {
     public private(set) var validAccessTokenCallCount = 0
     public private(set) var capturedValidAccessTokenProviderKey: String?
 
+    // MARK: device code
+
+    public var stubStartDeviceCodeFlowResponse: Result<DeviceCodeResponse, Error>?
+    public private(set) var startDeviceCodeFlowCallCount = 0
+    public private(set) var capturedStartDeviceCodeFlowProviderKey: String?
+
+    public var stubPollForDeviceCodeTokenResponse: Result<OAuthCredential, Error>?
+    public private(set) var pollForDeviceCodeTokenCallCount = 0
+    public private(set) var capturedPolledDeviceCode: String?
+
     // MARK: - OAuthManager conformance
 
     public func isSignedIn(provider: some OAuthProvider) -> Bool {
@@ -93,5 +103,23 @@ public final class MockOAuthManager: OAuthManager {
         validAccessTokenCallCount += 1
         capturedValidAccessTokenProviderKey = provider.keychainKey
         return try stubValidAccessTokenResponse.evaluate()
+    }
+
+    public func startDeviceCodeFlow(provider: some OAuthProvider) async throws -> DeviceCodeResponse {
+        startDeviceCodeFlowCallCount += 1
+        capturedStartDeviceCodeFlowProviderKey = provider.keychainKey
+        return try stubStartDeviceCodeFlowResponse.evaluate()
+    }
+
+    public func pollForDeviceCodeToken(provider: some OAuthProvider, deviceCode: DeviceCodeResponse) async throws -> OAuthCredential {
+        pollForDeviceCodeTokenCallCount += 1
+        capturedPolledDeviceCode = deviceCode.deviceCode
+        let credential = try stubPollForDeviceCodeTokenResponse.evaluate() as OAuthCredential
+        // Mirror DefaultOAuthManager: a completed poll stores the credential.
+        signedInProviders.insert(provider.keychainKey)
+        if let email = credential.accountEmail {
+            accountEmails[provider.keychainKey] = email
+        }
+        return credential
     }
 }

--- a/Modules/OAuth/Sources/OAuthMocks/MockOAuthProvider.swift
+++ b/Modules/OAuth/Sources/OAuthMocks/MockOAuthProvider.swift
@@ -20,6 +20,8 @@ public final class MockOAuthProvider: OAuthProvider, @unchecked Sendable {
     public var tokenRequestUsesJSON: Bool
     public var clientSecret: String?
     public var userinfoURL: String?
+    public var deviceCodeURL: String?
+    public var deviceAuthExtraParams: [String: String]
 
     public var stubExtractedAccountInfo: (id: String?, email: String?) = (nil, nil)
     public var stubPostAuthSetupResponse: Result<String?, Error>?
@@ -40,7 +42,9 @@ public final class MockOAuthProvider: OAuthProvider, @unchecked Sendable {
         keychainKey: String = "mockOAuthCredential",
         tokenRequestUsesJSON: Bool = false,
         clientSecret: String? = nil,
-        userinfoURL: String? = nil
+        userinfoURL: String? = nil,
+        deviceCodeURL: String? = nil,
+        deviceAuthExtraParams: [String: String] = [:]
     ) {
         self.providerName = providerName
         self.clientId = clientId
@@ -53,6 +57,8 @@ public final class MockOAuthProvider: OAuthProvider, @unchecked Sendable {
         self.tokenRequestUsesJSON = tokenRequestUsesJSON
         self.clientSecret = clientSecret
         self.userinfoURL = userinfoURL
+        self.deviceCodeURL = deviceCodeURL
+        self.deviceAuthExtraParams = deviceAuthExtraParams
     }
 
     public func extractAccountInfo(from claims: [String: Any]) -> (id: String?, email: String?) {

--- a/Modules/OAuth/Tests/OAuthTests/DeviceCodeFlowTests.swift
+++ b/Modules/OAuth/Tests/OAuthTests/DeviceCodeFlowTests.swift
@@ -5,6 +5,7 @@ import Foundation
 @testable import OAuth
 import OAuthMocks
 import KeychainMocks
+import Networking
 import NetworkingMocks
 import TestUtilities
 
@@ -238,6 +239,31 @@ struct DeviceCodeFlowTests {
                 deviceCode: makeDeviceCode(expiresIn: 0)
             )
         }
+    }
+
+    /// A dropped connection (commonly -1005 right after the app backgrounds for
+    /// the browser) is transient - keep polling rather than failing the sign-in.
+    @Test func transientTransportErrorIsRetriedAsPending() async throws {
+        network.stubSendResponses = [
+            .failure(NetworkError.transport(URLError(.networkConnectionLost))),
+            .success((tokenBody(), httpResponse(200)))
+        ]
+
+        let credential = try await sut.pollForDeviceCodeToken(provider: provider, deviceCode: makeDeviceCode())
+
+        #expect(credential.accessToken == "granted-token")
+        #expect(network.sendCallCount == 2)
+    }
+
+    /// Cancelling the in-flight poll must read as cancellation, not as a network
+    /// failure - the caller stays silent instead of alerting the user.
+    @Test func cancelledRequestSurfacesAsCancellationError() async {
+        network.stubSendResponses = [.failure(NetworkError.transport(URLError(.cancelled)))]
+
+        await #expect(throws: CancellationError.self) {
+            _ = try await sut.pollForDeviceCodeToken(provider: provider, deviceCode: makeDeviceCode())
+        }
+        #expect(sut.isSignedIn(provider: provider) == false)
     }
 
     @Test func assumesOneHourLifetimeWhenTokenResponseOmitsExpiry() async throws {

--- a/Modules/OAuth/Tests/OAuthTests/DeviceCodeFlowTests.swift
+++ b/Modules/OAuth/Tests/OAuthTests/DeviceCodeFlowTests.swift
@@ -1,0 +1,287 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Testing
+import Foundation
+@testable import OAuth
+import OAuthMocks
+import KeychainMocks
+import NetworkingMocks
+import TestUtilities
+
+/// Covers `DefaultOAuthManager`'s RFC 8628 device-code flow - the sign-in path
+/// used by xAI Grok, and the only sign-in path that is testable without a
+/// browser session.
+///
+/// Poll tests use `interval: 1` because the manager waits one interval before
+/// its first poll (a 0/absent interval is floored to 1s), so each poll round
+/// costs a real second of wall clock.
+@MainActor
+struct DeviceCodeFlowTests {
+
+    private let keychain: MockKeychainService
+    private let network: MockNetworkService
+    private let provider: MockOAuthProvider
+    private let sut: DefaultOAuthManager
+
+    init() {
+        self.keychain = MockKeychainService()
+        self.network = MockNetworkService()
+        self.provider = MockOAuthProvider(
+            keychainKey: "test.device.credential",
+            deviceCodeURL: "https://auth.example.com/oauth2/device/code"
+        )
+        self.sut = DefaultOAuthManager(keychain: keychain, networkService: network)
+        self.provider.stubPostAuthSetupResponse = .success(nil)
+    }
+
+    // MARK: - startDeviceCodeFlow
+
+    @Test func throwsWhenProviderDoesNotSupportDeviceCode() async {
+        provider.deviceCodeURL = nil
+
+        await #expect(throws: OAuthError.self) {
+            _ = try await sut.startDeviceCodeFlow(provider: provider)
+        }
+    }
+
+    @Test func parsesCompleteDeviceCodeResponse() async throws {
+        network.stubSendResponse = .success((deviceCodeBody(), httpResponse(200)))
+
+        let result = try await sut.startDeviceCodeFlow(provider: provider)
+
+        #expect(result.deviceCode == "device-abc")
+        #expect(result.userCode == "WXYZ-1234")
+        #expect(result.verificationUri == "https://auth.example.com/device")
+        #expect(result.verificationUriComplete == "https://auth.example.com/device?code=WXYZ-1234")
+        #expect(result.interval == 3)
+        #expect(result.expiresIn == 600)
+    }
+
+    @Test func browserURIPrefersThePreFilledVerificationURI() async throws {
+        network.stubSendResponse = .success((deviceCodeBody(), httpResponse(200)))
+
+        let result = try await sut.startDeviceCodeFlow(provider: provider)
+
+        #expect(result.browserURI == "https://auth.example.com/device?code=WXYZ-1234")
+    }
+
+    /// RFC 8628 permits `interval: 0` and allows omitting it entirely. Neither
+    /// is an error, and neither may become a zero-delay poll loop.
+    @Test(arguments: ["\"interval\":0,", "\"interval\":-4,", ""])
+    func fallsBackToFiveSecondIntervalWhenServerIntervalIsUnusable(_ intervalField: String) async throws {
+        let body = Data("""
+        {"device_code":"device-abc","user_code":"WXYZ-1234",\
+        "verification_uri":"https://auth.example.com/device",\(intervalField)"expires_in":600}
+        """.utf8)
+        network.stubSendResponse = .success((body, httpResponse(200)))
+
+        let result = try await sut.startDeviceCodeFlow(provider: provider)
+
+        #expect(result.interval == 5)
+    }
+
+    @Test func fallsBackToDefaultExpiryWhenServerOmitsIt() async throws {
+        let body = Data("""
+        {"device_code":"device-abc","user_code":"WXYZ-1234",\
+        "verification_uri":"https://auth.example.com/device","interval":3}
+        """.utf8)
+        network.stubSendResponse = .success((body, httpResponse(200)))
+
+        let result = try await sut.startDeviceCodeFlow(provider: provider)
+
+        #expect(result.expiresIn == 900)
+    }
+
+    /// The verification URI is handed to the system opener, so a non-https
+    /// scheme must never survive parsing - it would let a spoofed response
+    /// launch an arbitrary handler.
+    @Test(arguments: [
+        "javascript:alert(1)",
+        "vivadicta://auth/callback",
+        "http://auth.example.com/device",
+        "not a url at all"
+    ])
+    func rejectsNonHTTPSVerificationURI(_ hostileURI: String) async {
+        let body = Data("""
+        {"device_code":"device-abc","user_code":"WXYZ-1234",\
+        "verification_uri":"\(hostileURI)","interval":3,"expires_in":600}
+        """.utf8)
+        network.stubSendResponse = .success((body, httpResponse(200)))
+
+        await #expect(throws: OAuthError.self) {
+            _ = try await sut.startDeviceCodeFlow(provider: provider)
+        }
+    }
+
+    /// A hostile *optional* pre-filled URI is dropped rather than failing the
+    /// whole sign-in: the plain https URI still works, so the user is not
+    /// blocked, and the bad value never reaches the opener.
+    @Test func dropsNonHTTPSPreFilledURIButKeepsTheFlowUsable() async throws {
+        let body = Data("""
+        {"device_code":"device-abc","user_code":"WXYZ-1234",\
+        "verification_uri":"https://auth.example.com/device",\
+        "verification_uri_complete":"javascript:alert(1)",\
+        "interval":3,"expires_in":600}
+        """.utf8)
+        network.stubSendResponse = .success((body, httpResponse(200)))
+
+        let result = try await sut.startDeviceCodeFlow(provider: provider)
+
+        #expect(result.verificationUriComplete == nil)
+        #expect(result.browserURI == "https://auth.example.com/device")
+    }
+
+    @Test(arguments: [
+        #"{"user_code":"WXYZ","verification_uri":"https://a.example.com","expires_in":600}"#,
+        #"{"device_code":"d","verification_uri":"https://a.example.com","expires_in":600}"#,
+        #"{"device_code":"d","user_code":"WXYZ","expires_in":600}"#,
+        #"{"device_code":"","user_code":"WXYZ","verification_uri":"https://a.example.com"}"#
+    ])
+    func throwsWhenRequiredFieldsAreMissingOrEmpty(_ json: String) async {
+        network.stubSendResponse = .success((Data(json.utf8), httpResponse(200)))
+
+        await #expect(throws: OAuthError.self) {
+            _ = try await sut.startDeviceCodeFlow(provider: provider)
+        }
+    }
+
+    @Test func surfacesServerErrorDetailOnNonSuccessStatus() async {
+        let body = Data(#"{"error":"invalid_client","error_description":"unknown client"}"#.utf8)
+        network.stubSendResponse = .success((body, httpResponse(400)))
+
+        await #expect(throws: OAuthError.self) {
+            _ = try await sut.startDeviceCodeFlow(provider: provider)
+        }
+    }
+
+    // MARK: - pollForDeviceCodeToken
+
+    @Test func pendingThenAuthorizedReturnsCredential() async throws {
+        network.stubSendResponses = [
+            .success((Data(#"{"error":"authorization_pending"}"#.utf8), httpResponse(400))),
+            .success((tokenBody(), httpResponse(200)))
+        ]
+
+        let credential = try await sut.pollForDeviceCodeToken(provider: provider, deviceCode: makeDeviceCode())
+
+        #expect(credential.accessToken == "granted-token")
+        #expect(credential.refreshToken == "granted-refresh")
+        #expect(network.sendCallCount == 2)
+    }
+
+    @Test func authorizedCredentialIsPersistedAndMarksProviderSignedIn() async throws {
+        network.stubSendResponses = [.success((tokenBody(), httpResponse(200)))]
+
+        _ = try await sut.pollForDeviceCodeToken(provider: provider, deviceCode: makeDeviceCode())
+
+        #expect(sut.isSignedIn(provider: provider))
+        let persisted = try #require(keychain.getData(forKey: provider.keychainKey, syncable: false))
+        let decoded = try JSONDecoder().decode(OAuthCredential.self, from: persisted)
+        #expect(decoded.accessToken == "granted-token")
+    }
+
+    /// `slow_down` is a throttle signal, not a failure: the poll must back off
+    /// and keep going.
+    @Test func slowDownBacksOffAndKeepsPolling() async throws {
+        network.stubSendResponses = [
+            .success((Data(#"{"error":"slow_down","interval":1}"#.utf8), httpResponse(400))),
+            .success((tokenBody(), httpResponse(200)))
+        ]
+
+        let credential = try await sut.pollForDeviceCodeToken(provider: provider, deviceCode: makeDeviceCode())
+
+        #expect(credential.accessToken == "granted-token")
+        #expect(network.sendCallCount == 2)
+    }
+
+    @Test(arguments: ["access_denied", "authorization_denied"])
+    func deniedAuthorizationThrows(_ error: String) async {
+        network.stubSendResponses = [
+            .success((Data("{\"error\":\"\(error)\"}".utf8), httpResponse(400)))
+        ]
+
+        await #expect(throws: OAuthError.self) {
+            _ = try await sut.pollForDeviceCodeToken(provider: provider, deviceCode: makeDeviceCode())
+        }
+        #expect(sut.isSignedIn(provider: provider) == false)
+    }
+
+    @Test func expiredDeviceCodeThrows() async {
+        network.stubSendResponses = [
+            .success((Data(#"{"error":"expired_token"}"#.utf8), httpResponse(400)))
+        ]
+
+        await #expect(throws: OAuthError.self) {
+            _ = try await sut.pollForDeviceCodeToken(provider: provider, deviceCode: makeDeviceCode())
+        }
+    }
+
+    /// An unrecognized `error` code is a real failure, not something to keep
+    /// polling through until the code expires.
+    @Test func unknownErrorCodeFailsFast() async {
+        network.stubSendResponses = [
+            .success((Data(#"{"error":"invalid_grant"}"#.utf8), httpResponse(400)))
+        ]
+
+        await #expect(throws: OAuthError.self) {
+            _ = try await sut.pollForDeviceCodeToken(provider: provider, deviceCode: makeDeviceCode())
+        }
+        #expect(network.sendCallCount == 1)
+    }
+
+    @Test func givesUpOnceTheDeviceCodeWindowHasPassed() async {
+        network.stubSendResponse = .success((Data(#"{"error":"authorization_pending"}"#.utf8), httpResponse(400)))
+
+        await #expect(throws: OAuthError.self) {
+            _ = try await sut.pollForDeviceCodeToken(
+                provider: provider,
+                deviceCode: makeDeviceCode(expiresIn: 0)
+            )
+        }
+    }
+
+    @Test func assumesOneHourLifetimeWhenTokenResponseOmitsExpiry() async throws {
+        let body = Data(#"{"access_token":"granted-token","refresh_token":"granted-refresh"}"#.utf8)
+        network.stubSendResponses = [.success((body, httpResponse(200)))]
+
+        let credential = try await sut.pollForDeviceCodeToken(provider: provider, deviceCode: makeDeviceCode())
+
+        // 3600s default, allowing slack for the poll's own wall-clock delay.
+        let lifetime = credential.expiresAt.timeIntervalSinceNow
+        #expect(lifetime > 3500 && lifetime <= 3600)
+    }
+
+    // MARK: - Helpers
+
+    private func makeDeviceCode(expiresIn: Int = 600) -> DeviceCodeResponse {
+        DeviceCodeResponse(
+            deviceCode: "device-abc",
+            userCode: "WXYZ-1234",
+            verificationUri: "https://auth.example.com/device",
+            interval: 1,
+            expiresIn: expiresIn
+        )
+    }
+
+    private func deviceCodeBody() -> Data {
+        Data("""
+        {"device_code":"device-abc","user_code":"WXYZ-1234",\
+        "verification_uri":"https://auth.example.com/device",\
+        "verification_uri_complete":"https://auth.example.com/device?code=WXYZ-1234",\
+        "interval":3,"expires_in":600}
+        """.utf8)
+    }
+
+    private func tokenBody() -> Data {
+        Data(#"{"access_token":"granted-token","refresh_token":"granted-refresh","expires_in":3600}"#.utf8)
+    }
+
+    private func httpResponse(_ statusCode: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: URL(string: "https://auth.example.com/oauth2/token")!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/json"]
+        )!
+    }
+}

--- a/VivaDicta/Services/AIEnhance/AIService+Chat.swift
+++ b/VivaDicta/Services/AIEnhance/AIService+Chat.swift
@@ -34,6 +34,8 @@ extension AIService {
             return isOpenAISignedIn || provider.apiKey != nil
         case .gemini:
             return isGeminiSignedIn || provider.apiKey != nil
+        case .grok:
+            return isGrokSignedIn || provider.apiKey != nil
         case .copilot:
             return isCopilotSignedIn
         default:
@@ -184,6 +186,34 @@ extension AIService {
                     )
                 }
                 throw EnhancementError.customError(error.errorDescription ?? "Gemini OAuth error")
+            }
+
+        case .grokOAuth:
+            do {
+                let (token, _, _) = try await oauthManager.validAccessToken(for: GrokOAuthProvider())
+                guard let url = URL(string: provider.baseURL) else {
+                    throw EnhancementError.customError("Invalid URL for \(provider.displayName)")
+                }
+                return try await makeOpenAIChatStreamingRequest(
+                    url: url,
+                    model: model,
+                    systemMessage: systemMessage,
+                    messages: messages,
+                    headers: ["Authorization": "Bearer \(token)"],
+                    onPartialResponse: onPartialResponse
+                )
+            } catch let error as OAuthError {
+                if let apiKey = provider.apiKey, let url = URL(string: provider.baseURL) {
+                    return try await makeOpenAIChatStreamingRequest(
+                        url: url,
+                        model: model,
+                        systemMessage: systemMessage,
+                        messages: messages,
+                        headers: ["Authorization": "Bearer \(apiKey)"],
+                        onPartialResponse: onPartialResponse
+                    )
+                }
+                throw EnhancementError.customError(error.errorDescription ?? "Grok OAuth error")
             }
 
         case nil:
@@ -355,7 +385,7 @@ extension AIService {
     // MARK: - Private Helpers
 
     private enum ChatStreamingRoute {
-        case anthropic, openAICompatibleCloud, copilot, ollama, customOpenAI, openAIOAuth, geminiOAuth
+        case anthropic, openAICompatibleCloud, copilot, ollama, customOpenAI, openAIOAuth, geminiOAuth, grokOAuth
     }
 
     private func chatStreamingRoute(for provider: AIProvider, model: String) -> ChatStreamingRoute? {
@@ -379,6 +409,14 @@ extension AIService {
         case .gemini:
             if isGeminiSignedIn {
                 return .geminiOAuth
+            }
+            if provider.supportsResponseStreaming(model: model), provider.apiKey != nil {
+                return .openAICompatibleCloud
+            }
+            return nil
+        case .grok:
+            if isGrokSignedIn {
+                return .grokOAuth
             }
             if provider.supportsResponseStreaming(model: model), provider.apiKey != nil {
                 return .openAICompatibleCloud
@@ -417,6 +455,14 @@ extension AIService {
                 headers["Authorization"] = "Bearer \(apiKey)"
             }
             return (url, headers)
+
+        case .grok where isGrokSignedIn:
+            // Subscription token in the API key's place - same endpoint.
+            let (token, _, _) = try await oauthManager.validAccessToken(for: GrokOAuthProvider())
+            guard let url = URL(string: provider.baseURL) else {
+                throw EnhancementError.customError("Invalid URL for \(provider.displayName)")
+            }
+            return (url, ["Authorization": "Bearer \(token)"])
 
         default:
             guard let apiKey = provider.apiKey else {

--- a/VivaDicta/Services/AIEnhance/AIService.swift
+++ b/VivaDicta/Services/AIEnhance/AIService.swift
@@ -68,6 +68,7 @@ class AIService {
         case copilot
         case geminiOAuth
         case openAIOAuth
+        case grokOAuth
         case openAICompatibleCloud
         case ollama
         case customOpenAI
@@ -85,6 +86,11 @@ class AIService {
     public var isGeminiSignedIn: Bool = false
     public var geminiEmail: String?
     public var isGeminiSigningIn: Bool = false
+
+    // MARK: - Grok OAuth (SuperGrok / X Premium subscription)
+    public var isGrokSignedIn: Bool = false
+    public var grokEmail: String?
+    public var isGrokSigningIn: Bool = false
 
     // MARK: - GitHub Copilot
     public var isCopilotSignedIn: Bool = false
@@ -223,6 +229,7 @@ class AIService {
         switch provider {
         case .openAI: return isOpenAISignedIn
         case .gemini: return isGeminiSignedIn
+        case .grok: return isGrokSignedIn
         case .copilot: return isCopilotSignedIn
         default: return false
         }
@@ -277,6 +284,7 @@ class AIService {
         Task {
             refreshOpenAIOAuthState()
             refreshGeminiOAuthState()
+            refreshGrokOAuthState()
             refreshCopilotOAuthState()
             refreshConnectedProviders()
             await dismissTranscriptionTipsIfModelConfigured()
@@ -821,6 +829,8 @@ class AIService {
             // OpenAI is connected (via OpenAI OAuth or API key)
         } else if aiProvider == .gemini && connectedProviders.contains(.gemini) {
             // Gemini is connected (via Gemini OAuth or API key)
+        } else if aiProvider == .grok && connectedProviders.contains(.grok) {
+            // Grok is connected (via subscription OAuth or API key)
         } else if aiProvider == .copilot && isCopilotSignedIn {
             // Copilot is connected (OAuth only, no API key)
         } else {
@@ -1111,6 +1121,11 @@ class AIService {
                 return nil
             }
             return .anthropic
+        case .grok:
+            if isGrokSignedIn {
+                return .grokOAuth
+            }
+            return aiProvider.supportsResponseStreaming(model: mode.aiModel) ? .openAICompatibleCloud : nil
         case .copilot:
             return isCopilotSignedIn ? .copilot : nil
         case .ollama:
@@ -1258,6 +1273,22 @@ class AIService {
                     break
                 } else {
                     throw EnhancementError.customError(error.errorDescription ?? "OpenAI OAuth error")
+                }
+            }
+        case .grokOAuth:
+            do {
+                let provider = try await aiProviderRegistry.makeTextProvider(for: .grokOAuth, model: mode.aiModel)
+                let result = try await provider.enhanceStreaming(systemMessage: sysMsg, userMessage: userMsg, onPartialResponse: onPartialResponse)
+                return await finalizeStreamingResult(result, onPartialResponse: onPartialResponse)
+            } catch let error as EnhancementError {
+                // Carries the 403 subscription message - actionable as-is.
+                throw error
+            } catch let error as OAuthError {
+                if self.getAPIKey(for: aiProvider) != nil {
+                    logger.logWarning("Grok OAuth streaming failed, falling back to API key: \(error.localizedDescription)")
+                    break
+                } else {
+                    throw EnhancementError.customError(error.errorDescription ?? "Grok OAuth error")
                 }
             }
         case .openAICompatibleCloud:
@@ -1811,6 +1842,9 @@ class AIService {
                     && VivAgentsClient.isVerified
                     && VivAgentsClient.isGeminiCliActive
                 return cliAvailable || isGeminiSignedIn || provider.apiKey != nil
+            }
+            if provider == .grok {
+                return isGrokSignedIn || provider.apiKey != nil
             }
             if provider == .copilot {
                 return isCopilotSignedIn
@@ -2531,6 +2565,51 @@ extension AIService {
         oauthManager.signOut(provider: provider)
         isGeminiSignedIn = false
         geminiEmail = nil
+        refreshConnectedProviders()
+    }
+}
+
+// MARK: - Grok OAuth
+
+extension AIService {
+    /// Refreshes the Grok OAuth state from stored credentials.
+    @MainActor
+    func refreshGrokOAuthState() {
+        let provider = GrokOAuthProvider()
+        isGrokSignedIn = oauthManager.isSignedIn(provider: provider)
+        grokEmail = oauthManager.accountEmail(for: provider)
+    }
+
+    /// Starts the xAI device-code flow. The caller shows `userCode`, opens
+    /// `browserURI`, then awaits ``signInWithGrok(deviceCode:)``.
+    ///
+    /// Split in two because the user has to authorize in a browser between the
+    /// steps - the same shape as the Copilot flow.
+    @MainActor
+    func startGrokDeviceCodeFlow() async throws -> DeviceCodeResponse {
+        try await oauthManager.startDeviceCodeFlow(provider: GrokOAuthProvider())
+    }
+
+    /// Polls xAI until the device code is authorized, then stores the credential.
+    @MainActor
+    func signInWithGrok(deviceCode: DeviceCodeResponse) async throws {
+        isGrokSigningIn = true
+        defer { isGrokSigningIn = false }
+
+        let provider = GrokOAuthProvider()
+        let credential = try await oauthManager.pollForDeviceCodeToken(provider: provider, deviceCode: deviceCode)
+        isGrokSignedIn = true
+        grokEmail = credential.accountEmail
+        refreshConnectedProviders()
+    }
+
+    /// Signs out from Grok OAuth.
+    @MainActor
+    func signOutFromGrok() {
+        let provider = GrokOAuthProvider()
+        oauthManager.signOut(provider: provider)
+        isGrokSignedIn = false
+        grokEmail = nil
         refreshConnectedProviders()
     }
 }

--- a/VivaDicta/Services/OAuth/OAuthSingletons.swift
+++ b/VivaDicta/Services/OAuth/OAuthSingletons.swift
@@ -8,7 +8,13 @@ import OAuth
 /// live in `Modules/OAuth` and are dependency-injected; this file is the
 /// composition root for the convenience singletons used across the app.
 extension DefaultOAuthManager {
-    @MainActor public static let shared = DefaultOAuthManager(keychain: DefaultKeychainService())
+    /// `backgroundTaskService` keeps device-code polling alive while the user is
+    /// away in Safari approving the code (the app is backgrounded for that
+    /// stretch). Unused by the redirect flow, which never leaves the app.
+    @MainActor public static let shared = DefaultOAuthManager(
+        keychain: DefaultKeychainService(),
+        backgroundTaskService: BackgroundTaskServiceAdapter()
+    )
 }
 
 extension DefaultCopilotOAuthManager {

--- a/VivaDicta/Views/SettingsScreen/AIProvidersView.swift
+++ b/VivaDicta/Views/SettingsScreen/AIProvidersView.swift
@@ -211,6 +211,14 @@ struct AIProviders: View {
                                         .font(.subheadline)
                                         .foregroundStyle(.secondary)
                                 }
+                            } else if provider == .grok && appState.aiService.isGrokSignedIn {
+                                HStack(spacing: 4) {
+                                    Image(systemName: "checkmark.circle.fill")
+                                        .foregroundStyle(.green)
+                                    Text("Subscription")
+                                        .font(.subheadline)
+                                        .foregroundStyle(.secondary)
+                                }
                             } else if provider == .copilot && appState.aiService.isCopilotSignedIn {
                                 HStack(spacing: 4) {
                                     Image(systemName: "checkmark.circle.fill")
@@ -230,7 +238,7 @@ struct AIProviders: View {
                                         .foregroundStyle(.secondary)
                                 }
                             } else if !appState.aiService.connectedProviders.contains(provider) {
-                                if provider == .anthropic || provider == .openAI || provider == .gemini {
+                                if provider == .anthropic || provider == .openAI || provider == .gemini || provider == .grok {
                                     HStack(spacing: 4) {
                                         Image(systemName: "gear")
                                             .foregroundStyle(.orange)
@@ -318,6 +326,8 @@ struct AIProviders: View {
                 OpenAIConfigurationView(aiService: appState.aiService)
             } else if provider == .gemini {
                 GeminiConfigurationView(aiService: appState.aiService)
+            } else if provider == .grok {
+                GrokConfigurationView(aiService: appState.aiService)
             } else if provider == .copilot {
                 CopilotConfigurationView(aiService: appState.aiService)
             } else {

--- a/VivaDicta/Views/SettingsScreen/GrokConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/GrokConfigurationView.swift
@@ -1,0 +1,420 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import SwiftUI
+import OAuth
+import AICore
+
+/// Grok (xAI) setup: sign in with a SuperGrok / X Premium subscription, or use
+/// an API key. Both hit the same `api.x.ai` endpoint - only the bearer differs.
+struct GrokConfigurationView: View {
+    let aiService: AIService
+
+    @State private var hasExistingKey = false
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 24) {
+                VStack(spacing: 8) {
+                    if let iconName = AIProvider.grok.iconName {
+                        Image(iconName)
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 64, height: 64)
+                    }
+
+                    Text(AIProvider.grok.displayName)
+                        .font(.title2)
+
+                    if aiService.connectedProviders.contains(.grok) {
+                        HStack(spacing: 4) {
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundStyle(.green)
+                            Text(aiService.isGrokSignedIn ? "Subscription Connected" : "API Key Configured")
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+                .padding(.top, 8)
+
+                GrokSubscriptionSection(aiService: aiService)
+
+                GrokAPIKeySection(aiService: aiService, hasExistingKey: $hasExistingKey)
+
+                GrokFallbackNote(isSignedIn: aiService.isGrokSignedIn, hasExistingKey: hasExistingKey)
+            }
+            .padding()
+        }
+        .scrollDismissesKeyboard(.interactively)
+        .navigationTitle(AIProvider.grok.displayName)
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            hasExistingKey = AIProvider.grok.apiKey != nil
+        }
+    }
+}
+
+// MARK: - Subscription Sign-In
+
+/// Drives xAI's device-code sign-in: request a code, send the user to the
+/// browser to approve it, then poll until xAI reports the approval.
+private struct GrokSubscriptionSection: View {
+    let aiService: AIService
+
+    @State private var deviceCode: DeviceCodeResponse?
+    @State private var signInTask: Task<Void, Never>?
+    @State private var showError = false
+    @State private var errorMessage = ""
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Grok Subscription")
+                .font(.headline)
+
+            Text("Use your SuperGrok or X Premium subscription instead of an API key.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            // Set expectations before the user signs in: xAI gates which plans
+            // may connect an app, so a valid subscription can still be refused.
+            Label {
+                Text("xAI limits which plans can connect an app, so this may not work on every subscription. An API key always works.")
+            } icon: {
+                Image(systemName: "info.circle")
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+
+            if aiService.isGrokSignedIn {
+                signedInRow
+            } else if let deviceCode {
+                pendingAuthorization(deviceCode)
+            } else {
+                signInButton
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background {
+            RoundedRectangle(cornerRadius: 12)
+                .fill(.background.secondary)
+        }
+        .onDisappear {
+            signInTask?.cancel()
+        }
+        .alert("Sign-In Error", isPresented: $showError) {
+            Button("OK") {}
+        } message: {
+            Text(errorMessage)
+        }
+    }
+
+    private var signedInRow: some View {
+        HStack {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(.green)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Signed in")
+                    .font(.callout)
+                if let email = aiService.grokEmail {
+                    Text(email)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Spacer()
+            Button("Sign Out", role: .destructive) {
+                aiService.signOutFromGrok()
+            }
+            .controlSize(.small)
+        }
+    }
+
+    private func pendingAuthorization(_ code: DeviceCodeResponse) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Approve this code at x.ai:")
+                .font(.callout)
+
+            Text(code.userCode)
+                .font(.system(size: 28, weight: .bold, design: .monospaced))
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .center)
+                .padding(.vertical, 8)
+
+            if let url = URL(string: code.browserURI) {
+                Link(destination: url) {
+                    Label("Open x.ai to approve", systemImage: "arrow.up.right.square")
+                        .frame(maxWidth: .infinity, alignment: .center)
+                }
+            }
+
+            HStack {
+                ProgressView()
+                    .controlSize(.small)
+                Text("Waiting for approval...")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Button("Cancel") {
+                signInTask?.cancel()
+                deviceCode = nil
+            }
+            .foregroundStyle(.red)
+        }
+    }
+
+    private var signInButton: some View {
+        Button {
+            startSignIn()
+        } label: {
+            HStack(spacing: 6) {
+                if aiService.isGrokSigningIn {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+                Text("Sign in with Grok")
+                    .font(.headline.weight(.medium))
+            }
+        }
+        .disabled(aiService.isGrokSigningIn)
+        .padding(.vertical, 8)
+        .padding(.horizontal, 16)
+        .background {
+            Capsule()
+                .stroke(.blue, lineWidth: 2)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func startSignIn() {
+        signInTask = Task {
+            do {
+                let code = try await aiService.startGrokDeviceCodeFlow()
+                deviceCode = code
+
+                // The pre-filled URI usually carries the code, but copy it too so
+                // the user can paste if xAI asks them to type it.
+                UIPasteboard.general.string = code.userCode
+                if let url = URL(string: code.browserURI) {
+                    await UIApplication.shared.open(url)
+                }
+
+                try await aiService.signInWithGrok(deviceCode: code)
+                deviceCode = nil
+                HapticManager.success()
+            } catch is CancellationError {
+                deviceCode = nil
+            } catch {
+                deviceCode = nil
+                errorMessage = error.localizedDescription
+                showError = true
+                HapticManager.error()
+            }
+        }
+    }
+}
+
+// MARK: - API Key
+
+private struct GrokAPIKeySection: View {
+    let aiService: AIService
+    @Binding var hasExistingKey: Bool
+
+    @State private var apiKey = ""
+    @State private var isVerifying = false
+    @State private var verificationError: String?
+    @State private var showDeleteConfirmation = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("API Key")
+                .font(.headline)
+
+            Text("Billed per token by xAI. Works on any account and unlocks the full model list.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            if let apiKeyURL = AIProvider.grok.apiKeyURL {
+                Button {
+                    UIApplication.shared.open(apiKeyURL)
+                } label: {
+                    Label("Get API Key", systemImage: "key")
+                        .font(.headline.weight(.medium))
+                        .foregroundStyle(.blue)
+                }
+                .buttonStyle(.plain)
+            }
+
+            TextField("API Key", text: $apiKey)
+                .privacySensitive()
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .padding()
+                .background {
+                    Capsule()
+                        .stroke(verificationError != nil ? .red : .gray, lineWidth: verificationError != nil ? 1.5 : 0.5)
+                }
+                .onChange(of: apiKey) { _, _ in
+                    verificationError = nil
+                }
+
+            if let verificationError {
+                Text(verificationError)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+
+            HStack {
+                Button {
+                    saveAPIKey()
+                } label: {
+                    HStack(spacing: 6) {
+                        if isVerifying {
+                            ProgressView()
+                                .controlSize(.small)
+                        }
+                        Text("Save API Key")
+                            .font(.headline.weight(.medium))
+                    }
+                    .padding(.vertical, 8)
+                    .padding(.horizontal, 16)
+                    .background {
+                        Capsule()
+                            .stroke(.blue, lineWidth: 2)
+                    }
+                }
+                .disabled(apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isVerifying)
+                .buttonStyle(.plain)
+
+                Button {
+                    pasteAndSave()
+                } label: {
+                    Text("Paste")
+                        .font(.headline.weight(.medium))
+                        .padding(.vertical, 8)
+                        .padding(.horizontal, 16)
+                        .background {
+                            Capsule()
+                                .stroke(.gray, lineWidth: 2)
+                        }
+                }
+                .buttonStyle(.plain)
+            }
+
+            if hasExistingKey {
+                Button {
+                    showDeleteConfirmation = true
+                    HapticManager.warning()
+                } label: {
+                    Text("Delete API Key")
+                        .font(.headline.weight(.semibold))
+                        .foregroundStyle(.red)
+                }
+                .padding(.vertical, 8)
+                .padding(.horizontal, 16)
+                .overlay {
+                    Capsule()
+                        .stroke(.red, lineWidth: 1.5)
+                }
+                .padding(.top, 4)
+            }
+        }
+        .padding()
+        .background {
+            RoundedRectangle(cornerRadius: 12)
+                .fill(.background.secondary)
+        }
+        .onAppear {
+            apiKey = AIProvider.grok.apiKey ?? ""
+        }
+        .alert("Delete API Key", isPresented: $showDeleteConfirmation) {
+            Button("Cancel", role: .cancel) {}
+            Button("Delete", role: .destructive) {
+                deleteAPIKey()
+            }
+        } message: {
+            Text("Are you sure you want to delete the API key for \(AIProvider.grok.displayName)? This action cannot be undone.")
+        }
+    }
+
+    private func saveAPIKey() {
+        Task {
+            isVerifying = true
+            verificationError = nil
+            HapticManager.mediumImpact()
+
+            let success = await aiService.saveAPIKey(apiKey, for: .grok)
+            isVerifying = false
+            if success {
+                hasExistingKey = true
+                HapticManager.success()
+            } else {
+                verificationError = "Invalid API key"
+                HapticManager.error()
+            }
+        }
+    }
+
+    private func pasteAndSave() {
+        guard let clipboard = UIPasteboard.general.string else { return }
+        let trimmed = clipboard.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        apiKey = trimmed
+        saveAPIKey()
+    }
+
+    private func deleteAPIKey() {
+        aiService.deleteAPIKey(for: .grok)
+        apiKey = ""
+        hasExistingKey = false
+        aiService.refreshConnectedProviders()
+        if !aiService.connectedProviders.contains(.grok) {
+            aiService.disableAIEnhancementForModesUsingProvider(.grok)
+        }
+        HapticManager.success()
+    }
+}
+
+// MARK: - Fallback Chain
+
+private struct GrokFallbackNote: View {
+    let isSignedIn: Bool
+    let hasExistingKey: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label("Fallback Chain", systemImage: "arrow.triangle.branch")
+                .font(.subheadline.bold())
+                .foregroundStyle(.secondary)
+
+            HStack(spacing: 6) {
+                chip("Subscription", isActive: isSignedIn)
+                Image(systemName: "chevron.right")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                chip("API Key", isActive: hasExistingKey)
+            }
+            .foregroundStyle(.secondary)
+
+            Text("If the subscription cannot be used, the API key is tried automatically.")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background {
+            RoundedRectangle(cornerRadius: 12)
+                .fill(.background.secondary)
+        }
+    }
+
+    private func chip(_ title: String, isActive: Bool) -> some View {
+        Text(title)
+            .font(.caption.bold())
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(isActive ? Color.green.opacity(0.15) : Color.secondary.opacity(0.1))
+            .clipShape(.capsule)
+    }
+}

--- a/VivaDicta/Views/SettingsScreen/GrokConfigurationView.swift
+++ b/VivaDicta/Views/SettingsScreen/GrokConfigurationView.swift
@@ -141,6 +141,16 @@ private struct GrokSubscriptionSection: View {
                 .frame(maxWidth: .infinity, alignment: .center)
                 .padding(.vertical, 8)
 
+            // The opened URI usually carries the code already, so copying is an
+            // explicit action - it clobbers the clipboard and shows the system
+            // paste banner, which is rude to do on the user's behalf.
+            Button("Copy Code", systemImage: "doc.on.doc") {
+                UIPasteboard.general.string = code.userCode
+                HapticManager.success()
+            }
+            .font(.caption)
+            .frame(maxWidth: .infinity, alignment: .center)
+
             if let url = URL(string: code.browserURI) {
                 Link(destination: url) {
                     Label("Open x.ai to approve", systemImage: "arrow.up.right.square")
@@ -193,9 +203,6 @@ private struct GrokSubscriptionSection: View {
                 let code = try await aiService.startGrokDeviceCodeFlow()
                 deviceCode = code
 
-                // The pre-filled URI usually carries the code, but copy it too so
-                // the user can paste if xAI asks them to type it.
-                UIPasteboard.general.string = code.userCode
                 if let url = URL(string: code.browserURI) {
                     await UIApplication.shared.open(url)
                 }
@@ -207,6 +214,9 @@ private struct GrokSubscriptionSection: View {
                 deviceCode = nil
             } catch {
                 deviceCode = nil
+                // A cancelled request can still surface as a transport error,
+                // so don't alert on a sign-in the user walked away from.
+                guard !Task.isCancelled else { return }
                 errorMessage = error.localizedDescription
                 showError = true
                 HapticManager.error()
@@ -397,7 +407,14 @@ private struct GrokFallbackNote: View {
             }
             .foregroundStyle(.secondary)
 
-            Text("If the subscription cannot be used, the API key is tried automatically.")
+            // Be precise about which failure falls back: a broken token quietly
+            // switches to the key, but xAI refusing the plan is reported instead
+            // of silently spending API credits.
+            Text("If the sign-in cannot be used - the token fails to refresh, for example - the API key is used automatically.")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+
+            Text("If xAI refuses the subscription itself, that is reported rather than switched to the API key.")
                 .font(.caption)
                 .foregroundStyle(.tertiary)
         }


### PR DESCRIPTION
## Summary

Lets users run Grok from a **SuperGrok or X Premium subscription** instead of a metered xAI API key.

The subscription access token is a plain bearer for `api.x.ai`, so it simply takes the API key's place on the existing OpenAI-compatible transport. No new client, no new wire format, and the model list is unchanged.

Sign-in uses the **device-code grant** rather than the browser redirect: xAI validates `redirect_uri` against the values registered for its public client, which would otherwise force a loopback listener on one specific port. Device code needs no callback at all.

## Device-code support is generic

Added to the OAuth module rather than to Grok, so the next device-code provider needs only a config struct:

- `OAuthProvider` gains optional `deviceCodeURL` / `deviceAuthExtraParams`. Redirect-only providers are unaffected.
- `OAuthManager` gains `startDeviceCodeFlow(provider:)` and `pollForDeviceCodeToken(provider:deviceCode:)`.
- `DefaultOAuthManager` implements RFC 8628:
  - **https-only verification URIs** - the URI is handed to the system opener, so a malformed or spoofed response must never be able to launch an arbitrary handler.
  - Strict validation of every response field.
  - Absent-or-zero `interval` floored to 5s (RFC 8628 permits `0`; a literal reading would produce a zero-delay poll loop).
  - `slow_down` honors the server-supplied interval.
  - `access_denied`, `authorization_denied` and `expired_token` handled distinctly; an unrecognized `error` code fails fast instead of spinning until the code expires.
- Credential construction extracted so the redirect, device-code and refresh paths share account extraction and expiry math.
- Form bodies encoded against RFC 3986's *unreserved* set. `.urlQueryAllowed` let reserved characters (`&`, `=`, `+`, spaces) through intact.
- `DeviceCodeResponse` gains `verificationUriComplete` plus a `browserURI` accessor preferring the pre-filled URI, so the user usually doesn't have to type the code.

## The 403 case is handled deliberately

xAI runs its own allowlist on the OAuth API surface, so sign-in can succeed while inference still answers **403** - reported by standard SuperGrok and X Premium subscribers alike. That case surfaces a message naming the cause and pointing at the API key, and **deliberately does not fall back silently**: spending the user's API credits without telling them is worse than an explanatory error.

Supporting it required widening `unauthorizedMessage` to cover 403 as well as 401, and adding the parameter to the non-streaming `enhance` path, which previously had no way to surface either. Ollama and Custom OpenAI get better 403 messages as a side effect.

## Incidental fix

`DefaultOAuthManager.shared` had no `backgroundTaskService`. Device-code polling continues while the user is in Safari approving the code, so the app is backgrounded for that stretch and polling would have been suspended. The Copilot manager already held an assertion; this one now does too.

## Testing

- App build **SUCCEEDED**; test targets build **SUCCEEDED**.
- **17 new device-code tests** covering the parsing and polling edge cases above (hostile URI schemes, missing/empty fields, `interval: 0`, `slow_down`, both denial codes, expiry, unknown error codes, credential persistence, default token lifetime).
- **2 new tests** pinning the 401/403 `unauthorizedMessage` mapping and confirming the generic mapping still applies without an override.
- Suites green: OAuth 42/42, AIProviders 109/109, AIKit 18/18, app `AIServiceEnhanceRoutingTests` + `AIServiceConfigurationTests` 37/37.

## Notes

- **Not verified end-to-end against a live subscription.** The device flow, token parsing and error mapping are unit-tested against synthetic responses, but the first real sign-in is still the real test.
- No fallback to the Grok Build surface (`cli-chat-proxy`) is included. It would need a second transport (Responses API plus client identity headers) that cannot be verified without a live subscription, so the 403 message stands in for it. Worth revisiting if real users hit the allowlist.
- The settings screen states up front that xAI limits which plans can connect an app, so a valid subscription can still be refused.