### PR TITLE
Return to 15 more host apps, and stop losing mappings to the query cap

### DIFF
--- a/.agents/skills/analyze-unrecognized-apps/SKILL.md
+++ b/.agents/skills/analyze-unrecognized-apps/SKILL.md
@@ -6,7 +6,7 @@ disable-model-invocation: true
 
 # Analyze Unrecognized Host Apps
 
-**Last run:** 2026-03-29 — added 7 URL scheme mappings (ShellFish, Termius, Teams, Reddit, iA Writer, Gemini, Yandex Translate) and 12 knownNoSchemeHosts entries
+**Last run:** 2026-08-29 - added 15 return-URL mappings (Swiftgram, Open Minis, WeChat, Spotify team-ID variant, Reminders, Letterboxd, Eudic, Notion, Meituan, nPlayer, plus 5 universal-link fallbacks) and 5 knownNoSchemeHosts entries. Also removed the `canOpenURL` gate and the dead `LSApplicationQueriesSchemes` array, which had exceeded Apple's 50-entry cap and was silently killing the most recent mappings. Note: this sample predates the iOS 26.4 host-resolution fix, so it under-reports - re-run once 3.9.0 has been out a few weeks.
 
 You are given the following context:
 $ARGUMENTS

--- a/.agents/skills/analyze-unrecognized-apps/SKILL.md
+++ b/.agents/skills/analyze-unrecognized-apps/SKILL.md
@@ -17,40 +17,53 @@ Analyze unrecognized host app bundle IDs from Firebase/Google Analytics and dete
 
 ## Instructions
 
-1. **Read the current mappings** from `VivaDicta/VivaDictaApp.swift` — find the `knownSchemes` dictionary inside `getURLSchemeForBundleId()`
+1. **Read the current mappings** from `VivaDicta/VivaDictaApp.swift` — find the `knownURLs` dictionary inside `returnURL(forHostId:)`. The `knownNoSchemeHosts` set lives just above it, in `attemptReturnToHost(hostId:)`.
 
 2. **Get the analytics data** — the user will provide a screenshot or list of bundle IDs from the Google Analytics "Unrecognized Host Apps" exploration (see `internal/firebase-analytics-events.md` for how to access it)
 
-3. **Cross-reference** each bundle ID against the existing `knownSchemes` dictionary and categorize into:
+3. **Cross-reference** each bundle ID against `knownURLs` and `knownNoSchemeHosts`, and categorize into:
 
-   **Already mapped** — bundle ID exists in `knownSchemes` (these show up in analytics from before the mapping was added)
+   **Already mapped** — bundle ID exists in `knownURLs` (these show up in analytics from before the mapping was added)
 
-   **Not actionable** — system services that can't be returned to via URL scheme:
+   **Variant of a mapped app** — same app under a different bundle ID: a team-ID suffix (`com.spotify.client.L32G8C83V9`), a regional build (`com.amazon.AmazonDE`), or an app extension (`net.whatsapp.WhatsApp.ShareExtension`). Aliasing a suffixed build to the same URL is safe. An *extension* is a judgement call — returning to the parent app is not the surface the user was in.
+
+   **Not actionable** — system services that can't be returned to:
    - `(not set)` — pre-custom-dimension-registration data
    - `com.apple.SafariViewService` — SFSafariViewController embedded in other apps
    - `com.apple.springboard` — iOS home screen
    - Other Apple system services
 
-   **Need to add** — real third-party apps not yet in `knownSchemes`
+   **Need to add** — real third-party apps not yet in `knownURLs`
 
-4. **Research URL schemes** for the "need to add" apps — use the web-researcher agent to search for:
+4. **Research a way back** for the "need to add" apps. Search for:
    - "[app name] iOS URL scheme"
    - "[app name] deep link"
    - "[bundle id] URL scheme"
    - Known URL scheme databases and GitHub repos
 
