### PR TITLE
Stop seeding the next keyboard session with this session's host

### DIFF
--- a/VivaDicta/VivaDictaApp.swift
+++ b/VivaDicta/VivaDictaApp.swift
@@ -309,11 +309,14 @@ struct VivaDictaApp: App {
         // 2. If we CANNOT return: Start recording → Show return prompt → User manually switches
         //    User sees recording already happening when they arrive
         
-        logger.logInfo("🔄 attemptReturnToHost called with hostId: \(hostId)")
-        logger.logInfo("🔄 Attempting to return to host: \(hostId)")
-        
+        // `.notice` rather than `.info` throughout this path: info-level
+        // entries are memory backed, so they are gone by the time a device log
+        // is collected - and the app is usually terminated moments after a
+        // handoff, which is exactly when a wrong host needs explaining.
+        logger.logNotice("🔄 Attempting to return to host: \(hostId)")
+
         if let url = returnURL(forHostId: hostId) {
-            logger.logInfo("🚀 Found return URL, attempting to open: \(url.absoluteString)")
+            logger.logNotice("🚀 Found return URL, attempting to open: \(url.absoluteString)")
 
             Task {
                 // Check if we have a transcription model selected
@@ -342,14 +345,14 @@ struct VivaDictaApp: App {
 
                 // Now return to the host app
                 if await UIApplication.shared.open(url) {
-                    logger.logInfo("✅ Successfully opened host app: \(hostId) with recording started")
+                    logger.logNotice("✅ Successfully opened host app: \(hostId) with recording started")
                 } else {
                     logger.logError("❌ Failed to open host app: \(hostId)")
                     appState.showKeyboardReturnPrompt = true
                 }
             }
         } else {
-            logger.logInfo("❌ No URL scheme available for host: \(hostId)")
+            logger.logNotice("❌ No URL scheme available for host: \(hostId)")
             // No URL scheme found - start recording and show keyboard return prompt
             // so user can switch back manually and find recording already in progress
             Task {
@@ -563,17 +566,17 @@ struct VivaDictaApp: App {
     /// Returns to the host app without starting recording.
     /// Used by the text processing keyboard flow.
     private func returnToHost(hostId: String) {
-        logger.logInfo("🔄 Returning to host app (no recording): \(hostId)")
+        logger.logNotice("🔄 Returning to host app (no recording): \(hostId)")
 
         guard let url = returnURL(forHostId: hostId) else {
-            logger.logInfo("❌ No return URL for host: \(hostId)")
+            logger.logNotice("❌ No return URL for host: \(hostId)")
             appState.showKeyboardReturnPrompt = true
             return
         }
 
         Task {
             if await UIApplication.shared.open(url) {
-                logger.logInfo("✅ Returned to host app: \(hostId)")
+                logger.logNotice("✅ Returned to host app: \(hostId)")
             } else {
                 logger.logError("❌ Failed to open host app: \(hostId)")
                 appState.showKeyboardReturnPrompt = true

--- a/VivaDictaKeyboard/KeyboardViewController.swift
+++ b/VivaDictaKeyboard/KeyboardViewController.swift
@@ -101,11 +101,12 @@ class KeyboardViewController: KeyboardInputViewController {
     /// that has to be activated and then polled, so the bundle ID is no longer
     /// available as an instant property read.
     ///
-    /// The task is deliberately *not* backed by the persisted
-    /// `KeyboardContext.hostApplicationBundleId`: a controller is created fresh
-    /// per keyboard session, so a plain property can never hand back the bundle
-    /// ID of the app the keyboard was in last time - which would teleport the
-    /// user into the wrong app.
+    /// The task is deliberately *not* backed by
+    /// `KeyboardContext.hostApplicationBundleId`. That property is persisted to
+    /// the App Group and therefore outlives both this controller and the
+    /// extension process, so reading it can hand back the bundle ID of the app
+    /// the keyboard was in *last* time - which teleports the user into the
+    /// wrong app.
     private var hostApplicationBundleIdTask: Task<String?, Never>?
 
     /// The host app's bundle ID, waiting up to `timeout` for a resolution that
@@ -130,22 +131,48 @@ class KeyboardViewController: KeyboardInputViewController {
     }
 
     private func startResolvingHostApplicationBundleId() {
+        let resolutionStart = Date.now
         hostApplicationBundleIdTask = Task { [weak self] in
             guard let self else { return nil }
             let bundleId: String?
             do {
                 bundleId = try await resolveHostApplicationBundleId()
-                logger.logInfo("🏠 Resolved host app: \(bundleId ?? "nil")")
             } catch {
                 logger.logError("🏠 Failed to resolve host app: \(error.localizedDescription)")
-                bundleId = nil
+                return nil
             }
-            // Mirror into the context KeyboardKit itself reads, including when
-            // resolution failed - leaving a previous session's value in place
-            // is worse than having none.
-            state.keyboardContext.hostApplicationBundleId = bundleId
+
+            // KeyboardKit persists `hostApplicationBundleId` to the App Group
+            // and, per its Host article, "will not sync the bundle ID to the
+            // KeyboardContext unless absolutely necessary". Nothing here reads
+            // it back - the handoff URL carries this task's value instead - so
+            // writing it would only seed the *next* keyboard session with this
+            // session's host. Clear it, so neither this session nor a value
+            // left behind by an earlier build can outlive the keyboard.
+            let syncDate = state.keyboardContext.hostApplicationBundleIdSyncDate
+            state.keyboardContext.hostApplicationBundleId = nil
+
+            // `.notice` rather than `.info`: info-level entries are memory
+            // backed and die with the extension process, so a mis-teleport was
+            // invisible in any log captured after the fact. The sync date says
+            // whether the resolved ID predates this resolution, which is what
+            // distinguishes a stale host from a correctly resolved one.
+            logger.logNotice(
+                "🏠 Resolved host app: \(bundleId ?? "nil") (context last synced \(Self.syncAgeDescription(syncDate, relativeTo: resolutionStart)))"
+            )
             return bundleId
         }
+    }
+
+    /// How long before `reference` the keyboard context's host bundle ID was
+    /// last written, for the resolution log.
+    ///
+    /// A positive age means the persisted value predates this resolution, and
+    /// so belongs to an earlier keyboard session.
+    private static func syncAgeDescription(_ syncDate: Date?, relativeTo reference: Date) -> String {
+        guard let syncDate else { return "never" }
+        let age = reference.timeIntervalSince(syncDate)
+        return "\(age.formatted(.number.precision(.fractionLength(1))))s before this resolution"
     }
     
     override func viewWillSetupKeyboardView() {


### PR DESCRIPTION
## Summary

The keyboard could hand the main app the bundle ID of the app it was in **last** time, teleporting the user into the wrong app. Reproduced manually as a clean off-by-one:

| Step | Persisted value read | Where the user landed |
|---|---|---|
| Telegram, cold start | *(nil)* | nowhere |
| Notes | `ph.telegra.Telegraph` | Telegram |
| Telegram | `com.apple.mobilenotes` | Notes |

`KeyboardContext.hostApplicationBundleId` is persisted to the App Group, so it outlives both the controller and the extension process. Per KeyboardKit's Host article it "will not sync the bundle ID to the `KeyboardContext` unless absolutely necessary" for exactly that reason. We were writing it on every resolve, and nothing in this codebase reads it back (the handoff URL carries the resolved value directly), so the write did nothing but leave this session's host sitting there for the next one to pick up.

Now cleared instead, which also wipes anything an earlier build left behind.

The doc comment asserting that a fresh controller made staleness impossible was wrong on the same point: the persistence lives in the App Group, not the controller.

## Diagnosability

Host resolution and the teleport decision path move from `.info` to `.notice`. Info level is memory backed and dies with the process, and the app is usually terminated moments after a handoff, so a wrong host left no trace in a log collected afterwards. In a recent device capture, four of five handoffs were invisible for this reason.

The resolution log now also reports how long before the resolution the persisted value was last written, which is what distinguishes a stale host from a freshly resolved one.

## Deliberately not included

Rejecting a resolved value whose `hostApplicationBundleIdSyncDate` predates the keyboard session. That would also reject the common case of using the keyboard twice in the same app, and whether the resolver refreshes that date is not verifiable against a binary framework. Shipping it blind risks trading "teleports to the wrong app" for "never teleports."

The logging above is what settles the threshold. The guard is a follow-up gated on one device capture.

## Testing

- `xcodebuild build` against iPhone 17 Pro Max / iOS 26.4: success, 0 errors.
- Behavior verification needs a device capture reproducing the Telegram to Notes to Telegram sequence on a build with these changes, since the failure only shows on a physical device and the relevant logs did not previously persist.