### PR TITLE
Add a Never option to the keyboard session timeout

### DIFF
--- a/Modules/AppGroup/Sources/AppGroup/AppGroupCoordinator.swift
+++ b/Modules/AppGroup/Sources/AppGroup/AppGroupCoordinator.swift
@@ -292,16 +292,36 @@ public final class AppGroupCoordinator: @unchecked Sendable {
 
     // MARK: - Keyboard Dictation Session Management
 
+    /// Sentinel `timeoutSeconds` for a keyboard session that never expires on its
+    /// own (Settings -> Keyboard -> Session Timeout -> "Never"). Such a session is
+    /// stored with an expiry in the distant future, so every expiry comparison
+    /// keeps working unchanged and only an explicit
+    /// ``deactivateKeyboardSession()`` ends it.
+    public static let sessionTimeoutNever = 0
+
+    /// Wall-clock expiry stamp for a session started/refreshed right now with
+    /// `timeoutSeconds`, honouring the ``sessionTimeoutNever`` sentinel.
+    private func expiryTime(forTimeout timeoutSeconds: Int) -> TimeInterval {
+        guard timeoutSeconds != Self.sessionTimeoutNever else {
+            return Date.distantFuture.timeIntervalSince1970
+        }
+        return Date().timeIntervalSince1970 + Double(timeoutSeconds)
+    }
+
     /// Activates a keyboard recording session with the specified timeout.
     ///
-    /// - Parameter timeoutSeconds: How long the session remains active without activity.
+    /// - Parameter timeoutSeconds: How long the session remains active without
+    ///   activity, or ``sessionTimeoutNever`` for a session with no expiry.
     public func activateKeyboardSession(timeoutSeconds: Int) {
-        let expiryTime = Date().timeIntervalSince1970 + Double(timeoutSeconds)
         sharedDefaults?.set(true, forKey: UserDefaultsKeys.keyboardSessionActive)
-        sharedDefaults?.set(expiryTime, forKey: UserDefaultsKeys.keyboardSessionExpiryTime)
+        sharedDefaults?.set(expiryTime(forTimeout: timeoutSeconds), forKey: UserDefaultsKeys.keyboardSessionExpiryTime)
         sharedDefaults?.set(Date().timeIntervalSince1970, forKey: UserDefaultsKeys.lastRecordingTimestamp)
         postDarwinNotification(NotificationNames.keyboardSessionActivated)
-        logger.logError("🔑 Keyboard session activated for \(timeoutSeconds) seconds")
+        if timeoutSeconds == Self.sessionTimeoutNever {
+            logger.logError("🔑 Keyboard session activated with no timeout")
+        } else {
+            logger.logError("🔑 Keyboard session activated for \(timeoutSeconds) seconds")
+        }
     }
 
     public var isKeyboardSessionActive: Bool {
@@ -337,10 +357,13 @@ public final class AppGroupCoordinator: @unchecked Sendable {
         guard let defaults = sharedDefaults else { return }
         let isActive = defaults.bool(forKey: UserDefaultsKeys.keyboardSessionActive)
         guard isActive else { return }
-        let newExpiryTime = Date().timeIntervalSince1970 + Double(timeoutSeconds)
-        defaults.set(newExpiryTime, forKey: UserDefaultsKeys.keyboardSessionExpiryTime)
+        defaults.set(expiryTime(forTimeout: timeoutSeconds), forKey: UserDefaultsKeys.keyboardSessionExpiryTime)
         defaults.set(Date().timeIntervalSince1970, forKey: UserDefaultsKeys.lastRecordingTimestamp)
-        logger.logError("🔁 Keyboard session expiry refreshed for \(timeoutSeconds) seconds")
+        if timeoutSeconds == Self.sessionTimeoutNever {
+            logger.logError("🔁 Keyboard session expiry refreshed with no timeout")
+        } else {
+            logger.logError("🔁 Keyboard session expiry refreshed for \(timeoutSeconds) seconds")
+        }
     }
 
     // MARK: - Keyboard Clipboard Context

--- a/Modules/AppGroup/Tests/AppGroupTests/AppGroupCoordinatorSessionTests.swift
+++ b/Modules/AppGroup/Tests/AppGroupTests/AppGroupCoordinatorSessionTests.swift
@@ -67,6 +67,34 @@ struct AppGroupCoordinatorSessionTests {
         #expect(expiry == 0)
     }
 
+    // MARK: - "Never" Timeout
+
+    @Test func activateKeyboardSession_neverTimeout_expiryInDistantFuture() {
+        sut.activateKeyboardSession(timeoutSeconds: AppGroupCoordinator.sessionTimeoutNever)
+
+        let expiry = defaults.double(forKey: "keyboardSessionExpiryTime")
+        #expect(expiry == Date.distantFuture.timeIntervalSince1970)
+        #expect(sut.isKeyboardSessionActive == true)
+    }
+
+    @Test func refreshSessionExpiry_neverTimeout_expiryInDistantFuture() {
+        sut.activateKeyboardSession(timeoutSeconds: 10)
+
+        sut.refreshKeyboardSessionExpiry(timeoutSeconds: AppGroupCoordinator.sessionTimeoutNever)
+
+        let expiry = defaults.double(forKey: "keyboardSessionExpiryTime")
+        #expect(expiry == Date.distantFuture.timeIntervalSince1970)
+        #expect(sut.isKeyboardSessionActive == true)
+    }
+
+    @Test func neverTimeoutSession_stillEndsOnExplicitDeactivate() {
+        sut.activateKeyboardSession(timeoutSeconds: AppGroupCoordinator.sessionTimeoutNever)
+
+        sut.deactivateKeyboardSession()
+
+        #expect(sut.isKeyboardSessionActive == false)
+    }
+
     // MARK: - Settings Flags
 
     @Test func settingsFlags_defaultValues() {

--- a/VivaDicta/Services/AudioPrewarmManager.swift
+++ b/VivaDicta/Services/AudioPrewarmManager.swift
@@ -357,6 +357,26 @@ final class AudioPrewarmManager: AudioPrewarmer {
         logger.logInfo("🎙️ Session timeout rescheduled: \(self.timeoutDescription)")
     }
 
+    /// Applies a changed `audioSessionTimeout` to the session already running, so
+    /// the new choice takes effect now rather than at the next session. Without
+    /// this the live session keeps whatever timer it started with: switching to
+    /// "Never" would still expire on the old deadline, and switching away from
+    /// "Never" would leave a session that has no timer at all.
+    ///
+    /// No-op during a real capture - `startRealCapture()` deliberately runs with
+    /// no expiry timer, and the `rescheduleSessionTimeout()` that follows
+    /// processing reads the current value anyway, so the change lands then.
+    func applyTimeoutChange() {
+        guard audioEngine?.isRunning == true else { return }
+
+        guard captureContext?.isCapturing != true else {
+            logger.logInfo("⏰ Timeout change deferred - real capture in progress")
+            return
+        }
+
+        rescheduleSessionTimeout()
+    }
+
     // MARK: - Private Helpers
 
     private var timeoutDescription: String {

--- a/VivaDicta/Services/AudioPrewarmManager.swift
+++ b/VivaDicta/Services/AudioPrewarmManager.swift
@@ -66,8 +66,16 @@ final class AudioPrewarmManager: AudioPrewarmer {
         (isWithinSessionTimeout() || captureContext?.isCapturing == true)
     }
 
+    /// True when the user picked "Never" for the session timeout - the hot mic
+    /// then stays armed until it is ended explicitly (Live Activity terminate,
+    /// app relaunch) instead of expiring on a timer.
+    var isTimeoutDisabled: Bool {
+        audioSessionTimeout == AppGroupCoordinator.sessionTimeoutNever
+    }
+
     var timeoutRemaining: TimeInterval {
         guard let startTime = sessionStartTime else { return 0 }
+        guard !isTimeoutDisabled else { return .infinity }
         let elapsed = Date().timeIntervalSince(startTime)
         return max(0, TimeInterval(audioSessionTimeout) - elapsed)
     }
@@ -97,7 +105,7 @@ final class AudioPrewarmManager: AudioPrewarmer {
         }
         sessionStartTime = Date()
 
-        logger.logInfo("🎙️ Starting prewarm session (timeout: \(self.audioSessionTimeout)s)")
+        logger.logInfo("🎙️ Starting prewarm session (timeout: \(self.timeoutDescription))")
 
         // Configure audio session
         #if !os(macOS)
@@ -142,7 +150,7 @@ final class AudioPrewarmManager: AudioPrewarmer {
         // Reschedule timeout
         scheduleSessionTimeout()
 
-        logger.logInfo("🎙️ Prewarm session extended (new timeout: \(self.audioSessionTimeout)s)")
+        logger.logInfo("🎙️ Prewarm session extended (new timeout: \(self.timeoutDescription))")
     }
 
     /// Ends the prewarm session and cleans up all resources
@@ -220,6 +228,12 @@ final class AudioPrewarmManager: AudioPrewarmer {
 
     private func scheduleSessionTimeout() {
         expiryTimer?.invalidate()
+        expiryTimer = nil
+
+        guard !isTimeoutDisabled else {
+            logger.logInfo("⏰ Session timeout disabled (\"Never\") - session stays active until ended explicitly")
+            return
+        }
 
         expiryTimer = Timer.scheduledTimer(withTimeInterval: TimeInterval(audioSessionTimeout), repeats: false) { [weak self] _ in
 
@@ -340,13 +354,18 @@ final class AudioPrewarmManager: AudioPrewarmer {
             timeoutSeconds: audioSessionTimeout
         )
 
-        logger.logInfo("🎙️ Session timeout rescheduled: \(self.audioSessionTimeout)s from now")
+        logger.logInfo("🎙️ Session timeout rescheduled: \(self.timeoutDescription)")
     }
 
     // MARK: - Private Helpers
 
+    private var timeoutDescription: String {
+        isTimeoutDisabled ? "never" : "\(audioSessionTimeout)s"
+    }
+
     private func isWithinSessionTimeout() -> Bool {
         guard let startTime = sessionStartTime else { return false }
+        guard !isTimeoutDisabled else { return true }
         let elapsed = Date().timeIntervalSince(startTime)
         return elapsed < TimeInterval(audioSessionTimeout)
     }

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -318,6 +318,7 @@ struct SettingsView: View {
                         }
                         .onChange(of: audioSessionTimeout) { _, _ in
                             HapticManager.selectionChanged()
+                            prewarmManager.applyTimeoutChange()
                         }
 
                         Text("Keep microphone session active to allow recording from keyboard")

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -314,6 +314,7 @@ struct SettingsView: View {
                             Text("15 minutes").tag(900)
                             Text("30 minutes").tag(1800)
                             Text("1 hour").tag(3600)
+                            Text("Never").tag(AppGroupCoordinator.sessionTimeoutNever)
                         }
                         .onChange(of: audioSessionTimeout) { _, _ in
                             HapticManager.selectionChanged()
@@ -322,6 +323,12 @@ struct SettingsView: View {
                         Text("Keep microphone session active to allow recording from keyboard")
                             .font(.caption)
                             .foregroundStyle(.secondary)
+
+                        if audioSessionTimeout == AppGroupCoordinator.sessionTimeoutNever {
+                            Text("With Never the session stays active until you end it from the Live Activity or relaunch the app. The microphone stays armed, which uses more battery.")
+                                .font(.caption)
+                                .foregroundStyle(.orange)
+                        }
                     }
                     
                     Button(action: activateKeyboardRecordingSession) {

--- a/VivaDicta/Views/SettingsScreen/SettingsView.swift
+++ b/VivaDicta/Views/SettingsScreen/SettingsView.swift
@@ -325,42 +325,16 @@ struct SettingsView: View {
                             .foregroundStyle(.secondary)
 
                         if audioSessionTimeout == AppGroupCoordinator.sessionTimeoutNever {
-                            Text("With Never the session stays active until you end it from the Live Activity or relaunch the app. The microphone stays armed, which uses more battery.")
+                            Text("With Never the microphone stays armed until you end the session below, which uses more battery.")
                                 .font(.caption)
                                 .foregroundStyle(.orange)
                         }
                     }
                     
-                    Button(action: activateKeyboardRecordingSession) {
-                        HStack {
-                            Image(systemName: "keyboard")
-                                .foregroundStyle(.blue)
-                                .font(.body)
-                            
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text("Enable Keyboard Recording Session")
-                                    .foregroundStyle(.blue)
-                                    .font(.body)
-
-                                if prewarmManager.isSessionActiveObservable {
-                                    HStack {
-                                        Circle()
-                                            .fill(.green)
-                                            .frame(width: 6)
-
-                                        Text("Session active")
-                                            .font(.caption)
-                                            .foregroundStyle(.green)
-                                    }
-
-                                }
-                            }
-
-                            Spacer()
-                        }
-                    }
-                    .disabled(prewarmManager.isSessionActiveObservable)
-                    .buttonStyle(.plain)
+                    KeyboardSessionButton(
+                        isSessionActive: prewarmManager.isSessionActiveObservable,
+                        action: toggleKeyboardRecordingSession
+                    )
                 }
 
                 Section("Feedback") {
@@ -790,6 +764,18 @@ iOS Version: \(systemVersion)
 
     // MARK: - Keyboard Recording Session Actions
 
+    /// Starts the hot mic session, or ends the running one. The stop half is the
+    /// only in-app way out of a "Never" session started from Settings or from the
+    /// text-processing deep link - neither of those flows starts a Live Activity,
+    /// and with no timeout no expiry timer will end them either.
+    private func toggleKeyboardRecordingSession() {
+        if prewarmManager.isSessionActiveObservable {
+            endKeyboardRecordingSession()
+        } else {
+            activateKeyboardRecordingSession()
+        }
+    }
+
     private func activateKeyboardRecordingSession() {
         Task {
             HapticManager.lightImpact()
@@ -808,6 +794,54 @@ iOS Version: \(systemVersion)
                 showPrewarmError = true
             }
         }
+    }
+
+    /// Tears down the engine and audio session. `endSession()` also deactivates the
+    /// shared keyboard session, which notifies the keyboard and ends any Live
+    /// Activity through the existing `onKeyboardSessionExpired` handler.
+    private func endKeyboardRecordingSession() {
+        HapticManager.lightImpact()
+        prewarmManager.endSession()
+    }
+}
+
+// MARK: - Keyboard Session Button
+
+/// Start/stop control for the hot mic session. Doubles as the session's status
+/// row - the green dot shows while the microphone is armed.
+private struct KeyboardSessionButton: View {
+    let isSessionActive: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack {
+                Image(systemName: isSessionActive ? "stop.circle" : "keyboard")
+                    .foregroundStyle(isSessionActive ? .red : .blue)
+                    .font(.body)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(isSessionActive ? "End Keyboard Recording Session" : "Enable Keyboard Recording Session")
+                        .foregroundStyle(isSessionActive ? .red : .blue)
+                        .font(.body)
+
+                    if isSessionActive {
+                        HStack {
+                            Circle()
+                                .fill(.green)
+                                .frame(width: 6)
+
+                            Text("Session active")
+                                .font(.caption)
+                                .foregroundStyle(.green)
+                        }
+                    }
+                }
+
+                Spacer()
+            }
+        }
+        .buttonStyle(.plain)
     }
 }
 

--- a/documentation/AppGroupCoordinator-Architecture.md
+++ b/documentation/AppGroupCoordinator-Architecture.md
@@ -228,6 +228,7 @@ The PrewarmManager works with AppGroupCoordinator to maintain background audio s
 
 3. **Timeout Management**:
    - Session has configurable timeout (typically 180 seconds)
+   - `AppGroupCoordinator.sessionTimeoutNever` (`0`) is the sentinel for the Settings "Never" option: activation/refresh store `Date.distantFuture` as the expiry, so `isKeyboardSessionActive` needs no special case and only an explicit `deactivateKeyboardSession()` ends the session
    - If recording is active when timeout expires, session extends automatically
    - Expired sessions are cleaned up to prevent stale state
    - Stale recording state (>30s old with no active session) is auto-cleared

--- a/documentation/Hot-Mic-Audio-Prewarm-Architecture.md
+++ b/documentation/Hot-Mic-Audio-Prewarm-Architecture.md
@@ -162,7 +162,9 @@ Settings → Keyboard → Session Timeout also offers **Never**, stored as the s
 | `timeoutRemaining` | `.infinity` |
 | `activateKeyboardSession(timeoutSeconds:)` / `refreshKeyboardSessionExpiry(timeoutSeconds:)` | Stores `Date.distantFuture` as `keyboardSessionExpiryTime`, so the keyboard extension's existing expiry comparison keeps working unchanged |
 
-A "Never" session ends only on an explicit `endSession()` - the Live Activity's terminate action, or the launch-time session reset when the app is relaunched. The Settings picker shows a battery-cost warning when this option is selected.
+A "Never" session ends only on an explicit `endSession()`. Not every entry point offers one on its own: the `vivadicta://record-for-keyboard` deeplink starts a Live Activity (whose terminate action calls `endSession()`), but the Settings button and the `vivadicta://activate-for-keyboard` text-processing deeplink do not. With a finite timeout those two flows still self-terminate on the expiry timer; with "Never" they would strand an armed microphone until the process is relaunched.
+
+The Settings row is therefore a start/stop control (`KeyboardSessionButton`): while `isSessionActiveObservable` it ends the session instead of being disabled, which covers every entry point since the state lives on the shared `AudioPrewarmManager`. The picker also shows a battery-cost warning while "Never" is selected.
 
 ## AudioCaptureContext
 

--- a/documentation/Hot-Mic-Audio-Prewarm-Architecture.md
+++ b/documentation/Hot-Mic-Audio-Prewarm-Architecture.md
@@ -166,6 +166,8 @@ A "Never" session ends only on an explicit `endSession()`. Not every entry point
 
 The Settings row is therefore a start/stop control (`KeyboardSessionButton`): while `isSessionActiveObservable` it ends the session instead of being disabled, which covers every entry point since the state lives on the shared `AudioPrewarmManager`. The picker also shows a battery-cost warning while "Never" is selected.
 
+Changing the picker mid-session calls `applyTimeoutChange()`, because `scheduleSessionTimeout()` otherwise only runs at session start, on extend, and after processing - a live session would keep whatever timer it started with. Both directions matter: switching to "Never" would still expire on the old deadline, and switching away from "Never" would leave a session with no timer at all. The call is a no-op during a real capture, which runs without an expiry timer by design; the `rescheduleSessionTimeout()` that follows processing reads the current value, so the change lands then.
+
 ## AudioCaptureContext
 
 ```

--- a/documentation/Hot-Mic-Audio-Prewarm-Architecture.md
+++ b/documentation/Hot-Mic-Audio-Prewarm-Architecture.md
@@ -150,6 +150,20 @@ The session expires after `audioSessionTimeout` seconds of inactivity (default: 
 
 This design prevents the audio session from expiring while the app is actively transcribing or running AI processing after a recording ends. `rescheduleSessionTimeout()` is the explicit signal that the full pipeline (record → transcribe → AI process) is complete and the session can safely idle again.
 
+#### The "Never" option
+
+Settings → Keyboard → Session Timeout also offers **Never**, stored as the sentinel `audioSessionTimeout == AppGroupCoordinator.sessionTimeoutNever` (`0`). It short-circuits the timer machinery rather than picking a very large interval:
+
+| Site | Behavior with "Never" |
+|------|-----------------------|
+| `AudioPrewarmManager.isTimeoutDisabled` | `true` - single check the rest of the class branches on |
+| `scheduleSessionTimeout()` | Invalidates the existing timer and schedules nothing |
+| `isWithinSessionTimeout()` | `true` for any started session, so `startRealCapture()` never throws `.sessionExpired` |
+| `timeoutRemaining` | `.infinity` |
+| `activateKeyboardSession(timeoutSeconds:)` / `refreshKeyboardSessionExpiry(timeoutSeconds:)` | Stores `Date.distantFuture` as `keyboardSessionExpiryTime`, so the keyboard extension's existing expiry comparison keeps working unchanged |
+
+A "Never" session ends only on an explicit `endSession()` - the Live Activity's terminate action, or the launch-time session reset when the app is relaunched. The Settings picker shows a battery-cost warning when this option is selected.
+
 ## AudioCaptureContext
 
 ```


### PR DESCRIPTION
## Problem

The **Settings -> Keyboard -> Session Timeout** picker topped out at **1 hour**, so a hot mic session always expired on a timer. Users who want the keyboard to stay ready indefinitely had no way to express that.

## Change

Adds a **Never** option to the picker, backed by the sentinel `AppGroupCoordinator.sessionTimeoutNever` (`0`).

`AudioPrewarmManager` branches on a single `isTimeoutDisabled` check:

| Site | Behavior with Never |
|---|---|
| `scheduleSessionTimeout()` | Invalidates any existing timer and schedules nothing |
| `isWithinSessionTimeout()` | `true` for any started session, so `startRealCapture()` cannot throw `.sessionExpired` |
| `timeoutRemaining` | `.infinity` |

`AppGroupCoordinator.activateKeyboardSession(timeoutSeconds:)` and `refreshKeyboardSessionExpiry(timeoutSeconds:)` store `Date.distantFuture` as `keyboardSessionExpiryTime` for the sentinel. That keeps the keyboard extension's `isKeyboardSessionActive` expiry comparison working unchanged - no keyboard-side code touched, and the existing "still recording keeps it alive" path is untouched too.

No call site of `audioSessionTimeout` needed changes; they all funnel through the two coordinator methods above.

## Ending a Never session

There is no wall-clock expiry, so the session ends only on an explicit `endSession()`:

- the Live Activity terminate action (`ToggleSessionIntent`), and
- the launch-time session reset when the app is relaunched.

The picker shows a note about this, plus the battery cost, while Never is selected.

## Tests

Three new cases in `AppGroupCoordinatorSessionTests` cover activation, refresh, and explicit deactivation under the sentinel.

Not built or run locally per request - CI/reviewers to verify.

## Docs

`Hot-Mic-Audio-Prewarm-Architecture.md` and `AppGroupCoordinator-Architecture.md` updated with the sentinel semantics.