+   Two sources beat any blog list, and are worth the extra step for high-volume apps:
+   - **The app's own registration** — its open-source `Info.plist` or build file (`CFBundleURLSchemes`), or, for Apple apps, the binary in a simulator runtime under `/Library/Developer/CoreSimulator/.../RuntimeRoot/Applications/`.
+   - **The app's AASA file** — `https://<domain>/.well-known/apple-app-site-association`. If it lists the bundle ID, the matching `https://` URL is a valid fallback for an app that registers no custom scheme. This works *only* on this code path, because the lookup runs solely for the app the keyboard was just typing into, so it is installed by definition.
+
+   Watch for schemes shared between apps. Swiftgram registers `tg://` *and* `telegram://` alongside official Telegram; iOS picks between claimants unpredictably, so map only a scheme the app owns outright (`sg://`).
+
 5. **Output a summary table** with:
    - Bundle ID
    - Event count
-   - Category (already mapped / not actionable / need to add)
-   - URL scheme (if found) and confidence level
+   - Category (already mapped / variant / not actionable / need to add)
+   - Return URL (if found) and confidence level
 
-6. **After user confirms** which schemes to add, update:
-   - The `knownSchemes` dictionary in `VivaDicta/VivaDictaApp.swift`
-   - The `LSApplicationQueriesSchemes` array in the app's `Info.plist` (if the scheme isn't already declared there)
+6. **After user confirms** which entries to add, update `VivaDicta/VivaDictaApp.swift`:
+   - Apps with a way back → the `knownURLs` dictionary in `returnURL(forHostId:)`
+   - Apps with none → the `knownNoSchemeHosts` set, so they stop being reported as unrecognized
+
+   **There is no plist step, and adding one is a regression.** `LSApplicationQueriesSchemes` was deleted on 2026-08-29 along with the `canOpenURL` gate it existed to permit. Apple caps that array at 50 entries, and past the cap `canOpenURL` returns false whether or not the app is installed — which silently killed the newest mappings. `UIApplication.open` needs no declaration and reports failure through its own result, so the table can now grow without limit. Do not reintroduce either.
+
+7. **Update the "Last run" line** at the top of this file with the date and what changed.
 
 <IMPORTANT>
 - Do NOT add URL schemes you are not confident about without user confirmation
-- Low-confidence schemes should be flagged — the most reliable verification is installing the app and checking its Info.plist for CFBundleURLSchemes
+- Low-confidence schemes should be flagged — the most reliable verification is the app's own `CFBundleURLSchemes`, from its source, its shipped binary, or an installed copy
 - Some bundle IDs (Apple system services, embedded browser views) are not actionable and should be called out as such
+- Treat the event counts as a floor, not a census. `.unrecognizedHostApp` only fires when the keyboard resolves a host bundle ID, so any period where resolution was broken under-reports every app at once
 </IMPORTANT>

--- a/VivaDicta/Info.plist
+++ b/VivaDicta/Info.plist
@@ -65,61 +65,6 @@
 	</array>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
-	<key>LSApplicationQueriesSchemes</key>
-	<array>
-		<string>mobilenotes</string>
-		<string>sms</string>
-		<string>message</string>
-		<string>x-web-search</string>
-		<string>ms-word</string>
-		<string>things</string>
-		<string>googlegmail</string>
-		<string>messenger</string>
-		<string>fb</string>
-		<string>fb-messenger</string>
-		<string>twitter</string>
-		<string>snapchat</string>
-		<string>instagram</string>
-		<string>whatsapp</string>
-		<string>whatsapp-consumer</string>
-		<string>telegram</string>
-		<string>tg</string>
-		<string>viber</string>
-		<string>spotify</string>
-		<string>pages</string>
-		<string>numbers</string>
-		<string>keynote</string>
-		<string>googlechrome</string>
-		<string>ms-outlook</string>
-		<string>dbapi-1</string>
-		<string>googletranslate</string>
-		<string>linkedin</string>
-		<string>com.openai.chat</string>
-		<string>perplexity-app</string>
-		<string>claude</string>
-		<string>obsidian</string>
-		<string>monica</string>
-		<string>mem</string>
-		<string>google</string>
-		<string>tinder</string>
-		<string>readdle-spark</string>
-		<string>discord</string>
-		<string>googlemobileapp</string>
-		<string>sgnl</string>
-		<string>fsnotes</string>
-		<string>threema</string>
-		<string>barcelona</string>
-		<string>logseq</string>
-		<string>github</string>
-		<string>grok</string>
-		<string>shellfish</string>
-		<string>termius</string>
-		<string>msteams</string>
-		<string>reddit</string>
-		<string>ia-writer</string>
-		<string>gemini-app</string>
-		<string>yandextranslate</string>
-	</array>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>

