### PR TITLE
Add a Czech QWERTZ keyboard layout

### DIFF
--- a/Modules/AppGroup/Sources/AppGroup/KeyboardLanguage.swift
+++ b/Modules/AppGroup/Sources/AppGroup/KeyboardLanguage.swift
@@ -20,6 +20,7 @@ public enum KeyboardLanguage: String, CaseIterable, Sendable, Hashable, Identifi
     case english
     case french
     case german
+    case czech
     case spanish
     case russian
 
@@ -31,6 +32,7 @@ public enum KeyboardLanguage: String, CaseIterable, Sendable, Hashable, Identifi
         case .english: "EN"
         case .french: "FR"
         case .german: "DE"
+        case .czech: "CZ"
         case .spanish: "ES"
         case .russian: "RU"
         }
@@ -42,6 +44,7 @@ public enum KeyboardLanguage: String, CaseIterable, Sendable, Hashable, Identifi
         case .english: "English"
         case .french: "Français"
         case .german: "Deutsch"
+        case .czech: "Čeština"
         case .spanish: "Español"
         case .russian: "Русский"
         }
@@ -53,6 +56,7 @@ public enum KeyboardLanguage: String, CaseIterable, Sendable, Hashable, Identifi
         case .english: "QWERTY"
         case .french: "AZERTY"
         case .german: "QWERTZ"
+        case .czech: "QWERTZ"
         case .spanish: "QWERTY + ñ"
         case .russian: "ЙЦУКЕН"
         }
@@ -67,6 +71,7 @@ public enum KeyboardLanguage: String, CaseIterable, Sendable, Hashable, Identifi
         case .english: ["en"]
         case .french: ["fr"]
         case .german: ["de"]
+        case .czech: ["cs"]
         case .spanish: ["es"]
         case .russian: ["ru"]
         }

--- a/VivaDictaKeyboard/CzechLayout.swift
+++ b/VivaDictaKeyboard/CzechLayout.swift
@@ -1,0 +1,95 @@
+//
+//  CzechLayout.swift
+//  VivaDictaKeyboard
+//
+//  Created by Anton Novoselov on 2026.09.02
+//
+
+import KeyboardKit
+
+/// Rewrites a `KeyboardLayout` to Czech QWERTZ.
+///
+/// Unlike `AzertyLayout`, `GermanLayout`, `SpanishLayout` and `RussianLayout`,
+/// this one does not rebuild the letter rows from a character table. The Czech
+/// layout is the English QWERTY layout with `y` and `z` swapped and nothing
+/// else, so we take the standard layout as-is and swap those two keys in
+/// place. Key counts (10/9/7), sizes, shift, backspace and space are therefore
+/// bit-for-bit identical to English.
+///
+///   Row 0: q w e r t z u i o p  (10)
+///   Row 1: a s d f g h j k l    (9)
+///   Row 2: y x c v b n m        (7)
+///
+/// All Czech diacritics (á č ď é ě í ň ó ř š ť ú ů ý ž) are reached via
+/// long-press — see `CzechCallouts`. No German umlauts appear on the keys.
+enum CzechLayout {
+
+    static func rewrite(_ layout: KeyboardLayout) -> KeyboardLayout {
+        var result = layout
+
+        for rowIndex in result.itemRows.indices {
+            for itemIndex in result.itemRows[rowIndex].indices {
+                guard case .character(let char) = result.itemRows[rowIndex][itemIndex].action,
+                      let swapped = swapped(char) else { continue }
+                result.itemRows[rowIndex][itemIndex].action = .character(swapped)
+            }
+        }
+
+        return result
+    }
+
+    /// The QWERTY -> QWERTZ swap, preserving letter case.
+    private static func swapped(_ char: String) -> String? {
+        switch char {
+        case "y": "z"
+        case "z": "y"
+        case "Y": "Z"
+        case "Z": "Y"
+        default: nil
+        }
+    }
+}
+
+/// Long-press callout alternates for Czech.
+///
+/// Czech-only: every alternate here is a letter of the Czech alphabet, so the
+/// callouts stay short and there is no foreign accent (à, œ, ß, …) to scroll
+/// past. Uppercase is derived from the pressed key, so `C` long-presses to `Č`.
+///
+/// Letters with no Czech diacritic get *no* callout at all rather than falling
+/// back to `standardActions()`, which would offer KeyboardKit's pan-European
+/// set (ŵ, ġ, ħ, ķ, ł, …) — none of which exist in Czech. Non-letters do keep
+/// their standard callouts, so quotes, punctuation and digits still work.
+enum CzechCallouts {
+
+    static let actionsBuilder: KeyboardCalloutActions.Builder = { params in
+        guard case .character(let char) = params.action else {
+            return params.standardActions()
+        }
+        let lower = char.lowercased()
+        guard let alternates = byCharacter[lower] else {
+            return lower.first?.isLetter == true ? [] : params.standardActions()
+        }
+        let isUppercase = char != lower
+        return alternates.map { alternate in
+            let value = isUppercase ? String(alternate).uppercased() : String(alternate)
+            return .character(value)
+        }
+    }
+
+    private static let byCharacter: [String: String] = [
+        "a": "á",
+        "c": "č",
+        "d": "ď",
+        "e": "éě",
+        "i": "í",
+        "n": "ň",
+        "o": "ó",
+        "r": "ř",
+        "s": "š",
+        "t": "ť",
+        "u": "úů",
+        "y": "ý",
+        "z": "ž"
+    ]
+}

--- a/VivaDictaKeyboard/KeyboardCustomView.swift
+++ b/VivaDictaKeyboard/KeyboardCustomView.swift
@@ -83,6 +83,7 @@ struct KeyboardCustomView: View {
         case .english: result = base
         case .french: result = AzertyLayout.rewrite(base)
         case .german: result = GermanLayout.rewrite(base)
+        case .czech: result = CzechLayout.rewrite(base)
         case .spanish: result = SpanishLayout.rewrite(base)
         case .russian: result = RussianLayout.rewrite(base)
         }
@@ -246,6 +247,7 @@ struct KeyboardCustomView: View {
                                 case .english: return params.standardActions()
                                 case .french: return AzertyCallouts.actionsBuilder(params)
                                 case .german: return GermanCallouts.actionsBuilder(params)
+                                case .czech: return CzechCallouts.actionsBuilder(params)
                                 case .spanish: return SpanishCallouts.actionsBuilder(params)
                                 case .russian: return RussianCallouts.actionsBuilder(params)
                                 }


### PR DESCRIPTION
The keyboard offered German as its only QWERTZ layout, but German carries ü, ö and ä on the keys and long-presses to ß, à and œ — none of which Czech uses.

Czech is the English QWERTY layout with y and z swapped and nothing else, so CzechLayout takes the standard layout and swaps just those two keys in place rather than rebuilding the letter rows from a character table the way the other layouts do. Key counts, sizes, shift, backspace and space stay identical to English.

Callouts are Czech-only: á č ď é ě í ň ó ř š ť ú ů ý ž. Letters with no Czech diacritic get no callout at all instead of falling back to KeyboardKit's pan-European set (ŵ, ġ, ħ, ķ, ł); non-letters keep their standard callouts so quotes, punctuation and digits still work.