### PR TITLE
Support Base64/Data URI audio for custom transcription providers

### DIFF
--- a/Modules/CloudTranscription/Sources/CloudTranscription/CustomTranscriptionRequestFormat.swift
+++ b/Modules/CloudTranscription/Sources/CloudTranscription/CustomTranscriptionRequestFormat.swift
@@ -1,0 +1,19 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+
+/// How `CustomTranscriptionService` puts the audio on the wire.
+///
+/// OpenAI's own `/audio/transcriptions` takes a binary `multipart/form-data`
+/// upload and most self-hosted Whisper servers copy that, so it stays the
+/// default. Some gateways instead expect a JSON body whose `file` field is a
+/// base64 data URI and answer multipart with HTTP 400, which is why the
+/// format is user-selectable per custom endpoint.
+public enum CustomTranscriptionRequestFormat: String, Codable, Sendable, CaseIterable {
+    /// `multipart/form-data` with the raw audio bytes as the `file` part.
+    case multipartFormData
+
+    /// `application/json` with the audio inlined into `file` as
+    /// `data:<mime-type>;base64,<payload>`.
+    case jsonBase64
+}

--- a/Modules/CloudTranscription/Sources/CloudTranscription/CustomTranscriptionService.swift
+++ b/Modules/CloudTranscription/Sources/CloudTranscription/CustomTranscriptionService.swift
@@ -8,6 +8,10 @@ import TranscriptionCore
 /// User-configured OpenAI-compatible transcription endpoint. The endpoint URL,
 /// optional API key, and model name come from the user's stored custom model;
 /// the router builds the config from `CustomTranscriptionModel` at call time.