--- a/VivaDicta/VivaDictaApp.swift
+++ b/VivaDicta/VivaDictaApp.swift
@@ -312,47 +312,39 @@ struct VivaDictaApp: App {
         logger.logInfo("🔄 attemptReturnToHost called with hostId: \(hostId)")
         logger.logInfo("🔄 Attempting to return to host: \(hostId)")
         
-        if let urlScheme = getURLSchemeForBundleId(hostId),
-           let url = URL(string: urlScheme) {
-            logger.logInfo("🚀 Found URL scheme, attempting to open: \(urlScheme)")
+        if let url = returnURL(forHostId: hostId) {
+            logger.logInfo("🚀 Found return URL, attempting to open: \(url.absoluteString)")
 
-            // Check if we can open the URL before starting recording
             Task {
-                if UIApplication.shared.canOpenURL(url) {
-                    // We can return to host - start actual recording first
-                    logger.logInfo("🎙️ Starting recording before returning to host app")
-                    
-                    // Check if we have a transcription model selected
-                    guard let vm = appState.recordViewModel else {
-                        logger.logError("❌ RecordViewModel not available")
-                        appState.showKeyboardReturnPrompt = true
-                        return
-                    }
-                    
-                    if vm.transcriptionManager.getCurrentTranscriptionModel() == nil {
-                        logger.logWarning("⚠️ No transcription model selected - showing keyboard return prompt")
-                        appState.showKeyboardReturnPrompt = true
-                        return
-                    }
-                    
-                    // Start the actual recording
-                    vm.startCaptureAudio(sourceTag: SourceTag.keyboard)
-                    
-                    // Small delay to ensure recording is fully started
-                    try? await Task.sleep(for: .milliseconds(200))
-                    
-                    // Now return to the host app
-                    UIApplication.shared.open(url, options: [:]) { success in
-                        if success {
-                            self.logger.logInfo("✅ Successfully opened host app: \(hostId) with recording started")
-                        } else {
-                            self.logger.logError("❌ Failed to open host app: \(hostId)")
-                            // Failed to open - recording is already started, user can continue
-                        }
-                    }
+                // Check if we have a transcription model selected
+                guard let vm = appState.recordViewModel else {
+                    logger.logError("❌ RecordViewModel not available")
+                    appState.showKeyboardReturnPrompt = true
+                    return
+                }
+
+                if vm.transcriptionManager.getCurrentTranscriptionModel() == nil {
+                    logger.logWarning("⚠️ No transcription model selected - showing keyboard return prompt")
+                    appState.showKeyboardReturnPrompt = true
+                    return
+                }
+
+                // Recording starts before the open is known to have succeeded.
+                // `open` only reports failure once it has already tried, and the
+                // user arrives in the host app expecting to be recording
+                // already, so waiting for the answer would cost the head of the
+                // recording. A failure falls back to the prompt below.
+                logger.logInfo("🎙️ Starting recording before returning to host app")
+                vm.startCaptureAudio(sourceTag: SourceTag.keyboard)
+
+                // Small delay to ensure recording is fully started
+                try? await Task.sleep(for: .milliseconds(200))
+
+                // Now return to the host app
+                if await UIApplication.shared.open(url) {
+                    logger.logInfo("✅ Successfully opened host app: \(hostId) with recording started")
                 } else {
-                    logger.logInfo("❌ Cannot open URL scheme: \(urlScheme)")
-                    // Can't open URL - don't start recording, show keyboard return prompt
+                    logger.logError("❌ Failed to open host app: \(hostId)")
                     appState.showKeyboardReturnPrompt = true
                 }
             }
@@ -389,7 +381,12 @@ struct VivaDictaApp: App {
                 "com.weichart.Zettel",          // Zettel Notes - no known URL scheme
                 "h3p.Neon-Vision-Editor",       // Neon Vision Editor - no known URL scheme
                 "mystxtalk",                    // Unknown messaging app
-                "ru.ozon.sellerApp"             // Ozon Seller - no known URL scheme
+                "ru.ozon.sellerApp",            // Ozon Seller - no known URL scheme
+                "kz.origon.empapp",             // KZ telemedicine app - no known URL scheme
+                "com.cloud-compiler",           // CodeSnack IDE - no known URL scheme
+                "com.corp.messenger.syncer",    // Syncer corporate messenger - no known URL scheme
+                "com.yottaram.eMoods",          // eMoods tracker - no known URL scheme
+                "com.anton"                     // Not a shipping App Store app - a dev build
             ]
 
             if !knownNoSchemeHosts.contains(hostId) {
@@ -568,32 +565,37 @@ struct VivaDictaApp: App {
     private func returnToHost(hostId: String) {
         logger.logInfo("🔄 Returning to host app (no recording): \(hostId)")
 
-        if let urlScheme = getURLSchemeForBundleId(hostId),
-           let url = URL(string: urlScheme) {
-            Task {
-                if UIApplication.shared.canOpenURL(url) {
-                    UIApplication.shared.open(url, options: [:]) { success in
-                        if success {
-                            self.logger.logInfo("✅ Returned to host app: \(hostId)")
-                        } else {
-                            self.logger.logError("❌ Failed to open host app: \(hostId)")
-                        }
-                    }
-                } else {
-                    logger.logInfo("❌ Cannot open URL scheme: \(urlScheme)")
-                    appState.showKeyboardReturnPrompt = true
-                }
-            }
-        } else {
-            logger.logInfo("❌ No URL scheme for host: \(hostId)")
+        guard let url = returnURL(forHostId: hostId) else {
+            logger.logInfo("❌ No return URL for host: \(hostId)")
             appState.showKeyboardReturnPrompt = true
+            return
+        }
+
+        Task {
+            if await UIApplication.shared.open(url) {
+                logger.logInfo("✅ Returned to host app: \(hostId)")
+            } else {
+                logger.logError("❌ Failed to open host app: \(hostId)")
+                appState.showKeyboardReturnPrompt = true
+            }
         }
     }
 
-    private func getURLSchemeForBundleId(_ bundleId: String) -> String? {
-        // Map of common apps and their URL schemes
-        // Note: This is not comprehensive and many apps don't have public URL schemes
-        let knownSchemes: [String: String] = [
+    /// The URL that sends the user back to `bundleId`, or nil when there is no
+    /// known way back.
+    ///
+    /// Most entries are custom schemes. A few apps register none but do claim a
+    /// universal link in their `apple-app-site-association`, which works here
+    /// because the host app is installed by definition - it is the app the
+    /// keyboard was just typing into. The trade-off is that a user who has told
+    /// iOS to open that domain in Safari lands on the web page instead of
+    /// getting the manual return prompt.
+    ///
+    /// Not comprehensive: plenty of apps publish no way back at all. Those are
+    /// listed in `knownNoSchemeHosts` so they stop being reported as
+    /// unrecognized.
+    private func returnURL(forHostId bundleId: String) -> URL? {
+        let knownURLs: [String: String] = [
             "com.apple.mobilenotes": "mobilenotes://",
             "com.apple.MobileSMS": "sms://",
             "com.apple.mobilemail": "message://",
@@ -644,10 +646,33 @@ struct VivaDictaApp: App {
             "com.reddit.Reddit": "reddit://",
             "pro.writer": "ia-writer://",
             "com.google.gemini": "gemini-app://",
-            "ru.yandex.mobile.translate": "yandextranslate://"
+            "ru.yandex.mobile.translate": "yandextranslate://",
+
+            // Verified against the app's own Info.plist, official docs, or the
+            // shipping binary.
+            "app.swiftgram.ios": "sg://",            // NOT tg:// - shared with official Telegram
+            "com.openminis.app": "minis://",
+            "com.tencent.xin": "weixin://",
+            "com.spotify.client.L32G8C83V9": "spotify://",  // team-ID-suffixed Spotify build
+            "com.apple.reminders": "x-apple-reminderkit://", // NOT x-apple-reminder://, unregistered
+            "com.letterboxd.LetterboxdApp": "letterboxd://",
+            "eusoft.eudic.ip": "eudic://",
+
+            // Corroborated across independent sources but not read from the
+            // shipping app, so a miss is possible - it degrades to the prompt.
+            "notion.id": "notion://",
+            "com.meituan.imeituan": "imeituan://",
+            "com.newin.nplayer.basic": "nplayer-http://",
+
+            // No custom scheme; universal link confirmed in the app's AASA file.
+            "com.google.ios.ytcreator": "https://studio.youtube.com/",
+            "com.amazon.AmazonDE": "https://www.amazon.de/",
+            "ru.ivi": "https://www.ivi.ru/",
+            "ru.oneme.app": "https://max.ru/",
+            "ru.ozon.OzonStore": "https://www.ozon.ru/"
         ]
-        
-        return knownSchemes[bundleId]
+
+        return knownURLs[bundleId].flatMap(URL.init(string:))
     }
     
     func updateShortcutItems() {


### PR DESCRIPTION
## Summary

The keyboard hands its host app's bundle ID to the main app, which looks up a way back and sends the user there. Two problems with that lookup.

**The lookup was silently capped.** The scheme table had reached 50 distinct schemes and `LSApplicationQueriesSchemes` 52 entries. Apple caps that array at 50, and beyond the cap `canOpenURL` returns `false` regardless of whether the app is installed — so the gate in front of the open was failing for entries it had no opinion about, and the user fell through to the manual return prompt. The two most recently appended schemes (`gemini-app`, `yandextranslate`, both added in the previous mapping pass) were the likely casualties.

**The gate is removed rather than the array trimmed.** `LSApplicationQueriesSchemes` exists solely to permit `canOpenURL`; `open` requires no declaration and already reports failure through its result. The code was doing both anyway — checking, then opening and logging the outcome. It now just opens and falls back to the prompt when that fails, which removes the ceiling permanently. These were the only two `canOpenURL` calls in the app, so the array is dead and deleted with them.

## Behavior change

Recording now starts before the open is known to have succeeded. `open` only answers after it has tried, and the user arrives in the host app expecting to already be recording, so waiting would cost the head of the recording. The adjacent no-scheme branch already made that same trade.

## The 15 new mappings

Two were verified from primary sources rather than taken from a list:

- **Swiftgram** (`app.swiftgram.ios`, 23 of 65 events) registers `telegram`, `tg`, `tonsite` and `sg`. Only `sg` is its own — the rest are shared with official Telegram, and iOS picks unpredictably when two apps claim a scheme. Confirmed against the project's Bazel `BUILD` file and diffed against upstream Telegram-iOS.
- **Apple Reminders** registers exactly one scheme, `x-apple-reminderkit`, read out of the shipping binary in a simulator runtime. The `x-apple-reminder://` that circulates on blogs is not registered and would fail silently.

High confidence: `sg://`, `minis://` (Open Minis, from its own `Info.plist`), `weixin://` (WeChat, Tencent docs), `spotify://` for the team-ID-suffixed Spotify build, `x-apple-reminderkit://`, `letterboxd://` (official repo), `eudic://` (official docs).

Medium confidence — corroborated across independent sources but not read from a shipping app, and a miss degrades to the prompt: `notion://`, `imeituan://`, `nplayer-http://`.

**Universal-link fallbacks** for five apps that register no scheme but claim a link in their AASA file: YouTube Studio, Amazon DE, ivi, MAX, Ozon. This works here in a way it would not generally — the lookup only ever runs for the app the keyboard was just typing into, so it is installed by definition. Residual risk: a user who has told iOS to open that domain in Safari lands on the web page instead of the prompt.

## Other changes

- `getURLSchemeForBundleId` → `returnURL(forHostId:)`, now returning a `URL`. The old name stopped describing a table that also holds universal links.
- Five hosts added to `knownNoSchemeHosts` so they stop being reported, including `com.anton`, which matches no App Store app in any storefront and is a dev build.

## Testing

- Builds clean for the app and all extensions (0 errors, 0 new warnings).
- Mapping table validated programmatically: 66 entries, no duplicate bundle IDs, no malformed URLs.
- `Info.plist` passes `plutil -lint`; the diff is a pure deletion with no reformatting.
- The Swiftgram and Reminders schemes were each confirmed independently against their source of truth.
- Not exercised end-to-end on device — the return path needs a real host app per mapping.

## Note on the data

`.unrecognizedHostApp` only fires when a host ID resolves, and that returned `nil` on iOS 26.4+ for the entire reporting window. This sample is therefore iOS 25 and older users only: it under-reports, and the app mix will shift now that resolution works again. Worth re-running once 3.9.0 has been out a few weeks.