### PR TITLE
Stream Soniox dictation over the realtime WebSocket

### DIFF
--- a/Modules/CloudTranscription/Sources/CloudTranscription/SonioxTranscriptionService.swift
+++ b/Modules/CloudTranscription/Sources/CloudTranscription/SonioxTranscriptionService.swift
@@ -10,7 +10,6 @@ public struct SonioxTranscriptionService: TranscriptionService, Sendable {
     private let logger = Logger(cloudTranscriptionCategory: "SonioxTranscription")
     private let apiBase = "https://api.soniox.com/v1"
     private let maxWaitSeconds: TimeInterval = 300
-    private let pollIntervalNanoseconds: UInt64 = 1_000_000_000
 
     public struct Config: Sendable {
         public let apiKey: String
@@ -190,7 +189,19 @@ public struct SonioxTranscriptionService: TranscriptionService, Sendable {
                 throw CloudTranscriptionError.apiRequestFailed(statusCode: 504, message: "Transcription timed out")
             }
 
-            try await Task.sleep(for: .nanoseconds(pollIntervalNanoseconds))
+            try await Task.sleep(for: Self.pollInterval(elapsed: Date().timeIntervalSince(start)))
+        }
+    }
+
+    /// A flat 1s poll cost every dictation up to a second of dead air after the
+    /// job was already done. Short recordings - the common case - finish within
+    /// the first couple of seconds, so poll tightly there and back off for the
+    /// long files where an extra half-second is noise anyway.
+    private static func pollInterval(elapsed: TimeInterval) -> Duration {
+        switch elapsed {
+        case ..<2: .milliseconds(200)
+        case ..<10: .milliseconds(500)
+        default: .seconds(1)
         }
     }
 

--- a/VivaDicta/Models/TranscriptionModelProvider.swift
+++ b/VivaDicta/Models/TranscriptionModelProvider.swift
@@ -80,11 +80,23 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
     /// hopping to MainActor just to look up a string constant.
     nonisolated static let sonioxRealtimeModel = "stt-rt-v5"
 