+///
+/// The body is sent as `multipart/form-data` by default and as JSON with a
+/// base64 data URI when the config asks for it - see
+/// `CustomTranscriptionRequestFormat`.
 public struct CustomTranscriptionService: TranscriptionService, Sendable {
     private let logger = Logger(cloudTranscriptionCategory: "CustomTranscription")
 
@@ -17,12 +21,21 @@ public struct CustomTranscriptionService: TranscriptionService, Sendable {
         public let modelName: String
         /// `"auto"` or BCP-47.
         public let language: String
+        /// Wire format the endpoint expects. See `CustomTranscriptionRequestFormat`.
+        public let requestFormat: CustomTranscriptionRequestFormat
 
-        public init(apiEndpoint: String, apiKey: String?, modelName: String, language: String = "auto") {
+        public init(
+            apiEndpoint: String,
+            apiKey: String?,
+            modelName: String,
+            language: String = "auto",
+            requestFormat: CustomTranscriptionRequestFormat = .multipartFormData
+        ) {
             self.apiEndpoint = apiEndpoint
             self.apiKey = apiKey
             self.modelName = modelName
             self.language = language
+            self.requestFormat = requestFormat
         }
     }
 
@@ -49,10 +62,8 @@ public struct CustomTranscriptionService: TranscriptionService, Sendable {
             throw CloudTranscriptionError.unsupportedProvider
         }
 
-        let boundary = "Boundary-\(UUID().uuidString)"
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
-        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
 
         if let apiKey = config.apiKey, !apiKey.isEmpty {
             request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
@@ -60,7 +71,17 @@ public struct CustomTranscriptionService: TranscriptionService, Sendable {
 
         request.timeoutInterval = NetworkRetry.defaultTimeout
 
-        let body = try createRequestBody(audioURL: audioURL, boundary: boundary)
+        let body: Data
+        switch config.requestFormat {
+        case .multipartFormData:
+            let boundary = "Boundary-\(UUID().uuidString)"
+            request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+            body = try createMultipartBody(audioURL: audioURL, boundary: boundary)
+
+        case .jsonBase64:
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            body = try createJSONBody(audioURL: audioURL)
+        }
 
         logger.logInfo("Sending request to custom endpoint: \(config.apiEndpoint)")
 
@@ -81,7 +102,14 @@ public struct CustomTranscriptionService: TranscriptionService, Sendable {
         }
     }
 
-    private func createRequestBody(audioURL: URL, boundary: String) throws -> Data {
+    /// `nil` when the user left the language on auto-detect, so the field is
+    /// dropped from the request instead of pinning the server to a language.
+    private var explicitLanguage: String? {
+        guard config.language != "auto", !config.language.isEmpty else { return nil }
+        return config.language
+    }
+
+    private func createMultipartBody(audioURL: URL, boundary: String) throws -> Data {
         var body = Data()
         let crlf = "\r\n"
 
@@ -100,10 +128,10 @@ public struct CustomTranscriptionService: TranscriptionService, Sendable {
         body.append(config.modelName.data(using: .utf8)!)
         body.append(crlf.data(using: .utf8)!)
 
-        if config.language != "auto", !config.language.isEmpty {
+        if let language = explicitLanguage {
             body.append("--\(boundary)\(crlf)".data(using: .utf8)!)
             body.append("Content-Disposition: form-data; name=\"language\"\(crlf)\(crlf)".data(using: .utf8)!)
-            body.append(config.language.data(using: .utf8)!)
+            body.append(language.data(using: .utf8)!)
             body.append(crlf.data(using: .utf8)!)
         }
 
@@ -120,6 +148,43 @@ public struct CustomTranscriptionService: TranscriptionService, Sendable {
         body.append("--\(boundary)--\(crlf)".data(using: .utf8)!)
 
         return body
+    }
+
+    /// Same fields as the multipart body, but as JSON with the audio inlined
+    /// as a data URI - the shape gateways like Polza.ai expect.
+    private func createJSONBody(audioURL: URL) throws -> Data {
+        guard let audioData = try? Data(contentsOf: audioURL) else {
+            throw CloudTranscriptionError.audioFileNotFound
+        }
+
+        let payload = JSONRequestBody(
+            file: "data:\(audioURL.audioMIMEType);base64,\(audioData.base64EncodedString())",
+            model: config.modelName,
+            language: explicitLanguage,
+            responseFormat: "json",
+            temperature: 0
+        )
+
+        do {
+            return try JSONEncoder().encode(payload)
+        } catch {
+            logger.logError("Failed to encode JSON request body: \(error.localizedDescription)")
+            throw CloudTranscriptionError.dataEncodingError
+        }
+    }
+
+    private struct JSONRequestBody: Encodable {
+        let file: String
+        let model: String
+        /// Omitted entirely when nil, matching the multipart body.
+        let language: String?
+        let responseFormat: String
+        let temperature: Double
+
+        enum CodingKeys: String, CodingKey {
+            case file, model, language, temperature
+            case responseFormat = "response_format"
+        }
     }
 
     private struct TranscriptionResponse: Decodable {

--- a/Modules/CloudTranscription/Tests/CloudTranscriptionTests/CustomTranscriptionServiceTests.swift
+++ b/Modules/CloudTranscription/Tests/CloudTranscriptionTests/CustomTranscriptionServiceTests.swift
@@ -8,9 +8,9 @@ import Testing
 import TranscriptionCore
 
 /// Tests exercise `CustomTranscriptionService` end-to-end with a stubbed
-/// `MockNetworkService`. Verifies request shape (URL, method, headers,
-/// multipart body) and response handling (success, non-2xx, undecodable
-/// JSON).
+/// `MockNetworkService`. Verifies request shape (URL, method, headers, and
+/// both body formats - multipart and JSON/base64) and response handling
+/// (success, non-2xx, undecodable JSON).
 ///
 /// Unlike the fixed-provider services, this service builds its endpoint from
 /// `config.apiEndpoint`, so the endpoint assertions match whatever base URL
@@ -53,17 +53,27 @@ struct CustomTranscriptionServiceTests {
         apiEndpoint: String = endpoint,
         apiKey: String? = "custom-test-key",
         modelName: String = "whisper-1",
-        language: String = "auto"
+        language: String = "auto",
+        requestFormat: CustomTranscriptionRequestFormat = .multipartFormData
     ) -> CustomTranscriptionService {
         CustomTranscriptionService(
             config: .init(
                 apiEndpoint: apiEndpoint,
                 apiKey: apiKey,
                 modelName: modelName,
-                language: language
+                language: language,
+                requestFormat: requestFormat
             ),
             networkService: networkService
         )
+    }
+
+    /// Decodes the captured body as the JSON object the `.jsonBase64` format
+    /// is supposed to produce.
+    private func capturedJSONBody(_ networkService: MockNetworkService) throws -> [String: Any] {
+        let body = try #require(networkService.capturedBody)
+        let object = try JSONSerialization.jsonObject(with: body)
+        return try #require(object as? [String: Any])
     }
 
     // MARK: - Success path
@@ -174,6 +184,102 @@ struct CustomTranscriptionServiceTests {
         let body = try #require(networkService.capturedBody)
         let bodyString = try #require(String(data: body, encoding: .utf8))
         #expect(bodyString.contains("name=\"language\"") == false)
+    }
+
+    // MARK: - JSON / base64 request format
+
+    @Test func jsonFormatSendsApplicationJSONContentTypeWithoutBoundary() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, requestFormat: .jsonBase64)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let req = try #require(networkService.capturedRequest)
+        #expect(req.value(forHTTPHeaderField: "Content-Type") == "application/json")
+    }
+
+    @Test func jsonFormatInlinesAudioAsBase64DataURI() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, requestFormat: .jsonBase64)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let json = try capturedJSONBody(networkService)
+        let file = try #require(json["file"] as? String)
+        let prefix = "data:audio/wav;base64,"
+        #expect(file.hasPrefix(prefix))
+
+        let payload = String(file.dropFirst(prefix.count))
+        let decoded = try #require(Data(base64Encoded: payload))
+        #expect(decoded == (try Data(contentsOf: audio)))
+    }
+
+    @Test func jsonFormatBodyContainsModelResponseFormatAndTemperature() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(
+            networkService: networkService,
+            modelName: "custom-stt-v2",
+            requestFormat: .jsonBase64
+        )
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let json = try capturedJSONBody(networkService)
+        #expect(json["model"] as? String == "custom-stt-v2")
+        #expect(json["response_format"] as? String == "json")
+        #expect(json["temperature"] as? Double == 0)
+    }
+
+    @Test func jsonFormatIncludesLanguageWhenNotAuto() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, language: "de", requestFormat: .jsonBase64)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let json = try capturedJSONBody(networkService)
+        #expect(json["language"] as? String == "de")
+    }
+
+    @Test func jsonFormatOmitsLanguageWhenAuto() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "ok")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, language: "auto", requestFormat: .jsonBase64)
+
+        _ = try await sut.transcribe(audioURL: audio)
+
+        let json = try capturedJSONBody(networkService)
+        #expect(json["language"] == nil)
+    }
+
+    @Test func jsonFormatSuccessReturnsTranscribedText() async throws {
+        let networkService = MockNetworkService()
+        stubSuccess(on: networkService, text: "base64 hello")
+        let audio = try makeAudioFile()
+        let sut = makeService(networkService: networkService, requestFormat: .jsonBase64)
+
+        let result = try await sut.transcribe(audioURL: audio)
+
+        #expect(result.text == "base64 hello")
+        #expect(networkService.uploadCallCount == 1)
+    }
+
+    @Test func jsonFormatMissingAudioFileThrowsAudioFileNotFound() async {
+        let networkService = MockNetworkService()
+        let audio = URL.temporaryDirectory.appending(path: "definitely-not-a-real-file-\(UUID()).wav")
+        let sut = makeService(networkService: networkService, requestFormat: .jsonBase64)
+
+        await #expect(throws: CloudTranscriptionError.self) {
+            _ = try await sut.transcribe(audioURL: audio)
+        }
     }
 
     // MARK: - Validation / short-circuit

