### PR TITLE
Re-resolve the host app at handoff instead of reusing viewDidLoad's answer

### DIFF
--- a/VivaDicta/VivaDictaApp.swift
+++ b/VivaDicta/VivaDictaApp.swift
@@ -309,11 +309,14 @@ struct VivaDictaApp: App {
         // 2. If we CANNOT return: Start recording → Show return prompt → User manually switches
         //    User sees recording already happening when they arrive
         
-        logger.logInfo("🔄 attemptReturnToHost called with hostId: \(hostId)")
-        logger.logInfo("🔄 Attempting to return to host: \(hostId)")
-        
+        // `.notice` rather than `.info` throughout this path: info-level
+        // entries are memory backed, so they are gone by the time a device log
+        // is collected - and the app is usually terminated moments after a
+        // handoff, which is exactly when a wrong host needs explaining.
+        logger.logNotice("🔄 Attempting to return to host: \(hostId)")
+
         if let url = returnURL(forHostId: hostId) {
-            logger.logInfo("🚀 Found return URL, attempting to open: \(url.absoluteString)")
+            logger.logNotice("🚀 Found return URL, attempting to open: \(url.absoluteString)")
 
             Task {
                 // Check if we have a transcription model selected
@@ -342,14 +345,14 @@ struct VivaDictaApp: App {
 
                 // Now return to the host app
                 if await UIApplication.shared.open(url) {
-                    logger.logInfo("✅ Successfully opened host app: \(hostId) with recording started")
+                    logger.logNotice("✅ Successfully opened host app: \(hostId) with recording started")
                 } else {
                     logger.logError("❌ Failed to open host app: \(hostId)")
                     appState.showKeyboardReturnPrompt = true
                 }
             }
         } else {
-            logger.logInfo("❌ No URL scheme available for host: \(hostId)")
+            logger.logNotice("❌ No URL scheme available for host: \(hostId)")
             // No URL scheme found - start recording and show keyboard return prompt
             // so user can switch back manually and find recording already in progress
             Task {
@@ -563,17 +566,17 @@ struct VivaDictaApp: App {
     /// Returns to the host app without starting recording.
     /// Used by the text processing keyboard flow.
     private func returnToHost(hostId: String) {
-        logger.logInfo("🔄 Returning to host app (no recording): \(hostId)")
+        logger.logNotice("🔄 Returning to host app (no recording): \(hostId)")
 
         guard let url = returnURL(forHostId: hostId) else {
-            logger.logInfo("❌ No return URL for host: \(hostId)")
+            logger.logNotice("❌ No return URL for host: \(hostId)")
             appState.showKeyboardReturnPrompt = true
             return
         }
 
         Task {
             if await UIApplication.shared.open(url) {
-                logger.logInfo("✅ Returned to host app: \(hostId)")
+                logger.logNotice("✅ Returned to host app: \(hostId)")
             } else {
                 logger.logError("❌ Failed to open host app: \(hostId)")
                 appState.showKeyboardReturnPrompt = true

--- a/VivaDicta/VivaDictaApp.swift
+++ b/VivaDicta/VivaDictaApp.swift
@@ -454,7 +454,7 @@ struct VivaDictaApp: App {
                         // return prompt so the user can switch back by hand.
                         if let vm = appState.recordViewModel,
                            vm.transcriptionManager.getCurrentTranscriptionModel() != nil {
-                            logger.logInfo("🎙️ Starting recording before showing manual switch prompt (no hostId)")
+                            logger.logNotice("🎙️ Starting recording before showing manual switch prompt (no hostId)")
                             vm.startCaptureAudio(sourceTag: SourceTag.keyboard)
                         }
                         appState.showKeyboardReturnPrompt = true

--- a/VivaDictaKeyboard/KeyboardCustomView.swift
+++ b/VivaDictaKeyboard/KeyboardCustomView.swift
@@ -304,7 +304,7 @@ struct KeyboardCustomView: View {
     /// already finished by the time this runs.
     private func openMainApp() {
         Task {
-            let hostId = await keyboardVC?.hostApplicationBundleId()
+            let hostId = await keyboardVC?.hostApplicationBundleIdForHandoff()
             guard let url = URL.keyboardHandoff(
                 "vivadicta://activate-for-keyboard",
                 hostId: hostId

--- a/VivaDictaKeyboard/KeyboardCustomView.swift
+++ b/VivaDictaKeyboard/KeyboardCustomView.swift
@@ -300,8 +300,9 @@ struct KeyboardCustomView: View {
 
     /// Wakes the main app so it can service a text-processing request, tagging
     /// the deep link with the host app so the app can hand the user back.
-    /// Resolving the host is async since KeyboardKit 10.9, but has normally
-    /// already finished by the time this runs.
+    /// Resolving the host is async since KeyboardKit 10.9, and deliberately
+    /// re-runs here rather than reusing the answer from `viewDidLoad`, which is
+    /// taken before the resolver has settled on the current host.
     private func openMainApp() {
         Task {
             let hostId = await keyboardVC?.hostApplicationBundleIdForHandoff()

--- a/VivaDictaKeyboard/KeyboardViewController.swift
+++ b/VivaDictaKeyboard/KeyboardViewController.swift
@@ -86,8 +86,10 @@ class KeyboardViewController: KeyboardInputViewController {
         // Configure sound feedback based on user preference
         state.feedbackContext.settings.isAudioFeedbackEnabled = AppGroupCoordinator.shared.isKeyboardSoundFeedbackEnabled
 
-        // Start resolving the host app now so the answer is already cached by
-        // the time the user taps a button that hands off to the main app.
+        // Start resolving the host app now. A handoff deliberately resolves
+        // again rather than reusing this answer, but starting here activates
+        // KeyboardKit's resolver early, so that later call reads a warm one and
+        // returns without stalling the button.
         startResolvingHostApplicationBundleId()
     }
 
@@ -110,13 +112,8 @@ class KeyboardViewController: KeyboardInputViewController {
     private var hostApplicationBundleIdTask: Task<String?, Never>?
 
     /// The host app's bundle ID, waiting up to `timeout` for a resolution that
-    /// is still in flight.
-    ///
-    /// Resolution starts in `viewDidLoad`, so in practice this returns
-    /// immediately. The bound only matters when the user taps within the first
-    /// moments of the keyboard appearing, where stalling the button would feel
-    /// worse than falling back to the main app's manual return prompt.
-    func hostApplicationBundleId(waitingUpTo timeout: Duration = .seconds(1)) async -> String? {
+    /// is still in flight, or nil if it does not land in time.
+    private func hostApplicationBundleId(waitingUpTo timeout: Duration) async -> String? {
         guard let task = hostApplicationBundleIdTask else { return nil }
         return await withTaskGroup(of: String?.self) { group in
             group.addTask { await task.value }
@@ -139,21 +136,27 @@ class KeyboardViewController: KeyboardInputViewController {
     /// resolution in the same capture that was taken 8s or more after its host
     /// appeared was correct.
     ///
-    /// The value cached at `viewDidLoad` is therefore the one most likely to be
-    /// wrong, since it is taken the instant the keyboard reaches a new host. A
-    /// handoff re-resolves, and falls back to the cached answer only when the
-    /// fresh one cannot be had inside `timeout`.
-    func hostApplicationBundleIdForHandoff(waitingUpTo timeout: Duration = .seconds(1)) async -> String? {
-        let cached = hostApplicationBundleIdTask
+    /// The value resolved at `viewDidLoad` is therefore the one most likely to
+    /// be wrong, since it is taken the instant the keyboard reaches a new host,
+    /// so a handoff asks again rather than reusing it. Until iOS 26.4 this was
+    /// a synchronous property read taken at exactly this moment; re-resolving
+    /// restores that timing on top of the async resolver.
+    ///
+    /// There is deliberately no fallback to the earlier answer when the fresh
+    /// one does not land in time. That answer is the least trustworthy value
+    /// the keyboard holds, and it is wrong in precisely the case this method
+    /// exists to handle. An unresolved host costs the automatic teleport and
+    /// leaves the user with the main app's manual return prompt, recording
+    /// already running - far cheaper than opening the wrong app, which also
+    /// relaunches an app they had closed.
+    func hostApplicationBundleIdForHandoff(waitingUpTo timeout: Duration = .seconds(2)) async -> String? {
         startResolvingHostApplicationBundleId()
 
-        if let fresh = await hostApplicationBundleId(waitingUpTo: timeout) {
-            return fresh
+        guard let bundleId = await hostApplicationBundleId(waitingUpTo: timeout) else {
+            logger.logNotice("🏠 Host unresolved within \(timeout); handing off without one")
+            return nil
         }
-
-        guard let cached else { return nil }
-        logger.logNotice("🏠 Fresh host resolution timed out; falling back to the cached one")
-        return await cached.value
+        return bundleId
     }
 
     private func startResolvingHostApplicationBundleId() {

--- a/VivaDictaKeyboard/KeyboardViewController.swift
+++ b/VivaDictaKeyboard/KeyboardViewController.swift
@@ -101,11 +101,12 @@ class KeyboardViewController: KeyboardInputViewController {
     /// that has to be activated and then polled, so the bundle ID is no longer
     /// available as an instant property read.
     ///
-    /// The task is deliberately *not* backed by the persisted
-    /// `KeyboardContext.hostApplicationBundleId`: a controller is created fresh
-    /// per keyboard session, so a plain property can never hand back the bundle
-    /// ID of the app the keyboard was in last time - which would teleport the
-    /// user into the wrong app.
+    /// The task is deliberately *not* backed by
+    /// `KeyboardContext.hostApplicationBundleId`. That property is persisted to
+    /// the App Group and therefore outlives both this controller and the
+    /// extension process, so reading it can hand back the bundle ID of the app
+    /// the keyboard was in *last* time - which teleports the user into the
+    /// wrong app.
     private var hostApplicationBundleIdTask: Task<String?, Never>?
 
     /// The host app's bundle ID, waiting up to `timeout` for a resolution that
@@ -129,21 +130,56 @@ class KeyboardViewController: KeyboardInputViewController {
         }
     }
 
+    /// The host app's bundle ID for a handoff to the main app, resolved afresh.
+    ///
+    /// KeyboardKit's resolver lags a change of host app. In a device capture it
+    /// returned a bundle ID for an app that had been terminated for three
+    /// seconds and was never the current host, 1.3s after the keyboard moved
+    /// into a different app - and the main app duly relaunched that app. Every
+    /// resolution in the same capture that was taken 8s or more after its host
+    /// appeared was correct.
+    ///
+    /// The value cached at `viewDidLoad` is therefore the one most likely to be
+    /// wrong, since it is taken the instant the keyboard reaches a new host. A
+    /// handoff re-resolves, and falls back to the cached answer only when the
+    /// fresh one cannot be had inside `timeout`.
+    func hostApplicationBundleIdForHandoff(waitingUpTo timeout: Duration = .seconds(1)) async -> String? {
+        let cached = hostApplicationBundleIdTask
+        startResolvingHostApplicationBundleId()
+
+        if let fresh = await hostApplicationBundleId(waitingUpTo: timeout) {
+            return fresh
+        }
+
+        guard let cached else { return nil }
+        logger.logNotice("🏠 Fresh host resolution timed out; falling back to the cached one")
+        return await cached.value
+    }
+
     private func startResolvingHostApplicationBundleId() {
         hostApplicationBundleIdTask = Task { [weak self] in
             guard let self else { return nil }
             let bundleId: String?
             do {
                 bundleId = try await resolveHostApplicationBundleId()
-                logger.logInfo("🏠 Resolved host app: \(bundleId ?? "nil")")
             } catch {
                 logger.logError("🏠 Failed to resolve host app: \(error.localizedDescription)")
-                bundleId = nil
+                return nil
             }
-            // Mirror into the context KeyboardKit itself reads, including when
-            // resolution failed - leaving a previous session's value in place
-            // is worse than having none.
-            state.keyboardContext.hostApplicationBundleId = bundleId
+
+            // KeyboardKit persists `hostApplicationBundleId` to the App Group
+            // and, per its Host article, "will not sync the bundle ID to the
+            // KeyboardContext unless absolutely necessary". Nothing here reads
+            // it back - the handoff URL carries this task's value instead - so
+            // writing it would only seed the *next* keyboard session with this
+            // session's host. Clear it, so neither this session nor a value
+            // left behind by an earlier build can outlive the keyboard.
+            state.keyboardContext.hostApplicationBundleId = nil
+
+            // `.notice` rather than `.info`: info-level entries are memory
+            // backed and die with the extension process, so a wrong host was
+            // invisible in any log captured after the fact.
+            logger.logNotice("🏠 Resolved host app: \(bundleId ?? "nil")")
             return bundleId
         }
     }
@@ -354,7 +390,7 @@ struct VivaDictaKeyboardToolbarView: View {
         // async since KeyboardKit 10.9, but has normally already finished here.
         // Doc - https://docs.keyboardkit.com/documentation/keyboardkit/host-article
         Task {
-            let hostId = await controller?.hostApplicationBundleId()
+            let hostId = await controller?.hostApplicationBundleIdForHandoff()
             guard let url = URL.keyboardHandoff(
                 "vivadicta://record-for-keyboard",
                 hostId: hostId

--- a/VivaDictaKeyboard/KeyboardViewController.swift
+++ b/VivaDictaKeyboard/KeyboardViewController.swift
@@ -134,9 +134,8 @@ class KeyboardViewController: KeyboardInputViewController {
     /// already running - far cheaper than opening the wrong app, which also
     /// relaunches an app they had closed.
     func hostApplicationBundleIdForHandoff(waitingUpTo timeout: TimeInterval = 2) async -> String? {
-        startResolvingHostApplicationBundleId(timeout: timeout)
+        let task = startResolvingHostApplicationBundleId(timeout: timeout)
 
-        guard let task = hostApplicationBundleIdTask else { return nil }
         guard let bundleId = await task.value else {
             logger.logNotice("🏠 Host unresolved; handing off without one")
             return nil
@@ -144,7 +143,8 @@ class KeyboardViewController: KeyboardInputViewController {
         return bundleId
     }
 
-    /// Starts a host resolution, bounded by KeyboardKit's own `timeout`.
+    /// Starts a host resolution, bounded by KeyboardKit's own `timeout`, and
+    /// returns the task running it.
     ///
     /// The bound belongs to the resolver rather than to a race here on purpose.
     /// Racing an unstructured `Task` against a sleep does not bound anything:
@@ -152,8 +152,16 @@ class KeyboardViewController: KeyboardInputViewController {
     /// losing child does not cancel the resolution it is awaiting, so a slow
     /// resolver would hold the handoff open well past the deadline and leave
     /// the user's tap looking inert.
-    private func startResolvingHostApplicationBundleId(timeout: TimeInterval = 2) {
-        hostApplicationBundleIdTask = Task { [weak self] in
+    ///
+    /// Any resolution still in flight is cancelled first. The resolver polls on
+    /// the main actor, so letting a superseded one run would leave two polling
+    /// loops competing for the actor that also draws the keyboard and handles
+    /// its touches.
+    @discardableResult
+    private func startResolvingHostApplicationBundleId(timeout: TimeInterval = 2) -> Task<String?, Never> {
+        hostApplicationBundleIdTask?.cancel()
+
+        let task = Task<String?, Never> { [weak self] in
             guard let self else { return nil }
             // KeyboardKit persists `hostApplicationBundleId` to the App Group
             // and, per its Host article, "will not sync the bundle ID to the
@@ -182,6 +190,9 @@ class KeyboardViewController: KeyboardInputViewController {
             logger.logNotice("🏠 Resolved host app: \(bundleId ?? "nil")")
             return bundleId
         }
+
+        hostApplicationBundleIdTask = task
+        return task
     }
     
     override func viewWillSetupKeyboardView() {
@@ -387,7 +398,9 @@ struct VivaDictaKeyboardToolbarView: View {
     private func openMainAppForHotMic() {
         // The host app ID rides along as a query parameter so the main app can
         // hand the user straight back once the mic is warm. Resolving it is
-        // async since KeyboardKit 10.9, but has normally already finished here.
+        // async since KeyboardKit 10.9, and deliberately re-runs here rather
+        // than reusing the answer from `viewDidLoad`, which is taken before the
+        // resolver has settled on the current host.
         // Doc - https://docs.keyboardkit.com/documentation/keyboardkit/host-article
         Task {
             let hostId = await controller?.hostApplicationBundleIdForHandoff()
@@ -395,7 +408,7 @@ struct VivaDictaKeyboardToolbarView: View {
                 "vivadicta://record-for-keyboard",
                 hostId: hostId
             ) else { return }
-            controller?.logger.logInfo("📱 Opening main app with URL: \(url.absoluteString)")
+            controller?.logger.logNotice("📱 Opening main app with URL: \(url.absoluteString)")
             openURL(url)
         }
     }

--- a/VivaDictaKeyboard/KeyboardViewController.swift
+++ b/VivaDictaKeyboard/KeyboardViewController.swift
@@ -111,22 +111,6 @@ class KeyboardViewController: KeyboardInputViewController {
     /// wrong app.
     private var hostApplicationBundleIdTask: Task<String?, Never>?
 
-    /// The host app's bundle ID, waiting up to `timeout` for a resolution that
-    /// is still in flight, or nil if it does not land in time.
-    private func hostApplicationBundleId(waitingUpTo timeout: Duration) async -> String? {
-        guard let task = hostApplicationBundleIdTask else { return nil }
-        return await withTaskGroup(of: String?.self) { group in
-            group.addTask { await task.value }
-            group.addTask {
-                try? await Task.sleep(for: timeout)
-                return nil
-            }
-            let first = await group.next() ?? nil
-            group.cancelAll()
-            return first
-        }
-    }
-
     /// The host app's bundle ID for a handoff to the main app, resolved afresh.
     ///
     /// KeyboardKit's resolver lags a change of host app. In a device capture it
@@ -149,22 +133,31 @@ class KeyboardViewController: KeyboardInputViewController {
     /// leaves the user with the main app's manual return prompt, recording
     /// already running - far cheaper than opening the wrong app, which also
     /// relaunches an app they had closed.
-    func hostApplicationBundleIdForHandoff(waitingUpTo timeout: Duration = .seconds(2)) async -> String? {
-        startResolvingHostApplicationBundleId()
+    func hostApplicationBundleIdForHandoff(waitingUpTo timeout: TimeInterval = 2) async -> String? {
+        startResolvingHostApplicationBundleId(timeout: timeout)
 
-        guard let bundleId = await hostApplicationBundleId(waitingUpTo: timeout) else {
-            logger.logNotice("🏠 Host unresolved within \(timeout); handing off without one")
+        guard let task = hostApplicationBundleIdTask else { return nil }
+        guard let bundleId = await task.value else {
+            logger.logNotice("🏠 Host unresolved; handing off without one")
             return nil
         }
         return bundleId
     }
 
-    private func startResolvingHostApplicationBundleId() {
+    /// Starts a host resolution, bounded by KeyboardKit's own `timeout`.
+    ///
+    /// The bound belongs to the resolver rather than to a race here on purpose.
+    /// Racing an unstructured `Task` against a sleep does not bound anything:
+    /// a task group awaits every child before it returns, and cancelling the
+    /// losing child does not cancel the resolution it is awaiting, so a slow
+    /// resolver would hold the handoff open well past the deadline and leave
+    /// the user's tap looking inert.
+    private func startResolvingHostApplicationBundleId(timeout: TimeInterval = 2) {
         hostApplicationBundleIdTask = Task { [weak self] in
             guard let self else { return nil }
             let bundleId: String?
             do {
-                bundleId = try await resolveHostApplicationBundleId()
+                bundleId = try await resolveHostApplicationBundleId(timeout: timeout)
             } catch {
                 logger.logError("🏠 Failed to resolve host app: \(error.localizedDescription)")
                 return nil

--- a/VivaDictaKeyboard/KeyboardViewController.swift
+++ b/VivaDictaKeyboard/KeyboardViewController.swift
@@ -155,14 +155,6 @@ class KeyboardViewController: KeyboardInputViewController {
     private func startResolvingHostApplicationBundleId(timeout: TimeInterval = 2) {
         hostApplicationBundleIdTask = Task { [weak self] in
             guard let self else { return nil }
-            let bundleId: String?
-            do {
-                bundleId = try await resolveHostApplicationBundleId(timeout: timeout)
-            } catch {
-                logger.logError("🏠 Failed to resolve host app: \(error.localizedDescription)")
-                return nil
-            }
-
             // KeyboardKit persists `hostApplicationBundleId` to the App Group
             // and, per its Host article, "will not sync the bundle ID to the
             // KeyboardContext unless absolutely necessary". Nothing here reads
@@ -170,7 +162,19 @@ class KeyboardViewController: KeyboardInputViewController {
             // writing it would only seed the *next* keyboard session with this
             // session's host. Clear it, so neither this session nor a value
             // left behind by an earlier build can outlive the keyboard.
+            //
+            // Cleared before resolving, so that a resolution which throws does
+            // not leave an older value in place - the case where a stale host
+            // is least wanted.
             state.keyboardContext.hostApplicationBundleId = nil
+
+            let bundleId: String?
+            do {
+                bundleId = try await resolveHostApplicationBundleId(timeout: timeout)
+            } catch {
+                logger.logError("🏠 Failed to resolve host app: \(error.localizedDescription)")
+                return nil
+            }
 
             // `.notice` rather than `.info`: info-level entries are memory
             // backed and die with the extension process, so a wrong host was

--- a/documentation/Deep-Linking-URL-Routing-Architecture.md
+++ b/documentation/Deep-Linking-URL-Routing-Architecture.md
@@ -77,7 +77,9 @@ When the keyboard's mic button is tapped and the Hot Mic session is not yet acti
 vivadicta://record-for-keyboard?hostId=<percent-encoded bundle ID>
 ```
 
-The `hostId` is obtained from `KeyboardInputViewController.hostApplicationBundleId` (provided by KeyboardKit). It identifies which app the keyboard is currently serving so the main app can return the user there after starting recording.
+The `hostId` is resolved at the moment of the tap by `KeyboardViewController.hostApplicationBundleIdForHandoff()`, which wraps KeyboardKit's async `resolveHostApplicationBundleId(timeout:)`. It identifies which app the keyboard is currently serving so the main app can return the user there after starting recording.
+
+Resolving at the tap rather than reusing an earlier answer is deliberate. KeyboardKit's resolver lags a change of host app, so the value available when the keyboard first appears can still name the previous app; asking again at the tap gives it time to settle. When it cannot answer, the `hostId` is omitted and the main app falls back to asking the user to switch back by hand. See `Keyboard-Extension-Architecture.md` for the full rationale.
 
 ### Phase 2: VivaDicta prepares and returns to host
 

--- a/documentation/Keyboard-Extension-Architecture.md
+++ b/documentation/Keyboard-Extension-Architecture.md
@@ -300,19 +300,31 @@ The session has a 180-second timeout managed by `PrewarmManager`. If no recordin
 
 When the keyboard is in `.notReady` state (no active main app session) and the user taps the mic, the extension cannot start recording directly. Instead, it deep-links into the main app to initiate a "hot-mic" flow — the main app opens, begins recording immediately (bypassing the normal recording screen), and the text flows back to the original text field when done.
 
-The URL scheme is `vivadicta://record-for-keyboard`. KeyboardKit's `hostApplicationBundleId` property (available on `KeyboardInputViewController`) identifies the app currently hosting the keyboard.
+The URL scheme is `vivadicta://record-for-keyboard`. The app hosting the keyboard is identified by `KeyboardViewController.hostApplicationBundleIdForHandoff()`.
 
 ```swift
 // From VivaDictaKeyboardToolbarView
-var urlString = "vivadicta://record-for-keyboard"
-if let hostId = controller?.hostApplicationBundleId {
-    if let encodedHostId = hostId.addingPercentEncoding(
-        withAllowedCharacters: .urlQueryAllowed) {
-        urlString += "?hostId=\(encodedHostId)"
-    }
+Task {
+    let hostId = await controller?.hostApplicationBundleIdForHandoff()
+    guard let url = URL.keyboardHandoff(
+        "vivadicta://record-for-keyboard",
+        hostId: hostId
+    ) else { return }
+    openURL(url)
 }
-openURL(URL(string: urlString)!)
 ```
+
+### Why the host is resolved at the tap
+
+Until iOS 26.4 this was a synchronous property read, `KeyboardInputViewController.hostApplicationBundleId`, taken inline at the tap. Apple removed the API behind it, so KeyboardKit 10.9 replaced it with an async resolver that must be activated and then polled.
+
+That resolver lags a change of host app. A device capture recorded it returning a bundle ID for an app that had been terminated for three seconds and was never the current host, 1.3s after the keyboard moved into a different app - and the main app duly relaunched that app. Every resolution in the same capture taken 8s or more after its host appeared was correct.
+
+So the answer available when the keyboard first appears is the one most likely to be wrong, and a handoff resolves again rather than reusing it. That restores the timing of the old synchronous read on top of the async API. A resolution is still started in `viewDidLoad`, but only to activate the resolver early so the call at the tap reads a warm one instead of starting cold; its value is not used.
+
+There is deliberately no fallback to the earlier answer. It is the least trustworthy value the keyboard holds, and it is wrong in precisely the case the re-resolve exists to handle. An unresolved host omits the `hostId`, and the main app starts recording and shows its manual return prompt - much cheaper than opening the wrong app, which also relaunches an app the user had closed.
+
+The deadline is passed to `resolveHostApplicationBundleId(timeout:)` rather than enforced by racing the resolution against a sleep. Racing does not bound anything here: a task group awaits every child before it returns, and cancelling the losing child does not cancel the unstructured `Task` it is awaiting, so a slow resolver would hold the handoff open past the deadline and leave the tap looking inert.
 
 The `hostId` query parameter carries the bundle identifier of the calling app (e.g., `com.apple.mobilenotes`, `com.apple.MobileSMS`). The main app receives this via its `onOpenURL` handler in the scene delegate, passes `hostId` to `RecordViewModel`, and after transcription completes, constructs a return URL to bring the user back to the originating app:
 


### PR DESCRIPTION
Replaces #381, whose diagnosis a device capture disproved.

## The bug

Tap the mic in Notes, land in Telegram. The keyboard hands the main app the bundle ID of an app it was not typing into, and the main app dutifully opens it.

## What the capture shows

KeyboardKit's resolver lags a change of host app:

| Time | Event |
|---|---|
| 17:16:21.93 | Telegram process **terminated** |
| 17:16:23.53 | Notes goes **foreground** |
| **17:16:24.88** | keyboard resolves `ph.telegra.Telegraph` |
| 17:16:27.97 | mic tapped, reusing that 3.1s-old value |
| 17:16:28.98 | main app opens `tg://`, **relaunching** Telegram |

The resolved app was neither foreground nor running. Foreground and process-termination times are from SpringBoard and runningboardd in the same archive, so this is system ground truth, not inference.

Every resolution in that capture taken 8s or more after its host appeared was correct. The single wrong one was taken **1.3s** after the host switched.

## The fix

Resolution starts in `viewDidLoad` - the instant the keyboard reaches a new host, and so the least reliable moment to ask. That answer was then cached and reused for a handoff seconds later, by which point a fresh resolve would very likely have been right.

Handoffs now call `hostApplicationBundleIdForHandoff()`, which re-resolves and falls back to the cached answer only if the fresh one cannot be had inside the existing 1s bound. Both handoff call sites already awaited an async accessor, so the shape is unchanged.

## Also included

- **Stop writing `KeyboardContext.hostApplicationBundleId`.** It is persisted to the App Group, KeyboardKit only writes it "unless absolutely necessary" for that reason, and nothing here reads it back, so the write only left this session's host sitting there for the next one. Cleared instead. This was *not* the cause of the bug above, but it is a second route to a stale host and costs nothing to close.
- **Host resolution and the teleport decision path move from `.info` to `.notice`.** Info level is memory backed and dies with the process, and the app is usually terminated moments after a handoff, so a wrong host left no trace in a log collected afterwards. Four of five handoffs in an earlier capture were invisible for this reason.

Dropped from #381: the sync-age suffix on the resolution log. It reported our own `= nil` write, so it measured nothing useful.

## Trade-off

A handoff can now wait up to 1s for a fresh resolve before opening the main app. In practice the resolver returns fast; the bound only bites when it cannot answer at all, which is exactly when the cached value is least trustworthy anyway.

## Testing

- `xcodebuild build`, iPhone 17 Pro Max / iOS 26.4: success, 0 errors.
- Needs a device run of the reproducer: Telegram to Notes to Telegram, force-quitting the app between each, checking you land in the app you started from. The `.notice` logging above makes that verifiable from a collected log for the first time.

Worth reporting upstream against KeyboardKit 10.9.1 separately - a dead, non-foreground bundle ID returned 1.3s after a host switch is a tight repro.