### PR TITLE
Auto-enable a newly added keyboard language on update

### DIFF
--- a/Modules/AppGroup/Sources/AppGroup/AppGroupCoordinator.swift
+++ b/Modules/AppGroup/Sources/AppGroup/AppGroupCoordinator.swift
@@ -70,6 +70,10 @@ public final class AppGroupCoordinator: @unchecked Sendable {
     public static let kEnabledKeyboardLanguages = "enabledKeyboardLanguages"
     public static let kCurrentKeyboardLanguage = "currentKeyboardLanguage"
     private static let kDidMigrateLanguageSettings = "didMigrateLanguageSettings_v1"
+    /// Languages already offered to this install, so a language added in a
+    /// later release can be auto-enabled exactly once. See
+    /// `ensureNewLanguagesSeeded()`.
+    private static let kSeededLanguages = "seededKeyboardLanguages"
     // Legacy keys, kept here only so the migration code can read and clear them.
     private static let kLegacyKeyboardLayoutStyle = "keyboardLayoutStyle"
     private static let kLegacyIsRussianLayoutEnabled = "isRussianLayoutEnabled"
@@ -740,28 +744,20 @@ public final class AppGroupCoordinator: @unchecked Sendable {
     /// Stored as a comma-separated list of raw values in shared UserDefaults.
     public var enabledKeyboardLanguages: Set<KeyboardLanguage> {
         get {
-            ensureLanguageSettingsMigrated()
-            guard let raw = sharedDefaults?.string(forKey: AppGroupCoordinator.kEnabledKeyboardLanguages),
-                  !raw.isEmpty else {
-                return [.english]
-            }
-            let langs = raw
-                .split(separator: ",")
-                .compactMap { KeyboardLanguage(rawValue: String($0)) }
-            return langs.isEmpty ? [.english] : Set(langs)
+            ensureLanguageSettingsUpToDate()
+            let langs = AppGroupCoordinator.parseLanguages(
+                sharedDefaults?.string(forKey: AppGroupCoordinator.kEnabledKeyboardLanguages)
+            )
+            return langs.isEmpty ? [.english] : langs
         }
         set {
-            // Run migration before persisting so a write that beats any read
-            // (e.g. a future code path that calls the setter first) cannot leave
-            // the marker unset and have the next getter overwrite the user's
-            // value with the legacy-derived seed.
-            ensureLanguageSettingsMigrated()
+            // Run migration and seeding before persisting so a write that beats
+            // any read (e.g. a future code path that calls the setter first)
+            // cannot leave the markers unset and have the next getter overwrite
+            // the user's value with the derived seed.
+            ensureLanguageSettingsUpToDate()
             let safe = newValue.isEmpty ? Set([KeyboardLanguage.english]) : newValue
-            // Serialize in canonical (allCases) order for deterministic storage.
-            let raw = KeyboardLanguage.allCases
-                .filter { safe.contains($0) }
-                .map(\.rawValue)
-                .joined(separator: ",")
+            let raw = AppGroupCoordinator.serializeLanguages(safe)
             sharedDefaults?.set(raw, forKey: AppGroupCoordinator.kEnabledKeyboardLanguages)
             // If the currently active language was just disabled, snap to the
             // first enabled language so the keyboard never points at a missing one.
@@ -781,7 +777,7 @@ public final class AppGroupCoordinator: @unchecked Sendable {
     /// enabled language if the persisted value is missing or no longer enabled.
     public var currentKeyboardLanguage: KeyboardLanguage {
         get {
-            ensureLanguageSettingsMigrated()
+            ensureLanguageSettingsUpToDate()
             let enabled = enabledKeyboardLanguages
             guard let raw = sharedDefaults?.string(forKey: AppGroupCoordinator.kCurrentKeyboardLanguage),
                   let lang = KeyboardLanguage(rawValue: raw),
@@ -791,7 +787,7 @@ public final class AppGroupCoordinator: @unchecked Sendable {
             return lang
         }
         set {
-            ensureLanguageSettingsMigrated()
+            ensureLanguageSettingsUpToDate()
             sharedDefaults?.set(newValue.rawValue, forKey: AppGroupCoordinator.kCurrentKeyboardLanguage)
             sharedDefaults?.synchronize()
         }
@@ -840,18 +836,114 @@ public final class AppGroupCoordinator: @unchecked Sendable {
             current = .english
         }
 
-        let rawEnabled = KeyboardLanguage.allCases
-            .filter { enabled.contains($0) }
-            .map(\.rawValue)
-            .joined(separator: ",")
-        defaults.set(rawEnabled, forKey: AppGroupCoordinator.kEnabledKeyboardLanguages)
+        defaults.set(
+            AppGroupCoordinator.serializeLanguages(enabled),
+            forKey: AppGroupCoordinator.kEnabledKeyboardLanguages
+        )
         defaults.set(current.rawValue, forKey: AppGroupCoordinator.kCurrentKeyboardLanguage)
+        // This install has now been offered every language that exists today,
+        // so `ensureNewLanguagesSeeded()` has nothing left to do until a new
+        // case is added.
+        defaults.set(
+            AppGroupCoordinator.serializeLanguages(Set(KeyboardLanguage.allCases)),
+            forKey: AppGroupCoordinator.kSeededLanguages
+        )
 
         defaults.removeObject(forKey: AppGroupCoordinator.kLegacyKeyboardLayoutStyle)
         defaults.removeObject(forKey: AppGroupCoordinator.kLegacyIsRussianLayoutEnabled)
         defaults.removeObject(forKey: AppGroupCoordinator.kLegacyIsCurrentlyRussian)
         defaults.set(true, forKey: AppGroupCoordinator.kDidMigrateLanguageSettings)
         defaults.synchronize()
+    }
+
+    /// The languages that had already been offered to users before per-language
+    /// seeding existed, used to backfill `kSeededLanguages` for installs that
+    /// ran the one-shot migration under an older build.
+    ///
+    /// This is a frozen historical fact - the set that shipped on the App Store
+    /// before this key was introduced. **Do not add new cases here.** A new
+    /// language belongs in `KeyboardLanguage` only; leaving it out of this set
+    /// is precisely what lets `ensureNewLanguagesSeeded()` pick it up.
+    private static let preSeedingLanguages: Set<KeyboardLanguage> = [
+        .english, .french, .german, .spanish, .russian
+    ]
+
+    /// Runs the language-settings migration, then auto-enables any language
+    /// added since this install last looked.
+    private func ensureLanguageSettingsUpToDate() {
+        ensureLanguageSettingsMigrated()
+        ensureNewLanguagesSeeded()
+    }
+
+    /// Auto-enables any `KeyboardLanguage` case that this install has never been
+    /// offered, when it matches one of the user's iOS system languages.
+    ///
+    /// `ensureLanguageSettingsMigrated()` consults `preferredFromSystem()` only
+    /// once, behind a boolean marker, so a language shipped in a later release
+    /// would never auto-enable for anyone who had already migrated - a Czech
+    /// user updating the app would have to find the toggle by hand. This runs
+    /// on every access and closes that gap for every future language too.
+    ///
+    /// Each language is considered **exactly once**: `kSeededLanguages` records
+    /// what has been offered, whether or not it was enabled. So a language the
+    /// user deliberately switched off is never switched back on, and one that
+    /// did not match their locales is not re-evaluated if they later change
+    /// them. Seeding only ever adds, so the English floor is unaffected.
+    ///
+    /// - Parameter systemPreferred: The languages matching the user's iOS
+    ///   language list. A parameter so the seeding is testable without touching
+    ///   `Locale.preferredLanguages`, and an `@autoclosure` so that list is not
+    ///   read on the common path where there is nothing new to seed - this runs
+    ///   on every language read, including from the keyboard extension.
+    func ensureNewLanguagesSeeded(
+        systemPreferred: @autoclosure () -> Set<KeyboardLanguage> = KeyboardLanguage.preferredFromSystem()
+    ) {
+        guard let defaults = sharedDefaults else { return }
+
+        let seeded: Set<KeyboardLanguage>
+        if let raw = defaults.string(forKey: AppGroupCoordinator.kSeededLanguages) {
+            seeded = AppGroupCoordinator.parseLanguages(raw)
+        } else {
+            seeded = AppGroupCoordinator.preSeedingLanguages
+        }
+
+        let unseen = Set(KeyboardLanguage.allCases).subtracting(seeded)
+        guard !unseen.isEmpty else { return }
+
+        let toEnable = unseen.intersection(systemPreferred())
+        if !toEnable.isEmpty {
+            let enabled = AppGroupCoordinator.parseLanguages(
+                defaults.string(forKey: AppGroupCoordinator.kEnabledKeyboardLanguages)
+            )
+            let updated = (enabled.isEmpty ? [.english] : enabled).union(toEnable)
+            defaults.set(
+                AppGroupCoordinator.serializeLanguages(updated),
+                forKey: AppGroupCoordinator.kEnabledKeyboardLanguages
+            )
+            logger.logInfo("Auto-enabled new keyboard languages: \(AppGroupCoordinator.serializeLanguages(toEnable))")
+        }
+
+        defaults.set(
+            AppGroupCoordinator.serializeLanguages(Set(KeyboardLanguage.allCases)),
+            forKey: AppGroupCoordinator.kSeededLanguages
+        )
+        defaults.synchronize()
+    }
+
+    /// Parses the comma-separated raw-value list used to persist a language set.
+    /// Unknown raw values (a language removed in a later build) are dropped.
+    static func parseLanguages(_ raw: String?) -> Set<KeyboardLanguage> {
+        guard let raw, !raw.isEmpty else { return [] }
+        return Set(raw.split(separator: ",").compactMap { KeyboardLanguage(rawValue: String($0)) })
+    }
+
+    /// Serializes a language set in canonical `allCases` order, so storage is
+    /// deterministic and diffable regardless of `Set` iteration order.
+    static func serializeLanguages(_ languages: Set<KeyboardLanguage>) -> String {
+        KeyboardLanguage.allCases
+            .filter { languages.contains($0) }
+            .map(\.rawValue)
+            .joined(separator: ",")
     }
 
     // MARK: - Share Extension Audio Handling

--- a/Modules/AppGroup/Sources/AppGroup/KeyboardLanguage.swift
+++ b/Modules/AppGroup/Sources/AppGroup/KeyboardLanguage.swift
@@ -81,12 +81,19 @@ public enum KeyboardLanguage: String, CaseIterable, Sendable, Hashable, Identifi
     /// preference list, set in iOS Settings -> General -> Language & Region)
     /// and returns the subset of `KeyboardLanguage` cases that match.
     ///
-    /// Used during the one-shot onboarding migration to pre-check toggles for
-    /// languages the user is likely to want. After that first run the user's
-    /// explicit choices take precedence.
-    public static func preferredFromSystem() -> Set<KeyboardLanguage> {
+    /// Used to pre-check toggles for languages the user is likely to want:
+    /// once during the onboarding migration, and again for any language added
+    /// in a later release (see `AppGroupCoordinator.ensureNewLanguagesSeeded`).
+    /// A language is only ever considered once - after that the user's explicit
+    /// choice takes precedence.
+    ///
+    /// - Parameter preferredLanguages: BCP-47 tags to inspect. Defaults to the
+    ///   live system list; injectable so the matching is testable.
+    public static func preferredFromSystem(
+        preferredLanguages: [String] = Locale.preferredLanguages
+    ) -> Set<KeyboardLanguage> {
         var result: Set<KeyboardLanguage> = []
-        for tag in Locale.preferredLanguages {
+        for tag in preferredLanguages {
             // Locale(identifier:).language.languageCode gives the primary
             // language code without region (e.g. "en-US" -> "en").
             guard let code = Locale(identifier: tag).language.languageCode?.identifier else { continue }

--- a/Modules/AppGroup/Tests/AppGroupTests/KeyboardLanguageSeedingTests.swift
+++ b/Modules/AppGroup/Tests/AppGroupTests/KeyboardLanguageSeedingTests.swift
@@ -1,0 +1,162 @@
+//
+//  KeyboardLanguageSeedingTests.swift
+//  AppGroupTests
+//
+//  Created by Anton Novoselov on 2026.09.06
+//
+
+import Foundation
+import Testing
+@testable import AppGroup
+
+/// Covers `AppGroupCoordinator.ensureNewLanguagesSeeded` - the path that
+/// auto-enables a language added after the one-shot onboarding migration has
+/// already run.
+struct KeyboardLanguageSeedingTests {
+
+    private let suiteName = "KeyboardLanguageSeedingTests.\(UUID().uuidString)"
+    let defaults: UserDefaults
+    let sut: AppGroupCoordinator
+
+    init() {
+        defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        sut = AppGroupCoordinator(userDefaults: defaults)
+    }
+
+    /// Puts the suite in the state of an install that migrated under a build
+    /// predating `kSeededLanguages`: migration marker set, no seeded record.
+    private func simulateAlreadyMigrated(enabled: Set<KeyboardLanguage>) {
+        defaults.set(true, forKey: "didMigrateLanguageSettings_v1")
+        defaults.set(
+            AppGroupCoordinator.serializeLanguages(enabled),
+            forKey: AppGroupCoordinator.kEnabledKeyboardLanguages
+        )
+        defaults.removeObject(forKey: "seededKeyboardLanguages")
+    }
+
+    private var storedEnabled: Set<KeyboardLanguage> {
+        AppGroupCoordinator.parseLanguages(
+            defaults.string(forKey: AppGroupCoordinator.kEnabledKeyboardLanguages)
+        )
+    }
+
+    // MARK: - The bug this fixes
+
+    @Test func newLanguageIsEnabledForAnAlreadyMigratedInstall() {
+        simulateAlreadyMigrated(enabled: [.english])
+
+        sut.ensureNewLanguagesSeeded(systemPreferred: [.english, .czech])
+
+        #expect(storedEnabled == [.english, .czech])
+    }
+
+    @Test func newLanguageIsSkippedWhenItDoesNotMatchSystemLanguages() {
+        simulateAlreadyMigrated(enabled: [.english])
+
+        sut.ensureNewLanguagesSeeded(systemPreferred: [.english, .german])
+
+        #expect(storedEnabled == [.english])
+    }
+
+    // MARK: - Never override an explicit user choice
+
+    @Test func aLanguageAlreadyOfferedIsNotReEnabled() {
+        // The user was offered Russian, then deliberately switched it off.
+        defaults.set(true, forKey: "didMigrateLanguageSettings_v1")
+        defaults.set(
+            AppGroupCoordinator.serializeLanguages([.english]),
+            forKey: AppGroupCoordinator.kEnabledKeyboardLanguages
+        )
+        defaults.set(
+            AppGroupCoordinator.serializeLanguages(Set(KeyboardLanguage.allCases)),
+            forKey: "seededKeyboardLanguages"
+        )
+
+        sut.ensureNewLanguagesSeeded(systemPreferred: [.english, .russian])
+
+        #expect(storedEnabled == [.english])
+    }
+
+    @Test func eachLanguageIsConsideredOnlyOnce() {
+        simulateAlreadyMigrated(enabled: [.english])
+
+        // First pass: Czech is not among the user's system languages.
+        sut.ensureNewLanguagesSeeded(systemPreferred: [.english])
+        #expect(storedEnabled == [.english])
+
+        // Later the user adds Czech in iOS Settings. Czech has already been
+        // offered, so we do not reconsider it.
+        sut.ensureNewLanguagesSeeded(systemPreferred: [.english, .czech])
+        #expect(storedEnabled == [.english])
+    }
+
+    @Test func seedingIsAdditiveAndKeepsExistingSelections() {
+        simulateAlreadyMigrated(enabled: [.english, .french, .russian])
+
+        sut.ensureNewLanguagesSeeded(systemPreferred: [.czech])
+
+        #expect(storedEnabled == [.english, .french, .russian, .czech])
+    }
+
+    // MARK: - Bookkeeping
+
+    @Test func seedingRecordsEveryLanguageAsOffered() {
+        simulateAlreadyMigrated(enabled: [.english])
+
+        sut.ensureNewLanguagesSeeded(systemPreferred: [.czech])
+
+        let seeded = AppGroupCoordinator.parseLanguages(
+            defaults.string(forKey: "seededKeyboardLanguages")
+        )
+        #expect(seeded == Set(KeyboardLanguage.allCases))
+    }
+
+    @Test func theOneShotMigrationMarksEverythingAsOffered() {
+        // A fresh install: the migration seeds from the system list itself, so
+        // seeding must find nothing left to do.
+        _ = sut.enabledKeyboardLanguages
+
+        let seeded = AppGroupCoordinator.parseLanguages(
+            defaults.string(forKey: "seededKeyboardLanguages")
+        )
+        #expect(seeded == Set(KeyboardLanguage.allCases))
+    }
+
+    // MARK: - Serialization helpers
+
+    @Test func serializationUsesCanonicalOrderRegardlessOfSetOrder() {
+        let raw = AppGroupCoordinator.serializeLanguages([.russian, .english, .czech])
+
+        #expect(raw == "english,czech,russian")
+    }
+
+    @Test func parsingDropsUnknownRawValues() {
+        let parsed = AppGroupCoordinator.parseLanguages("english,klingon,czech")
+
+        #expect(parsed == [.english, .czech])
+    }
+
+    @Test func parsingEmptyOrMissingYieldsNoLanguages() {
+        #expect(AppGroupCoordinator.parseLanguages(nil).isEmpty)
+        #expect(AppGroupCoordinator.parseLanguages("").isEmpty)
+    }
+
+    // MARK: - System language matching
+
+    @Test func systemMatchingIgnoresRegionSubtags() {
+        let matched = KeyboardLanguage.preferredFromSystem(
+            preferredLanguages: ["cs-CZ", "en-GB"]
+        )
+
+        #expect(matched == [.czech, .english])
+    }
+
+    @Test func systemMatchingIgnoresUnsupportedLanguages() {
+        let matched = KeyboardLanguage.preferredFromSystem(
+            preferredLanguages: ["ja-JP", "cs-CZ"]
+        )
+
+        #expect(matched == [.czech])
+    }
+}


### PR DESCRIPTION
## Summary

The keyboard seeds its enabled-languages set from the user's iOS language list exactly once, inside `ensureLanguageSettingsMigrated()`, behind the `didMigrateLanguageSettings_v1` boolean. Every install that has launched 3.2.x or later already has that flag set, so the seeding never runs again - a language shipped in a later release stays off no matter what the user has configured in iOS Settings.

Czech (#383) landed straight into that hole. A Czech user updating the app would have had to find the toggle by hand, and the same would have been true of every language added after it. `case .czech: ["cs"]` was correct and completely inert for the existing user base.

## What changed

Replace the one-shot boolean with a record of which languages have already been *offered*. `ensureNewLanguagesSeeded()` diffs `allCases` against that record on every language read and considers only the difference:

- A new case is auto-enabled when it matches the user's system languages.
- A language the user deliberately switched off is never switched back on - it is already in the offered record.
- Each language is evaluated exactly once, whether or not it ended up enabled, so adding Czech to iOS Settings *after* the update does not resurrect a language the user already rejected.
- Seeding only ever adds, so the English floor is untouched.

Installs that migrated under an older build have no such record, so they backfill from `preSeedingLanguages` - the set that shipped before this key existed (`english, french, german, spanish, russian`). That constant is a frozen historical fact rather than a list to maintain: a new language is picked up precisely *by being absent from it*, and the doc comment says so.

The system list is read through an `@autoclosure`, so `Locale.preferredLanguages` is not touched on the common path where there is nothing new to seed. This runs on every language read, including from the keyboard extension.

Two pieces of cleanup along the way:
- The comma-separated parse/serialize of the language set was written out three times (getter, setter, migration). Folded into `parseLanguages` / `serializeLanguages`.
- `preferredFromSystem()` now takes an injectable tag list (defaulting to the live one) so the locale matching is testable.

## Testing

New `KeyboardLanguageSeedingTests` (12 tests) covering the bug and its edges: a new language enabled for an already-migrated install, skipped when it does not match the system list, an already-offered language never re-enabled, each language considered only once across two passes, seeding staying additive, the bookkeeping key, the migration marking everything offered on a fresh install, canonical serialization order, unknown raw values dropped, and region-subtag/unsupported-language matching.

- `swift test` in `Modules/AppGroup`: 37 tests, all passing.
- `xcodebuild build` for the app scheme: success, 0 errors.

## Notes

No schema or CloudKit impact - this is UserDefaults in the app group. Behavior for a fresh install is unchanged: the migration seeds from the system list and marks everything offered, so seeding finds nothing to do.