--- a/VivaDicta/Models/CustomTranscriptionModel.swift
+++ b/VivaDicta/Models/CustomTranscriptionModel.swift
@@ -5,6 +5,7 @@
 //  Created by Anton Novoselov on 2026.01.17
 //
 
+import CloudTranscription
 import Foundation
 
 struct CustomTranscriptionModel: @MainActor TranscriptionModel, Codable {
@@ -18,6 +19,7 @@ struct CustomTranscriptionModel: @MainActor TranscriptionModel, Codable {
     var apiEndpoint: String
     var modelName: String
     var isMultilingual: Bool
+    var requestFormat: CustomTranscriptionRequestFormat
 
     var supportManyLanguages: Bool { isMultilingual }
     var supportedLanguages: [String: String] {
@@ -30,7 +32,8 @@ struct CustomTranscriptionModel: @MainActor TranscriptionModel, Codable {
         displayName: String,
         apiEndpoint: String,
         modelName: String,
-        isMultilingual: Bool = true
+        isMultilingual: Bool = true,
+        requestFormat: CustomTranscriptionRequestFormat = .multipartFormData
     ) {
         self.id = id
         self.name = name
@@ -38,11 +41,28 @@ struct CustomTranscriptionModel: @MainActor TranscriptionModel, Codable {
         self.apiEndpoint = apiEndpoint
         self.modelName = modelName
         self.isMultilingual = isMultilingual
+        self.requestFormat = requestFormat
     }
 
     // Custom Codable to exclude computed properties
     enum CodingKeys: String, CodingKey {
-        case id, name, displayName, apiEndpoint, modelName, isMultilingual
+        case id, name, displayName, apiEndpoint, modelName, isMultilingual, requestFormat
+    }
+
+    // Hand-written so configurations saved before `requestFormat` existed keep
+    // decoding, falling back to the multipart body they were set up against.
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        displayName = try container.decode(String.self, forKey: .displayName)
+        apiEndpoint = try container.decode(String.self, forKey: .apiEndpoint)
+        modelName = try container.decode(String.self, forKey: .modelName)
+        isMultilingual = try container.decode(Bool.self, forKey: .isMultilingual)
+        requestFormat = try container.decodeIfPresent(
+            CustomTranscriptionRequestFormat.self,
+            forKey: .requestFormat
+        ) ?? .multipartFormData
     }
 }
 

--- a/VivaDicta/Services/Transcription/CustomTranscription/CustomTranscriptionModelManager.swift
+++ b/VivaDicta/Services/Transcription/CustomTranscription/CustomTranscriptionModelManager.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import AppGroup
+import CloudTranscription
 import Keychain
 import os
 
@@ -62,7 +63,13 @@ final class CustomTranscriptionModelManager: CustomTranscriptionModelSource {
 
     // MARK: - Save/Update
 
-    func saveConfiguration(apiEndpoint: String, apiKey: String, modelName: String, isMultilingual: Bool) -> Bool {
+    func saveConfiguration(
+        apiEndpoint: String,
+        apiKey: String,
+        modelName: String,
+        isMultilingual: Bool,
+        requestFormat: CustomTranscriptionRequestFormat
+    ) -> Bool {
         let errors = validateConfiguration(apiEndpoint: apiEndpoint, modelName: modelName)
         guard errors.isEmpty else {
             return false
@@ -82,7 +89,8 @@ final class CustomTranscriptionModelManager: CustomTranscriptionModelSource {
             displayName: "Custom",
             apiEndpoint: apiEndpoint.trimmingCharacters(in: .whitespaces),
             modelName: modelName.trimmingCharacters(in: .whitespaces),
-            isMultilingual: isMultilingual
+            isMultilingual: isMultilingual,
+            requestFormat: requestFormat
         )
 
         saveModel()

--- a/VivaDicta/Services/Transcription/TranscriptionManager.swift
+++ b/VivaDicta/Services/Transcription/TranscriptionManager.swift
@@ -406,7 +406,8 @@ class TranscriptionManager: Transcriber {
                 apiEndpoint: customModel.apiEndpoint,
                 apiKey: customModel.apiKey,
                 modelName: customModel.modelName,
-                language: selectedLanguage
+                language: selectedLanguage,
+                requestFormat: customModel.requestFormat
             ))
         }
     }

--- a/VivaDicta/Views/ModelsScreen/AddCustomTranscriptionModelView.swift
+++ b/VivaDicta/Views/ModelsScreen/AddCustomTranscriptionModelView.swift
@@ -5,6 +5,7 @@
 //  Created by Anton Novoselov on 2026.01.17
 //
 
+import CloudTranscription
 import SwiftUI
 
 struct AddCustomTranscriptionModelView: View {
@@ -16,6 +17,7 @@ struct AddCustomTranscriptionModelView: View {
     @State private var apiKey: String = ""
     @State private var modelName: String = ""
     @State private var isMultilingual: Bool = true
+    @State private var requestFormat: CustomTranscriptionRequestFormat = .multipartFormData
     @State private var isChecking = false
     @State private var connectionStatus: ConnectionStatus = .unknown
     @State private var showingClearConfirmation = false
@@ -140,6 +142,25 @@ struct AddCustomTranscriptionModelView: View {
                                 }
 
                             Text("The model identifier as expected by your API server")
+                                .font(.caption2)
+                                .foregroundStyle(.tertiary)
+                        }
+
+                        // Request format picker
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("Request Format")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+
+                            Picker("Request Format", selection: $requestFormat) {
+                                ForEach(CustomTranscriptionRequestFormat.allCases, id: \.self) { format in
+                                    Text(format.title).tag(format)
+                                }
+                            }
+                            .pickerStyle(.segmented)
+                            .labelsHidden()
+
+                            Text(requestFormat.explanation)
                                 .font(.caption2)
                                 .foregroundStyle(.tertiary)
                         }
@@ -351,6 +372,7 @@ struct AddCustomTranscriptionModelView: View {
         apiEndpoint = model.apiEndpoint
         modelName = model.modelName
         isMultilingual = model.isMultilingual
+        requestFormat = model.requestFormat
 
         if let existingKey = manager.apiKey {
             apiKey = existingKey
@@ -379,7 +401,8 @@ struct AddCustomTranscriptionModelView: View {
             apiEndpoint: trimmedEndpoint,
             apiKey: trimmedApiKey,
             modelName: trimmedModelName,
-            isMultilingual: isMultilingual
+            isMultilingual: isMultilingual,
+            requestFormat: requestFormat
         )
 
         handleSaveResult(success)
@@ -409,6 +432,24 @@ struct AddCustomTranscriptionModelView: View {
         manager.clearConfiguration()
         onSave()
         dismiss()
+    }
+}
+
+private extension CustomTranscriptionRequestFormat {
+    var title: LocalizedStringKey {
+        switch self {
+        case .multipartFormData: "Multipart"
+        case .jsonBase64: "JSON Base64"
+        }
+    }
+
+    var explanation: LocalizedStringKey {
+        switch self {
+        case .multipartFormData:
+            "Uploads the audio as a binary file. Works with OpenAI and most self-hosted servers."
+        case .jsonBase64:
+            "Sends a JSON body with the audio inlined as a Base64 data URI. Pick this if the server rejects file uploads."
+        }
     }
 }
 

--- a/documentation/Transcription-System-Architecture.md
+++ b/documentation/Transcription-System-Architecture.md
@@ -89,6 +89,17 @@ Cloud transcription services use dynamic MIME types derived from the audio file 
 
 The iOS app records WAV (16kHz mono PCM). The Watch app records M4A (16kHz mono AAC). On-device providers (WhisperKit, Parakeet) use AVFoundation to load audio files and handle format detection automatically - no MIME type needed.
 
+## Custom Endpoint Request Formats
+
+`CustomTranscriptionService` can send the same set of fields (`file`, `model`, `language`, `response_format`, `temperature`) in two wire formats, selected per endpoint via `CustomTranscriptionRequestFormat` and stored on `CustomTranscriptionModel.requestFormat`:
+
+| Format | Content-Type | `file` field |
+|--------|--------------|--------------|
+| `.multipartFormData` (default) | `multipart/form-data; boundary=…` | raw audio bytes as a file part |
+| `.jsonBase64` | `application/json` | `data:<mime-type>;base64,<payload>` string |
+
+OpenAI's own API and most self-hosted Whisper servers want multipart. Some gateways only accept the JSON/base64 shape and answer multipart with HTTP 400, so the user picks the format in `AddCustomTranscriptionModelView`. Configurations saved before the field existed decode as `.multipartFormData`.
+
 ## Model Availability Checking
 
 ```


### PR DESCRIPTION
Closes #368

## Summary

Custom OpenAI-compatible transcription endpoints were always sent a binary `multipart/form-data` upload. Some gateways only accept a JSON body whose `file` field is a Base64 data URI and answer multipart with HTTP 400, so those endpoints could not be used at all.

Each custom endpoint can now pick its wire format. Both formats carry the same fields (`file`, `model`, `language`, `response_format`, `temperature`) and share the existing response decoder, since the JSON path returns the same `{text, language, duration}` shape.

| Format | Content-Type | `file` field |
|---|---|---|
| `.multipartFormData` (default) | `multipart/form-data; boundary=…` | raw audio bytes as a file part |
| `.jsonBase64` | `application/json` | `data:<mime-type>;base64,<payload>` |

## Changes

- **`CustomTranscriptionRequestFormat.swift`** (new) - public enum in `CloudTranscription` with the two cases.
- **`CustomTranscriptionService.swift`** - `Config.requestFormat`; request building branches on it. `createRequestBody` renamed to `createMultipartBody`, new `createJSONBody` alongside it. The auto-vs-explicit language check is hoisted into one `explicitLanguage` property both builders share, so the two bodies cannot drift.
- **`CustomTranscriptionModel.swift`** - persists `requestFormat`. `init(from:)` is hand-written so configurations saved before the field existed decode as `.multipartFormData` rather than failing outright.
- **`CustomTranscriptionModelManager.swift`** / **`TranscriptionManager.swift`** - threaded through save and provider-config construction.
- **`AddCustomTranscriptionModelView.swift`** - segmented "Request Format" picker with a per-case hint ("Pick this if the server rejects file uploads").
- **`documentation/Transcription-System-Architecture.md`** - new "Custom Endpoint Request Formats" section.

## Testing

- 7 new tests in `CustomTranscriptionServiceTests` covering the JSON path: content-type, data-URI round-trip (the Base64 payload decodes back to the original file bytes), `model`/`response_format`/`temperature` fields, language present when explicit and omitted when auto, success path, and missing-file. Existing multipart tests are unchanged and still assert the default behaviour.
- `swift test --filter CustomTranscriptionServiceTests` - 18/18 pass.
- `xcodebuild build` (iPhone 17 Pro Max, iOS 26.4) - success, 0 errors.
- `xcodebuild test -only-testing:VivaDictaTests/TranscriptionManagerTests` - 7/7 pass.

## Notes

- No behaviour change for anyone who does not switch the picker; multipart stays the default for new and existing configurations.
- The data URI's MIME type comes from the existing `URL.audioMIMEType` helper, so iOS's WAV recordings send `data:audio/wav;base64,…` and Watch M4A sends `data:audio/mp4;base64,…`. Both subtypes are on the accepted file-type list of the usual upstream providers.
- Base64 inflates the payload by roughly a third. The whole file was already read into memory for the multipart path, so peak memory grows but the shape of the code does not.