### PR TITLE
Upgrade LumoKit to 3.3.0 and pin it to a version

### DIFF
--- a/VivaDicta.xcodeproj/project.pbxproj
+++ b/VivaDicta.xcodeproj/project.pbxproj
@@ -2440,8 +2440,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/rryam/LumoKit.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 3.3.0;
+				kind = exactVersion;
+				version = 3.3.0;
 			};
 		};
 		18B497EE2F268B2700538830 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {

--- a/VivaDicta.xcodeproj/project.pbxproj
+++ b/VivaDicta.xcodeproj/project.pbxproj
@@ -2440,8 +2440,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/rryam/LumoKit.git";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 3.3.0;
 			};
 		};
 		18B497EE2F268B2700538830 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {

--- a/VivaDicta/Services/RAG/RAGIndexingService.swift
+++ b/VivaDicta/Services/RAG/RAGIndexingService.swift
@@ -13,6 +13,7 @@ import SwiftData
 import os
 @preconcurrency import LumoKit
 @preconcurrency import VecturaKit
+import VecturaEmbeddingsKit
 
 /// Result of a RAG semantic search, mapping chunks back to source transcriptions.
 struct RAGSearchResult: Sendable {


### PR DESCRIPTION
## Summary

The RAG stack was two LumoKit releases behind locally, and `project.pbxproj` pinned LumoKit to `branch = main`. Because `Package.resolved` is gitignored (`.gitignore:67`, `*.xcworkspace`), the resolved revision lived only on the local machine while CI and every fresh clone resolved whatever `main` happened to be. This pins LumoKit to `exactVersion` 3.3.0.

| Package | Before | After |
|---|---|---|
| LumoKit | `c78ce04` (branch main) | **3.3.0** (exact) |
| VecturaKit | `5fed66f` (= 5.3.0) | **6.3.0** |
| VecturaEmbeddingsKit | absent | **1.1.1** |
| swift-embeddings | 0.0.26 | 0.0.26 (unchanged) |
| swift-transformers | 1.2.1 | 1.2.1 (unchanged) |

Scope note, since both reviewers raised it: `exactVersion` locks **LumoKit**. The transitive versions above are not themselves locked in-repo. They are stable only because LumoKit's manifest drives their resolution and LumoKit is now fixed. Genuinely locking the whole graph requires committing `Package.resolved`, which is a separate change (see Notes).

## Why the new import

VecturaKit 6.0.0 moved `SwiftEmbedder` and `VecturaModelSource` out of core into the separate VecturaEmbeddingsKit package. `RAGIndexingService` passes `modelSource: .id("minishlab/potion-base-32M")`, a `VecturaModelSource` case, so it now needs an explicit import. Previously the type was in VecturaKit, which the file already imported.

Without it, Xcode 26.6 fails with:

```
RAGIndexingService.swift:195:27: error: enum case 'id(_:type:)' is not available
due to missing import of defining module 'VecturaEmbeddingsKit'
```

Note that Xcode 26.3 (what `build.yml` currently selects) still permits using a transitively-reachable type without importing it, so CI compiles this either way. Xcode 26.4+ closed that.

## The index is unaffected

No re-index is needed, and this was the main risk worth ruling out:

- swift-embeddings is held at **0.0.26** by a transitive constraint: every release above it requires swift-transformers `from: 1.3.3`, while `mlx-swift-lm` requires `.upToNextMinor(from: "1.2.0")`, i.e. `< 1.3.0`. So the embedder cannot move and vectors are bit-identical. This holds by constraint, not by anything committed in-repo, so a future `mlx-swift-lm` bump should be treated as a RAG change.
- The new `SwiftEmbedder` is a strict superset of the old one. The encode path is untouched; additions are HF snapshot download coordination, cancellation propagation, and a BERT key-mapping fallback. Same `Documents/huggingface` cache base, so no model re-download either.
- `Model/VecturaDocument.swift` and `Core/VecturaConfig.swift` are byte-identical between VecturaKit 5.3.0 and 6.3.0, so the on-disk index stays readable.

## What the upgrade buys

Everything in VecturaKit 5.3.0 → 6.3.0 beyond the embedder extraction is concurrency correctness, and it lands on exactly how this app uses it. `RAGIndexingService` drives a `nonisolated(unsafe)` LumoKit instance from `@concurrent` wrappers and relies on VecturaKit serializing internally (see the comment at `RAGIndexingService.swift:152-153`):

- `FileStorageProvider` and `BM25SearchEngine` gained mutation-generation counters, so a slow full load can no longer install a stale snapshot over a newer index (which could drop a just-saved document or resurrect a just-deleted one)
- batch saves moved inside the rollback scope, so a partial `saveDocuments` failure no longer destroys the content it overwrote
- duplicate IDs within one `addDocuments` batch are rejected instead of silently collapsing

LumoKit 3.3.0 also adds per-chunk metadata persistence and `semanticSearchChunks()`, but that metadata is only populated by `parseAndIndex(url:)`. This app uses `addDocuments(texts:)`, so it is not used here yet.

## Testing

- `xcodebuild build` succeeds on iPhone 17 Pro Max / iOS 26.4, Debug, on both the `upToNextMajorVersion` and final `exactVersion` pins (identical resolved graph)
- Verified the import failure mode both ways: builds clean with it, fails with the error above without it
- Confirmed post-resolution that swift-embeddings stayed at 0.0.26, which is what makes the no-re-index claim hold
- There are no automated RAG tests, so device validation of SmartSearch quality is still worth a look. Vectors are unchanged, so this is a sanity check rather than a real risk.

## Notes

Follow-ups deliberately left out of scope:

- `Package.resolved` is not tracked, so the dependency graph as a whole is still resolved fresh. Un-ignoring it is the durable fix and touches every dependency in the project, so it deserves its own review.
- WhisperKit (`Modules/LocalTranscription/Package.swift:18`) and `swift-litert-lm` (`Modules/LocalLLM/Package.swift:19`) are still branch-pinned and float on every upstream push.
- `build.yml` selects Xcode 26.3 while local development is on 26.6, which is why the missing import would not have been caught by CI. Worth bumping separately.