+    /// Soniox's current async/batch model, used by the upload-and-poll path.
+    nonisolated static let sonioxAsyncModel = "stt-async-v5"
+
     /// Models that transcribe over a live socket while the user speaks, rather
     /// than uploading the finished file. These need the engine-backed capture
     /// path - `AVAudioRecorder` hands out no buffers to stream.
     static func isStreamingModel(_ modelName: String) -> Bool {
         modelName == sonioxRealtimeModel
+    }
+
+    /// The model to send to a batch/upload endpoint for a given selection.
+    /// Realtime slugs are rejected by Soniox's async `/v1/transcriptions` API,
+    /// so a realtime selection maps to its async counterpart whenever the
+    /// upload path runs - the keyboard flow, and the fallback after a dropped
+    /// socket. Everything else passes through untouched.
+    static func asyncEquivalent(of modelName: String) -> String {
+        isStreamingModel(modelName) ? sonioxAsyncModel : modelName
     }
     
     static let cloudProviders: [TranscriptionModelProvider] = [

--- a/VivaDicta/Models/TranscriptionModelProvider.swift
+++ b/VivaDicta/Models/TranscriptionModelProvider.swift
@@ -68,6 +68,24 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
     static let localProviders: [TranscriptionModelProvider] = [
         .whisperKit,
         .parakeet]
+
+    /// Soniox's current realtime model. Declared here rather than on
+    /// `SonioxRealtimeSTTClient` because this file is also compiled into the
+    /// app extensions, which don't link the app-only realtime client.
+    ///
+    /// Soniox retired `stt-rt-v4` on 2026-06-30; it still resolves as an alias
+    /// to v5, but name the current model explicitly rather than depend on that
+    /// aliasing surviving.
+    /// `nonisolated` so the realtime client - an actor - can read it without
+    /// hopping to MainActor just to look up a string constant.
+    nonisolated static let sonioxRealtimeModel = "stt-rt-v5"
+
+    /// Models that transcribe over a live socket while the user speaks, rather
+    /// than uploading the finished file. These need the engine-backed capture
+    /// path - `AVAudioRecorder` hands out no buffers to stream.
+    static func isStreamingModel(_ modelName: String) -> Bool {
+        modelName == sonioxRealtimeModel
+    }
     
     static let cloudProviders: [TranscriptionModelProvider] = [
         .groq,
@@ -220,6 +238,18 @@ enum TranscriptionModelProvider: String, Sendable, Codable, CaseIterable, Identi
                 recommended: true,
                 speed: 0.95,
                 accuracy: 0.98,
+                cost: 0.25,
+                supportManyLanguages: true,
+                supportedLanguages: sonioxLanguages
+            ),
+
+            CloudModel(
+                name: sonioxRealtimeModel,
+                displayName: "Soniox Realtime (stt-rt-v5)",
+                description: "Streams audio to Soniox while you speak instead of uploading after you stop, so the transcript is essentially ready the moment you finish. Same 60+ language coverage as the async model. Falls back to the standard upload path if the connection drops.",
+                provider: .soniox,
+                speed: 1.0,
+                accuracy: 0.97,
                 cost: 0.25,
                 supportManyLanguages: true,
                 supportedLanguages: sonioxLanguages

--- a/VivaDicta/Services/LiveTranslation/LiveTranslationService.swift
+++ b/VivaDicta/Services/LiveTranslation/LiveTranslationService.swift
@@ -312,6 +312,12 @@ final class LiveTranslationService {
     }
 
     private func appendTokens(_ batch: [LiveTranslationToken]) {
+        // The client now forwards empty batches so dictation can clear its
+        // interim tail. Live Translation keeps its previous behaviour and
+        // ignores them, rather than have the on-screen interim text blink out
+        // on every token-less response.
+        guard !batch.isEmpty else { return }
+
         // Split the batch by stream (original vs translation) and merge each
         // into its respective list. We split first so a response that updates
         // only one side doesn't disturb the other side's non-final tail.

--- a/VivaDicta/Services/LiveTranslation/LiveTranslationService.swift
+++ b/VivaDicta/Services/LiveTranslation/LiveTranslationService.swift
@@ -167,8 +167,8 @@ final class LiveTranslationService {
         sttTask = Task { [weak self] in
             let stream = await sttClient.connect(
                 apiKey: apiKey,
-                sourceLanguage: sourceLang,
-                targetLanguage: targetLang,
+                languageHints: [sourceLang.rawValue],
+                mode: .translation(target: targetLang),
                 vocabularyTerms: vocabularyTerms
             )
             for await event in stream {

--- a/VivaDicta/Services/LiveTranslation/SonioxRealtimeSTTClient.swift
+++ b/VivaDicta/Services/LiveTranslation/SonioxRealtimeSTTClient.swift
@@ -9,6 +9,15 @@ import Foundation
 import os
 
 actor SonioxRealtimeSTTClient {
+    /// What the socket is asked to produce. Live Translation wants a
+    /// translated stream alongside the original; dictation wants transcript
+    /// only, and sending a `translation` object there would make Soniox emit
+    /// translation tokens nobody consumes.
+    enum Mode: Sendable {
+        case transcription
+        case translation(target: LiveTranslationLanguage)
+    }
+
     enum Event: Sendable {
         /// All tokens from a single Soniox server response, in order. Per the
         /// Soniox protocol the non-final tokens in each response are a *full
@@ -23,14 +32,20 @@ actor SonioxRealtimeSTTClient {
     private let logger = Logger(category: .liveTranslationSTT)
     private let endpoint = URL(string: "wss://stt-rt.soniox.com/transcribe-websocket")!
 
+    /// Defined on the model catalog because that file is shared with the app
+    /// extensions; see `TranscriptionModelProvider.sonioxRealtimeModel`.
+    static let model = TranscriptionModelProvider.sonioxRealtimeModel
+
     private var task: URLSessionWebSocketTask?
     private var receiveTask: Task<Void, Never>?
     private var continuation: AsyncStream<Event>.Continuation?
 
+    /// - Parameter languageHints: BCP-47 codes passed to Soniox as soft hints.
+    ///   Empty means no hint at all, which is what auto-detect dictation wants.
     func connect(
         apiKey: String,
-        sourceLanguage: LiveTranslationLanguage,
-        targetLanguage: LiveTranslationLanguage,
+        languageHints: [String],
+        mode: Mode,
         vocabularyTerms: [String]
     ) -> AsyncStream<Event> {
         disconnect()
@@ -51,8 +66,8 @@ actor SonioxRealtimeSTTClient {
         do {
             let config = makeConfigPayload(
                 apiKey: apiKey,
-                sourceLanguage: sourceLanguage,
-                targetLanguage: targetLanguage,
+                languageHints: languageHints,
+                mode: mode,
                 vocabularyTerms: vocabularyTerms
             )
             let data = try JSONSerialization.data(withJSONObject: config)
@@ -100,29 +115,36 @@ actor SonioxRealtimeSTTClient {
 
     private func makeConfigPayload(
         apiKey: String,
-        sourceLanguage: LiveTranslationLanguage,
-        targetLanguage: LiveTranslationLanguage,
+        languageHints: [String],
+        mode: Mode,
         vocabularyTerms: [String]
     ) -> [String: Any] {
         var payload: [String: Any] = [
             "api_key": apiKey,
-            "model": "stt-rt-v4",
+            "model": Self.model,
             "audio_format": "pcm_s16le",
             "sample_rate": 16000,
             "num_channels": 1,
-            // Soft hint only - do NOT set language_hints_strict here. Lecturers
-            // routinely code-switch into English for technical terms, names, and
-            // slide titles; strict mode forces those into the source language's
-            // phonetics and produces garbled transcripts. Keep enable_language_identification
-            // on so each token still carries its detected language.
-            "language_hints": [sourceLanguage.rawValue],
             "enable_language_identification": true,
-            "enable_endpoint_detection": true,
-            "translation": [
-                "type": "one_way",
-                "target_language": targetLanguage.rawValue
-            ]
+            "enable_endpoint_detection": true
         ]
+
+        // Soft hint only - do NOT set language_hints_strict here. Lecturers
+        // routinely code-switch into English for technical terms, names, and
+        // slide titles; strict mode forces those into the source language's
+        // phonetics and produces garbled transcripts. Keep enable_language_identification
+        // on so each token still carries its detected language. On auto-detect
+        // dictation the hint list is empty and the key is dropped entirely.
+        if !languageHints.isEmpty {
+            payload["language_hints"] = languageHints
+        }
+
+        if case .translation(let target) = mode {
+            payload["translation"] = [
+                "type": "one_way",
+                "target_language": target.rawValue
+            ]
+        }
 
         if !vocabularyTerms.isEmpty {
             payload["context"] = ["terms": vocabularyTerms]

--- a/VivaDicta/Services/LiveTranslation/SonioxRealtimeSTTClient.swift
+++ b/VivaDicta/Services/LiveTranslation/SonioxRealtimeSTTClient.swift
@@ -199,9 +199,12 @@ actor SonioxRealtimeSTTClient {
                     batch.append(token)
                 }
             }
-            if !batch.isEmpty {
-                continuation?.yield(.tokens(batch))
-            }
+            // Forwarded even when empty. Non-final tokens are a full
+            // replacement set, so a response carrying none means the interim
+            // region was withdrawn - suppressing it leaves consumers holding
+            // text the server has retracted. Consumers that do not want that
+            // signal ignore empty batches themselves.
+            continuation?.yield(.tokens(batch))
         }
 
         if let finished = json["finished"] as? Bool, finished {

--- a/VivaDicta/Services/Transcription/Realtime/RealtimeDictationCoordinator.swift
+++ b/VivaDicta/Services/Transcription/Realtime/RealtimeDictationCoordinator.swift
@@ -97,9 +97,11 @@ final class RealtimeDictationCoordinator {
     /// Throws when realtime produced nothing usable, signalling the caller to
     /// fall back to uploading the recorded file.
     func finish() async throws -> String {
-        guard isActive else {
-            throw SonioxRealtimeDictationSession.SessionError.producedNoText
-        }
+        // Tear down before deciding whether there is anything to return. A stop
+        // can land while `start()` is still suspended, and bailing out early
+        // there would strand a running engine and socket behind a UI that has
+        // already moved on.
+        let wasActive = isActive
         isActive = false
 
         // Stop the mic first so no audio arrives after the end-of-audio marker.
@@ -112,6 +114,11 @@ final class RealtimeDictationCoordinator {
         // transcript, nothing downstream would notice the loss.
         await pumpTask?.value
         pumpTask = nil
+
+        guard wasActive else {
+            await session.cancel()
+            throw SonioxRealtimeDictationSession.SessionError.producedNoText
+        }
 
         return try await session.finish()
     }

--- a/VivaDicta/Services/Transcription/Realtime/RealtimeDictationCoordinator.swift
+++ b/VivaDicta/Services/Transcription/Realtime/RealtimeDictationCoordinator.swift
@@ -5,6 +5,7 @@
 //  Created by Anton Novoselov on 2026.08.08
 //
 
+import AppGroup
 import Foundation
 import Keychain
 import os
@@ -36,15 +37,29 @@ final class RealtimeDictationCoordinator {
         self.keychain = keychain
     }
 
-    /// Whether realtime should be used for this model right now. A missing API
+    /// Whether realtime should be used for this mode right now. A missing API
     /// key is not an error here - the caller just records normally and the
     /// usual missing-key error surfaces from the upload path.
+    ///
+    /// Modes asking for inline translation or speaker labels stay on the
+    /// upload path. The socket is opened in transcription-only mode, and since
+    /// a successful stream bypasses the Soniox job entirely, streaming those
+    /// modes would quietly save untranslated text with no speaker attribution
+    /// - a worse failure than simply being slower.
     static func canHandle(
+        mode: VivaMode,
         modelName: String?,
         keychain: any KeychainService = DefaultKeychainService()
     ) -> Bool {
         guard let modelName, TranscriptionModelProvider.isStreamingModel(modelName) else { return false }
         guard let key = keychain.getString(forKey: "sonioxAPIKey"), !key.isEmpty else { return false }
+
+        let translationTarget = mode.translationTargetLanguage ?? ""
+        guard translationTarget.isEmpty else { return false }
+
+        // Speaker labels are a global setting rather than a mode property.
+        guard !AppGroupCoordinator.shared.isSpeakerDiarizationEnabled else { return false }
+
         return true
     }
 
@@ -89,7 +104,13 @@ final class RealtimeDictationCoordinator {
 
         // Stop the mic first so no audio arrives after the end-of-audio marker.
         await capture.stop()
-        pumpTask?.cancel()
+
+        // `capture.stop()` finishes the stream, but up to ~1s of chunks may
+        // still be buffered in it. Wait for the pump to drain them rather than
+        // cancelling - cancelling here drops the tail of the recording, and
+        // because the socket would still return a successful (just truncated)
+        // transcript, nothing downstream would notice the loss.
+        await pumpTask?.value
         pumpTask = nil
 
         return try await session.finish()

--- a/VivaDicta/Services/Transcription/Realtime/RealtimeDictationCoordinator.swift
+++ b/VivaDicta/Services/Transcription/Realtime/RealtimeDictationCoordinator.swift
@@ -1,0 +1,105 @@
+//
+//  RealtimeDictationCoordinator.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.08.08
+//
+
+import Foundation
+import Keychain
+import os
+
+/// Pairs `StreamingAudioCapture` with `SonioxRealtimeDictationSession` for one
+/// dictation, so `RecordViewModel` deals with a single object rather than an
+/// engine, a socket, and the pump task between them.
+///
+/// The recorded WAV is still written throughout. If the socket fails at any
+/// point the caller can simply transcribe that file the normal way, which is
+/// why `finish()` throws instead of returning a partial transcript.
+@MainActor
+final class RealtimeDictationCoordinator {
+    private let logger = Logger(category: .sonioxRealtimeDictation)
+    private let capture = StreamingAudioCapture()
+    private let session = SonioxRealtimeDictationSession()
+    private let keychain: any KeychainService
+
+    private var pumpTask: Task<Void, Never>?
+    private(set) var isActive = false
+
+    /// Mic level for the waveform while streaming, standing in for
+    /// `AudioRecordingService.currentAudioPower` on this path.
+    var currentAudioLevel: Double {
+        Double(capture.currentAudioLevel)
+    }
+
+    init(keychain: any KeychainService = DefaultKeychainService()) {
+        self.keychain = keychain
+    }
+
+    /// Whether realtime should be used for this model right now. A missing API
+    /// key is not an error here - the caller just records normally and the
+    /// usual missing-key error surfaces from the upload path.
+    static func canHandle(
+        modelName: String?,
+        keychain: any KeychainService = DefaultKeychainService()
+    ) -> Bool {
+        guard let modelName, TranscriptionModelProvider.isStreamingModel(modelName) else { return false }
+        guard let key = keychain.getString(forKey: "sonioxAPIKey"), !key.isEmpty else { return false }
+        return true
+    }
+
+    /// Starts capture and opens the socket. Throws only if *capture* fails -
+    /// a socket that never connects surfaces later, at `finish()`, by which
+    /// point the WAV is complete and the fallback can take over.
+    func start(writingTo url: URL, transcriptionLanguage: String) async throws {
+        guard !isActive else { return }
+
+        guard let apiKey = keychain.getString(forKey: "sonioxAPIKey"), !apiKey.isEmpty else {
+            throw SonioxRealtimeDictationSession.SessionError.transportFailed("missing Soniox API key")
+        }
+
+        let stream = capture.makeStream()
+        try await capture.start(writingTo: url)
+        isActive = true
+
+        // "auto" means let Soniox detect; sending it as a hint would be wrong.
+        let hints = (transcriptionLanguage == "auto" || transcriptionLanguage.isEmpty) ? [] : [transcriptionLanguage]
+
+        await session.start(
+            apiKey: apiKey,
+            languageHints: hints,
+            vocabularyTerms: CustomVocabulary.getTerms()
+        )
+
+        pumpTask = Task { [session] in
+            for await chunk in stream {
+                await session.send(chunk)
+            }
+        }
+    }
+
+    /// Stops capture, flushes the socket, and returns the transcript.
+    /// Throws when realtime produced nothing usable, signalling the caller to
+    /// fall back to uploading the recorded file.
+    func finish() async throws -> String {
+        guard isActive else {
+            throw SonioxRealtimeDictationSession.SessionError.producedNoText
+        }
+        isActive = false
+
+        // Stop the mic first so no audio arrives after the end-of-audio marker.
+        await capture.stop()
+        pumpTask?.cancel()
+        pumpTask = nil
+
+        return try await session.finish()
+    }
+
+    func cancel() async {
+        isActive = false
+        await capture.stop()
+        pumpTask?.cancel()
+        pumpTask = nil
+        await session.cancel()
+    }
+}

--- a/VivaDicta/Services/Transcription/Realtime/RealtimeTranscriptAccumulator.swift
+++ b/VivaDicta/Services/Transcription/Realtime/RealtimeTranscriptAccumulator.swift
@@ -1,0 +1,53 @@
+//
+//  RealtimeTranscriptAccumulator.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.08.08
+//
+
+import Foundation
+
+/// Merges Soniox realtime token batches into a running transcript.
+///
+/// The subtlety this exists to contain: Soniox treats the non-final tokens in
+/// each response as a **full replacement set** for the unstable tail, while
+/// final tokens are append-only and never resent. Appending both would
+/// duplicate every word as it firms up, so interims are rebuilt per batch and
+/// only finals accumulate.
+///
+/// Pure value type with no actor or socket involvement, so the merge rule can
+/// be tested directly. `nonisolated` because the session actor owns one and
+/// mutates it off MainActor.
+nonisolated struct RealtimeTranscriptAccumulator {
+    private(set) var finalText = ""
+    private(set) var interimText = ""
+
+    /// Finals plus the current unstable tail. Soniox tokens carry their own
+    /// leading spaces, so plain concatenation is correct - inserting
+    /// separators here would double the spacing.
+    var text: String {
+        finalText + interimText
+    }
+
+    mutating func ingest(_ batch: [LiveTranslationToken]) {
+        var interim = ""
+
+        for token in batch {
+            // Dictation never requests translation, but guard anyway so a stray
+            // translation token can't be spliced into the transcript. Matched by
+            // pattern rather than `==` because Kind's Equatable conformance is
+            // MainActor-isolated and this is consumed from an actor.
+            guard case .original = token.kind else { continue }
+
+            if token.isFinal {
+                finalText += token.text
+            } else {
+                interim += token.text
+            }
+        }
+
+        // Replace, never append - including with an empty batch tail, which is
+        // how Soniox signals that the interim region has firmed up entirely.
+        interimText = interim
+    }
+}

--- a/VivaDicta/Services/Transcription/Realtime/SonioxRealtimeDictationSession.swift
+++ b/VivaDicta/Services/Transcription/Realtime/SonioxRealtimeDictationSession.swift
@@ -87,6 +87,11 @@ actor SonioxRealtimeDictationSession {
 
         let deadline = ContinuousClock.now.advanced(by: Self.finalizeTimeout)
         while !didFinish, failureMessage == nil, ContinuousClock.now < deadline {
+            // On a cancelled task `Task.sleep` throws immediately and `try?`
+            // swallows it, so without this the loop spins at full speed until
+            // the deadline. Breaking lands in the timeout path below, which
+            // throws - the right outcome for a cancel.
+            if Task.isCancelled { break }
             try? await Task.sleep(for: .milliseconds(50))
         }
 

--- a/VivaDicta/Services/Transcription/Realtime/SonioxRealtimeDictationSession.swift
+++ b/VivaDicta/Services/Transcription/Realtime/SonioxRealtimeDictationSession.swift
@@ -44,9 +44,6 @@ actor SonioxRealtimeDictationSession {
     private var failureMessage: String?
     private var didFinish = false
 
-    /// Emits the best-known transcript (finals + current interim) as it grows,
-    /// so callers can show live text while the user is still speaking.
-    private var previewContinuation: AsyncStream<String>.Continuation?
     private var receiveTask: Task<Void, Never>?
 
     /// Text captured so far. Safe to read at any point.
@@ -73,12 +70,6 @@ actor SonioxRealtimeDictationSession {
         }
     }
 
-    func makePreviewStream() -> AsyncStream<String> {
-        AsyncStream<String> { continuation in
-            previewContinuation = continuation
-        }
-    }
-
     func send(_ pcmChunk: Data) async {
         guard isRunning, failureMessage == nil else { return }
         await client.sendAudioChunk(pcmChunk)
@@ -99,10 +90,22 @@ actor SonioxRealtimeDictationSession {
             try? await Task.sleep(for: .milliseconds(50))
         }
 
+        let didTimeOut = !didFinish && failureMessage == nil
+
         await teardown()
 
         if let failureMessage {
             throw SessionError.transportFailed(failureMessage)
+        }
+
+        // A timeout means the server never confirmed it was done, so whatever
+        // accumulated may be missing the tail and can still contain an
+        // unsettled interim region. Returning it would silently save a
+        // truncated transcript, so treat it as a transport failure and let the
+        // caller upload the recorded file instead.
+        if didTimeOut {
+            logger.logWarning("Realtime finalize timed out; deferring to the upload fallback")
+            throw SessionError.transportFailed("timed out waiting for final tokens")
         }
 
         let text = accumulator.text.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -131,7 +134,6 @@ actor SonioxRealtimeDictationSession {
 
     private func apply(_ batch: [LiveTranslationToken]) {
         accumulator.ingest(batch)
-        previewContinuation?.yield(accumulator.text)
     }
 
     private func markStreamEnded() {
@@ -142,8 +144,6 @@ actor SonioxRealtimeDictationSession {
         isRunning = false
         receiveTask?.cancel()
         receiveTask = nil
-        previewContinuation?.finish()
-        previewContinuation = nil
         await client.disconnect()
     }
 }

--- a/VivaDicta/Services/Transcription/Realtime/SonioxRealtimeDictationSession.swift
+++ b/VivaDicta/Services/Transcription/Realtime/SonioxRealtimeDictationSession.swift
@@ -1,0 +1,149 @@
+//
+//  SonioxRealtimeDictationSession.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.08.08
+//
+
+import Foundation
+import os
+
+/// Drives one dictation over Soniox's realtime WebSocket.
+///
+/// The async REST path can only start work once the user stops talking (upload
+/// → create job → poll). This streams PCM while they speak, so by the time
+/// `finish()` is called the server has usually emitted every final token
+/// already and only the tail is outstanding.
+///
+/// Soniox sends non-final tokens as a *full replacement set* for the current
+/// interim region, so this keeps finals and interims apart and rebuilds the
+/// preview text on every batch rather than appending blindly.
+actor SonioxRealtimeDictationSession {
+    enum SessionError: LocalizedError {
+        case transportFailed(String)
+        case producedNoText
+
+        var errorDescription: String? {
+            switch self {
+            case .transportFailed(let message): "Realtime transcription failed: \(message)"
+            case .producedNoText: "Realtime transcription returned no text"
+            }
+        }
+    }
+
+    /// How long `finish()` waits for the server to flush remaining tokens after
+    /// the end-of-audio marker. Streaming has already delivered the bulk of the
+    /// transcript by then, so this is a tail-latency guard, not the main wait.
+    private static let finalizeTimeout: Duration = .seconds(10)
+
+    private let logger = Logger(category: .sonioxRealtimeDictation)
+    private let client = SonioxRealtimeSTTClient()
+
+    private var accumulator = RealtimeTranscriptAccumulator()
+    private var isRunning = false
+    private var failureMessage: String?
+    private var didFinish = false
+
+    /// Emits the best-known transcript (finals + current interim) as it grows,
+    /// so callers can show live text while the user is still speaking.
+    private var previewContinuation: AsyncStream<String>.Continuation?
+    private var receiveTask: Task<Void, Never>?
+
+    /// Text captured so far. Safe to read at any point.
+    var currentText: String {
+        accumulator.text
+    }
+
+    func start(apiKey: String, languageHints: [String], vocabularyTerms: [String]) async {
+        guard !isRunning else { return }
+        isRunning = true
+
+        let stream = await client.connect(
+            apiKey: apiKey,
+            languageHints: languageHints,
+            mode: .transcription,
+            vocabularyTerms: vocabularyTerms
+        )
+
+        receiveTask = Task { [weak self] in
+            for await event in stream {
+                await self?.handle(event)
+            }
+            await self?.markStreamEnded()
+        }
+    }
+
+    func makePreviewStream() -> AsyncStream<String> {
+        AsyncStream<String> { continuation in
+            previewContinuation = continuation
+        }
+    }
+
+    func send(_ pcmChunk: Data) async {
+        guard isRunning, failureMessage == nil else { return }
+        await client.sendAudioChunk(pcmChunk)
+    }
+
+    /// Signals end-of-audio and waits for the server's remaining tokens.
+    ///
+    /// Throws rather than returning partial text on transport failure so the
+    /// caller can fall back to uploading the recorded file - the file is
+    /// written in parallel precisely so that fallback stays available.
+    func finish() async throws -> String {
+        guard isRunning else { throw SessionError.producedNoText }
+
+        await client.finalizeAudio()
+
+        let deadline = ContinuousClock.now.advanced(by: Self.finalizeTimeout)
+        while !didFinish, failureMessage == nil, ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+
+        await teardown()
+
+        if let failureMessage {
+            throw SessionError.transportFailed(failureMessage)
+        }
+
+        let text = accumulator.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { throw SessionError.producedNoText }
+        return text
+    }
+
+    /// Aborts without waiting - used when the user cancels the recording.
+    func cancel() async {
+        await teardown()
+    }
+
+    // MARK: - Private
+
+    private func handle(_ event: SonioxRealtimeSTTClient.Event) {
+        switch event {
+        case .tokens(let batch):
+            apply(batch)
+        case .finished:
+            didFinish = true
+        case .failed(let message):
+            logger.logError("Realtime dictation failed: \(message)")
+            failureMessage = message
+        }
+    }
+
+    private func apply(_ batch: [LiveTranslationToken]) {
+        accumulator.ingest(batch)
+        previewContinuation?.yield(accumulator.text)
+    }
+
+    private func markStreamEnded() {
+        didFinish = true
+    }
+
+    private func teardown() async {
+        isRunning = false
+        receiveTask?.cancel()
+        receiveTask = nil
+        previewContinuation?.finish()
+        previewContinuation = nil
+        await client.disconnect()
+    }
+}

--- a/VivaDicta/Services/Transcription/Realtime/StreamingAudioCapture.swift
+++ b/VivaDicta/Services/Transcription/Realtime/StreamingAudioCapture.swift
@@ -1,0 +1,345 @@
+//
+//  StreamingAudioCapture.swift
+//  VivaDicta
+//
+//  Created by Anton Novoselov on 2026.08.08
+//
+
+import AVFoundation
+import Foundation
+import os
+
+/// Records to a WAV file *and* hands out the same PCM as a live stream.
+///
+/// `AVAudioRecorder` (the normal dictation recorder) exposes no buffer
+/// callbacks, so realtime streaming needs an engine-backed capture. Rather
+/// than migrate the default path - which every user and every provider goes
+/// through - this is a parallel implementation used only when a streaming
+/// model is selected. The file it writes is what the upload-and-poll fallback
+/// and normal storage/playback use, so nothing downstream has to care which
+/// capture produced it.
+@MainActor
+final class StreamingAudioCapture {
+    /// Matches what the file-based recorder writes and what Soniox realtime
+    /// expects (`pcm_s16le` @ 16 kHz mono), so no second conversion is needed.
+    static let sampleRate: Double = 16_000
+
+    enum CaptureError: LocalizedError {
+        case sessionFailure(String)
+        case engineFailure(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .sessionFailure(let message): "Audio session failed: \(message)"
+            case .engineFailure(let message): "Audio engine failed: \(message)"
+            }
+        }
+    }
+
+    private let logger = Logger(category: .streamingAudioCapture)
+    private let engine = AVAudioEngine()
+
+    private var continuation: AsyncStream<Data>.Continuation?
+    private var sink: CaptureSink?
+    private var isStarted = false
+    private var tapInstalled = false
+    private var sessionActivated = false
+
+    private let captureFormat: AVAudioFormat = {
+        AVAudioFormat(
+            commonFormat: .pcmFormatInt16,
+            sampleRate: StreamingAudioCapture.sampleRate,
+            channels: 1,
+            interleaved: true
+        )!
+    }()
+
+    /// Normalised 0...1 mic level for the waveform, mirroring what the
+    /// `AVAudioRecorder` path feeds the visualizer. Read from MainActor while
+    /// the tap writes it on the audio thread, so it goes through the sink's lock.
+    var currentAudioLevel: Float {
+        sink?.currentLevel ?? 0
+    }
+
+    /// Bounded so a stalled WebSocket drops old audio instead of growing
+    /// memory without limit. ~50 chunks of ~20ms is about a second of slack.
+    func makeStream() -> AsyncStream<Data> {
+        AsyncStream<Data>(bufferingPolicy: .bufferingNewest(50)) { continuation in
+            self.continuation = continuation
+            continuation.onTermination = { @Sendable [weak self] _ in
+                Task { @MainActor in self?.continuation = nil }
+            }
+        }
+    }
+
+    func start(writingTo url: URL) async throws {
+        guard !isStarted else { return }
+
+        do {
+            try configureSession()
+            try await configureEngine(writingTo: url)
+            try engine.start()
+            isStarted = true
+        } catch {
+            await stop()
+            throw error
+        }
+    }
+
+    /// Idempotent. Teardown runs off MainActor because `engine.stop()` and
+    /// `removeTap` can block for a noticeable moment after a route change, and
+    /// blocking MainActor there freezes the stop button.
+    func stop() async {
+        guard isStarted || tapInstalled || sessionActivated else { return }
+
+        let needsTap = tapInstalled
+        let needsDeactivate = sessionActivated
+
+        isStarted = false
+        tapInstalled = false
+        sessionActivated = false
+
+        continuation?.finish()
+        continuation = nil
+
+        let context = StreamingTeardownContext(
+            engine: engine,
+            sink: sink,
+            removeTap: needsTap,
+            deactivateSession: needsDeactivate,
+            logger: logger
+        )
+        sink = nil
+
+        await Task(priority: .userInitiated) { @concurrent in
+            context.perform()
+        }.value
+    }
+
+    // MARK: - Private
+
+    private func configureSession() throws {
+        let session = AVAudioSession.sharedInstance()
+        do {
+            try session.setCategory(.playAndRecord, mode: .spokenAudio, options: [.allowBluetoothHFP, .defaultToSpeaker])
+            try session.setPreferredIOBufferDuration(0.02)
+            try session.setActive(true, options: [])
+            sessionActivated = true
+        } catch {
+            throw CaptureError.sessionFailure(error.localizedDescription)
+        }
+    }
+
+    private func configureEngine(writingTo url: URL) async throws {
+        let inputNode = engine.inputNode
+        let inputFormat = inputNode.outputFormat(forBus: 0)
+
+        guard inputFormat.sampleRate > 0, inputFormat.channelCount > 0 else {
+            throw CaptureError.engineFailure("invalid input format")
+        }
+
+        guard let continuation else {
+            throw CaptureError.engineFailure("capture stream not initialized")
+        }
+
+        guard let converter = AVAudioConverter(from: inputFormat, to: captureFormat) else {
+            throw CaptureError.engineFailure("converter init failed")
+        }
+
+        // Write a real 16-bit PCM WAV so the fallback upload, playback, and
+        // retranscription all see the same file shape the normal recorder makes.
+        let fileSettings: [String: Any] = [
+            AVFormatIDKey: kAudioFormatLinearPCM,
+            AVSampleRateKey: Self.sampleRate,
+            AVNumberOfChannelsKey: 1,
+            AVLinearPCMBitDepthKey: 16,
+            AVLinearPCMIsBigEndianKey: false,
+            AVLinearPCMIsFloatKey: false
+        ]
+
+        let audioFile: AVAudioFile
+        do {
+            audioFile = try AVAudioFile(forWriting: url, settings: fileSettings, commonFormat: .pcmFormatInt16, interleaved: true)
+        } catch {
+            throw CaptureError.engineFailure("audio file open failed: \(error.localizedDescription)")
+        }
+
+        let sink = CaptureSink(
+            converter: converter,
+            captureFormat: captureFormat,
+            audioFile: audioFile,
+            continuation: continuation
+        )
+        self.sink = sink
+
+        // Install from a background queue so the tap closure does not inherit
+        // MainActor isolation - AVAudioEngine calls it on its realtime thread
+        // and an isolated closure trips _dispatch_assert_queue_fail.
+        await withCheckedContinuation { resume in
+            DispatchQueue.global(qos: .userInitiated).async {
+                installStreamingInputTap(inputNode: inputNode, format: inputFormat, sink: sink)
+                resume.resume()
+            }
+        }
+        tapInstalled = true
+
+        engine.prepare()
+    }
+}
+
+/// Hardware-side teardown, wrapped in an `@unchecked Sendable` class so it can
+/// run off MainActor. Mirrors `LiveTranslationAudio`'s teardown, including its
+/// hard-won detail: deactivate the session WITHOUT
+/// `.notifyOthersOnDeactivation`, which fires synchronous notifications to
+/// other apps and has been observed to take seconds.
+nonisolated private final class StreamingTeardownContext: @unchecked Sendable {
+    private let engine: AVAudioEngine
+    private let sink: CaptureSink?
+    private let removeTap: Bool
+    private let deactivateSession: Bool
+    private let logger: Logger
+
+    init(
+        engine: AVAudioEngine,
+        sink: CaptureSink?,
+        removeTap: Bool,
+        deactivateSession: Bool,
+        logger: Logger
+    ) {
+        self.engine = engine
+        self.sink = sink
+        self.removeTap = removeTap
+        self.deactivateSession = deactivateSession
+        self.logger = logger
+    }
+
+    func perform() {
+        if removeTap {
+            engine.inputNode.removeTap(onBus: 0)
+        }
+
+        engine.stop()
+
+        // Close after the tap is gone so no write can be in flight.
+        sink?.closeFile()
+
+        if deactivateSession {
+            do {
+                try AVAudioSession.sharedInstance().setActive(false)
+            } catch {
+                logger.logWarning("Streaming capture: session deactivate failed: \(error.localizedDescription)")
+            }
+        }
+    }
+}
+
+/// Installs the tap from a nonisolated context so the closure stays free of
+/// MainActor isolation.
+nonisolated private func installStreamingInputTap(
+    inputNode: AVAudioInputNode,
+    format: AVAudioFormat,
+    sink: CaptureSink
+) {
+    inputNode.installTap(onBus: 0, bufferSize: 4096, format: format) { buffer, _ in
+        sink.process(buffer)
+    }
+}
+
+/// Runs entirely on AVAudioEngine's realtime audio thread. Converts each input
+/// buffer once, then fans the result out to both the file and the socket -
+/// converting twice would be wasted work on a thread that must not stall.
+nonisolated private final class CaptureSink: @unchecked Sendable {
+    private let converter: AVAudioConverter
+    private let captureFormat: AVAudioFormat
+    private let continuation: AsyncStream<Data>.Continuation
+    private let lock = NSLock()
+    private var audioFile: AVAudioFile?
+    private var level: Float = 0
+
+    var currentLevel: Float {
+        lock.lock()
+        defer { lock.unlock() }
+        return level
+    }
+
+    init(
+        converter: AVAudioConverter,
+        captureFormat: AVAudioFormat,
+        audioFile: AVAudioFile,
+        continuation: AsyncStream<Data>.Continuation
+    ) {
+        self.converter = converter
+        self.captureFormat = captureFormat
+        self.audioFile = audioFile
+        self.continuation = continuation
+    }
+
+    func process(_ buffer: AVAudioPCMBuffer) {
+        let sourceFormat = buffer.format
+        let ratio = captureFormat.sampleRate / sourceFormat.sampleRate
+        let estimatedFrames = Double(buffer.frameLength) * ratio
+        let outCapacity = AVAudioFrameCount(estimatedFrames.rounded(.up)) + 1024
+
+        guard let outBuffer = AVAudioPCMBuffer(pcmFormat: captureFormat, frameCapacity: outCapacity) else {
+            return
+        }
+
+        var providedInput = false
+        var conversionError: NSError?
+        let status = converter.convert(to: outBuffer, error: &conversionError) { _, statusPtr in
+            if providedInput {
+                statusPtr.pointee = .noDataNow
+                return nil
+            }
+            providedInput = true
+            statusPtr.pointee = .haveData
+            return buffer
+        }
+
+        if status == .error || conversionError != nil {
+            return
+        }
+
+        guard outBuffer.frameLength > 0, let channelData = outBuffer.int16ChannelData else {
+            return
+        }
+
+        let frameCount = Int(outBuffer.frameLength)
+        let meterLevel = Self.normalizedLevel(samples: channelData[0], frameCount: frameCount)
+
+        lock.lock()
+        try? audioFile?.write(from: outBuffer)
+        level = meterLevel
+        lock.unlock()
+
+        continuation.yield(Data(bytes: channelData[0], count: frameCount * 2))
+    }
+
+    /// RMS of the Int16 samples mapped onto 0...1 with a dB curve, so the
+    /// waveform responds like it does on the `AVAudioRecorder` path rather
+    /// than sitting near zero for normal speech.
+    private static func normalizedLevel(samples: UnsafeMutablePointer<Int16>, frameCount: Int) -> Float {
+        guard frameCount > 0 else { return 0 }
+
+        var sumOfSquares: Float = 0
+        for index in 0..<frameCount {
+            let sample = Float(samples[index]) / Float(Int16.max)
+            sumOfSquares += sample * sample
+        }
+
+        let rms = (sumOfSquares / Float(frameCount)).squareRoot()
+        guard rms > 0 else { return 0 }
+
+        let decibels = 20 * log10(rms)
+        return min(1, max(0, 1 - abs(decibels / 50)))
+    }
+
+    /// AVAudioFile finalises its header on deallocation, so dropping the
+    /// reference under the same lock the tap uses is what closes the WAV
+    /// cleanly without racing an in-flight write.
+    func closeFile() {
+        lock.lock()
+        audioFile = nil
+        lock.unlock()
+    }
+}

--- a/VivaDicta/Services/Transcription/Realtime/StreamingAudioCapture.swift
+++ b/VivaDicta/Services/Transcription/Realtime/StreamingAudioCapture.swift
@@ -175,6 +175,13 @@ final class StreamingAudioCapture {
         // Install from a background queue so the tap closure does not inherit
         // MainActor isolation - AVAudioEngine calls it on its realtime thread
         // and an isolated closure trips _dispatch_assert_queue_fail.
+        //
+        // This is the one deliberate exception to the repo's no-GCD rule, and
+        // it matches what `LiveTranslationAudio.configureEngine` and
+        // `AudioPrewarmManager` already do for the same reason. A structured
+        // alternative that reliably strips the isolation from a closure handed
+        // to a C-level realtime callback does not exist today; swapping in a
+        // Task here reintroduces the crash those two call sites solved.
         await withCheckedContinuation { resume in
             DispatchQueue.global(qos: .userInitiated).async {
                 installStreamingInputTap(inputNode: inputNode, format: inputFormat, sink: sink)

--- a/VivaDicta/Services/Transcription/Realtime/StreamingAudioCapture.swift
+++ b/VivaDicta/Services/Transcription/Realtime/StreamingAudioCapture.swift
@@ -99,8 +99,8 @@ final class StreamingAudioCapture {
         tapInstalled = false
         sessionActivated = false
 
-        continuation?.finish()
-        continuation = nil
+        let continuation = self.continuation
+        self.continuation = nil
 
         let context = StreamingTeardownContext(
             engine: engine,
@@ -111,9 +111,16 @@ final class StreamingAudioCapture {
         )
         sink = nil
 
+        // Silence the producer BEFORE closing the stream. Finishing first
+        // leaves a window where an in-flight tap callback still writes its
+        // buffer to the WAV but yields into an already-terminated stream - the
+        // socket would then return a successful transcript quietly missing that
+        // audio, with nothing to trigger the upload fallback.
         await Task(priority: .userInitiated) { @concurrent in
             context.perform()
         }.value
+
+        continuation?.finish()
     }
 
     // MARK: - Private

--- a/VivaDicta/Services/Transcription/Transcriber.swift
+++ b/VivaDicta/Services/Transcription/Transcriber.swift
@@ -27,4 +27,9 @@ protocol Transcriber {
     /// Transcribe `audioURL` under the current mode, apply the post-processing
     /// pipeline, and return the final text.
     func transcribe(audioURL: URL, progressHandler: TranscriptionProgressHandler?) async throws -> String
+
+    /// Apply the same post-processing pipeline to text that arrived over the
+    /// realtime WebSocket rather than from an upload, so both paths produce
+    /// identically filtered and formatted output.
+    func postProcessStreamedText(_ text: String, startTime: Date) -> String
 }

--- a/VivaDicta/Services/Transcription/TranscriptionManager.swift
+++ b/VivaDicta/Services/Transcription/TranscriptionManager.swift
@@ -345,9 +345,15 @@ class TranscriptionManager: Transcriber {
             ))
 
         case .soniox:
+            // This provider is the upload-and-poll `/v1/transcriptions` job,
+            // which only accepts `stt-async-*` models. When the realtime model
+            // is selected we still land here for the keyboard path and for the
+            // fallback after a dropped socket, so swap in the async model -
+            // otherwise the very fallback the streaming design relies on would
+            // be rejected for sending a realtime slug to the async endpoint.
             return .soniox(.init(
                 apiKey: try requireAPIKey(model),
-                modelName: model.name,
+                modelName: TranscriptionModelProvider.asyncEquivalent(of: model.name),
                 language: selectedLanguage,
                 vocabulary: CustomVocabulary.getTerms(),
                 isSpeakerDiarizationEnabled: diarizationEnabled,

--- a/VivaDicta/Services/Transcription/TranscriptionManager.swift
+++ b/VivaDicta/Services/Transcription/TranscriptionManager.swift
@@ -163,6 +163,23 @@ class TranscriptionManager: Transcriber {
             progress: progressHandler
         )
 
+        return postProcess(transcriptionResult, model: model, startTime: startTime)
+    }
+
+    /// Runs the same post-processing the file-based path applies, for text that
+    /// arrived over the realtime WebSocket instead of an upload. Keeping this
+    /// one implementation is the point - filters, formatting, replacements, and
+    /// the completion analytics must not diverge between the two paths.
+    public func postProcessStreamedText(_ text: String, startTime: Date) -> String {
+        guard let model = getCurrentTranscriptionModel() else { return text }
+        return postProcess(.plain(text), model: model, startTime: startTime)
+    }
+
+    private func postProcess(
+        _ transcriptionResult: TranscriptionServiceResult,
+        model: any TranscriptionModel,
+        startTime: Date
+    ) -> String {
         // When inline translation is active (e.g. Soniox Spanish → Russian) the
         // output text is in the TARGET language, so the filler set must match the
         // target, not the source transcription language - otherwise target-language

--- a/VivaDicta/Utilities/LoggerExtension.swift
+++ b/VivaDicta/Utilities/LoggerExtension.swift
@@ -41,6 +41,8 @@ public enum LogCategory: String {
     case cohereTranscriptionService = "CohereTranscriptionService"
     case cartesiaTranscriptionService = "CartesiaTranscriptionService"
     case customTranscriptionService = "CustomTranscriptionService"
+    case sonioxRealtimeDictation = "SonioxRealtimeDictation"
+    case streamingAudioCapture = "StreamingAudioCapture"
 
     // MARK: - Services - Live Translation
     case liveTranslationService = "LiveTranslationService"

--- a/VivaDicta/Views/RecordViewModel.swift
+++ b/VivaDicta/Views/RecordViewModel.swift
@@ -287,7 +287,10 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
                     // buffers to send. They get an engine-backed capture that
                     // writes the same WAV, so the fallback and storage are unaffected.
                     let modelName = transcriptionManager.getCurrentTranscriptionModel()?.name
-                    if RealtimeDictationCoordinator.canHandle(modelName: modelName) {
+                    if RealtimeDictationCoordinator.canHandle(
+                        mode: transcriptionManager.currentMode,
+                        modelName: modelName
+                    ) {
                         let coordinator = RealtimeDictationCoordinator()
                         try await coordinator.start(
                             writingTo: captureURL,
@@ -380,7 +383,17 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
             // here just falls through to the normal upload path below.
             self.realtimeCoordinator = nil
 
-            Task {
+            // Leave `.recording` before awaiting the flush, which can take up
+            // to the finalize timeout. Staying in `.recording` would keep Stop
+            // enabled, and a second tap would take the normal branch and move
+            // the capture file out from under this task.
+            recordingState = .transcribing
+            appGroupBridge.updateRecordingState(false)
+
+            // Held in `transcribingSpeechTask` so `cancelTranscribe()` can
+            // actually cancel the flush; an untracked task would keep running
+            // and save a transcription the user already cancelled.
+            transcribingSpeechTask = Task {
                 do {
                     realtimeTranscript = try await realtimeCoordinator.finish()
                     logger.logInfo("🎙️ Realtime transcript ready at stop")
@@ -389,8 +402,12 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
                     logger.logWarning("🎙️ Realtime transcription failed, falling back to upload: \(error.localizedDescription)")
                 }
 
+                guard !Task.isCancelled else {
+                    await realtimeCoordinator.cancel()
+                    return
+                }
+
                 resetValues()
-                appGroupBridge.updateRecordingState(false)
                 finishRecording(sourceTag: sourceTag, destination: destination, modelContext: modelContext)
             }
         } else {

--- a/VivaDicta/Views/RecordViewModel.swift
+++ b/VivaDicta/Views/RecordViewModel.swift
@@ -145,6 +145,14 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
     private var activeRecordingDestination: RecordingDestination = .newNote
     private var activeSourceTag: String = SourceTag.app
 
+    /// Non-nil only while a streaming model is recording. Its presence is what
+    /// makes stop/cancel take the realtime branch.
+    private var realtimeCoordinator: RealtimeDictationCoordinator?
+    /// Transcript produced by the realtime socket, handed to
+    /// `transcribeSpeechTask` so it skips the upload entirely. Nil means the
+    /// normal file-based path runs, including after a realtime failure.
+    private var realtimeTranscript: String?
+
     var captureURL: URL {
         FileManager.appDirectory(for: .audio).appendingPathComponent("recording.wav")
     }
@@ -212,6 +220,9 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
             // Clear any stale selection now; the filter-inherited tags are seeded only
             // once capture has actually started, so failed/denied starts leave it empty.
             pendingTagIds.removeAll()
+            // Cleared here rather than in resetValues(), which the realtime stop
+            // path calls *after* capturing the transcript.
+            realtimeTranscript = nil
 
             // Check if prewarm session is active (keyboard recording)
             if prewarmManager.isSessionActive {
@@ -272,25 +283,45 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
                 appGroupBridge.updateRecordingState(true)
 
                 do {
-                    let settings: [String : Any] = [
-                        AVFormatIDKey: kAudioFormatLinearPCM,
-                        AVSampleRateKey: 16_000.0,
-                        AVNumberOfChannelsKey: 1,
-                        AVLinearPCMBitDepthKey: 16,
-                        AVLinearPCMIsBigEndianKey: false,
-                        AVLinearPCMIsFloatKey: false
-                    ]
-                    
-                    try audioRecordingService.startRecording(to: captureURL, settings: settings)
+                    // Streaming models can't use AVAudioRecorder - it exposes no
+                    // buffers to send. They get an engine-backed capture that
+                    // writes the same WAV, so the fallback and storage are unaffected.
+                    let modelName = transcriptionManager.getCurrentTranscriptionModel()?.name
+                    if RealtimeDictationCoordinator.canHandle(modelName: modelName) {
+                        let coordinator = RealtimeDictationCoordinator()
+                        try await coordinator.start(
+                            writingTo: captureURL,
+                            transcriptionLanguage: transcriptionManager.currentMode.transcriptionLanguage ?? "auto"
+                        )
+                        realtimeCoordinator = coordinator
+                        logger.logInfo("🎙️ Recording with realtime streaming transcription")
+                    } else {
+                        let settings: [String : Any] = [
+                            AVFormatIDKey: kAudioFormatLinearPCM,
+                            AVSampleRateKey: 16_000.0,
+                            AVNumberOfChannelsKey: 1,
+                            AVLinearPCMBitDepthKey: 16,
+                            AVLinearPCMIsBigEndianKey: false,
+                            AVLinearPCMIsFloatKey: false
+                        ]
+
+                        try audioRecordingService.startRecording(to: captureURL, settings: settings)
+                    }
 
                     // Recording is live - seed tags inherited from an active filter.
                     pendingTagIds = initialTagIds
 
                     animationTimer = Timer.scheduledTimer(withTimeInterval: 0.2, repeats: true, block: { [weak self]_ in
                         Task { @MainActor in
-                            guard let self, self.audioRecordingService.isRecording else { return }
-                            let rawPower = Double(self.audioRecordingService.currentAudioPower)
-                            let power = min(1, max(0, 1 - abs(rawPower / 50)))
+                            guard let self else { return }
+                            let power: Double
+                            if let realtimeCoordinator = self.realtimeCoordinator {
+                                power = realtimeCoordinator.currentAudioLevel
+                            } else {
+                                guard self.audioRecordingService.isRecording else { return }
+                                let rawPower = Double(self.audioRecordingService.currentAudioPower)
+                                power = min(1, max(0, 1 - abs(rawPower / 50)))
+                            }
                             self.audioPower = power
                             self.appGroupBridge.updateAudioLevel(power)
                         }
@@ -343,6 +374,25 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
                     logger.logError("📱 Failed to move audio file: \(error.localizedDescription)")
                 }
             }
+        } else if let realtimeCoordinator {
+            // Realtime mode: close the socket and collect the transcript before
+            // touching the file. The WAV was written all along, so any failure
+            // here just falls through to the normal upload path below.
+            self.realtimeCoordinator = nil
+
+            Task {
+                do {
+                    realtimeTranscript = try await realtimeCoordinator.finish()
+                    logger.logInfo("🎙️ Realtime transcript ready at stop")
+                } catch {
+                    realtimeTranscript = nil
+                    logger.logWarning("🎙️ Realtime transcription failed, falling back to upload: \(error.localizedDescription)")
+                }
+
+                resetValues()
+                appGroupBridge.updateRecordingState(false)
+                finishRecording(sourceTag: sourceTag, destination: destination, modelContext: modelContext)
+            }
         } else {
             // Normal mode
             resetValues()
@@ -350,18 +400,28 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
             // Notify keyboard that recording has stopped
             appGroupBridge.updateRecordingState(false)
 
-            let finalURL = FileManager.appDirectory(for: .audio).appendingPathComponent("\(UUID().uuidString).wav")
-            do {
-                try audioFileService.move(from: captureURL, to: finalURL)
-                transcribingSpeechTask = transcribeSpeechTask(
-                    recordURL: finalURL,
-                    modelContext: modelContext,
-                    sourceTag: sourceTag,
-                    destination: destination
-                )
-            } catch {
-                logger.logError("📱 Failed to move audio file: \(error.localizedDescription)")
-            }
+            finishRecording(sourceTag: sourceTag, destination: destination, modelContext: modelContext)
+        }
+    }
+
+    /// Moves the capture file into place and kicks off transcription. Shared by
+    /// the normal and realtime paths so both persist audio identically.
+    private func finishRecording(
+        sourceTag: String,
+        destination: RecordingDestination,
+        modelContext: ModelContext
+    ) {
+        let finalURL = FileManager.appDirectory(for: .audio).appendingPathComponent("\(UUID().uuidString).wav")
+        do {
+            try audioFileService.move(from: captureURL, to: finalURL)
+            transcribingSpeechTask = transcribeSpeechTask(
+                recordURL: finalURL,
+                modelContext: modelContext,
+                sourceTag: sourceTag,
+                destination: destination
+            )
+        } catch {
+            logger.logError("📱 Failed to move audio file: \(error.localizedDescription)")
         }
     }
     
@@ -431,14 +491,22 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
                 try Task.checkCancellation()
 
                 let transcriptionStart = Date()
-                let transcribedText = try await transcriptionManager.transcribe(
-                    audioURL: audioURLToTranscribe,
-                    progressHandler: { progress in
-                        await MainActor.run {
-                            self.transcriptionProgress = progress
+                let transcribedText: String
+                if let streamed = realtimeTranscript {
+                    // Realtime already produced the text while recording; run it
+                    // through the same filters/formatting the upload path uses.
+                    realtimeTranscript = nil
+                    transcribedText = transcriptionManager.postProcessStreamedText(streamed, startTime: transcriptionStart)
+                } else {
+                    transcribedText = try await transcriptionManager.transcribe(
+                        audioURL: audioURLToTranscribe,
+                        progressHandler: { progress in
+                            await MainActor.run {
+                                self.transcriptionProgress = progress
+                            }
                         }
-                    }
-                )
+                    )
+                }
                 let transcriptionDuration = Date().timeIntervalSince(transcriptionStart)
 
                 // Check for cancellation after transcription
@@ -653,6 +721,16 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
             logger.logInfo("🎙️ Stopping real capture on cancel")
             prewarmManager.stopRealCapture()
         }
+
+        // Tear down the streaming engine and socket too - resetValues() only
+        // knows about AVAudioRecorder, so without this the mic and WebSocket
+        // would stay live after a cancel.
+        if let realtimeCoordinator {
+            self.realtimeCoordinator = nil
+            logger.logInfo("🎙️ Cancelling realtime dictation")
+            Task { await realtimeCoordinator.cancel() }
+        }
+        realtimeTranscript = nil
 
         resetValues()
         recordingState = .idle

--- a/VivaDicta/Views/RecordViewModel.swift
+++ b/VivaDicta/Views/RecordViewModel.swift
@@ -292,11 +292,31 @@ class RecordViewModel: NSObject, AVAudioPlayerDelegate {
                         modelName: modelName
                     ) {
                         let coordinator = RealtimeDictationCoordinator()
-                        try await coordinator.start(
-                            writingTo: captureURL,
-                            transcriptionLanguage: transcriptionManager.currentMode.transcriptionLanguage ?? "auto"
-                        )
+
+                        // Published BEFORE awaiting start: the state is already
+                        // `.recording`, so a Stop or Cancel landing during the
+                        // engine spin-up must find the coordinator. Otherwise
+                        // stop takes the normal branch and moves the capture
+                        // file out from under an engine that is still starting.
                         realtimeCoordinator = coordinator
+
+                        do {
+                            try await coordinator.start(
+                                writingTo: captureURL,
+                                transcriptionLanguage: transcriptionManager.currentMode.transcriptionLanguage ?? "auto"
+                            )
+                        } catch {
+                            realtimeCoordinator = nil
+                            throw error
+                        }
+
+                        // Stop/cancel may have run while start was suspended.
+                        guard realtimeCoordinator === coordinator else {
+                            logger.logInfo("🎙️ Recording ended during realtime start-up; tearing down")
+                            await coordinator.cancel()
+                            return
+                        }
+
                         logger.logInfo("🎙️ Recording with realtime streaming transcription")
                     } else {
                         let settings: [String : Any] = [

--- a/VivaDictaTests/Acceptance/RecordEnhanceStoreAcceptanceTests.swift
+++ b/VivaDictaTests/Acceptance/RecordEnhanceStoreAcceptanceTests.swift
@@ -47,6 +47,7 @@ struct RecordEnhanceStoreAcceptanceTests {
         func transcribe(audioURL: URL, progressHandler: TranscriptionProgressHandler?) async throws -> String {
             stubbedText
         }
+        func postProcessStreamedText(_ text: String, startTime: Date) -> String { text }
     }
 
     /// CLI server is off, so the orchestration takes the cloud path.

--- a/VivaDictaTests/Mocks/MockTranscriber.swift
+++ b/VivaDictaTests/Mocks/MockTranscriber.swift
@@ -30,4 +30,11 @@ final class MockTranscriber: Transcriber {
         transcribeCallCount += 1
         return stubbedText
     }
+
+    func postProcessStreamedText(_ text: String, startTime: Date) -> String {
+        postProcessStreamedCallCount += 1
+        return text
+    }
+
+    private(set) var postProcessStreamedCallCount = 0
 }

--- a/VivaDictaTests/RealtimeTranscriptAccumulatorTests.swift
+++ b/VivaDictaTests/RealtimeTranscriptAccumulatorTests.swift
@@ -1,0 +1,87 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import Testing
+@testable import VivaDicta
+
+/// Covers the Soniox realtime merge rule: final tokens accumulate, non-final
+/// tokens are a full replacement set for the unstable tail. Getting this
+/// backwards duplicates words as they firm up, which is invisible until you
+/// read a real transcript - hence the direct tests.
+@MainActor
+struct RealtimeTranscriptAccumulatorTests {
+
+    private func token(_ text: String, isFinal: Bool, kind: LiveTranslationToken.Kind = .original) -> LiveTranslationToken {
+        LiveTranslationToken(id: UUID(), text: text, isFinal: isFinal, kind: kind)
+    }
+
+    @Test func finalTokensAccumulateAcrossBatches() {
+        var sut = RealtimeTranscriptAccumulator()
+
+        sut.ingest([token("Hello", isFinal: true)])
+        sut.ingest([token(" world", isFinal: true)])
+
+        #expect(sut.text == "Hello world")
+    }
+
+    @Test func interimTokensAreReplacedNotAppended() {
+        var sut = RealtimeTranscriptAccumulator()
+
+        sut.ingest([token(" rec", isFinal: false)])
+        sut.ingest([token(" recog", isFinal: false)])
+        sut.ingest([token(" recognition", isFinal: false)])
+
+        #expect(sut.text == " recognition")
+    }
+
+    @Test func interimFirmingUpIntoFinalDoesNotDuplicate() {
+        var sut = RealtimeTranscriptAccumulator()
+
+        sut.ingest([token("Hello", isFinal: true), token(" wor", isFinal: false)])
+        sut.ingest([token(" world", isFinal: true)])
+
+        #expect(sut.text == "Hello world")
+    }
+
+    @Test func emptyBatchClearsTheInterimTail() {
+        var sut = RealtimeTranscriptAccumulator()
+
+        sut.ingest([token("Done", isFinal: true), token(" maybe", isFinal: false)])
+        #expect(sut.text == "Done maybe")
+
+        sut.ingest([])
+
+        #expect(sut.text == "Done")
+    }
+
+    @Test func mixedBatchSplitsFinalsFromInterims() {
+        var sut = RealtimeTranscriptAccumulator()
+
+        sut.ingest([
+            token("The", isFinal: true),
+            token(" quick", isFinal: true),
+            token(" bro", isFinal: false)
+        ])
+
+        #expect(sut.finalText == "The quick")
+        #expect(sut.interimText == " bro")
+        #expect(sut.text == "The quick bro")
+    }
+
+    @Test func translationTokensAreIgnored() {
+        var sut = RealtimeTranscriptAccumulator()
+
+        sut.ingest([
+            token("Hello", isFinal: true),
+            token("Привет", isFinal: true, kind: .translation)
+        ])
+
+        #expect(sut.text == "Hello")
+    }
+
+    @Test func startsEmpty() {
+        let sut = RealtimeTranscriptAccumulator()
+
+        #expect(sut.text.isEmpty)
+    }
+}

--- a/VivaDictaTests/SonioxStreamingModelRoutingTests.swift
+++ b/VivaDictaTests/SonioxStreamingModelRoutingTests.swift
@@ -1,0 +1,54 @@
+// Copyright © 2026 Anton Novoselov. All rights reserved.
+
+import Foundation
+import Testing
+@testable import VivaDicta
+
+/// Guards the realtime-to-async model mapping.
+///
+/// Soniox's realtime slug (`stt-rt-v5`) is rejected by the async
+/// `/v1/transcriptions` endpoint, but two paths deliberately reach that
+/// endpoint while the realtime model is selected: keyboard dictation, and the
+/// fallback after a dropped socket. Without the remap the fallback the whole
+/// streaming design depends on would fail with the very error it exists to
+/// recover from - so this stays pinned.
+@MainActor
+struct SonioxStreamingModelRoutingTests {
+
+    @Test func realtimeModelIsRecognisedAsStreaming() {
+        #expect(TranscriptionModelProvider.isStreamingModel(TranscriptionModelProvider.sonioxRealtimeModel))
+    }
+
+    @Test func asyncModelIsNotStreaming() {
+        #expect(TranscriptionModelProvider.isStreamingModel(TranscriptionModelProvider.sonioxAsyncModel) == false)
+    }
+
+    @Test func realtimeModelMapsToAsyncForUploadPath() {
+        let mapped = TranscriptionModelProvider.asyncEquivalent(of: TranscriptionModelProvider.sonioxRealtimeModel)
+
+        #expect(mapped == TranscriptionModelProvider.sonioxAsyncModel)
+        #expect(mapped != TranscriptionModelProvider.sonioxRealtimeModel)
+    }
+
+    @Test func asyncModelPassesThroughUnchanged() {
+        let name = TranscriptionModelProvider.sonioxAsyncModel
+
+        #expect(TranscriptionModelProvider.asyncEquivalent(of: name) == name)
+    }
+
+    @Test(arguments: ["whisper-1", "nova-3", "scribe_v1", "solaria-1", ""])
+    func otherProviderModelsPassThroughUnchanged(name: String) {
+        #expect(TranscriptionModelProvider.asyncEquivalent(of: name) == name)
+    }
+
+    /// The realtime entry has to exist in the catalog for the picker to offer
+    /// it, and it has to sit under the Soniox provider for key lookup to work.
+    @Test func catalogExposesRealtimeModelUnderSoniox() {
+        let realtime = TranscriptionModelProvider.allCloudModels.first {
+            $0.name == TranscriptionModelProvider.sonioxRealtimeModel
+        }
+
+        let model = try? #require(realtime)
+        #expect(model?.provider == .soniox)
+    }
+}


### PR DESCRIPTION
Addresses #370

## Problem

Soniox dictation used the async REST path - upload the finished file, create a job, poll until it completes - so transcription could not begin until the user stopped speaking. `SonioxRealtimeSTTClient` already existed but was wired only to Live Translation.

## Approach

A new **"Soniox Realtime (stt-rt-v5)"** entry in the transcription model picker. Selection is per-mode and the async entry stays available, so this is opt-in and the existing Soniox behaviour is untouched for anyone who does not pick it.

`AVAudioRecorder` exposes no buffers to stream, so streaming models get `StreamingAudioCapture` - an `AVAudioEngine` capture that writes the same 16 kHz mono WAV **and** fans the identical PCM out to the socket. The default recorder is not modified, so every non-streaming dictation on every provider takes exactly the path it did before.

```
realtime OFF  ->  AVAudioRecorder -> file -> upload/poll        (unchanged)

realtime ON   ->  AVAudioEngine ---+--> WAV file (fallback + storage)
                                   \--> 16k Int16 PCM -> WebSocket
```

Because the WAV is written throughout, a socket failure at any point falls back to the ordinary upload with the recording intact - which is why `finish()` throws rather than returning a partial transcript.

## Changes

- **`StreamingAudioCapture`** - engine capture writing the WAV plus a live PCM stream, bounded at ~1s of backpressure. Also exposes a mic level so the waveform keeps animating on this path.
- **`SonioxRealtimeDictationSession`** - actor owning the socket, accumulating tokens, and flushing on end-of-audio with a 10s tail guard.
- **`RealtimeTranscriptAccumulator`** - the merge rule as a pure value type: finals accumulate, non-finals *replace* the unstable tail. Getting that backwards duplicates every word as it firms up, so it is separated out and tested directly.
- **`RealtimeDictationCoordinator`** - pairs capture and session so `RecordViewModel` deals with one object.
- **`TranscriptionManager.postProcessStreamedText`** - streamed text runs through the same filters, formatting, replacements, and completion analytics as uploaded text. One implementation, so the two paths cannot drift.
- **`SonioxRealtimeSTTClient`** - gains a transcription-only mode (it previously always requested translation), language hints are now optional so auto-detect sends none, and the model moves off the deprecated `stt-rt-v4`.
- **`SonioxTranscriptionService`** - async polling ramps 200ms/500ms/1s instead of a flat 1s. Independent of streaming; helps the upload path on its own.

## Testing

- 7 new tests on the accumulator: finals accumulate, interims replace, interim-firming-into-final does not duplicate, empty batch clears the tail, mixed batches split correctly, translation tokens ignored.
- `VivaDictaTests` - 360/360 pass.
- `CloudTranscription` - 211/211 pass.
- `xcodebuild build` (iPhone 17 Pro Max, iOS 26.4) - success, 0 errors.

## Notes and caveats

- **The WebSocket round-trip is unverified.** Unit tests cover the merge rule and everything builds, but the live socket, the finalize handshake, and fallback-on-drop need a device with a Soniox key. Treat "streaming produces a correct transcript" as unproven until that is run.
- **Live Translation moves to `stt-rt-v5` as a side effect.** It was silently riding `stt-rt-v4`, deprecated 2026-06-30 and currently surviving only as an alias. This is a fix, but it does change Live Translation's model and is worth a look before shipping.
- **Keyboard dictation still uses upload-and-poll.** The prewarm capture has its own `AVAudioEngine` tap that is not wired to the socket yet, so issue acceptance criterion 1 is only met for the in-app record button. Left as follow-up rather than half-wired - hence "Addresses" rather than "Closes".
- `TranscriptionModelProvider.sonioxRealtimeModel` holds the model id because that file is compiled into the app extensions, which do not link the app-only realtime client.